### PR TITLE
Ignore symlinked node_modules for yarn workspaces.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ styles/core-ui*
 
 # Dependencies #
 ################
-node_modules/
+node_modules
 
 # Logs #
 ########


### PR DESCRIPTION
The yarn workspace project symlinks `node_modules` in all project directories. This fixes `.gitignore` to ignore that symlink.