### PR TITLE
refactor(src): Remove deprecated goog.string.isEmpty/isEmptySafe.

### DIFF
--- a/src/os/metrics/metrics.js
+++ b/src/os/metrics/metrics.js
@@ -284,7 +284,7 @@ os.metrics.Metrics.prototype.hasMetric_ = function(key, obj) {
  */
 os.metrics.Metrics.prototype.updateMetric = function(key, value) {
   try {
-    if (this.enabled_ && !goog.string.isEmptySafe(key)) {
+    if (this.enabled_ && !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(key))) {
       // send to metric service, if defined.
       if (this.metricServiceProvider_) {
         // add on the app name so it's clear what app is being used
@@ -334,7 +334,7 @@ os.metrics.Metrics.prototype.recordClickEvent = function(args) {
     var element = args.target;
     var attr = element.attributes.getNamedItem('metric');
     var metricKey = attr ? attr.value : null;
-    if (goog.string.isEmptySafe(metricKey) && element.parentElement) {
+    if (goog.string.isEmptyOrWhitespace(goog.string.makeSafe(metricKey)) && element.parentElement) {
       attr = element.parentElement.attributes.getNamedItem('metric');
       metricKey = attr ? attr.value : null;
     }

--- a/src/os/net/parammodifier.js
+++ b/src/os/net/parammodifier.js
@@ -91,9 +91,9 @@ os.net.ParamModifier.prototype.setParam = function(param) {
  * @inheritDoc
  */
 os.net.ParamModifier.prototype.modify = function(uri) {
-  goog.asserts.assert(!goog.string.isEmptySafe(this.param_),
+  goog.asserts.assert(!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(this.param_)),
       'The parameter for modifier ' + this.getId() + ' was not set. Request will not load.');
-  goog.asserts.assert(!goog.string.isEmptySafe(this.replaceTerm_),
+  goog.asserts.assert(!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(this.replaceTerm_)),
       'The replacement term for modifier ' + this.getId() + ' was not set. Request will not load.');
   goog.asserts.assert(goog.isDefAndNotNull(this.replacement_),
       'The replacement for modifier ' + this.getId() + ' was not set. Request will not load.');

--- a/src/os/olcs/sync/featureconverter.js
+++ b/src/os/olcs/sync/featureconverter.js
@@ -263,7 +263,7 @@ os.olcs.sync.FeatureConverter.prototype.wrapFillAndOutlineGeometries = function(
 os.olcs.sync.FeatureConverter.prototype.createLabels = function(feature, geometry, labels, context) {
   var allOptions = [];
   goog.array.forEach(labels, function(label) {
-    if (!goog.string.isEmptySafe(label.getText())) {
+    if (!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(label.getText()))) {
       var options = /** @type {!Cesium.optionsLabelCollection} */ ({
         heightReference: this.getHeightReference(context.layer, feature, geometry)
       });

--- a/src/os/query/temporalquerymanager.js
+++ b/src/os/query/temporalquerymanager.js
@@ -92,7 +92,8 @@ os.query.TemporalQueryManager.prototype.hasHandler = function(id) {
  * @param {os.query.TemporalHandler} handler The handler
  */
 os.query.TemporalQueryManager.prototype.registerHandler = function(id, handler) {
-  goog.asserts.assert(!goog.string.isEmptySafe(id), 'Cannot register handler with empty/null id!');
+  goog.asserts.assert(!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(id)),
+      'Cannot register handler with empty/null id!');
   goog.asserts.assert(handler != null, 'Cannot register null handler (id = ' + id + ')');
 
   this.handlers_[id] = handler;

--- a/src/os/search/favorite.js
+++ b/src/os/search/favorite.js
@@ -28,7 +28,8 @@ os.search.Favorite = function(name, uri, title, opt_type) {
  */
 os.search.Favorite.fromBookmark = function(bookmark, opt_type) {
   if (bookmark) {
-    var uri = goog.string.isEmptySafe(bookmark['key']) ? bookmark['key2'] : bookmark['key'];
+    var uri = goog.string.isEmptyOrWhitespace(goog.string.makeSafe(bookmark['key'])) ?
+        bookmark['key2'] : bookmark['key'];
     return new os.search.Favorite(bookmark['value'], uri, uri, opt_type);
   }
   return null;

--- a/src/os/source/source.js
+++ b/src/os/source/source.js
@@ -226,7 +226,9 @@ os.source.getExportFields = function(source, opt_internal) {
         //  - already in the list
         //  - are internal to opensphere (unless specified otherwise)
         //
-        if (column['visible'] && !goog.string.isEmptySafe(field) && !goog.array.contains(fields, field) &&
+        if (column['visible'] &&
+            !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(field)) &&
+            !goog.array.contains(fields, field) &&
             (opt_internal || !os.feature.isInternalField(field))) {
           fields.push(field);
         }

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -676,7 +676,7 @@ os.source.Vector.prototype.getEmptyColumns = function() {
     for (var i = 0; i < features.length && empty.length > 0; i++) {
       var j = empty.length;
       while (j--) {
-        if (!goog.string.isEmptySafe(features[i].values_[empty[j]['field']])) {
+        if (!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(features[i].values_[empty[j]['field']]))) {
           // if a value is encountered, remove the column so it's no longer considered
           empty.splice(j, 1);
         }

--- a/src/os/state/v2/layerstate.js
+++ b/src/os/state/v2/layerstate.js
@@ -359,7 +359,8 @@ os.state.v2.LayerState.prototype.layerToXML = function(layer, options, opt_exclu
           break;
         case os.style.StyleField.LABELS:
           var labelColumn = /** @type {Array<os.style.label.LabelConfig>} */ (value);
-          if (bfs && labelColumn.length > 0 && !goog.string.isEmptySafe(labelColumn[0]['column'])) {
+          if (bfs && labelColumn.length > 0 &&
+              !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(labelColumn[0]['column']))) {
             // Support legacy
             os.xml.appendElement(os.state.v2.LayerTag.LABEL_COLUMN, bfs, labelColumn[0]['column']);
 
@@ -374,7 +375,7 @@ os.state.v2.LayerState.prototype.layerToXML = function(layer, options, opt_exclu
           }
           break;
         case os.style.StyleField.LABEL_COLOR:
-          if (bfs && goog.isString(value) && !goog.string.isEmptySafe(value)) {
+          if (bfs && goog.isString(value) && !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(value))) {
             var color = os.color.toHexString(value).replace(/^#/, '');
             os.xml.appendElement(os.state.v2.LayerTag.LABEL_COLOR, bfs, color);
           }
@@ -659,7 +660,8 @@ os.state.v2.LayerState.prototype.xmlToOptions = function(node) {
                   }
                   var source = this.getSource(node);
                   if (source && source.indexOf('MIST3D') > -1) {
-                    options[os.style.StyleField.SHOW_LABELS] = !goog.string.isEmptySafe(column);
+                    options[os.style.StyleField.SHOW_LABELS] =
+                        !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(column));
                   }
                   break;
                 case os.state.v2.LayerTag.LABEL_COLUMNS:

--- a/src/os/state/v3/layerstate.js
+++ b/src/os/state/v3/layerstate.js
@@ -380,7 +380,8 @@ os.state.v3.LayerState.prototype.layerToXML = function(layer, options, opt_exclu
           break;
         case os.style.StyleField.LABELS:
           var labelColumn = /** @type {Array<os.style.label.LabelConfig>} */ (value);
-          if (bfs && labelColumn.length > 0 && !goog.string.isEmptySafe(labelColumn[0]['column'])) {
+          if (bfs && labelColumn.length > 0 &&
+              !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(labelColumn[0]['column']))) {
             // Support legacy
             os.xml.appendElement(os.state.v3.LayerTag.LABEL_COLUMN, bfs, labelColumn[0]['column']);
 
@@ -395,7 +396,7 @@ os.state.v3.LayerState.prototype.layerToXML = function(layer, options, opt_exclu
           }
           break;
         case os.style.StyleField.LABEL_COLOR:
-          if (bfs && goog.isString(value) && !goog.string.isEmptySafe(value)) {
+          if (bfs && goog.isString(value) && !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(value))) {
             var color = os.color.toHexString(value).replace(/^#/, '');
             os.xml.appendElement(os.state.v3.LayerTag.LABEL_COLOR, bfs, color);
           }
@@ -718,7 +719,8 @@ os.state.v3.LayerState.prototype.xmlToOptions = function(node) {
                   }
                   var source = this.getSource(node);
                   if (source && source.indexOf('MIST3D') > -1) {
-                    options[os.style.StyleField.SHOW_LABELS] = !goog.string.isEmptySafe(column);
+                    options[os.style.StyleField.SHOW_LABELS] =
+                        !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(column));
                   }
                   break;
                 case os.state.v3.LayerTag.LABEL_COLUMNS:

--- a/src/os/state/v4/baselayerstate.js
+++ b/src/os/state/v4/baselayerstate.js
@@ -238,7 +238,8 @@ os.state.v4.BaseLayerState.prototype.load = function(obj, id) {
 os.state.v4.BaseLayerState.prototype.getLayerType_ = function(layer) {
   if (layer.getLayerOptions()) {
     var type = layer.getLayerOptions()['type'];
-    return goog.string.isEmptySafe(type) ? '' : /** @type {string} */ (layer.getLayerOptions()['type']);
+    return goog.string.isEmptyOrWhitespace(goog.string.makeSafe(type)) ?
+        '' : /** @type {string} */ (layer.getLayerOptions()['type']);
   }
   return '';
 };
@@ -467,7 +468,8 @@ os.state.v4.BaseLayerState.prototype.configKeyToXML = function(layerConfig, type
       break;
     case os.style.StyleField.LABELS:
       var labelColumn = /** @type {Array<os.style.label.LabelConfig>} */ (value);
-      if (bfs && labelColumn.length > 0 && !goog.string.isEmptySafe(labelColumn[0]['column'])) {
+      if (bfs && labelColumn.length > 0 &&
+          !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(labelColumn[0]['column']))) {
         // New Multi column
         var labelColumns = os.xml.appendElement(os.state.v4.LayerTag.LABEL_COLUMNS, bfs);
         goog.array.forEach(labelColumn, function(label) {
@@ -479,7 +481,7 @@ os.state.v4.BaseLayerState.prototype.configKeyToXML = function(layerConfig, type
       }
       break;
     case os.style.StyleField.LABEL_COLOR:
-      if (bfs && goog.isString(value) && !goog.string.isEmptySafe(value)) {
+      if (bfs && goog.isString(value) && !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(value))) {
         var color = os.color.toServerString(value);
         os.xml.appendElement(os.state.v4.LayerTag.LABEL_COLOR, bfs, color);
       }
@@ -879,7 +881,7 @@ os.state.v4.BaseLayerState.prototype.xmlToConfigKey = function(node, child, name
             }
             var source = this.getSource(node);
             if (source && source.indexOf('MIST3D') > -1) {
-              options[os.style.StyleField.SHOW_LABELS] = !goog.string.isEmptySafe(column);
+              options[os.style.StyleField.SHOW_LABELS] = !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(column));
             }
             break;
           case os.state.v4.LayerTag.LABEL_COLUMNS:
@@ -1091,7 +1093,7 @@ os.state.v4.BaseLayerState.prototype.colorModeOptionsFromXml_ = function(node) {
     valElement = pairElement.querySelector(os.state.v4.LayerTag.COLOR_MODEL_VALUE);
     name = os.xml.getElementValueOrDefault(nameElement, null);
     value = os.xml.getElementValueOrDefault(valElement, null);
-    if (!goog.string.isEmptySafe(name)) {
+    if (!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(name))) {
       result['manualColors'][name] = value;
     }
   }

--- a/src/os/string/string.js
+++ b/src/os/string/string.js
@@ -163,7 +163,7 @@ os.string.split = function(str, opt_removeSpaces, opt_precedence) {
     }
     result = delim ? trimmed.split(delim) : [trimmed];
     result = goog.array.filter(result, function(r) {
-      return !goog.string.isEmptySafe(r);
+      return !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(r));
     });
   }
   return result || [];

--- a/src/os/style/label.js
+++ b/src/os/style/label.js
@@ -373,7 +373,7 @@ os.style.label.createOrUpdate = function(feature, config, opt_layerConfig) {
 
     if (labelConfigs) {
       var labelText = os.style.label.getLabelsText(feature, labelConfigs);
-      if (!goog.string.isEmptySafe(labelText)) {
+      if (!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(labelText))) {
         var labels = labelText.split('\n');
 
         labelStyles =

--- a/src/os/ui/descriptioninfo.js
+++ b/src/os/ui/descriptioninfo.js
@@ -63,7 +63,7 @@ os.ui.DescriptionInfoCtrl = function($scope, $element) {
   this.element_ = $element;
 
   var sanitized = os.ui.sanitize(this.scope_.description || '');
-  if (!goog.string.isEmptySafe(sanitized)) {
+  if (!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(sanitized))) {
     // force anchor tags to launch a new tab
     sanitized = sanitized.replace(/<a /g, '<a target="_blank" ');
 

--- a/src/os/ui/featureinfo.js
+++ b/src/os/ui/featureinfo.js
@@ -215,11 +215,11 @@ os.ui.FeatureInfoCtrl.prototype.updateProperties = function() {
       var description = properties[os.data.RecordField.HTML_DESCRIPTION];
       if (!description) {
         description = /** @type {string|undefined} */ (goog.object.findValue(properties, function(val, key) {
-          return os.fields.DESC_REGEXP.test(key) && !goog.string.isEmptySafe(val);
+          return os.fields.DESC_REGEXP.test(key) && !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(val));
         })) || '';
       }
 
-      if (!goog.string.isEmptySafe(description)) {
+      if (!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(description))) {
         // force anchor tags to launch a new tab - we may want to instead just launch a new window for the entire
         // description
         description = description.replace(/<a /g, '<a target="_blank" ');

--- a/src/os/ui/file/kml/abstractkmlexporter.js
+++ b/src/os/ui/file/kml/abstractkmlexporter.js
@@ -512,7 +512,7 @@ os.ui.file.kml.AbstractKMLExporter.prototype.processFolder = function(element, i
  */
 os.ui.file.kml.AbstractKMLExporter.prototype.processPlacemark = function(element, item) {
   var styleId = this.getStyleId(item);
-  if (!goog.string.isEmptySafe(styleId)) {
+  if (!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(styleId))) {
     os.xml.appendElementNS('styleUrl', this.kmlNS, element, '#' + styleId);
   }
 
@@ -567,7 +567,7 @@ os.ui.file.kml.AbstractKMLExporter.prototype.processPlacemark = function(element
           // strip out carriage returns, because screw windows
           val.replace(/\r/g, '');
 
-          if (!goog.string.isEmptySafe(val)) {
+          if (!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(val))) {
             descEl = os.xml.appendElementNS('description', this.kmlNS, element);
 
             var cdata = this.doc.createCDATASection(val);

--- a/src/os/ui/filter/filter.js
+++ b/src/os/ui/filter/filter.js
@@ -483,7 +483,7 @@ os.ui.filter.filterColumns = function(col, c, arr) {
 os.ui.filter.getFilterableTypes = function(type) {
   var types = [];
 
-  if (!goog.string.isEmpty(type)) {
+  if (!goog.string.isEmptyOrWhitespace(type)) {
     // find the filterable descriptor to which that filter belongs
     var descriptors = os.dataManager.getDescriptors();
     var filterables = /** @type {!Array<!os.filter.IFilterable>} */ (descriptors.filter(

--- a/src/os/ui/query/queryhandler.js
+++ b/src/os/ui/query/queryhandler.js
@@ -403,7 +403,7 @@ os.ui.query.QueryHandler.prototype.wrap = function(filter, order, excludes, grou
 
       result = this.exclusionFormatter.wrapMultiple(result);
     }
-  } else if (this.filterFormatter && !goog.string.isEmptySafe(filter)) {
+  } else if (this.filterFormatter && !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(filter))) {
     // don't do this if filter is an empty string, otherwise this will add an empty group
     result += this.filterFormatter.wrap(filter, group);
   }

--- a/src/os/ui/text/text.js
+++ b/src/os/ui/text/text.js
@@ -11,7 +11,7 @@ goog.require('os.ui.window');
  * @param {string} text
  */
 os.ui.text.copy = function(text) {
-  if (text && !goog.string.isEmptySafe(text)) {
+  if (text && !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(text))) {
     var textArea = document.createElement('textarea');
     textArea.style.top = '-2000px';
     textArea.style.left = '-2000px';

--- a/src/os/xml.js
+++ b/src/os/xml.js
@@ -244,7 +244,7 @@ os.xml.serialize = function(xml) {
  * @return {*}
  */
 os.xml.getElementValueOrDefault = function(element, defaultValue) {
-  if (element && !goog.string.isEmptySafe(element.textContent)) {
+  if (element && !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(element.textContent))) {
     return element.textContent;
   }
   return defaultValue;

--- a/src/plugin/file/csv/csvparser.js
+++ b/src/plugin/file/csv/csvparser.js
@@ -90,7 +90,7 @@ plugin.file.csv.CSVParser.prototype.processResult = function(result, opt_mapping
 
     // if both lat and lon aren't set, throw the feature out
     if (goog.isDefAndNotNull(lat) && goog.isDefAndNotNull(lon)) {
-      if (goog.string.isEmpty(lat) || goog.string.isEmpty(lon)) {
+      if (goog.string.isEmptyOrWhitespace(lat) || goog.string.isEmptyOrWhitespace(lon)) {
         return null;
       }
     } else {

--- a/src/plugin/file/shp/shpexporter.js
+++ b/src/plugin/file/shp/shpexporter.js
@@ -303,7 +303,7 @@ plugin.file.shp.SHPExporter.prototype.parseColumns = function() {
             'name': column['name'],
             'field': column['field']
           };
-          if (columns[j]['visible'] && !goog.string.isEmptySafe(colNameField['name'])) {
+          if (columns[j]['visible'] && !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(colNameField['name']))) {
             this.parseColumn_(item, colNameField);
           }
         }
@@ -315,7 +315,7 @@ plugin.file.shp.SHPExporter.prototype.parseColumns = function() {
             'name': column,
             'field': column
           };
-          if (!goog.string.isEmptySafe(colNameField['name'])) {
+          if (!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(colNameField['name']))) {
             this.parseColumn_(item, colNameField);
           }
         }


### PR DESCRIPTION
Straight substitution of equivalent code, per https://github.com/google/closure-library/blob/master/closure/goog/string/string.js#L182