### PR TITLE
Disable missingOverride warning until warnings are handled.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
         "/google-closure-library/",
         "/openlayers/",
         "/ol-cesium/"
+      ],
+      "jscomp_off": [
+        "missingOverride"
       ]
     }
   },


### PR DESCRIPTION
Disable the `missingOverride` compiler check until #32 is worked.