### PR TITLE
Suppress sass-lint warnings, as for scss-lint

### DIFF
--- a/scss/os/partials/_tree.scss
+++ b/scss/os/partials/_tree.scss
@@ -36,6 +36,7 @@
   // see THIN-6980
 
   // scss-lint:disable DeclarationOrder
+  // sass-lint:disable mixins-before-declarations
 
   background: #fcfff4;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfff4', endColorstr='#b3bead',GradientType=0);

--- a/scss/ui/partials/_tristate.scss
+++ b/scss/ui/partials/_tristate.scss
@@ -6,6 +6,7 @@
   // if the @include are moved to the top, we lose the gradient, so the lint check is turned off
   // see THIN-6979
   // scss-lint:disable DeclarationOrder
+  // sass-lint:disable mixins-before-declarations
 
   background: #fcfff4;
   cursor: pointer;


### PR DESCRIPTION
These seemed reasonably well justified, and the change is only to match previous scss-lint suppressions.