### PR TITLE
Update moment to 2.20.1.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,10 +7,10 @@ const resolver = require('opensphere-build-resolver/utils');
 
 module.exports = function(config) {
   var closureFiles = helper.readManifest(path.resolve('.build', 'gcc-test-manifest'))
-    .filter(function(item) {
-      return item.indexOf('/src/core/debugutil.js') === -1 &&
-        item.indexOf('test/') !== 0;
-    });
+      .filter(function(item) {
+        return item.indexOf('/src/core/debugutil.js') === -1 &&
+          item.indexOf(__dirname + '/test/') !== 0;
+      });
 
   config.set({
     // base path, that will be used to resolve files and exclude

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "jquery": "^2.2.0",
     "jsts": "^1.5.0",
     "modernizr": "~3.3.x",
-    "moment": "~2.8.3",
+    "moment": "~2.20.1",
     "navigator.sendbeacon": "~0.0.x",
     "ol-cesium": "=1.32.0",
     "openlayers": "=4.4.2",

--- a/test/os/histo/datebinmethod.test.js
+++ b/test/os/histo/datebinmethod.test.js
@@ -20,23 +20,46 @@ describe('os.histo.DateBinMethod', function() {
     var utcItems = [
       {field: '2014-01-30T12:34:56Z'},
       {field: '2014-01-30T12:34:56+0000'},
-      {field: '01/30/2014 12:34:56 UTC'},
       {field: d},
       {field: new os.time.TimeInstant(d.getTime())},
       {field: new os.time.TimeRange(d.getTime(), d.getTime())},
-      {field: d.toString()}
+      {field: d.toISOString()}
     ];
     for (var i = 0, n = utcItems.length; i < n; i++) {
       expect(method.getValue(utcItems[i])).toBe(d.getTime());
     }
+  });
 
-    // todo: These may have worked in the past. Need to speak with Will.
-    var notSupportedItems = [
+  it('should convert time values that are deprecated by moment, but still supported', function() {
+    var d = new Date();
+    d.setUTCFullYear(2014, 0, 30);
+    d.setUTCHours(12, 34, 56, 0);
+
+    // Values that are supported but deprecated by moment. If these tests start failing, move them to the unsupported
+    // test.
+    var deprecatedItems = [
+      {field: '01/30/2014 12:34:56 UTC'},
+      {field: d.toString()},
+    ];
+
+    for (var i = 0, n = deprecatedItems.length; i < n; i++) {
+      expect(method.getValue(deprecatedItems[i])).toBe(d.getTime());
+    }
+  });
+
+  it('should not convert time values that are not supported by moment', function() {
+    var d = new Date();
+    d.setUTCFullYear(2014, 0, 30);
+    d.setUTCHours(12, 34, 56, 0);
+
+    // Values that are unsupported by moment
+    var unsupportedItems = [
       {field: '30/01/2014 12:34:56 UTC'},
       {field: d.getTime()}
     ];
-    for (var i = 0, n = notSupportedItems.length; i < n; i++) {
-      expect(method.getValue(notSupportedItems[i])).toBe(os.histo.DateBinMethod.MAGIC);
+
+    for (var i = 0, n = unsupportedItems.length; i < n; i++) {
+      expect(method.getValue(unsupportedItems[i])).toBe(os.histo.DateBinMethod.MAGIC);
     }
   });
 

--- a/test/os/state/v2/timestate.test.js
+++ b/test/os/state/v2/timestate.test.js
@@ -140,15 +140,15 @@ describe('os.state.v2.TimeState', function() {
     var rootObj = os.xml.createElement(os.state.v2.TimeTag.FILTERS);
 
     // Full time range.
-    var startDate = os.time.parseMoment('1970-01-01T00:16:39.999Z', [os.state.v2.TimeState.DATE_FORMAT], true);
-    var endDate = os.time.parseMoment('1974-03-15T02:21:41.010Z', [os.state.v2.TimeState.DATE_FORMAT], true);
+    var startDate = os.time.parseMoment('1970-01-01T00:16:39Z', [os.state.v2.TimeState.DATE_FORMAT], true);
+    var endDate = os.time.parseMoment('1974-03-15T02:21:41Z', [os.state.v2.TimeState.DATE_FORMAT], true);
     tlc.setRange(tlc.buildRange(startDate.valueOf(), endDate.valueOf()));
     var fullRangeString = state.rangeToDateFormatString_(tlc.getRange());
     tlc.setDuration('month');
     // Animate range
-    var animateStartDate = os.time.parseMoment('1971-01-01T00:16:39.999Z',
+    var animateStartDate = os.time.parseMoment('1971-01-01T00:16:39Z',
         [os.state.v2.TimeState.DATE_FORMAT], true);
-    var animateEndDate = os.time.parseMoment('1973-03-15T02:21:41.010Z',
+    var animateEndDate = os.time.parseMoment('1973-03-15T02:21:41Z',
         [os.state.v2.TimeState.DATE_FORMAT], true);
     var animateRange = new goog.math.Range(animateStartDate.valueOf(), animateEndDate.valueOf());
     var animateRangeString = state.rangeToDateFormatString_(animateRange);
@@ -156,9 +156,9 @@ describe('os.state.v2.TimeState', function() {
     tlc.addAnimateRange(animateRange);
 
     // Hold range
-    var holdStartDate = os.time.parseMoment('1971-03-01T00:16:39.999Z',
+    var holdStartDate = os.time.parseMoment('1971-03-01T00:16:39Z',
         [os.state.v2.TimeState.DATE_FORMAT], true);
-    var holdEndDate = os.time.parseMoment('1971-06-12T01:15:11.010Z',
+    var holdEndDate = os.time.parseMoment('1971-06-12T01:15:11Z',
         [os.state.v2.TimeState.DATE_FORMAT], true);
     var holdRange = new goog.math.Range(holdStartDate.valueOf(), holdEndDate.valueOf());
     var holdRangeString = state.rangeToDateFormatString_(holdRange);

--- a/test/os/state/v4/timestate.test.js
+++ b/test/os/state/v4/timestate.test.js
@@ -22,24 +22,24 @@ describe('os.state.v4.TimeState', function() {
     var state = new os.state.v4.TimeState();
     var tlc = os.time.TimelineController.getInstance();
     // Ensure the timeline controler is initalized
-    var startDate = os.time.parseMoment('1970-01-01T00:16:39.999Z', [os.state.v2.TimeState.DATE_FORMAT], true);
-    var endDate = os.time.parseMoment('1974-03-15T02:21:41.010Z', [os.state.v2.TimeState.DATE_FORMAT], true);
+    var startDate = os.time.parseMoment('1970-01-01T00:16:39Z', [os.state.v4.TimeState.DATE_FORMAT], true);
+    var endDate = os.time.parseMoment('1974-03-15T02:21:41Z', [os.state.v4.TimeState.DATE_FORMAT], true);
     tlc.setRange(tlc.buildRange(startDate.valueOf(), endDate.valueOf()));
     tlc.setDuration('month');
     // Animate range
-    var animateStartDate = os.time.parseMoment('1971-01-01T00:16:39.999Z',
-        [os.state.v2.TimeState.DATE_FORMAT], true);
-    var animateEndDate = os.time.parseMoment('1973-03-15T02:21:41.010Z',
-        [os.state.v2.TimeState.DATE_FORMAT], true);
+    var animateStartDate = os.time.parseMoment('1971-01-01T00:16:39Z',
+        [os.state.v4.TimeState.DATE_FORMAT], true);
+    var animateEndDate = os.time.parseMoment('1973-03-15T02:21:41Z',
+        [os.state.v4.TimeState.DATE_FORMAT], true);
     var animateRange = new goog.math.Range(animateStartDate.valueOf(), animateEndDate.valueOf());
     tlc.clearAnimateRanges();
     tlc.addAnimateRange(animateRange);
 
     // Hold range
-    var holdStartDate = os.time.parseMoment('1971-03-01T00:16:39.999Z',
-        [os.state.v2.TimeState.DATE_FORMAT], true);
-    var holdEndDate = os.time.parseMoment('1971-06-12T01:15:11.010Z',
-        [os.state.v2.TimeState.DATE_FORMAT], true);
+    var holdStartDate = os.time.parseMoment('1971-03-01T00:16:39Z',
+        [os.state.v4.TimeState.DATE_FORMAT], true);
+    var holdEndDate = os.time.parseMoment('1971-06-12T01:15:11Z',
+        [os.state.v4.TimeState.DATE_FORMAT], true);
     var holdRange = new goog.math.Range(holdStartDate.valueOf(), holdEndDate.valueOf());
     // make sure this is empty bfeore the test.
     tlc.clearHoldRanges();


### PR DESCRIPTION
Update moment to resolve CVE-2016-4055 vulnerability. The update broke some tests due to the strict flag being enforced more carefully. Date values in the tests were previously invalid but still passed due to the looser format validation, and have been corrected.

The Karma config change fixes filtering of test files, so developers can once again change which files are included while debugging tests.

Fixes #43.