### PR TITLE
fix(source): fix mismatched return type

### DIFF
--- a/src/os/data/columndefinition.js
+++ b/src/os/data/columndefinition.js
@@ -1,7 +1,5 @@
 goog.provide('os.data.ColumnDefinition');
 goog.require('os.IPersistable');
-goog.require('os.parse.IColumnDefinition');
-
 
 
 /**
@@ -9,7 +7,6 @@ goog.require('os.parse.IColumnDefinition');
  * @param {string=} opt_name
  * @param {string=} opt_field
  * @implements {os.IPersistable}
- * @implements {os.parse.IColumnDefinition}
  * @constructor
  */
 os.data.ColumnDefinition = function(opt_name, opt_field) {

--- a/src/os/parse/baseparserconfig.js
+++ b/src/os/parse/baseparserconfig.js
@@ -1,5 +1,5 @@
 goog.provide('os.parse.BaseParserConfig');
-goog.require('os.parse.IColumnDefinition');
+goog.require('os.data.ColumnDefinition');
 
 
 
@@ -10,7 +10,7 @@ goog.require('os.parse.IColumnDefinition');
  */
 os.parse.BaseParserConfig = function() {
   /**
-   * @type {Array.<os.parse.IColumnDefinition>}
+   * @type {Array.<os.data.ColumnDefinition>}
    */
   this['columns'] = [];
 

--- a/src/os/parse/icolumndefinition.js
+++ b/src/os/parse/icolumndefinition.js
@@ -1,9 +1,0 @@
-goog.provide('os.parse.IColumnDefinition');
-
-
-
-/**
- * Interface for parsed columns
- * @interface
- */
-os.parse.IColumnDefinition = function() {};

--- a/src/os/source/source.js
+++ b/src/os/source/source.js
@@ -3,6 +3,7 @@ goog.provide('os.source');
 goog.require('goog.Timer');
 goog.require('ol.layer.Property');
 goog.require('os');
+goog.require('os.data.ColumnDefinition');
 goog.require('os.data.RecordField');
 goog.require('os.filter.IFilterable');
 goog.require('os.implements');
@@ -89,12 +90,23 @@ os.source.getFilterColumns = function(source, opt_local) {
     if (!columns) {
       var filterable = os.ui.filter.FilterManager.getInstance().getFilterable(source.getId());
       if (filterable) {
-        columns = filterable.getFilterColumns();
+        columns = filterable.getFilterColumns().map(os.source.mapFilterColumns);
       }
     }
   }
 
   return columns;
+};
+
+
+/**
+ * @param {!os.ogc.FeatureTypeColumn} c The feature type column to convert
+ * @return {!os.data.ColumnDefinition}
+ */
+os.source.mapFilterColumns = function(c) {
+  var col = new os.data.ColumnDefinition(c.name);
+  col['type'] = c.type;
+  return col;
 };
 
 

--- a/src/os/ui/column/columnmanager.js
+++ b/src/os/ui/column/columnmanager.js
@@ -54,33 +54,33 @@ os.ui.column.ColumnManagerCtrl = function($scope, $element) {
   this.element_ = $element;
 
   /**
-   * @type {Object.<string, os.parse.IColumnDefinition>}
+   * @type {Object.<string, os.data.ColumnDefinition>}
    * @private
    */
   this.sourceColumns_ = {};
 
   /**
-   * @type {Array.<os.parse.IColumnDefinition>}
+   * @type {Array.<os.data.ColumnDefinition>}
    */
   this['shownColumns'] = [];
 
   /**
-   * @type {?Array.<os.parse.IColumnDefinition>}
+   * @type {?Array.<os.data.ColumnDefinition>}
    */
   this['shownSelected'] = [];
 
   /**
-   * @type {Array.<os.parse.IColumnDefinition>}
+   * @type {Array.<os.data.ColumnDefinition>}
    */
   this['hiddenColumns'] = [];
 
   /**
-   * @type {?Array.<os.parse.IColumnDefinition>}
+   * @type {?Array.<os.data.ColumnDefinition>}
    */
   this['hiddenSelected'] = [];
 
   /**
-   * @type {Array.<Object.<os.parse.IColumnDefinition, string>>}
+   * @type {Array.<{col: os.data.ColumnDefinition, list: string}>}
    */
   this['searchResults'] = [];
 
@@ -342,7 +342,7 @@ os.ui.column.ColumnManagerCtrl.prototype.validate_ = function() {
 
 /**
  * Generate row content in slick table
- * @param {os.parse.IColumnDefinition} column
+ * @param {os.data.ColumnDefinition} column
  * @param {(os.data.ColumnDefinition|string)} col
  * @return {string} The value
  * @private
@@ -355,7 +355,7 @@ os.ui.column.ColumnManagerCtrl.prototype.getColumnValue_ = function(column, col)
 /**
  * @param {string} term
  * @param {string} columnName
- * @return {Array.<Object.<os.parse.IColumnDefinition, string>>}
+ * @return {Array.<{col: os.data.ColumnDefinition, list: string}>}
  * @private
  */
 os.ui.column.ColumnManagerCtrl.prototype.find_ = function(term, columnName) {
@@ -473,7 +473,7 @@ os.ui.column.ColumnManagerCtrl.prototype.handleKeyEvent_ = function(event) {
 
 /**
  * Launches a column manager window with the given columns
- * @param {Array.<os.parse.IColumnDefinition>} columns
+ * @param {Array.<os.data.ColumnDefinition>} columns
  * @param {Function} callback
  */
 os.ui.column.launchColumnManager = function(columns, callback) {


### PR DESCRIPTION
There was an inferred union type here `{Array<!(ColumnDefinition\|FeatureTypeColumn)>}` that the compiler is not detecting as a mismatch with the declared type. I opened https://github.com/google/closure-compiler/issues/2783 with the compiler. This issue was causing filters programmatically created from histogram bins to fail.

I also removed a superfluous, empty interface.