### PR TITLE
Fix inner buffer and world query in non-EPSG:4326 projections

### DIFF
--- a/src/os/command/transformvectorscmd.js
+++ b/src/os/command/transformvectorscmd.js
@@ -127,8 +127,18 @@ os.command.TransformVectors.prototype.transform = function(sourceProjection, tar
           var geoms = [];
 
           for (var j = 0, m = features.length; j < m; j++) {
-            geoms.push(features[j].getGeometry());
-            geoms.push(/** @type {ol.geom.Geometry} */ (features[j].get(os.interpolate.ORIGINAL_GEOM_FIELD)));
+            var geometry = features[j].getGeometry();
+            if (geometry) {
+              geoms.push(geometry);
+
+              // if the original geometry is the same, don't re-add it or it will be transformed twice. this will
+              // happen for any geometry that is not interpolated.
+              var origGeometry = /** @type {ol.geom.Geometry} */ (features[j].get(os.interpolate.ORIGINAL_GEOM_FIELD));
+              if (origGeometry !== geometry) {
+                geoms.push(origGeometry);
+              }
+            }
+
             geoms.push(/** @type {(os.geom.Ellipse|undefined)} */ (features[j].get(os.data.RecordField.ELLIPSE)));
             geoms.push(/** @type {(ol.geom.LineString|undefined)} */
                 (features[j].get(os.data.RecordField.LINE_OF_BEARING)));

--- a/src/os/geo/jsts.js
+++ b/src/os/geo/jsts.js
@@ -797,9 +797,9 @@ os.geo.jsts.buffer = function(geometry, distance, opt_skipTransform) {
         //  - a positive value means the geometry can be split, buffered, and merged accurately
         //  - a negative value means the geometry cannot be accurately buffered with this approach
         //
-        var splitOffset = os.geo.jsts.getSplitOffset(clone, distance);
+        var extent = clone.getExtent();
+        var splitOffset = os.geo.jsts.getSplitOffset(extent, distance);
         if (!splitOffset) {
-          var extent = clone.getExtent();
           var avgLon = (extent[0] + extent[2]) / 2;
           buffer = os.geo.jsts.tmercBuffer_(clone, distance, avgLon);
         } else if (splitOffset > 0) {
@@ -889,14 +889,13 @@ os.geo.jsts.bufferPoint_ = function(point, distance) {
 
 /**
  * Get the offset to use when splitting a geometry for buffering.
- * @param {ol.geom.Geometry} geometry The geometry.
+ * @param {ol.Extent} extent The geometry's extent.
  * @param {number} distance The buffer distance.
  * @return {number} The offset between boxes to accurately buffer the geometry.
  */
-os.geo.jsts.getSplitOffset = function(geometry, distance) {
+os.geo.jsts.getSplitOffset = function(extent, distance) {
   var boxWidth = os.geo.jsts.UTM_WIDTH_DEGREES;
-  var extent = geometry.getExtent();
-  if (extent[2] - extent[0] > boxWidth) {
+  if (extent && extent[2] - extent[0] > boxWidth) {
     if (distance < 0) {
       // negative buffer distances require reducing the offset as the geometry approaches the poles. this is due to
       // splitting the geometry in EPSG:4326, where the lateral distance approaches 0 near the poles.
@@ -937,7 +936,7 @@ os.geo.jsts.getBoxesForExtent_ = function(geometry, distance) {
   var boxes;
 
   var extent = geometry.getExtent();
-  var offset = os.geo.jsts.getSplitOffset(geometry, distance);
+  var offset = os.geo.jsts.getSplitOffset(extent, distance);
   if (offset >= 0) {
     boxes = [];
 

--- a/src/os/query/query.js
+++ b/src/os/query/query.js
@@ -1,7 +1,9 @@
 goog.provide('os.query');
 
 goog.require('ol.Feature');
+goog.require('ol.extent');
 goog.require('ol.geom.Polygon');
+goog.require('ol.proj');
 goog.require('os.interpolate');
 goog.require('os.metrics.MapMetrics');
 goog.require('os.metrics.Metrics');
@@ -84,7 +86,10 @@ os.query.queryWorld = function() {
 os.query.isWorldQuery = function(geometry) {
   var world = os.query.WORLD_GEOM;
   if (world && geometry && geometry instanceof ol.geom.Polygon) {
-    if (geometry.getArea() >= world.getArea() || geometry.getArea() == 0) {
+    // transform the world extent to the current projection to compute the area
+    var worldExtent = ol.proj.transformExtent(os.query.WORLD_EXTENT, os.proj.EPSG4326, os.map.PROJECTION);
+    var worldArea = ol.extent.getArea(worldExtent);
+    if (geometry.getArea() >= worldArea || geometry.getArea() == 0) {
       geometry.setCoordinates(world.getCoordinates());
       return true;
     }
@@ -95,17 +100,18 @@ os.query.isWorldQuery = function(geometry) {
 
 
 /**
+ * The world extent in EPSG:4326. This is the max precision that a polygon can handle.
+ * @type {ol.Extent}
+ * @const
+ */
+os.query.WORLD_EXTENT = [-179.9999999999999, -89.99999999999999, 180, 90];
+
+
+/**
  * Polygon representing the whole world.
- * This is the max precision that a polygon can handle
  * @type {ol.geom.Polygon}
  */
-os.query.WORLD_GEOM = new ol.geom.Polygon([[
-  [180, 90],
-  [180, -89.99999999999999],
-  [-179.9999999999999, -89.99999999999999],
-  [-179.9999999999999, 90],
-  [180, 90]
-]]);
+os.query.WORLD_GEOM = ol.geom.Polygon.fromExtent(os.query.WORLD_EXTENT);
 
 
 /**
@@ -113,6 +119,6 @@ os.query.WORLD_GEOM = new ol.geom.Polygon([[
  * @type {ol.Feature}
  */
 os.query.WORLD_AREA = new ol.Feature({
+  'geometry': os.query.WORLD_GEOM,
   'title': 'Whole World'
 });
-os.query.WORLD_AREA.setGeometry(os.query.WORLD_GEOM);


### PR DESCRIPTION
`os.geo.jsts.getSplitOffset` only needed the geometry's extent. Extents are much cheaper to transform (and aren't done in-place), so I changed the first parameter to that. This made testing buffer form parameters work in other projections at little computational expense.

Found/fixed a second problem while testing buffering in projections other than EPSG:4326. `os.query.isWorldQuery` does not work in other projections because the whole world geometry is always in 4326. In 3857, basically every geometry returns true from that function and the coordinates are changed in the geometry. Fixed the function to test geometry area in the correct projection. 

Third bug fixed here is that any features with the same geometry/original geometry (those that aren't interpolated, like the whole world area) were being transformed twice when switching projections. This breaks the area.

Fixes #51.