### PR TITLE
Support Electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,11 @@ const overrideVersion = fs.existsSync(overrideVersionFile) ? fs.readFileSync(ove
  */
 const sharedResources = [
   {
+    source: 'src/electron',
+    target: 'electron',
+    scripts: ['electronvendorpre.js']
+  },
+  {
     source: buildPath,
     target: '',
     scripts: ['modernizr.js']
@@ -222,6 +227,11 @@ const sharedResources = [
     source: resolver.resolveModulePath('navigator.sendbeacon', __dirname),
     target: 'vendor/sendbeacon',
     scripts: ['sendbeacon.js']
+  },
+  {
+    source: 'src/electron',
+    target: 'electron',
+    scripts: ['electronvendorpost.js']
   }
 ];
 

--- a/src/electron/electronvendorpost.js
+++ b/src/electron/electronvendorpost.js
@@ -1,0 +1,7 @@
+if (navigator.userAgent.toLowerCase().indexOf(' electron/') > -1) {
+  // required to load jQuery
+  // @see https://stackoverflow.com/questions/32621988/electron-jquery-is-not-defined
+  if (window.module) {
+    module = window.module;
+  }
+}

--- a/src/electron/electronvendorpre.js
+++ b/src/electron/electronvendorpre.js
@@ -1,0 +1,11 @@
+if (navigator.userAgent.toLowerCase().indexOf(' electron/') > -1) {
+  // required to load jQuery
+  // @see https://stackoverflow.com/questions/32621988/electron-jquery-is-not-defined
+  if (typeof module === 'object') {
+    window.module = module;
+    module = undefined;
+  }
+
+  // allow the file:// protocol to be used by the fetch API
+  require('electron').webFrame.registerURLSchemeAsPrivileged('file');
+}


### PR DESCRIPTION
This adds scripts that run before/after vendor library loading to fix a few issues running inside an Electron container:
- jQuery cannot load because Electron registers `window.module`.
- The Fetch API cannot be used with the `file` protocol by default.