### PR TITLE
Don't change the original feature geometry.

### DIFF
--- a/src/os/ui/featureedit.js
+++ b/src/os/ui/featureedit.js
@@ -867,11 +867,13 @@ os.ui.FeatureEditCtrl.prototype.loadFromFeature_ = function(feature) {
 
   var geometry = feature.getGeometry();
   if (geometry) {
-    this.originalGeometry_ = geometry.clone();
-    geometry.toLonLat();
+    this.originalGeometry_ = geometry;
 
     if (geometry instanceof ol.geom.Point) {
-      var coordinate = geometry.getFirstCoordinate();
+      var clone = /** @type {!ol.geom.Point} */ (geometry.clone());
+      clone.toLonLat();
+
+      var coordinate = clone.getFirstCoordinate();
       if (coordinate) {
         this['pointGeometry'] = {
           'lon': coordinate[0],


### PR DESCRIPTION
When editing a place, the original geometry was being translated to lon/lat. If the edit was cancelled, the original geometry was restored to the feature without transforming it back. This moved the geometry in projections other than EPSG:4326.