### PR TITLE
docs(rtd): Minor guide cleanups.

### DIFF
--- a/docs/guides/plugin_server_guide/parsing.rst
+++ b/docs/guides/plugin_server_guide/parsing.rst
@@ -34,7 +34,7 @@ The last layer is a vector format, which we will ignore in this guide. The first
   :caption: ``src/plugin/tileserver/tileserver.js``
   :linenos:
   :language: javascript
-  :emphasize-lines: 3, 5, 7, 10-13, 58-67, 71-125
+  :emphasize-lines: 3, 5, 7, 10-13, 36-37, 58-67, 71-126
 
 Let's test it.
 

--- a/docs/guides/plugin_server_guide/provider.rst
+++ b/docs/guides/plugin_server_guide/provider.rst
@@ -27,7 +27,7 @@ Run ``yarn test`` to see if it tests properly. Now we need to register our provi
   :language: javascript
   :emphasize-lines: 3, 6, 33-39
 
-Lastly, we need to update our config so that the application instatiates a copy of our provider.
+Lastly, we need to update our config so that the application instantiates a copy of our provider.
 
 .. code-block:: json
   :caption: ``config/settings.json``

--- a/docs/guides/plugin_server_guide/src/plugin/tileserver/tileserver.js-provider
+++ b/docs/guides/plugin_server_guide/src/plugin/tileserver/tileserver.js-provider
@@ -38,13 +38,13 @@ plugin.tileserver.Tileserver.prototype.load = function(opt_ping) {
  */
 plugin.tileserver.Tileserver.prototype.onLoad = function(response) {
   try {
-    var json = JSON.parse(response);
+    var layers = JSON.parse(response);
   } catch (e) {
     this.onError('Malformed JSON');
     return;
   }
 
-  console.log('parsed json', json);
+  console.log('parsed json', layers);
 };
 
 


### PR DESCRIPTION
The guides are important (so want to be close to the top), but they need more introduction. 

The `json` -> `layers` change is just so you don't have to change that line later to match.