### PR TITLE
ci(travis): use yarn in build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,19 @@ os:
 - linux
 addons:
   chrome: stable
+  apt:
+    sources:
+    - key_url: 'https://dl.yarnpkg.com/debian/pubkey.gpg'
+    - sourceline: 'deb https://dl.yarnpkg.com/debian/ stable main'
+    packages:
+    - yarn
+install:
+- yarn
 script:
 - set -e
-- npm run build
-- npm run test
-- npm run apidoc
+- yarn run build
+- yarn run test
+- yarn run apidoc
 - set +e
 after_success:
 - chmod ugo+x ./deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 cache:
+  yarn: true
   directories:
   - "node_modules"
 notifications:
@@ -17,7 +18,6 @@ addons:
     packages:
     - yarn
 install:
-- yarn cache dir
 - yarn config list
 - yarn
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 cache:
   directories:
-  - "~/.npm"
+  - "node_modules"
 notifications:
   email: false
 node_js:
@@ -12,11 +12,13 @@ addons:
   chrome: stable
   apt:
     sources:
-    - key_url: 'https://dl.yarnpkg.com/debian/pubkey.gpg'
-    - sourceline: 'deb https://dl.yarnpkg.com/debian/ stable main'
+    - key_url: "https://dl.yarnpkg.com/debian/pubkey.gpg"
+    - sourceline: "deb https://dl.yarnpkg.com/debian/ stable main"
     packages:
     - yarn
 install:
+- yarn cache dir
+- yarn config list
 - yarn
 script:
 - set -e


### PR DESCRIPTION
This is an attempt to speed up dependency install and bypass the inexplicable `npm ls` errors in Travis.