### PR TITLE
fix(xyz): Add support for URLs containing server ranges.

### DIFF
--- a/docs/cookbook/osm/index.rst
+++ b/docs/cookbook/osm/index.rst
@@ -94,6 +94,8 @@ If your provider supports multiple URLs (which is the case for most OSM styles),
     }
   }
 
+Another way to express that is :code:`//{a-c}.tiles.example.com/osm/{z}/{x}/{y}.png`, where the :code:`{a-c}` part will be expanded. You can use single letter (upper or lower case) or single number ranges (e.g. :code:`{0-4}`) as appropriate to your server naming.
+
 Other important values are the :code:`minZoom` and :code:`maxZoom` values, which specify the zoom levels that OpenSphere will show this base map at. Different OSM tile servers will support different zoom levels (e.g. the Humanitarian style is provided to zoom level 20).
 
 You can also set up your own tile server, using the same system that OSM uses - see `switch2osm <https://switch2osm.org/serving-tiles/>`_ or a more general server like `GeoServer <http://docs.geoserver.org/latest/en/user/geowebcache/index.html>`_ .

--- a/test/os/layer/config/abstractlayerconfig.test.js
+++ b/test/os/layer/config/abstractlayerconfig.test.js
@@ -1,0 +1,65 @@
+goog.require('ol.source.XYZ');
+goog.require('os.layer.config.AbstractTileLayerConfig');
+goog.require('os.layer.config.LayerConfigManager');
+goog.require('os.layer.config.MockLayerConfig');
+goog.require('os.mock');
+goog.require('os.net');
+goog.require('os.source.MockSource');
+
+describe('os.layer.config.AbstractLayerConfig', function() {
+  it('has a default size option', function() {
+    var lc = new os.layer.config.AbstractLayerConfig();
+    var options = {};
+    lc.initializeConfig(options);
+    expect(lc.size).toBe(3);
+  });
+
+  it('handles the size option', function() {
+    var lc = new os.layer.config.AbstractLayerConfig();
+    var options = { 'size' : 4 };
+    lc.initializeConfig(options);
+    expect(lc.size).toBe(4);
+  });
+
+  it('is visible by default', function() {
+    var lc = new os.layer.config.AbstractLayerConfig();
+    var options = {};
+    lc.initializeConfig(options);
+    expect(lc.visible).toBe(true);
+  });
+
+  it('handles the visible option for false', function() {
+    var lc = new os.layer.config.AbstractLayerConfig();
+    var options = { 'visible': false };
+    lc.initializeConfig(options);
+    expect(lc.visible).toBe(false);
+  });
+
+  it('handles the visible option for true', function() {
+    var lc = new os.layer.config.AbstractLayerConfig();
+    var options = { 'visible': true };
+    lc.initializeConfig(options);
+    expect(lc.visible).toBe(true);
+  });
+
+  it('is does not colorize by default', function() {
+    var lc = new os.layer.config.AbstractLayerConfig();
+    var options = {};
+    lc.initializeConfig(options);
+    expect(lc.colorize).toBe(false);
+  });
+
+  it('handles the colorize option for true', function() {
+    var lc = new os.layer.config.AbstractLayerConfig();
+    var options = { 'colorize': true };
+    lc.initializeConfig(options);
+    expect(lc.colorize).toBe(true);
+  });
+
+  it('handles the colorize option for false', function() {
+    var lc = new os.layer.config.AbstractLayerConfig();
+    var options = { 'colorize': false };
+    lc.initializeConfig(options);
+    expect(lc.colorize).toBe(false);
+  });
+});

--- a/test/os/layer/config/abstracttilelayerconfig.test.js
+++ b/test/os/layer/config/abstracttilelayerconfig.test.js
@@ -1,0 +1,100 @@
+goog.require('ol.source.XYZ');
+goog.require('os.layer.config.AbstractTileLayerConfig');
+goog.require('os.layer.config.LayerConfigManager');
+goog.require('os.layer.config.MockLayerConfig');
+goog.require('os.mock');
+goog.require('os.net');
+goog.require('os.source.MockSource');
+
+describe('os.layer.config.AbstractTileLayerConfig', function() {
+  it('configures for an explicitType', function() {
+    var lc = new os.layer.config.AbstractTileLayerConfig();
+    var layer = new os.layer.MockLayer();
+    var options = { 'explicitType' : 'someType' };
+    lc.configureLayer(layer, options);
+    expect(layer.getExplicitType()).toBe('someType');
+  });
+
+  it('correctly replaces URLs with rotating numeric ranges', function() {
+    var lc = new os.layer.config.AbstractTileLayerConfig();
+    var expandedURL = lc.getUrlPattern('https://{0-4}.tile.bits/{x}/{y}/{z}.png');
+    expect(expandedURL.toString()).toBe('/^https:\\/\\/\\d.tile.bits\\/\\d+\\/\\d+\\/\\d+.png/');
+  });
+
+  it('correctly replaces URLs with rotating alpha ranges', function() {
+    var lc = new os.layer.config.AbstractTileLayerConfig();
+    var expandedURL = lc.getUrlPattern('https://{d-f}.tile.bits/{x}/{y}/{z}.png');
+    expect(expandedURL.toString()).toBe('/^https:\\/\\/[a-zA-Z].tile.bits\\/\\d+\\/\\d+\\/\\d+.png/');
+  });
+
+  it('returns URLs as Regexp when no rotating range', function() {
+    var lc = new os.layer.config.AbstractTileLayerConfig();
+    var expandedURL = lc.getUrlPattern('https://abc.tile.bits/{x}/{y}/{z}.png');
+    expect(expandedURL.toString()).toBe('/^https:\\/\\/abc.tile.bits\\/\\d+\\/\\d+\\/\\d+.png/');
+  });
+
+  it('sets desired projection for web Mercator if included in options', function() {
+    var testLayerId = 'test-layer';
+    var testOptions = {
+      'id': testLayerId,
+      'url': 'https://abc.layer.bits/{x}/{y}/{z}',
+      'type': os.layer.config.MockLayerConfig.TYPE,
+      'projection': os.proj.EPSG3857
+    };
+    os.layerConfigManager = os.layer.config.LayerConfigManager.getInstance();
+    os.layerConfigManager.registerLayerConfig(os.layer.config.MockLayerConfig.TYPE,
+        os.layer.config.MockLayerConfig);
+    var lc = new os.layer.config.AbstractTileLayerConfig();
+    lc.initializeConfig(testOptions);
+    expect(lc.projection.getCode()).toBe(os.proj.EPSG3857);
+  });
+
+  it('sets desired projection for WGS-84 if included in options', function() {
+    var testLayerId = 'test-layer';
+    var testOptions = {
+      'id': testLayerId,
+      'url': 'https://abc.layer.bits/{x}/{y}/{z}',
+      'type': os.layer.config.MockLayerConfig.TYPE,
+      'projection': os.proj.EPSG4326
+    };
+    os.layerConfigManager = os.layer.config.LayerConfigManager.getInstance();
+    os.layerConfigManager.registerLayerConfig(os.layer.config.MockLayerConfig.TYPE,
+        os.layer.config.MockLayerConfig);
+    var lc = new os.layer.config.AbstractTileLayerConfig();
+    lc.initializeConfig(testOptions);
+    expect(lc.projection.getCode()).toBe(os.proj.EPSG4326);
+  });
+
+  it('sets cross origin if included in options', function() {
+    var testLayerId = 'test-layer';
+    var testOptions = {
+      'id': testLayerId,
+      'url': 'https://{a-b}.layer.bits',
+      'type': os.layer.config.MockLayerConfig.TYPE,
+      'crossOrigin': os.net.CrossOrigin.USE_CREDENTIALS
+    };
+    os.layerConfigManager = os.layer.config.LayerConfigManager.getInstance();
+    os.layerConfigManager.registerLayerConfig(os.layer.config.MockLayerConfig.TYPE,
+        os.layer.config.MockLayerConfig);
+    var lc = new os.layer.config.AbstractTileLayerConfig();
+    lc.initializeConfig(testOptions);
+    expect(os.net.getCrossOrigin('https://a.layer.bits')).toBe(os.net.CrossOrigin.USE_CREDENTIALS);
+    expect(os.net.getCrossOrigin('https://b.layer.bits')).toBe(os.net.CrossOrigin.USE_CREDENTIALS);
+  });
+
+  it('sets attributions if included in options', function() {
+    var testOptions = {
+      'attributions': ['mock attribution', 'ex libris']
+    };
+    var source = new ol.source.XYZ({});
+    os.layerConfigManager = os.layer.config.LayerConfigManager.getInstance();
+    os.layerConfigManager.registerLayerConfig(os.layer.config.MockLayerConfig.TYPE,
+        os.layer.config.MockLayerConfig);
+    var lc = new os.layer.config.AbstractTileLayerConfig();
+    spyOn(lc, 'getSource').andCallFake(function() {return source;});
+    var layer = lc.createLayer(testOptions);
+    expect(layer.getSource().getAttributions()[0].getHTML()).toBe('mock attribution');
+    expect(layer.getSource().getAttributions()[1].getHTML()).toBe('ex libris');
+  });
+
+});

--- a/test/os/layer/layer.mock.js
+++ b/test/os/layer/layer.mock.js
@@ -13,6 +13,7 @@ goog.require('os.layer.ILayer');
 os.layer.MockLayer = function() {
   this.id = this.title = goog.string.getRandomString();
   this.loading = false;
+  this.explicitType = 'mock';
 };
 os.implements(os.layer.MockLayer, os.layer.ILayer.ID);
 
@@ -91,14 +92,16 @@ os.layer.MockLayer.prototype.setType = function(value) {};
  * @inheritDoc
  */
 os.layer.MockLayer.prototype.getExplicitType = function() {
-  return 'mock';
+  return this.explicitType;
 };
 
 
 /**
  * @inheritDoc
  */
-os.layer.MockLayer.prototype.setExplicitType = function(value) {};
+os.layer.MockLayer.prototype.setExplicitType = function(value) {
+  this.explicitType = value;
+};
 
 
 /**

--- a/test/plugin/ogc/xyz/xyzlayerconfig.test.js
+++ b/test/plugin/ogc/xyz/xyzlayerconfig.test.js
@@ -29,4 +29,108 @@ describe('plugin.xyz.XYZLayerConfig', function() {
 
     expect(proxyUrl).toBe(os.net.ProxyHandler.getProxyUri(originalUrl));
   });
+
+  it('should handle single URLs properly', function() {
+    var options = {
+      url: 'http://a.tiles.example.com/osm/{z}/{x}/{y}.png',
+      title: 'TestA'
+    };
+
+    var lc = new plugin.xyz.XYZLayerConfig();
+    var layer = lc.createLayer(options);
+
+    var tileFn = layer.getSource().getTileUrlFunction();
+
+    var tileCoord = [3, 2, -1];
+    var pixelRatio = 1;
+    var proj = ol.proj.get('EPSG:3857');
+
+    var resultURL = tileFn(tileCoord, pixelRatio, proj);
+
+    expect(resultURL).toBe('http://a.tiles.example.com/osm/3/2/0.png');
+  });
+
+  it('should handle single URLs as array properly', function() {
+    var options = {
+      urls: ['http://b.tiles.example.com/osm/{z}/{x}/{y}.png'],
+      title: 'TestB'
+    };
+
+    var lc = new plugin.xyz.XYZLayerConfig();
+    var layer = lc.createLayer(options);
+
+    var tileFn = layer.getSource().getTileUrlFunction();
+
+    var tileCoord = [3, 2, -1];
+    var pixelRatio = 1;
+    var proj = ol.proj.get('EPSG:3857');
+
+    var resultURL = tileFn(tileCoord, pixelRatio, proj);
+
+    expect(resultURL).toBe('http://b.tiles.example.com/osm/3/2/0.png');
+  });
+
+  it('should handle multiple URLs as array properly', function() {
+    var options = {
+      urls: ['http://a.tiles.example.com/osm/{z}/{x}/{y}.png', 'http://b.tiles.example.com/osm/{z}/{x}/{y}.png', 'http://c.tiles.example.com/osm/{z}/{x}/{y}.png'],
+      title: 'Test2'
+    };
+
+    var lc = new plugin.xyz.XYZLayerConfig();
+    var layer = lc.createLayer(options);
+
+    var tileFn = layer.getSource().getTileUrlFunction();
+
+    var tileCoord = [3, 2, -1];
+    var pixelRatio = 1;
+    var proj = ol.proj.get('EPSG:3857');
+
+    var resultURL = tileFn(tileCoord, pixelRatio, proj);
+
+    expect(resultURL).toMatch('http://[a-c].tiles.example.com/osm/3/2/0.png');
+  });
+
+  it('should handle wildcard URLs properly', function() {
+    var options = {
+      url: 'http://{a-c}.tiles.example.com/osm/{z}/{x}/{y}.png',
+      title: 'TestABC'
+    };
+
+    var lc = new plugin.xyz.XYZLayerConfig();
+    var layer = lc.createLayer(options);
+
+    var tileFn = layer.getSource().getTileUrlFunction();
+
+    var tileCoord = [3, 2, -1];
+    var pixelRatio = 1;
+    var proj = ol.proj.get('EPSG:3857');
+
+    var resultURL = tileFn(tileCoord, pixelRatio, proj);
+    expect(resultURL).toMatch('http://[a-c].tiles.example.com/osm/3/2/0.png');
+
+    resultURL = tileFn(tileCoord, pixelRatio, proj);
+    expect(resultURL).toMatch('http://[a-c].tiles.example.com/osm/3/2/0.png');
+  });
+
+  it('should handle wildcard URLs with numeric values properly', function() {
+    var options = {
+      url: 'http://{0-4}.tiles.example.com/osm/{z}/{x}/{y}.png',
+      title: 'Test04'
+    };
+
+    var lc = new plugin.xyz.XYZLayerConfig();
+    var layer = lc.createLayer(options);
+
+    var tileFn = layer.getSource().getTileUrlFunction();
+
+    var tileCoord = [3, 2, -1];
+    var pixelRatio = 1;
+    var proj = ol.proj.get('EPSG:3857');
+
+    var resultURL = tileFn(tileCoord, pixelRatio, proj);
+    expect(resultURL).toMatch('http://[0-4].tiles.example.com/osm/3/2/0.png');
+
+    resultURL = tileFn(tileCoord, pixelRatio, proj);
+    expect(resultURL).toMatch('http://[0-4].tiles.example.com/osm/3/2/0.png');
+  });
 });


### PR DESCRIPTION
Includes updates to OSM cookbook docs.

Resolves #86.