### PR TITLE
chore(sass-lint): Fix selectors single-line warnings.

### DIFF
--- a/scss/os/overrides/_bootstrap.scss
+++ b/scss/os/overrides/_bootstrap.scss
@@ -338,7 +338,8 @@ td > input {
 }
 
 @media (max-height: 800px) {
-  .modal:not(.window), .modal.fade.in {
+  .modal:not(.window),
+  .modal.fade.in {
     top: 0;
   }
 }

--- a/scss/ui/partials/_misc.scss
+++ b/scss/ui/partials/_misc.scss
@@ -298,18 +298,51 @@ div::-moz-focus-inner {
 }
 
 @include keyframes(ellipsis1) {
-  0%, 20%, 40%, 100% { @include translateY(0); opacity: .5; }
-  30% { @include translateY(-4px); opacity: 1; }
+  0%,
+  20% {
+    @include translateY(0); opacity: .5;
+  }
+
+  30% {
+    @include translateY(-4px); opacity: 1;
+  }
+
+  40%,
+  100% {
+    @include translateY(0); opacity: .5;
+  }
 }
 
 @include keyframes(ellipsis2) {
-  0%, 40%, 60%, 100% { @include translateY(0); opacity: .5; }
-  50% { @include translateY(-4px); opacity: 1; }
+  0%,
+  40% {
+    @include translateY(0); opacity: .5;
+  }
+
+  50% {
+    @include translateY(-4px); opacity: 1;
+  }
+
+  60%,
+  100% {
+    @include translateY(0); opacity: .5;
+  }
 }
 
 @include keyframes(ellipsis3) {
-  0%, 60%, 80%, 100% { @include translateY(0); opacity: .5; }
-  70% { @include translateY(-4px); opacity: 1; }
+  0%,
+  60% {
+    @include translateY(0); opacity: .5;
+  }
+
+  70% {
+    @include translateY(-4px); opacity: 1;
+  }
+
+  80%,
+  100% {
+    @include translateY(0); opacity: .5;
+  }
 }
 
 .ellipsis-bounce {
@@ -384,19 +417,33 @@ div::-moz-focus-inner {
     transform: rotate(0);
   }
 
-  10%, 20% {
+  10%,
+  20% {
     transform: rotate(-16deg);
   }
 
-  30%, 50%, 70% {
+  30% {
     transform: rotate(16deg);
   }
 
-  40%, 60% {
+  40% {
     transform: rotate(-16deg);
   }
 
-  80%, 100% {
+  50% {
+    transform: rotate(16deg);
+  }
+
+  60% {
+    transform: rotate(-16deg);
+  }
+
+  70% {
+    transform: rotate(16deg);
+  }
+
+  80%,
+  100% {
     transform: rotate(0);
   }
 }

--- a/scss/ui/partials/_misc.scss
+++ b/scss/ui/partials/_misc.scss
@@ -300,48 +300,57 @@ div::-moz-focus-inner {
 @include keyframes(ellipsis1) {
   0%,
   20% {
-    @include translateY(0); opacity: .5;
+    @include translateY(0); // sass-lint:disable-line mixin-name-format
+    opacity: .5; 
   }
 
   30% {
-    @include translateY(-4px); opacity: 1;
+    @include translateY(-4px); // sass-lint:disable-line mixin-name-format
+    opacity: 1;
   }
 
   40%,
   100% {
-    @include translateY(0); opacity: .5;
+    @include translateY(0); // sass-lint:disable-line mixin-name-format
+    opacity: .5;
   }
 }
 
 @include keyframes(ellipsis2) {
   0%,
   40% {
-    @include translateY(0); opacity: .5;
+    @include translateY(0); // sass-lint:disable-line mixin-name-format
+    opacity: .5;
   }
 
   50% {
-    @include translateY(-4px); opacity: 1;
+    @include translateY(-4px); // sass-lint:disable-line mixin-name-format
+    opacity: 1;
   }
 
   60%,
   100% {
-    @include translateY(0); opacity: .5;
+    @include translateY(0); // sass-lint:disable-line mixin-name-format
+    opacity: .5;
   }
 }
 
 @include keyframes(ellipsis3) {
   0%,
   60% {
-    @include translateY(0); opacity: .5;
+    @include translateY(0); // sass-lint:disable-line mixin-name-format
+    opacity: .5;
   }
 
   70% {
-    @include translateY(-4px); opacity: 1;
+    @include translateY(-4px); // sass-lint:disable-line mixin-name-format
+    opacity: 1;
   }
 
   80%,
   100% {
-    @include translateY(0); opacity: .5;
+    @include translateY(0); // sass-lint:disable-line mixin-name-format
+    opacity: .5;
   }
 }
 


### PR DESCRIPTION
This includes some minor cleanups to make the animations more readable, which unfortunately increases the complaints about `translateY` casing (`Mixin 'translateY' should be written in lowercase with hyphens  mixin-name-format`).