### PR TITLE
docs(actionmenu): suppress deprecation warnings for required actionme…

### DIFF
--- a/src/os/ui/actionmenu.js
+++ b/src/os/ui/actionmenu.js
@@ -208,6 +208,7 @@ os.ui.ActionMenuCtrl.prototype.constructMenu_ = function(actions) {
  * @param {Object} menuStructure JSON object structure which declares the depth and placement of the menu items
  * @param {Array} menuItems The list of menu items to which the converted menuStructure actions are placed.
  * @private
+ * @suppress {deprecated}
  */
 os.ui.ActionMenuCtrl.prototype.insertMenuItems_ = function(menuStructure, menuItems) {
   // insert item is sorted order

--- a/src/os/ui/slick/slickgrid.js
+++ b/src/os/ui/slick/slickgrid.js
@@ -1006,6 +1006,7 @@ os.ui.slick.SlickGridCtrl.prototype.getContextMenuFromSelected = function() {
  * @param {(angular.Scope.Event|goog.events.BrowserEvent)} event
  * @param {Array<number>=} opt_position The menu position
  * @private
+ * @suppress {deprecated}
  */
 os.ui.slick.SlickGridCtrl.prototype.onContextMenu_ = function(event, opt_position) {
   event.preventDefault();


### PR DESCRIPTION
Suppress warnings in `ActionMenu` itself and also in `Slickgrid` as that checks the context menu for both the old and new menu types.

Resolves #104