### PR TITLE
fix(test): Try to make QueryEntriesState test more robust.

### DIFF
--- a/test/os/state/v2/queryentriesstate.test.js
+++ b/test/os/state/v2/queryentriesstate.test.js
@@ -82,7 +82,7 @@ describe('os.state.v2.QueryEntries', function() {
     });
 
     waitsFor(function() {
-      return os.ui.queryManager.expandedEntries.length != 0;
+      return os.ui.queryManager.expandedEntries.length == 3;
     }, 'queryManager to expand its new entries');
 
     runs(function() {


### PR DESCRIPTION
This is a blind fix, trying to overcome occasional 2 != 3 results.