### PR TITLE
chore(hooks): prevent issue collisions between github and bitbucket

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "build:xt": "mkdirp .build dist/opensphere; os-compile $(cat src/os/xt/gcc-args); cp src/os/xt/xt-example.html dist/opensphere",
     "package:update": "if git diff --name-only ORIG_HEAD HEAD | grep --quiet package.json; then echo 'UPDATE: package.json was updated, consider running yarn in your workspace root'; fi",
     "perms": "chmod -R u+rwX,go+rX,go-w .",
-    "commitmsg": "validate-commit-msg",
+    "commitmsg": "scripts/commit-msg",
     "postmerge": "npm run package:update",
     "postrewrite": "npm run package:update",
     "semantic-release": "semantic-release",

--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+validate-commit-msg "$@"
+scripts/prevent-issue-collision.sh "$@"

--- a/scripts/prevent-issue-collision.sh
+++ b/scripts/prevent-issue-collision.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Our internal Bitbucket server uses the format:
+#
+# Merge pull request #{pr_id} in WV/opensphere from ...
+#
+# when merging. This causes collisions with unrelated issues on Github,
+# which is really more of an annoyance than a major issue.
+#
+# This rewrites that message slightly so that it won't collide. Note
+# that this avoids rewriting messages from Github merges because the
+# wording is different.
+
+file=$1
+if [ -z "$file" ]; then
+  file='.git/COMMIT_EDITMSG'
+fi
+
+perl -pi -e 's@^Merge pull request #(\d+) in WV/@Merge PR-\1 in WV/@g' "$file"


### PR DESCRIPTION
Our internal bitbucket server references `pull request #X in WV/...` in merge commit messages, but it doesn't use the `#` to actually reference anything. The `#X` reference is causing unrelated references in Github. Therefore, this hook rewrites that commit message in a way that keeps all the information but does not cause the unrelated references.