### PR TITLE
Add KML track support

### DIFF
--- a/src/os/feature/feature.js
+++ b/src/os/feature/feature.js
@@ -693,9 +693,15 @@ os.feature.getColor = function(feature, opt_source, opt_default) {
     }
 
     if (!color) {
-      var featureConfig = /** @type {Object|undefined} */ (feature.values_[os.style.StyleType.FEATURE]);
+      var featureConfig = /** @type {Array<Object>|Object|undefined} */ (feature.values_[os.style.StyleType.FEATURE]);
       if (featureConfig) {
-        color = os.style.getConfigColor(featureConfig) || undefined;
+        if (Array.isArray(featureConfig)) {
+          for (var i = 0; !color && i < featureConfig.length; i++) {
+            color = os.style.getConfigColor(featureConfig[i]) || undefined;
+          }
+        } else {
+          color = os.style.getConfigColor(featureConfig) || undefined;
+        }
       }
     }
 

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -2188,7 +2188,8 @@ os.source.Vector.prototype.updateAnimationOverlay = function() {
           hasDynamic = true;
 
           var featureTime = /** @type {os.time.ITime|undefined} */ (dynamicFeature.get(os.data.RecordField.TIME));
-          if (featureTime && (featureTime.getStart() > displayEnd || featureTime.getEnd() < displayStart)) {
+          if (featureTime && (featureTime.getStart() > displayEnd || featureTime.getEnd() < displayStart) &&
+              !this.isHidden(dynamicFeature)) {
             displayedFeatures.push(dynamicFeature);
           }
         }

--- a/src/os/ui/file/kml/abstractkmlexporter.js
+++ b/src/os/ui/file/kml/abstractkmlexporter.js
@@ -57,6 +57,13 @@ os.ui.file.kml.AbstractKMLExporter = function() {
   this.kmlNS = 'http://www.opengis.net/kml/2.2';
 
   /**
+   * The KML gx extension namespace to use for export.
+   * @type {string}
+   * @protected
+   */
+  this.gxNS = 'http://www.google.com/kml/ext/2.2';
+
+  /**
    * @type {!Object<string, function(!Element, T)>}
    * @protected
    */
@@ -366,6 +373,9 @@ os.ui.file.kml.AbstractKMLExporter.prototype.processItems = function() {
   this.doc = goog.dom.xml.createDocument('kml', this.kmlNS);
 
   var kml = /** @type {!Element} */ (goog.dom.getFirstElementChild(this.doc));
+
+  var xmlnsUri = 'http://www.w3.org/2000/xmlns/';
+  ol.xml.setAttributeNS(kml, xmlnsUri, 'xmlns:gx', this.gxNS);
 
   // create the Document element
   this.kmlDoc = os.xml.appendElementNS('Document', this.kmlNS, kml);

--- a/src/plugin/file/kml/kmlparser.js
+++ b/src/plugin/file/kml/kmlparser.js
@@ -12,6 +12,8 @@ goog.require('goog.object');
 goog.require('ol.Feature');
 goog.require('ol.format.Feature');
 goog.require('ol.format.XSD');
+goog.require('ol.geom.LineString');
+goog.require('ol.geom.flat.inflate');
 goog.require('ol.layer.Image');
 goog.require('ol.source.ImageStatic');
 goog.require('ol.xml');
@@ -33,6 +35,7 @@ goog.require('plugin.file.kml.tour.parseTour');
 goog.require('plugin.file.kml.ui.KMLNetworkLinkNode');
 goog.require('plugin.file.kml.ui.KMLNode');
 goog.require('plugin.file.kml.ui.KMLTourNode');
+goog.require('plugin.track');
 
 
 /**
@@ -959,7 +962,7 @@ plugin.file.kml.KMLParser.prototype.readNetworkLink_ = function(el) {
 /**
  * Parses a KML Placemark element into a map feature
  * @param {Element} el The XML element
- * @return {ol.Feature} The map feature
+ * @return {os.feature.DynamicFeature|ol.Feature|undefined} The map feature
  * @private
  *
  * I don't care what you think, compiler.
@@ -983,15 +986,18 @@ plugin.file.kml.KMLParser.prototype.readPlacemark_ = function(el) {
     set = set.parent ? this.parsersByPlacemarkTag_[set.parent] : null;
   }
 
-  if (!goog.isDef(object)) {
+  if (!object) {
     return null;
   }
 
   // set geometry fields on the object
-  if (goog.isDefAndNotNull(object.geometry)) {
+  var geometry = /** @type {ol.geom.Geometry|undefined} */ (object['geometry']);
+  delete object['geometry'];
+
+  if (geometry) {
     // grab the lon/lat coordinate before we potentially convert it to god knows what
-    if (object.geometry.getType() == ol.geom.GeometryType.POINT) {
-      var coord = /** @type {!ol.geom.Point} */ (object.geometry).getFirstCoordinate();
+    if (geometry.getType() == ol.geom.GeometryType.POINT) {
+      var coord = /** @type {!ol.geom.Point} */ (geometry).getFirstCoordinate();
       if (coord.length > 1) {
         object[os.Fields.LAT] = object[os.Fields.LAT] || coord[1];
         object[os.Fields.LON] = object[os.Fields.LON] || coord[0];
@@ -1003,7 +1009,7 @@ plugin.file.kml.KMLParser.prototype.readPlacemark_ = function(el) {
     }
 
     // convert to application projection
-    object.geometry = object.geometry.osTransform();
+    geometry.osTransform();
   }
 
   // make sure parsed styles don't appear as a source column
@@ -1012,28 +1018,52 @@ plugin.file.kml.KMLParser.prototype.readPlacemark_ = function(el) {
     delete object['Style'];
   }
 
-  var feature = new ol.Feature();
+  var feature;
+  if ((geometry instanceof ol.geom.LineString || geometry instanceof ol.geom.MultiLineString) &&
+      geometry.getLayout() === ol.geom.GeometryLayout.XYZM) {
+    // Openlayers parses KML tracks into a LineString/MultiLineString with the XYZM layout (lon, lat, alt, time). if one
+    // of these is encountered, create a track so it can be animated on the timeline.
 
-  // files containing duplicate network links will create features with duplicate id's. this allows us to merge features
-  // on refresh, while still creating an id that's unique from other network links (which will use a different parser)
-  var baseId = ol.getUid(feature);
-  var id = this.id_ + '#' + baseId;
-  feature.setId(id);
-  object[os.Fields.ID] = object[os.Fields.ID] || baseId;
+    if (geometry instanceof ol.geom.MultiLineString && geometry.get('interpolate')) {
+      // if a multi track should be interpolated, join it into a single line. the track updates will handle the
+      // interpolation between known positions.
+      var flatCoordinates = geometry.getFlatCoordinates();
+      var coordinates = ol.geom.flat.inflate.coordinates(flatCoordinates, 0, flatCoordinates.length, 4);
+      geometry = new ol.geom.LineString(coordinates);
+    }
 
-  feature.setProperties(object);
-
-  // create/modify the set of columns detected in the file. for now, just keep a basic set to keep this as low overhead
-  // as possible.
-  if (!this.columnMap_) {
-    this.columnMap_ = [];
+    feature = plugin.track.createTrack(/** @type {!plugin.track.CreateOptions} */ ({
+      geometry: geometry,
+      name: /** @type {string|undefined} */ (object['name'])
+    }));
+  } else {
+    feature = new ol.Feature(geometry);
   }
 
-  for (var key in object) {
-    this.columnMap_[key] = true;
+  if (feature) {
+    // files containing duplicate network links will create features with duplicate id's. this allows us to merge
+    // features on refresh, while still creating an id that's unique from other network links (which will use a
+    // different parser)
+    var baseId = ol.getUid(feature);
+    var id = this.id_ + '#' + baseId;
+    feature.setId(id);
+    object[os.Fields.ID] = object[os.Fields.ID] || baseId;
+
+    feature.setProperties(object);
+
+    // create/modify the set of columns detected in the file. for now, just keep a basic set to keep this as low
+    // overhead as possible.
+    if (!this.columnMap_) {
+      this.columnMap_ = [];
+    }
+
+    for (var key in object) {
+      this.columnMap_[key] = true;
+    }
+
+    this.applyStyles_(el, feature);
   }
 
-  this.applyStyles_(el, feature);
   return feature;
 };
 
@@ -1315,7 +1345,20 @@ plugin.file.kml.KMLParser.prototype.applyStyles_ = function(el, feature) {
   // reduce style sets to single set
   var mergedStyle = styleSets.reduce(plugin.file.kml.KMLParser.reduceStyles_, null);
   if (mergedStyle) {
-    feature.set(os.style.StyleType.FEATURE, mergedStyle, true);
+    var existingStyle = /** @type {Array<!Object>|Object|undefined} */ (feature.get(os.style.StyleType.FEATURE));
+    if (existingStyle) {
+      // if the feature already has a style config, merge in the KML style
+      if (goog.isArray(existingStyle)) {
+        for (var i = 0; i < existingStyle.length; i++) {
+          os.object.merge(mergedStyle, existingStyle[i]);
+        }
+      } else {
+        os.object.merge(mergedStyle, existingStyle);
+      }
+    } else {
+      // set the style config for the feature
+      feature.set(os.style.StyleType.FEATURE, mergedStyle, true);
+    }
 
     if (highlightStyle && highlightStyle.length) {
       feature.set(os.style.StyleType.CUSTOM_HIGHLIGHT, highlightStyle[0], true);
@@ -1331,6 +1374,7 @@ plugin.file.kml.KMLParser.prototype.applyStyles_ = function(el, feature) {
       feature.set(os.style.StyleField.CENTER_SHAPE, os.style.ShapeType.ICON);
     }
 
+    // apply the feature style
     os.style.setFeatureStyle(feature);
   }
 

--- a/src/plugin/track/trackmenu.js
+++ b/src/plugin/track/trackmenu.js
@@ -317,20 +317,20 @@ plugin.track.menu.handleLayerEvent_ = function(event) {
             var trackTitle = layer.getTitle() + ' Track';
             plugin.track.promptForTitle(trackTitle).then(function(title) {
               plugin.track.getSortField(features[0]).then(function(sortField) {
-                var options = /** @type {plugin.track.CreateOptions} */ ({
+                var options = /** @type {!plugin.track.CreateOptions} */ ({
                   features: features,
                   name: title,
                   sortField: sortField
                 });
 
-                plugin.track.createFromFeatures(options);
+                plugin.track.createAndAdd(options);
               });
             });
             break;
           case plugin.track.EventType.ADD_TO:
             plugin.track.promptForTrack().then(function(track) {
               if (track) {
-                plugin.track.addToTrack(track, features);
+                plugin.track.addFeaturesToTrack(track, features);
               }
             });
             break;

--- a/test/plugin/file/kml/kml.test.js
+++ b/test/plugin/file/kml/kml.test.js
@@ -1,9 +1,9 @@
-goog.require('os.time.TimeInstant');
-goog.require('os.time.TimeRange');
 goog.require('goog.dom');
 goog.require('goog.dom.xml');
 goog.require('ol.format.KML');
 goog.require('ol.xml');
+goog.require('os.time.TimeInstant');
+goog.require('os.time.TimeRange');
 goog.require('plugin.file.kml');
 
 
@@ -37,7 +37,7 @@ describe('plugin.file.kml', function() {
     expect(time.getEnd()).toBe(end.getTime());
   });
 
-  it('reads a kml:Link element better than OL3', function() {
+  it('reads a kml:Link element better than Openlayers', function() {
     var href = 'http://urmom.goes/tocollege';
     var refreshMode = 'onInterval';
     var refreshInterval = 10;
@@ -55,12 +55,135 @@ describe('plugin.file.kml', function() {
     var doc = goog.dom.xml.loadXml(linkXml);
     var linkEl = goog.dom.getFirstElementChild(doc);
 
-    // all but href are our extension to the OL3 parser
+    // all but href are our extension to the Openlayers parser
     var link = ol.xml.pushParseAndPop({}, plugin.file.kml.OL_LINK_PARSERS(), linkEl, []);
     expect(link['href']).toBe(href);
     expect(link['refreshMode']).toBe(refreshMode);
     expect(link['refreshInterval']).toBe(refreshInterval);
     expect(link['viewRefreshMode']).toBe(viewRefreshMode);
     expect(link['viewRefreshTime']).toBe(viewRefreshTime);
+  });
+
+  describe('Track and MultiTrack Support', function() {
+    /**
+     * Generate coord/when XML pairs to define a Track.
+     * @param {number} count The number of pairs.
+     * @param {string} coordNS The namespace for `coord` nodes.
+     * @param {number} startTime The start time for `when` nodes.
+     * @return {string} The XML text.
+     */
+    var generateCoordText = function(count, coordNS, startTime) {
+      var coordParts = [];
+
+      for (var i = 0; i < count; i++) {
+        var coord = [i / 100, i / 100, i];
+        coordParts.push('<when>' + new Date(startTime + i * 1000).toISOString() + '</when>');
+        coordParts.push('<' + coordNS + 'coord>' + coord.join(' ') + '</' + coordNS + 'coord>');
+      }
+
+      return coordParts.join('');
+    };
+
+    /**
+     * Verify the coordinates for a track.
+     * @param {!Array<!ol.Coordinate>} coordinates The coordinates.
+     * @param {number} startTime The start time from `generateCoordText`.
+     */
+    var verifyCoordinates = function(coordinates, startTime) {
+      for (var i = 0; i < coordinates.length; i++) {
+        var coord = coordinates[i];
+        expect(coord[0]).toEqual(i / 100);
+        expect(coord[1]).toEqual(i / 100);
+        expect(coord[2]).toEqual(i);
+        expect(coord[3]).toEqual(startTime + i * 1000);
+      }
+    };
+
+    /**
+     * Run KML Track/MultiTrack tests with the provided namespace.
+     * @param {string} namespace The track element namespace.
+     * @param {string} xmlns The `xmlns` to include in documents.
+     */
+    var runTrackTests = function(namespace, xmlns) {
+      it('parses ' + namespace + 'Track nodes', function() {
+        var format = new ol.format.KML();
+        var startTime = Date.now();
+        var numCoordinates = 20;
+        var trackXml = '<Placemark' + (xmlns ? ' ' : '') + xmlns + '><' + namespace + 'Track>' +
+            generateCoordText(numCoordinates, namespace, startTime) + '</' + namespace + 'Track></Placemark>';
+
+        var doc = goog.dom.xml.loadXml(trackXml);
+        var trackEl = goog.dom.getFirstElementChild(doc);
+
+        var feature = format.readPlacemark_(trackEl, []);
+        expect(feature).toBeDefined();
+
+        var geometry = feature.getGeometry();
+        expect(geometry instanceof ol.geom.LineString).toBe(true);
+        expect(geometry.getLayout()).toBe(ol.geom.GeometryLayout.XYZM);
+
+        var coordinates = geometry.getCoordinates();
+        expect(coordinates.length).toEqual(numCoordinates);
+        verifyCoordinates(coordinates, startTime);
+      });
+
+      it('parses ' + namespace + 'MultiTrack nodes', function() {
+        var format = new ol.format.KML();
+        var startTime = Date.now();
+        var numCoordinates = 20;
+        var numTracks = 5;
+        var trackXml = '<Placemark' + (xmlns ? ' ' : '') + xmlns + '><' + namespace + 'MultiTrack>';
+
+        for (var i = 0; i < numTracks; i++) {
+          trackXml += '<' + namespace + 'Track>' + generateCoordText(numCoordinates, namespace, startTime) +
+              '</' + namespace + 'Track>;';
+        }
+
+        trackXml += '</' + namespace + 'MultiTrack></Placemark>';
+
+        var doc = goog.dom.xml.loadXml(trackXml);
+        var trackEl = goog.dom.getFirstElementChild(doc);
+
+        var feature = format.readPlacemark_(trackEl, []);
+        expect(feature).toBeDefined();
+
+        var geometry = feature.getGeometry();
+        expect(geometry instanceof ol.geom.MultiLineString).toBe(true);
+        expect(geometry.getLayout()).toBe(ol.geom.GeometryLayout.XYZM);
+
+        var lines = geometry.getLineStrings();
+        expect(lines.length).toBe(numTracks);
+
+        for (var i = 0; i < numTracks; i++) {
+          var coordinates = lines[i].getCoordinates();
+          expect(coordinates.length).toEqual(numCoordinates);
+          verifyCoordinates(coordinates, startTime);
+        }
+      });
+
+      it('parses ' + namespace + 'MultiTrack properties', function() {
+        var format = new ol.format.KML();
+        var altitudeMode = 'clampToGround';
+        var trackXml = '<Placemark' + (xmlns ? ' ' : '') + xmlns + '><' + namespace + 'MultiTrack>' +
+            '<' + namespace + 'interpolate>1</' + namespace + 'interpolate>' +
+            '<altitudeMode>' + altitudeMode + '</altitudeMode>' +
+            '</' + namespace + 'MultiTrack></Placemark>';
+
+        var doc = goog.dom.xml.loadXml(trackXml);
+        var trackEl = goog.dom.getFirstElementChild(doc);
+
+        var feature = format.readPlacemark_(trackEl, []);
+        expect(feature).toBeDefined();
+
+        var geometry = feature.getGeometry();
+        expect(geometry instanceof ol.geom.MultiLineString).toBe(true);
+        expect(geometry.get('interpolate')).toBe(true);
+        expect(geometry.get('altitudeMode')).toBe(altitudeMode);
+      });
+    };
+
+    // run track tests for KML 2.2 w/ gx namespace, and KML 2.3 with no namespace
+    runTrackTests('gx:', 'xmlns:gx="http://www.google.com/kml/ext/2.2"');
+    runTrackTests('', '');
   });
 });


### PR DESCRIPTION
This adds support for parsing both KML 2.2 and 2.3 Track and MultiTrack elements into a `os.feature.DynamicFeature` that can be animated via the timeline.

Other changes:
* `plugin.track.createTrack` API was changed to take an options argument, instead of the old parameter train. Choo choo!
* `plugin.track.addToTrack` was renamed to `plugin.track.addFeaturesToTrack` for clarity.
* Tracks will now use `ol.geom.LineString` if possible (not a multi-track, and doesn't cross the date line) as a performance enhancement. This is particularly useful for 3D mode, since our feature converter recreates all line primitives representing a multi-line on each update. #135 will address the greater issue.