### PR TITLE
Cesium Image Layer Synchronizer

### DIFF
--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -1493,6 +1493,7 @@ Cesium.Polygon.prototype.material;
  * @typedef {{
  *   color: (Cesium.Color|undefined),
  *   horizontal: (boolean|undefined),
+ *   image: (string|undefined),
  *   repeat: (number|undefined),
  *   evenColor: (Cesium.Color|undefined),
  *   oddColor: (Cesium.Color|undefined)
@@ -1586,6 +1587,30 @@ Cesium.Material.prototype.uniforms;
 Cesium.Material.ColorType;
 
 
+
+/**
+ * @typedef {{
+ *  flat: (boolean|undefined),
+ *  faceForward: (boolean|undefined),
+ *  translucent: (boolean|undefined),
+ *  closed: (boolean|undefined),
+ *  material: (Cesium.Material|HTMLCanvasElement|HTMLVideoElement|Image|undefined),
+ *  vertexShaderSource: (string|undefined),
+ *  fragmentShaderSource: (string|undefined),
+ *  renderState: (Cesium.optionsRenderState|undefined)
+ *  }}
+ */
+Cesium.MaterialAppearanceOptions;
+
+
+/**
+ * @constructor
+ * @param {Cesium.MaterialAppearanceOptions} options
+ * @extends {Cesium.Appearance}
+ */
+Cesium.MaterialAppearance = function(options) {};
+
+
 /**
  * @typedef {{
  *   material: (Cesium.Material|undefined),
@@ -1643,9 +1668,32 @@ Cesium.Polyline.prototype.width;
 
 
 /**
+ * @typedef {{
+ *   translucent: (boolean|undefined),
+ *   closed: (boolean|undefined),
+ *   material: (Cesium.Material|undefined),
+ *  }}
+ */
+Cesium.AppearanceOptions
+
+
+/**
+ * @param {Cesium.AppearanceOptions} options
  * @constructor
  */
-Cesium.Appearance = function() {};
+Cesium.Appearance = function(options) {};
+
+
+/**
+ * @type {Cesium.Material}
+ */
+Cesium.Appearance.prototype.material;
+
+
+/**
+ * @type {boolean}
+ */
+Cesium.Appearance.prototype.translucent;
 
 
 /**
@@ -1653,6 +1701,7 @@ Cesium.Appearance = function() {};
  *   asynchronous: (boolean|undefined),
  *   releaseGeometryInstances: (boolean|undefined),
  *   geometryInstances: !Cesium.GeometryInstance,
+ *   show: (boolean|undefined),
  *   appearance: !Cesium.Appearance
  * }}
  */
@@ -1709,6 +1758,24 @@ Cesium.Primitive.prototype.geomRevision;
  * @type {boolean}
  */
 Cesium.Primitive.prototype.ready;
+
+
+/**
+ * @type {Promise<!Cesium.Primitive>}
+ */
+Cesium.Primitive.prototype.readyPromise;
+
+
+/**
+ * @type {boolean}
+ */
+Cesium.Primitive.prototype.show;
+
+
+/**
+ * @type {!Cesium.Appearance}
+ */
+Cesium.Primitive.prototype.appearance;
 
 
 /**

--- a/src/os/olcs/camera.js
+++ b/src/os/olcs/camera.js
@@ -187,7 +187,8 @@ os.olcs.Camera.prototype.setAltitude = function(altitude) {
 os.olcs.Camera.prototype.getExtent = function() {
   var rect = this.cam_.computeViewRectangle();
   if (rect) {
-    return [rect.west, rect.south, rect.east, rect.north];
+    // the values are returned in radians, so map them to degrees
+    return [rect.west, rect.south, rect.east, rect.north].map(Cesium.Math.toDegrees);
   }
 };
 

--- a/src/os/olcs/sync/imagesynchronizer.js
+++ b/src/os/olcs/sync/imagesynchronizer.js
@@ -108,10 +108,17 @@ os.olcs.sync.ImageSynchronizer.prototype.syncInternal = function(opt_force) {
 
     var map = os.MapContainer.getInstance().getMap();
     var viewExtent = map.getExtent();
-    var resolution = map.getView().getResolution();
 
-    if (!viewExtent || resolution === undefined) {
+    if (!viewExtent) {
       this.removeImmediate_();
+      return;
+    }
+
+    var pixelExtent = map.getPixelFromCoordinate(ol.extent.getBottomLeft(viewExtent)).concat(
+        map.getPixelFromCoordinate(ol.extent.getTopRight(viewExtent)));
+
+    var resolution = ol.extent.getWidth(viewExtent) / Math.abs(ol.extent.getWidth(pixelExtent));
+    if (isNaN(resolution)) {
       return;
     }
 


### PR DESCRIPTION
Our previous image layer synchronizer was a hack in the sense that it only supported KML Ground Overlay layers.

This addition should support any image layer generically, including ground overlays, heatmap rasters, and others.

Caveats (open to suggestions):
- This isn't perfect if the source is changing its image at a high speed (i.e. with the timeline). It can attempt to render an item that the underlying source has already cleaned up because it lags a bit.
- I also couldn't figure out anything to support layer opacity (at least in Cesium itself)