### PR TITLE
Change default menu item sort to 0.

### DIFF
--- a/src/os/ui/menu/layermenu.js
+++ b/src/os/ui/menu/layermenu.js
@@ -202,7 +202,7 @@ os.ui.menu.layer.setup = function() {
         beforeRender: os.ui.menu.layer.visibleIfSupported,
         handler: os.ui.menu.layer.onExport_,
         metricKey: os.metrics.Layer.EXPORT,
-        sort: os.ui.menu.layer.GroupSort.TOOLS++
+        sort: -1000 // commonly used, so prioritize above other items
       }]
     }]
   }));

--- a/src/os/ui/menu/menuitem.js
+++ b/src/os/ui/menu/menuitem.js
@@ -65,7 +65,7 @@ os.ui.menu.MenuItem = function(options) {
   this.icons = options.icons;
   this.tooltip = options.tooltip;
   this.shortcut = options.shortcut;
-  this.sort = options.sort != null ? options.sort : Infinity;
+  this.sort = options.sort || 0;
 
   /**
    * @type {Array<!os.ui.menu.MenuItem<T>>|undefined}

--- a/src/plugin/file/kml/kmlmenu.js
+++ b/src/plugin/file/kml/kmlmenu.js
@@ -111,8 +111,7 @@ plugin.file.kml.menu.treeSetup = function() {
       tooltip: 'Creates buffer regions around loaded data',
       icons: ['<i class="fa fa-fw ' + os.buffer.ICON + '"></i>'],
       beforeRender: plugin.file.kml.menu.visibleIfSupported_,
-      handler: plugin.file.kml.menu.onLayerEvent_,
-      sort: os.ui.menu.layer.GroupSort.TOOLS++
+      handler: plugin.file.kml.menu.onLayerEvent_
     });
   }
 };
@@ -130,18 +129,16 @@ plugin.file.kml.menu.visibleIfSupported_ = function(context) {
   if (this.eventType && context && context.length == 1) {
     var node = context[0];
     if (node instanceof plugin.file.kml.ui.KMLNode) {
-      var features = node.getFeatures();
-
       switch (this.eventType) {
         case plugin.file.kml.menu.EventType.BUFFER:
-          this.visible = features.length > 0;
+          this.visible = node.hasFeatures();
           break;
         case plugin.file.kml.menu.EventType.SELECT:
         case plugin.file.kml.menu.EventType.DESELECT:
-          this.visible = node.isFolder() && features.length > 0;
+          this.visible = node.isFolder() && node.hasFeatures();
           break;
         case plugin.file.kml.menu.EventType.GOTO:
-          this.visible = !!node.getImage() || features.length > 0;
+          this.visible = !!node.getImage() || node.hasFeatures();
           break;
         case plugin.file.kml.menu.EventType.LOAD:
           this.visible = node instanceof plugin.file.kml.ui.KMLNetworkLinkNode &&

--- a/src/plugin/file/kml/ui/kmlnode.js
+++ b/src/plugin/file/kml/ui/kmlnode.js
@@ -215,8 +215,25 @@ plugin.file.kml.ui.KMLNode.prototype.onFeatureChange = function(event) {
 
 
 /**
+ * If the node has one or more features beneath it.
+ * @param {boolean=} opt_unchecked If unchecked nodes should be included, defaults to false.
+ * @return {boolean} If the node has one or more features beneath it.
+ */
+plugin.file.kml.ui.KMLNode.prototype.hasFeatures = function(opt_unchecked) {
+  if (this.feature_) {
+    return true;
+  }
+
+  var children = this.getChildren();
+  return !!children && children.some(function(child) {
+    return (opt_unchecked || child.getState() != os.structs.TriState.OFF) && child.hasFeatures(opt_unchecked);
+  });
+};
+
+
+/**
  * Get the feature(s) associated with this node.
- * @param {boolean=} opt_unchecked If unchecked nodes should be included, defaults to false
+ * @param {boolean=} opt_unchecked If unchecked nodes should be included, defaults to false.
  * @return {!Array<!ol.Feature>} The features
  */
 plugin.file.kml.ui.KMLNode.prototype.getFeatures = function(opt_unchecked) {
@@ -334,28 +351,6 @@ plugin.file.kml.ui.KMLNode.prototype.getOverlays = function(opt_unchecked) {
   }
 
   return overlays;
-};
-
-
-/**
- * If the node has one or more features under it.
- * @return {boolean}
- */
-plugin.file.kml.ui.KMLNode.prototype.hasFeatures = function() {
-  if (this.feature_) {
-    return true;
-  }
-
-  var children = this.getChildren();
-  if (children) {
-    for (var i = 0, n = children.length; i < n; i++) {
-      if (children[i].hasFeatures()) {
-        return true;
-      }
-    }
-  }
-
-  return false;
 };
 
 

--- a/src/plugin/vectortools/vectortoolsplugin.js
+++ b/src/plugin/vectortools/vectortoolsplugin.js
@@ -56,12 +56,14 @@ plugin.vectortools.VectorToolsPlugin.prototype.init = function() {
       tooltip: 'Joins layers by a primary key'
     }];
 
+    // position these submenus after other menu items
+    var baseSort = 1000;
     parents.forEach(function(p) {
       var subMenu = group.addChild({
         label: p.label,
         type: os.ui.menu.MenuItemType.SUBMENU,
         icons: ['<i class="fa fa-fw ' + p.icon + '"></i>'],
-        sort: os.ui.menu.layer.GroupSort.GROUPS++
+        sort: baseSort++
       });
 
       for (var i = 0, n = labels.length; i < n; i++) {


### PR DESCRIPTION
Other changes:
* Kept Export at the top of the layer menu, because it's frequently used.
* Fixed KML menu performance from using `getFeatures` instead of `hasFeatures` when the features weren't actually needed.
* KML node `hasFeatures` supports the same checked parameter as `getFeatures`.