### PR TITLE
feat(electron): Support file:// URL's in Electron.

### DIFF
--- a/externs/closure-compiler.js
+++ b/externs/closure-compiler.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * @fileoverview Definitions for externs that are either missing or incorrect
  * in the current release version of the closure compiler we use.
@@ -110,3 +111,12 @@ DeviceOrientationEvent.prototype.webkitCompassHeading;
 
 /** @type {Storage} */
 var localStorage;
+
+
+/**
+ * Added by Electron to expose the file's real path on filesystem.
+ * @type {string|undefined}
+ *
+ * @see https://electronjs.org/docs/api/file-object
+ */
+File.prototype.path;

--- a/src/os/file/file.js
+++ b/src/os/file/file.js
@@ -2,7 +2,6 @@ goog.provide('os.file');
 goog.provide('os.file.File');
 
 goog.require('goog.async.Deferred');
-goog.require('goog.crypt.base64');
 goog.require('goog.fs.FileReader');
 goog.require('goog.net.jsloader');
 goog.require('os.IPersistable');
@@ -66,10 +65,13 @@ os.file.File.MAX_CONTENT_LEN = 1024 * 1024 * 100;
 
 
 /**
- * @type {string}
- * @const
+ * File URL schemes.
+ * @enum {string}
  */
-os.file.File.URL_SCHEME = 'local';
+os.file.FileScheme = {
+  FILE: 'file',
+  LOCAL: 'local'
+};
 
 
 /**
@@ -313,18 +315,43 @@ os.file.createFromContent = function(fileName, url, originalFile, content) {
 
 
 /**
- * Creates a local:// url used by file storage
- * @param {string} fileName The file name to use in generating the url
+ * Creates a `file://` url to reference files on the file system.
+ * @param {string} path The path to the file.
  * @return {string}
  */
-os.file.getLocalUrl = function(fileName) {
-  return os.file.File.URL_SCHEME + '://' + goog.crypt.base64.encodeString(fileName);
+os.file.getFileUrl = function(path) {
+  return os.file.FileScheme.FILE + '://' + path;
 };
 
 
 /**
- * Checks if a file was loaded locally (URL prefixed with local://)
+ * Creates a `local://` url used by file storage.
+ * @param {string} fileName The file name to use in generating the url.
+ * @return {string}
+ */
+os.file.getLocalUrl = function(fileName) {
+  return os.file.FileScheme.LOCAL + '://' + btoa(fileName);
+};
+
+
+/**
+ * Checks if a file was loaded from the file system (URL prefixed with `file://`).
  * @param {os.file.File|string|undefined} file The file or file's url
+ * @return {boolean}
+ */
+os.file.isFileSystem = function(file) {
+  if (!file) {
+    return false;
+  }
+
+  var url = goog.isString(file) ? file : file.getUrl();
+  return !!url && goog.string.startsWith(url, os.file.FileScheme.FILE + '://');
+};
+
+
+/**
+ * Checks if a file was loaded from file storage (URL prefixed with `local://`).
+ * @param {os.file.File|string|undefined} file The file or file's url.
  * @return {boolean}
  */
 os.file.isLocal = function(file) {
@@ -333,7 +360,7 @@ os.file.isLocal = function(file) {
   }
 
   var url = goog.isString(file) ? file : file.getUrl();
-  return !!url && goog.string.startsWith(url, os.file.File.URL_SCHEME + '://');
+  return !!url && goog.string.startsWith(url, os.file.FileScheme.LOCAL + '://');
 };
 
 

--- a/src/os/file/file.js
+++ b/src/os/file/file.js
@@ -75,6 +75,13 @@ os.file.FileScheme = {
 
 
 /**
+ * If `file://` URL's should be supported by the application. Defaults to false.
+ * @type {boolean}
+ */
+os.file.FILE_URL_ENABLED = false;
+
+
+/**
  * @return {?(Object|string)}
  */
 os.file.File.prototype.getContent = function() {

--- a/src/os/mainctrl.js
+++ b/src/os/mainctrl.js
@@ -913,9 +913,16 @@ os.MainCtrl.prototype.onToggleUI_ = function(event) {
 os.MainCtrl.prototype.handleFileDrop_ = function(files) {
   var file = files[0];
 
-  var reader = os.file.createFromFile(file);
-  if (reader) {
-    reader.addCallbacks(this.handleResult_, this.handleError_, this);
+  if (file) {
+    if (file.path) {
+      // running in Electron, so request the file with a file:// URL
+      this.handleURLDrop_(os.file.getFileUrl(file.path));
+    } else {
+      var reader = os.file.createFromFile(file);
+      if (reader) {
+        reader.addCallbacks(this.handleResult_, this.handleError_, this);
+      }
+    }
   }
 };
 

--- a/src/os/mainctrl.js
+++ b/src/os/mainctrl.js
@@ -914,7 +914,7 @@ os.MainCtrl.prototype.handleFileDrop_ = function(files) {
   var file = files[0];
 
   if (file) {
-    if (file.path) {
+    if (file.path && os.file.FILE_URL_ENABLED) {
       // running in Electron, so request the file with a file:// URL
       this.handleURLDrop_(os.file.getFileUrl(file.path));
     } else {

--- a/src/os/map/mapinteractions.js
+++ b/src/os/map/mapinteractions.js
@@ -8,7 +8,6 @@ goog.require('ol.interaction.Interaction');
 goog.require('os.interaction.ContextMenu');
 goog.require('os.interaction.DoubleClick');
 goog.require('os.interaction.DoubleClickZoom');
-goog.require('os.interaction.DragAndDrop');
 goog.require('os.interaction.DragBox');
 goog.require('os.interaction.DragCircle');
 goog.require('os.interaction.DragZoom');

--- a/src/os/net/extdomainhandler.js
+++ b/src/os/net/extdomainhandler.js
@@ -40,7 +40,7 @@ os.net.ExtDomainHandler.MIXED_CONTENT_ENABLED = false;
  */
 os.net.ExtDomainHandler.prototype.handles = function(method, uri) {
   if (window) {
-    if (uri.getDomain() && uri.getScheme() != os.file.File.URL_SCHEME) {
+    if (uri.getDomain() && uri.getScheme() != os.file.FileScheme.LOCAL) {
       var local = new goog.Uri(window.location);
 
       var localScheme = local.getScheme().toLowerCase();

--- a/src/os/net/localfilehandler.js
+++ b/src/os/net/localfilehandler.js
@@ -71,7 +71,7 @@ os.net.LocalFileHandler.prototype.getScore = function() {
  * @inheritDoc
  */
 os.net.LocalFileHandler.prototype.handles = function(method, uri) {
-  return uri.getScheme() == os.file.File.URL_SCHEME;
+  return uri.getScheme() == os.file.FileScheme.LOCAL;
 };
 
 

--- a/src/os/net/samedomainhandler.js
+++ b/src/os/net/samedomainhandler.js
@@ -63,7 +63,7 @@ os.net.SameDomainHandler.prototype.handles = function(method, uri) {
     if (!uri.getDomain()) {
       // relative is local, so we're good
       return true;
-    } else if (uri.getScheme() != os.file.File.URL_SCHEME) {
+    } else if (uri.getScheme() != os.file.FileScheme.LOCAL) {
       var local = new goog.Uri(window.location);
       return local.hasSameDomainAs(uri);
     }

--- a/src/os/state/v4/baselayerstate.js
+++ b/src/os/state/v4/baselayerstate.js
@@ -166,6 +166,18 @@ os.state.v4.BaseLayerState.prototype.hasLocalData = function(layerOptions) {
 
 
 /**
+ * Checks if a layer was loaded from the file system.
+ * @param {Object.<string, *>} layerOptions The layer options.
+ * @return {boolean} If the layer was loaded from the file system.
+ * @protected
+ */
+os.state.v4.BaseLayerState.prototype.hasFileSystemData = function(layerOptions) {
+  return os.file.isFileSystem(/** @type {string|undefined} */ (layerOptions['url'])) ||
+      os.file.isFileSystem(/** @type {string|undefined} */ (layerOptions['url2']));
+};
+
+
+/**
  * Checks if the provided layer is valid for addition to the state file
  * @param {os.layer.ILayer} layer The layer
  * @return {boolean} If the layer should be added
@@ -185,8 +197,8 @@ os.state.v4.BaseLayerState.prototype.isValid = function(layer) {
       return false;
     }
 
-    // skip local data (these are handled separately)
-    return !this.hasLocalData(layerOptions);
+    // skip local/file system data (these are handled separately)
+    return !this.hasLocalData(layerOptions) && !this.hasFileSystemData(layerOptions);
   } catch (e) {
     // may not be a os.layer.ILayer... so don't persist it
   }

--- a/src/os/ui/abstractmainctrl.js
+++ b/src/os/ui/abstractmainctrl.js
@@ -213,7 +213,11 @@ os.ui.AbstractMainCtrl.prototype.initialize = function() {
   // set up URL replacements
   os.net.URLModifier.configure(/** @type {Object<string, string>} */ (os.settings.get('urlReplace')));
 
+  // set if mixed content should be enabled
   os.net.ExtDomainHandler.MIXED_CONTENT_ENABLED = /** @type {boolean} */ (os.settings.get('mixedContent', false));
+
+  // set if file:// URL's should be supported
+  os.file.FILE_URL_ENABLED = /** @type {boolean} */ (os.settings.get('fileUrls', false));
 
   // set up cross origin config
   os.net.loadCrossOriginCache();

--- a/src/os/ui/file/fileimport.js
+++ b/src/os/ui/file/fileimport.js
@@ -1,6 +1,5 @@
 goog.provide('os.ui.file.FileImportCtrl');
 goog.provide('os.ui.file.fileImportDirective');
-goog.require('goog.crypt.base64');
 goog.require('goog.events.EventType');
 goog.require('goog.fs.FileReader');
 goog.require('goog.log');

--- a/src/os/ui/file/filexthandler.js
+++ b/src/os/ui/file/filexthandler.js
@@ -50,7 +50,7 @@ os.ui.file.FileXTHandler.prototype.process = function(data, type, sender, time) 
   var url = /** @type {string} */ (data.url);
 
   if (type === os.ui.file.FileXTHandler.TYPE) {
-    if (goog.string.startsWith(url, os.file.File.URL_SCHEME + '://')) { // local file
+    if (goog.string.startsWith(url, os.file.FileScheme.LOCAL + '://')) { // local file
       var fs = new os.file.FileStorage(os.SHARED_FILE_DB_NAME); // read into memory
       fs.getFile(url).addCallbacks(this.onFileReady_, this.onFileError_, this); // local file handler??
     } else {

--- a/src/os/ui/file/importdialog.js
+++ b/src/os/ui/file/importdialog.js
@@ -1,6 +1,5 @@
 goog.provide('os.ui.file.ImportDialogCtrl');
 goog.provide('os.ui.file.importDialogDirective');
-goog.require('goog.crypt.base64');
 goog.require('goog.events.EventType');
 goog.require('goog.fs.FileReader');
 goog.require('goog.log');
@@ -148,16 +147,30 @@ os.ui.file.ImportDialogCtrl.prototype.accept = function() {
     this['loading'] = true;
 
     var method = /** @type {os.ui.file.method.ImportMethod} */ (this.scope_['method']);
+    var url;
+
     if (this['fileChosen']) {
-      // load a local file
-      var keepFile = method.getKeepFile();
-      var reader = os.file.createFromFile(this['file'], keepFile);
-      if (reader) {
-        reader.addCallbacks(this.onFileReady_, this.onFileError_, this);
+      var file = /** @type {File|undefined} */ (this['file']);
+      if (file) {
+        if (file.path) {
+          // running in Electron, so request the file with a file:// URL
+          url = os.file.getFileUrl(file.path);
+        } else {
+          // load a local file
+          var keepFile = method.getKeepFile();
+          var reader = os.file.createFromFile(this['file'], keepFile);
+          if (reader) {
+            reader.addCallbacks(this.onFileReady_, this.onFileError_, this);
+          }
+        }
       }
     } else {
+      url = this['url'];
+    }
+
+    if (url) {
       // load a remote url
-      method.setUrl(this['url']);
+      method.setUrl(url);
       method.listenOnce(os.events.EventType.COMPLETE, this.onLoadComplete_, false, this);
       method.listenOnce(os.events.EventType.CANCEL, this.onLoadComplete_, false, this);
       method.listenOnce(os.events.EventType.ERROR, this.onLoadError_, false, this);

--- a/src/os/ui/file/importdialog.js
+++ b/src/os/ui/file/importdialog.js
@@ -152,7 +152,7 @@ os.ui.file.ImportDialogCtrl.prototype.accept = function() {
     if (this['fileChosen']) {
       var file = /** @type {File|undefined} */ (this['file']);
       if (file) {
-        if (file.path) {
+        if (file.path && os.file.FILE_URL_ENABLED) {
           // running in Electron, so request the file with a file:// URL
           url = os.file.getFileUrl(file.path);
         } else {

--- a/src/os/ui/im/audioimportui.js
+++ b/src/os/ui/im/audioimportui.js
@@ -3,7 +3,7 @@ goog.provide('os.ui.im.AudioImportUI');
 goog.require('os.alert.AlertEventSeverity');
 goog.require('os.alert.AlertManager');
 goog.require('os.audio.AudioManager');
-goog.require('os.file.File');
+goog.require('os.file');
 goog.require('os.ui.im.AbstractImportUI');
 
 
@@ -28,7 +28,7 @@ os.ui.im.AudioImportUI.prototype.launchUI = function(file, opt_config) {
   var url = file.getUrl();
 
   var msg = null;
-  if (url && url.indexOf('file') !== 0 && url.indexOf(os.file.File.URL_SCHEME) !== 0) {
+  if (url && !os.file.isLocal(url)) {
     var label = os.audio.AudioManager.getInstance().addSound(url);
 
     msg = 'Added new sound "' + label + '"';

--- a/src/os/ui/im/audioimportui.js
+++ b/src/os/ui/im/audioimportui.js
@@ -28,7 +28,7 @@ os.ui.im.AudioImportUI.prototype.launchUI = function(file, opt_config) {
   var url = file.getUrl();
 
   var msg = null;
-  if (url && !os.file.isLocal(url)) {
+  if (url && !os.file.isLocal(url) && (os.file.FILE_URL_ENABLED || !os.file.isFileSystem(url))) {
     var label = os.audio.AudioManager.getInstance().addSound(url);
 
     msg = 'Added new sound "' + label + '"';

--- a/src/plugin/params/params.js
+++ b/src/plugin/params/params.js
@@ -37,6 +37,16 @@ plugin.params.Metrics = {
 
 
 /**
+ * If a URI supports parameter modification.
+ * @param {!goog.Uri} uri The URI.
+ * @return {boolean}
+ */
+plugin.params.isUriSupported = function(uri) {
+  return uri.getScheme() !== os.file.FileScheme.FILE && uri.getScheme() !== os.file.FileScheme.LOCAL;
+};
+
+
+/**
  * Check if a layer supports request parameter overrides.
  * @param {ol.layer.Layer} layer The layer.
  * @return {boolean} If the layer supports request parameter overrides.
@@ -47,7 +57,7 @@ plugin.params.supportsParamOverrides = function(layer) {
     var request = source.getRequest();
     if (request) {
       var uri = request.getUri();
-      return uri != null && uri.getScheme() !== os.file.File.URL_SCHEME;
+      return uri != null && plugin.params.isUriSupported(uri);
     }
   } else if (os.implements(layer, os.layer.ILayer.ID) && os.implements(source, os.ol.source.IUrlSource.ID)) {
     return true;
@@ -70,7 +80,7 @@ plugin.params.getParamsFromLayer = function(layer) {
     var request = source.getRequest();
     if (request) {
       var uri = request.getUri();
-      if (uri && uri.getScheme() !== os.file.File.URL_SCHEME) {
+      if (uri && plugin.params.isUriSupported(uri)) {
         // copy the existing params onto the object
         params = os.url.queryDataToObject(uri.getQueryData());
       }
@@ -100,7 +110,7 @@ plugin.params.setParamsForLayer = function(layer, params, opt_remove) {
     var request = source.getRequest();
     if (request) {
       var uri = request.getUri();
-      if (uri && uri.getScheme() !== os.file.File.URL_SCHEME) {
+      if (uri && plugin.params.isUriSupported(uri)) {
         var qd = uri.getQueryData();
         if (!qd) {
           qd = new goog.Uri.QueryData();

--- a/test/os/file/file.test.js
+++ b/test/os/file/file.test.js
@@ -2,28 +2,58 @@ goog.require('os.file.File');
 
 
 describe('os.file.File', function() {
-  var file = new os.file.File();
-  file.setFileName('testFile.xml');
-  file.setUrl('local://testfileurl');
-  file.setContent('you\'re a towel');
-  file.setContentType('test+content+and+stuff');
-  file.setType('test');
-  
+  var fsFile = new os.file.File();
+  fsFile.setFileName('testFile.xml');
+  fsFile.setUrl('file:///path/to/some/testFile.xml');
+  fsFile.setContent('test content');
+  fsFile.setContentType('test+content+and+stuff');
+  fsFile.setType('test');
+
+  var localFile = new os.file.File();
+  localFile.setFileName('testFile.xml');
+  localFile.setUrl('local://testfileurl');
+  localFile.setContent('test content');
+  localFile.setContentType('test+content+and+stuff');
+  localFile.setType('test');
+
+  it('gets file:// URLs from a path', function() {
+    var path = '/path/to/some/file.xml';
+    expect(os.file.getFileUrl(path)).toBe('file://' + path);
+  });
+
+  it('tests for file:// URLs', function() {
+    expect(os.file.isFileSystem(fsFile)).toBe(true);
+    expect(os.file.isFileSystem('file:///test')).toBe(true);
+
+    expect(os.file.isFileSystem(localFile)).toBe(false);
+    expect(os.file.isFileSystem('local://test')).toBe(false);
+    expect(os.file.isFileSystem('not file:///test')).toBe(false);
+  });
+
+  it('tests for local:// URLs', function() {
+    expect(os.file.isLocal(localFile)).toBe(true);
+    expect(os.file.isLocal('local://test')).toBe(true);
+
+    expect(os.file.isLocal(fsFile)).toBe(false);
+    expect(os.file.isLocal('file:///test')).toBe(false);
+    expect(os.file.isLocal('not local://test')).toBe(false);
+  });
+
   it('should persist and restore properly', function() {
-    var p = file.persist();
-    expect(p.fileName).toBe(file.getFileName());
-    expect(p.url).toBe(file.getUrl());
-    expect(p.content).toBe(file.getContent());
-    expect(p.contentType).toBe(file.getContentType());
-    expect(p.type).toBe(file.getType());
-    
+    var p = localFile.persist();
+    expect(p.fileName).toBe(localFile.getFileName());
+    expect(p.url).toBe(localFile.getUrl());
+    expect(p.content).toBe(localFile.getContent());
+    expect(p.contentType).toBe(localFile.getContentType());
+    expect(p.type).toBe(localFile.getType());
+
     var r = new os.file.File();
     r.restore(p);
-    
-    expect(r.getFileName()).toBe(file.getFileName());
-    expect(r.getUrl()).toBe(file.getUrl());
-    expect(r.getContent()).toBe(file.getContent());
-    expect(r.getContentType()).toBe(file.getContentType());
-    expect(r.getType()).toBe(file.getType());
+
+    expect(r.getFileName()).toBe(localFile.getFileName());
+    expect(r.getUrl()).toBe(localFile.getUrl());
+    expect(r.getContent()).toBe(localFile.getContent());
+    expect(r.getContentType()).toBe(localFile.getContentType());
+    expect(r.getType()).toBe(localFile.getType());
   });
 });


### PR DESCRIPTION
Electron [adds a `path` property](https://electronjs.org/docs/api/file-object) to the File API to expose the file system path. This PR detects that and loads the file directly from the file system. The file is treated as a remote URL so it will not be added to file storage. Support for `file://` URL's is disabled by default, and can be enabled by setting `fileUrls` to `true` in the app configuration.

Layers with `file://` URL's will always be ignored when creating state files and by request URL parameter edit. They _can_ be imported into the audio manager.