### PR TITLE
chore(deps): Remove unused dependency on jasmine-core.

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,6 @@
     "google-closure-compiler": "^20171203.0.0",
     "http-server": "^0.11.1",
     "husky": "^0.13.3",
-    "jasmine-core": "^2.5.2",
     "js-dossier": "^0.12.0",
     "json": "^9.0.4",
     "karma": "^1.3.0",


### PR DESCRIPTION
Jasmine comes bundled with [karma-jasmine](https://github.com/karma-runner/karma-jasmine) 0.1.0, and our dependency on `jasmine-core` is both unused and misleading (we're not using Jasmine 2). Removing it.