### PR TITLE
WIP: Fix implicit dependency issues

### DIFF
--- a/src/os/command/abstractlayercmd.js
+++ b/src/os/command/abstractlayercmd.js
@@ -5,6 +5,7 @@ goog.require('ol.layer.Layer');
 goog.require('os.command.ICommand');
 goog.require('os.command.State');
 goog.require('os.layer');
+goog.require('os.map');
 goog.require('os.metrics.Metrics');
 
 
@@ -101,12 +102,18 @@ os.command.AbstractLayer.prototype.add = function(options) {
     return false;
   }
 
+  if (!os.map.mapContainer) {
+    this.state = os.command.State.ERROR;
+    this.details = 'Map container has not been set.';
+    return false;
+  }
+
   var layer = os.layer.createFromOptions(options);
   if (layer instanceof ol.layer.Layer) {
     // don't add duplicate layers to the map. this may happen for legit reasons. one example is a single layer from
     // a state file being removed, the whole state file being removed, then undo both removes.
-    if (!os.MapContainer.getInstance().getLayer(layer.getId())) {
-      os.MapContainer.getInstance().addLayer(/** @type {!ol.layer.Layer} */ (layer));
+    if (!os.map.mapContainer.getLayer(layer.getId())) {
+      os.map.mapContainer.addLayer(/** @type {!ol.layer.Layer} */ (layer));
       os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.AddData.ADD_LAYER_COMMAND, 1);
       return true;
     }
@@ -134,7 +141,13 @@ os.command.AbstractLayer.prototype.remove = function(options) {
     return false;
   }
 
-  os.MapContainer.getInstance().removeLayer(/** @type {string} */ (options['id']));
+  if (!os.map.mapContainer) {
+    this.state = os.command.State.ERROR;
+    this.details = 'Map container has not been set.';
+    return false;
+  }
+
+  os.map.mapContainer.removeLayer(/** @type {string} */ (options['id']));
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.AddData.REMOVE_LAYER_COMMAND, 1);
   return true;
 };

--- a/src/os/data/areanode.js
+++ b/src/os/data/areanode.js
@@ -5,7 +5,6 @@ goog.require('ol.events');
 goog.require('os.command.AreaToggle');
 goog.require('os.data.ISearchable');
 goog.require('os.events.PropertyChangeEvent');
-goog.require('os.feature');
 goog.require('os.implements');
 goog.require('os.structs.TriState');
 goog.require('os.ui.menu.IMenuSupplier');

--- a/src/os/data/filternode.js
+++ b/src/os/data/filternode.js
@@ -7,7 +7,6 @@ goog.require('os.command.FilterEnable');
 goog.require('os.command.SequenceCommand');
 goog.require('os.data.ISearchable');
 goog.require('os.events.PropertyChangeEvent');
-goog.require('os.feature');
 goog.require('os.structs.TriState');
 goog.require('os.ui.filter.ui.FilterNode');
 goog.require('os.ui.filter.ui.filterNodeUIDirective');

--- a/src/os/data/histo/colorbin.js
+++ b/src/os/data/histo/colorbin.js
@@ -4,7 +4,6 @@ goog.require('goog.array');
 goog.require('goog.events');
 goog.require('os.data.RecordField');
 goog.require('os.histo.Bin');
-goog.require('os.style');
 
 
 

--- a/src/os/data/layersyncdescriptor.js
+++ b/src/os/data/layersyncdescriptor.js
@@ -13,6 +13,7 @@ goog.require('os.events.LayerEventType');
 goog.require('os.events.PropertyChangeEvent');
 goog.require('os.layer.ILayer');
 goog.require('os.layer.PropertyChange');
+goog.require('os.map');
 goog.require('os.ui.node.defaultLayerNodeUIDirective');
 
 
@@ -234,7 +235,7 @@ os.data.LayerSyncDescriptor.prototype.onLayerRemoved = function(evt) {
  */
 os.data.LayerSyncDescriptor.prototype.createLayers_ = function() {
   var options = this.getOptions();
-  if (options) {
+  if (options && os.map.mapContainer) {
     for (var i = 0; i < options.length; i++) {
       var layerOptions = options[i];
 
@@ -243,12 +244,12 @@ os.data.LayerSyncDescriptor.prototype.createLayers_ = function() {
       if (layerId) {
         goog.array.insert(this.layerIds, layerId);
 
-        var layer = os.MapContainer.getInstance().getLayer(layerId);
+        var layer = os.map.mapContainer.getLayer(layerId);
         if (!layer) {
           layer = os.layer.createFromOptions(layerOptions);
 
           if (layer) {
-            os.MapContainer.getInstance().addLayer(layer);
+            os.map.mapContainer.addLayer(layer);
           }
         } else {
           this.addLayer(/** @type {!os.layer.ILayer} */ (layer));
@@ -267,12 +268,14 @@ os.data.LayerSyncDescriptor.prototype.removeLayers_ = function() {
   // save the config prior to removing layers
   this.layerConfig = this.persistLayerConfig();
 
-  for (var i = this.layers.length - 1; i >= 0; i--) {
-    var layer = this.layers[i];
-    if (layer) {
-      // remove it from the map
-      os.MapContainer.getInstance().removeLayer(layer);
-      goog.array.remove(this.layerIds, layer.getId());
+  if (os.map.mapContainer) {
+    for (var i = this.layers.length - 1; i >= 0; i--) {
+      var layer = this.layers[i];
+      if (layer) {
+        // remove it from the map
+        os.map.mapContainer.removeLayer(layer);
+        goog.array.remove(this.layerIds, layer.getId());
+      }
     }
   }
 

--- a/src/os/data/osdatamanager.js
+++ b/src/os/data/osdatamanager.js
@@ -12,6 +12,7 @@ goog.require('os.data.event.DataEvent');
 goog.require('os.events.LayerEvent');
 goog.require('os.events.LayerEventType');
 goog.require('os.events.PropertyChangeEvent');
+goog.require('os.map');
 goog.require('os.structs.ArrayCollection');
 goog.require('os.ui.slick.SlickTreeNode');
 
@@ -50,9 +51,11 @@ os.data.OSDataManager = function() {
 
   this.init_();
 
-  var map = os.MapContainer.getInstance();
-  map.listen(os.events.LayerEventType.ADD, this.onLayerAdded_, false, this);
-  map.listen(os.events.LayerEventType.REMOVE, this.onLayerRemoved_, false, this);
+  var map = os.map.mapContainer;
+  if (map) {
+    map.listen(os.events.LayerEventType.ADD, this.onLayerAdded_, false, this);
+    map.listen(os.events.LayerEventType.REMOVE, this.onLayerRemoved_, false, this);
+  }
 };
 goog.inherits(os.data.OSDataManager, os.data.DataManager);
 goog.addSingletonGetter(os.data.OSDataManager);
@@ -97,9 +100,11 @@ os.data.OSDataManagerSetting = {
 os.data.OSDataManager.prototype.disposeInternal = function() {
   os.data.OSDataManager.base(this, 'disposeInternal');
 
-  var map = os.MapContainer.getInstance();
-  map.unlisten(os.events.LayerEventType.ADD, this.onLayerAdded_, false, this);
-  map.unlisten(os.events.LayerEventType.REMOVE, this.onLayerRemoved_, false, this);
+  var map = os.map.mapContainer;
+  if (map) {
+    map.unlisten(os.events.LayerEventType.ADD, this.onLayerAdded_, false, this);
+    map.unlisten(os.events.LayerEventType.REMOVE, this.onLayerRemoved_, false, this);
+  }
 };
 
 

--- a/src/os/feature/feature.js
+++ b/src/os/feature/feature.js
@@ -312,7 +312,6 @@ os.feature.createLineOfBearing = function(feature, opt_replace, opt_lobOpts) {
 
   var geom = feature ? feature.getGeometry() : null;
   if (opt_lobOpts && geom instanceof ol.geom.Point) {
-    // var use3D = os.MapContainer.getInstance().is3DEnabled();
     // the feature must have a center point and a bearing to generate a lob. no values should ever be assumed.
     var center = ol.proj.toLonLat(geom.getFirstCoordinate(), os.map.PROJECTION);
     var bearing = os.feature.getColumnValue(feature, opt_lobOpts.bearingColumn);
@@ -628,11 +627,11 @@ os.feature.isInternalField = function(field) {
  */
 os.feature.getLayer = function(feature) {
   var layer = null;
-  if (feature) {
+  if (feature && os.map.mapContainer) {
     var sourceId = /** @type {string|undefined} */ (feature.get(os.data.RecordField.SOURCE_ID));
     if (sourceId) {
       // look up the layer via the id
-      layer = os.MapContainer.getInstance().getLayer(sourceId);
+      layer = os.map.mapContainer.getLayer(sourceId);
     }
   }
 
@@ -813,8 +812,8 @@ os.feature.update = function(feature, opt_source) {
     opt_source = os.feature.getSource(feature);
   }
 
-  if (!opt_source && os.MapContainer.getInstance().containsFeature(feature)) {
-    opt_source = os.MapContainer.getInstance().getLayer(os.MapContainer.DRAW_ID).getSource();
+  if (!opt_source && os.map.mapContainer && os.map.mapContainer.containsFeature(feature)) {
+    opt_source = os.map.mapContainer.getLayer(os.MapContainer.DRAW_ID).getSource();
   }
 
   var id = feature.getId();

--- a/src/os/fn/fn.js
+++ b/src/os/fn/fn.js
@@ -6,8 +6,10 @@ goog.provide('os.fn');
 
 goog.require('ol.extent');
 goog.require('ol.layer.Layer');
+goog.require('os.data.IExtent');
 goog.require('os.extent');
 goog.require('os.geo');
+goog.require('os.implements');
 
 
 /**
@@ -37,10 +39,8 @@ os.fn.reduceExtentFromLayers = function(extent, layer) {
     if (!ex) {
       var source = olayer.getSource();
 
-      if (source instanceof ol.source.Vector ||
-          source instanceof ol.source.Image ||
-          source instanceof ol.source.Tile) {
-        ex = source.getExtent();
+      if (os.implements(source, os.data.IExtent.ID)) {
+        ex = /** @type {!os.data.IExtent} */ (source).getExtent();
       }
     }
 
@@ -96,7 +96,7 @@ os.fn.mapFeatureToGeometry = function(feature) {
  * @return {os.layer.ILayer|undefined} layer The layer, or undefined if not a layer node.
  */
 os.fn.mapNodeToLayer = function(node) {
-  return node instanceof os.data.LayerNode ? node.getLayer() : undefined;
+  return node instanceof os.data.LayerNode ? /** @type {!os.data.LayerNode} */ (node).getLayer() : undefined;
 };
 
 

--- a/src/os/layer/animationoverlay.js
+++ b/src/os/layer/animationoverlay.js
@@ -8,12 +8,13 @@ goog.require('ol.Feature');
 goog.require('ol.layer.Vector');
 goog.require('ol.render.EventType');
 goog.require('ol.source.Vector');
+goog.require('os.map');
 
 
 /**
  * @typedef {{
  *   features: (Array<!ol.Feature>|undefined),
- *   map: (ol.Map|undefined),
+ *   map: (ol.PluggableMap|undefined),
  *   style: (ol.style.Style|Array<ol.style.Style>|ol.StyleFunction|undefined),
  *   opacity: (number|undefined),
  *   zIndex: (number|undefined)
@@ -102,7 +103,7 @@ os.layer.AnimationOverlay.prototype.disposeInternal = function() {
  * not in the hidden root layer group.
  */
 os.layer.AnimationOverlay.prototype.changed = function() {
-  if (this.source_ && !os.MapContainer.getInstance().is3DEnabled()) {
+  if (this.source_ && os.map.mapContainer && !os.map.mapContainer.is3DEnabled()) {
     this.source_.changed();
   }
 };

--- a/src/os/layer/layer.js
+++ b/src/os/layer/layer.js
@@ -5,6 +5,7 @@ goog.require('goog.Timer');
 goog.require('goog.log');
 goog.require('os.layer.ILayer');
 goog.require('os.layer.config.LayerConfigManager');
+goog.require('os.map');
 goog.require('os.source.ISource');
 
 
@@ -112,7 +113,7 @@ os.layer.getTitle = function(layerId, opt_explicit) {
   var title = '';
 
   // no layer name specified, so try to assemble one to provide context
-  var layer = os.MapContainer.getInstance().getLayer(layerId);
+  var layer = os.map.mapContainer.getLayer(layerId);
   if (os.implements(layer, os.layer.ILayer.ID)) {
     layer = /** @type {os.layer.ILayer} */ (layer);
 
@@ -152,15 +153,19 @@ os.layer.getUniqueTitle = function(baseTitle) {
  * @return {boolean}
  */
 os.layer.hasLayer = function(title) {
-  var layers = os.MapContainer.getInstance().getLayers();
-  return layers.some(function(layer) {
-    try {
-      // catch errors in case a base OL3 layer is added
-      return /** @type {os.layer.ILayer} */ (layer).getTitle() == title;
-    } catch (e) {}
+  if (os.map.mapContainer) {
+    var layers = os.map.mapContainer.getLayers();
+    return layers.some(function(layer) {
+      try {
+        // catch errors in case a base OL3 layer is added
+        return /** @type {os.layer.ILayer} */ (layer).getTitle() == title;
+      } catch (e) {}
 
-    return false;
-  });
+      return false;
+    });
+  }
+
+  return false;
 };
 
 

--- a/src/os/map/imapcontainer.js
+++ b/src/os/map/imapcontainer.js
@@ -65,7 +65,50 @@ os.map.IMapContainer.prototype.getLayer;
 
 
 /**
+ * Get all map layers ordered from top to bottom.
+ * @return {!Array<!ol.layer.Layer>}
+ */
+os.map.IMapContainer.prototype.getLayers;
+
+
+/**
  * Get the Openlayers map reference.
  * @return {ol.PluggableMap}
  */
 os.map.IMapContainer.prototype.getMap;
+
+
+/**
+ * Add a layer to the map.
+ * @param {!(os.layer.ILayer|ol.layer.Layer)} layer The layer to add.
+ */
+os.map.IMapContainer.prototype.addLayer;
+
+
+/**
+ * Remove a layer from the map.
+ * @param {!(os.layer.ILayer|ol.layer.Layer|string)} layer The layer to remove.
+ * @param {boolean=} opt_dispose If the layer should be disposed. Defaults to true.
+ */
+os.map.IMapContainer.prototype.removeLayer;
+
+
+/**
+ * If the 3D globe is the active view.
+ * @return {boolean}
+ */
+os.map.IMapContainer.prototype.is3DEnabled;
+
+
+/**
+ * If a WebGL 3D globe is supported by the map container.
+ * @return {boolean}
+ */
+os.map.IMapContainer.prototype.is3DSupported;
+
+
+/**
+ * Get the extent of the current view.
+ * @return {ol.Extent}
+ */
+os.map.IMapContainer.prototype.getViewExtent;

--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -367,8 +367,7 @@ os.MapContainer.prototype.getCesiumCameraController = function() {
 
 
 /**
- * Get the extent of the current view.
- * @return {ol.Extent}
+ * @inheritDoc
  */
 os.MapContainer.prototype.getViewExtent = function() {
   var view = this.map_.getView();
@@ -1584,8 +1583,7 @@ os.MapContainer.prototype.onCesiumCameraMoveChange_ = function(isMoving) {
 
 
 /**
- * Checks if the Cesium globe is the active view.
- * @return {boolean}
+ * @inheritDoc
  */
 os.MapContainer.prototype.is3DEnabled = function() {
   return !!this.olCesium_ && this.olCesium_.getEnabled();
@@ -1593,8 +1591,7 @@ os.MapContainer.prototype.is3DEnabled = function() {
 
 
 /**
- * Checks if WebGL/Cesium are supported by the browser.
- * @return {boolean}
+ * @inheritDoc
  */
 os.MapContainer.prototype.is3DSupported = function() {
   if (this.is3DSupported_ == undefined) {
@@ -1657,8 +1654,7 @@ os.MapContainer.prototype.setBGColor = function(color) {
 
 
 /**
- * Adds a layer to the map
- * @param {!(os.layer.ILayer|ol.layer.Layer)} layer The layer to add
+ * @inheritDoc
  */
 os.MapContainer.prototype.addLayer = function(layer) {
   if (this.map_ && layer instanceof ol.layer.Layer) {
@@ -1750,9 +1746,7 @@ os.MapContainer.prototype.addGroup = function(group) {
 
 
 /**
- * Removes a layer from the map
- * @param {!(os.layer.ILayer|ol.layer.Layer|string)} layer
- * @param {boolean=} opt_dispose If the layer should be disposed. Defaults to true.
+ * @inheritDoc
  */
 os.MapContainer.prototype.removeLayer = function(layer, opt_dispose) {
   var dispose = opt_dispose != null ? opt_dispose : true;
@@ -1977,8 +1971,7 @@ os.MapContainer.prototype.getDrawingLayer = function() {
 
 
 /**
- * Gets an array of layers ordered from top to bottom
- * @return {!Array<!ol.layer.Layer>}
+ * @inheritDoc
  */
 os.MapContainer.prototype.getLayers = function() {
   var layers = [];

--- a/src/os/mixin/mixin.js
+++ b/src/os/mixin/mixin.js
@@ -11,6 +11,7 @@ goog.require('ol.extent');
 goog.require('ol.math');
 goog.require('ol.renderer.canvas.Map');
 goog.require('ol.renderer.canvas.VectorLayer');
+goog.require('os.map');
 goog.require('os.mixin.ResolutionConstraint');
 goog.require('os.mixin.TileImage');
 goog.require('os.mixin.UrlTileSource');
@@ -92,7 +93,7 @@ ol.renderer.canvas.VectorLayer.prototype.forEachFeatureAtCoordinate = function(c
    * @suppress {accessControls}
    */
   ol.renderer.canvas.Map.prototype.renderFrame = function(frameState) {
-    if (frameState && os.MapContainer.getInstance().is3DEnabled()) {
+    if (frameState && os.map.mapContainer && os.map.mapContainer.is3DEnabled()) {
       frameState.viewState.rotation = 0;
     }
 

--- a/src/os/mixin/urltilemixin.js
+++ b/src/os/mixin/urltilemixin.js
@@ -9,6 +9,8 @@ goog.require('ol.source.UrlTile');
 goog.require('os.events.PropertyChangeEvent');
 goog.require('os.implements');
 goog.require('os.ol.source.IUrlSource');
+goog.require('os.source');
+goog.require('os.source.PropertyChange');
 
 
 // add support for providing custom URL parameters

--- a/src/os/query/filtermanager.js
+++ b/src/os/query/filtermanager.js
@@ -1,10 +1,12 @@
 goog.provide('os.query.FilterManager');
+
 goog.require('goog.array');
 goog.require('goog.events.EventTarget');
 goog.require('goog.string');
 goog.require('os.config.Settings');
 goog.require('os.filter.FilterEntry');
 goog.require('os.filter.IFilterable');
+goog.require('os.map');
 goog.require('os.ui.filter.FilterEvent');
 goog.require('os.ui.filter.FilterManager');
 goog.require('os.ui.filter.FilterType');
@@ -84,10 +86,11 @@ os.query.FilterManager.prototype.isEnabled = function(filter, opt_type) {
  * @inheritDoc
  */
 os.query.FilterManager.prototype.getFilterable = function(layerId) {
-  var layer = os.MapContainer.getInstance().getLayer(layerId);
-
-  if (layer instanceof os.layer.Vector) {
-    return /** @type {os.filter.IFilterable} */ (layer);
+  if (os.map.mapContainer) {
+    var layer = os.map.mapContainer.getLayer(layerId);
+    if (layer instanceof os.layer.Vector) {
+      return /** @type {os.filter.IFilterable} */ (layer);
+    }
   }
 
   return os.query.FilterManager.base(this, 'getFilterable', layerId);
@@ -129,7 +132,8 @@ os.query.FilterManager.prototype.open = function(opt_type, opt_columns) {
 
     var scopeOptions = {};
     if (opt_type) {
-      var layer = /** @type {os.layer.ILayer} */ (os.MapContainer.getInstance().getLayer(opt_type));
+      var layer = os.map.mapContainer ?
+          /** @type {os.layer.ILayer} */ (os.map.mapContainer.getLayer(opt_type)) : undefined;
       if (layer) {
         if (!opt_columns) {
           try {

--- a/src/os/source/source.js
+++ b/src/os/source/source.js
@@ -5,9 +5,11 @@ goog.require('ol.layer.Property');
 goog.require('os');
 goog.require('os.data.ColumnDefinition');
 goog.require('os.data.RecordField');
+goog.require('os.data.event.DataEventType');
 goog.require('os.filter.IFilterable');
 goog.require('os.implements');
 goog.require('os.layer');
+goog.require('os.map');
 goog.require('os.time.ITime');
 goog.require('os.ui.slick.column');
 
@@ -33,8 +35,8 @@ os.source.RefreshTimers = {};
  */
 os.source.identifySource = function(source) {
   var overlay = source.getAnimationOverlay();
-  if (overlay && !os.MapContainer.getInstance().is3DEnabled()) {
-    // 2D  (OL3) will blink the entire layer regardless of what's in the timeline window
+  if (overlay && os.map.mapContainer && !os.map.mapContainer.is3DEnabled()) {
+    // 2D (Openlayers) will blink the entire layer regardless of what's in the timeline window
     // so we need to add and remove the exact features
     var tickCount = 0;
     var oldFeatures = overlay.getFeatures().splice(0, overlay.getFeatures().length);
@@ -54,8 +56,8 @@ os.source.identifySource = function(source) {
       featureTimer.listen(goog.Timer.TICK, toggleFeatures);
       featureTimer.start();
     }
-  } else {
-    var layer = /** @type {os.layer.Vector} */ (os.MapContainer.getInstance().getLayer(source.getId()));
+  } else if (os.map.mapContainer) {
+    var layer = /** @type {os.layer.Vector} */ (os.map.mapContainer.getLayer(source.getId()));
     if (layer) {
       os.layer.identifyLayer(layer);
     }
@@ -120,8 +122,8 @@ os.source.isFilterable = function(source) {
     var descriptor = os.dataManager.getDescriptor(id);
     if (descriptor && os.implements(descriptor, os.filter.IFilterable.ID)) {
       return /** @type {os.filter.IFilterable} */ (descriptor).isFilterable();
-    } else {
-      var layer = os.MapContainer.getInstance().getLayer(id);
+    } else if (os.map.mapContainer) {
+      var layer = os.map.mapContainer.getLayer(id);
       if (layer && os.implements(layer, os.filter.IFilterable.ID)) {
         return /** @type {os.filter.IFilterable} */ (layer).isFilterable();
       }
@@ -263,8 +265,8 @@ os.source.handleMaxFeatureCount = os.debounce(function(count) {
       'applying filters, shrinking your query areas, or removing some feature layers.';
 
   // when supported, prompt the user to try 3D mode if they are in 2D
-  var mm = os.MapContainer.getInstance();
-  if (!mm.is3DEnabled() && mm.is3DSupported()) {
+  var mc = os.map.mapContainer;
+  if (mc && !mc.is3DEnabled() && mc.is3DSupported()) {
     warning += ' Switching to 3D mode will also allow more data to be loaded. To enable 3D mode, right-click the map ' +
         'and choose Toggle 2D/3D Mode.';
   }

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -15,6 +15,7 @@ goog.require('ol.geom.Geometry');
 goog.require('ol.source.Vector');
 goog.require('os');
 goog.require('os.Fields');
+goog.require('os.action.EventType');
 goog.require('os.alert.AlertEventSeverity');
 goog.require('os.alert.AlertManager');
 goog.require('os.data.ColumnDefinition');
@@ -37,6 +38,7 @@ goog.require('os.implements');
 goog.require('os.interpolate');
 goog.require('os.layer.AnimationOverlay');
 goog.require('os.load.LoadingManager');
+goog.require('os.map');
 goog.require('os.ogc');
 goog.require('os.registerClass');
 goog.require('os.source');
@@ -1128,7 +1130,7 @@ os.source.Vector.prototype.getMaxDate = function() {
  * @override
  */
 os.source.Vector.prototype.getTitle = function(opt_doNoUseTypeInName) {
-  var layer = /** @type {os.layer.ILayer} */ (os.MapContainer.getInstance().getLayer(this.getId()));
+  var layer = /** @type {os.layer.ILayer} */ (os.map.mapContainer.getLayer(this.getId()));
   var explicitType = !opt_doNoUseTypeInName && layer ? layer.getExplicitType() : '';
   if (explicitType) {
     return this.title_ + ' ' + explicitType;
@@ -1201,7 +1203,7 @@ os.source.Vector.prototype.setCesiumEnabled = function(value) {
       this.dispatchAnimationFrame(this.animationOverlay.getFeatures());
 
       // set the map so the overlay is rendered again, and fire the change event to trigger a refresh
-      this.animationOverlay.setMap(os.MapContainer.getInstance().getMap());
+      this.animationOverlay.setMap(os.map.mapContainer.getMap());
       this.animationOverlay.changed();
     }
   }
@@ -2056,13 +2058,13 @@ os.source.Vector.prototype.getAnimationOverlay = function() {
  */
 os.source.Vector.prototype.createAnimationOverlay = function() {
   if (!this.animationOverlay) {
-    var layer = os.MapContainer.getInstance().getLayer(this.getId());
+    var layer = os.map.mapContainer.getLayer(this.getId());
     var opacity = /** @type {os.layer.ILayer} */ (layer).getOpacity();
     var zIndex = layer.getZIndex();
 
     // only set the map in 2D mode. we don't want the overlay to render while in 3D.
     this.animationOverlay = new os.layer.AnimationOverlay({
-      map: this.cesiumEnabled ? null : os.MapContainer.getInstance().getMap(),
+      map: this.cesiumEnabled ? null : os.map.mapContainer.getMap(),
       opacity: opacity,
       zIndex: zIndex
     });

--- a/src/os/style/label.js
+++ b/src/os/style/label.js
@@ -162,15 +162,15 @@ os.style.label.TRUNCATE_LENGTH = 50;
  */
 os.style.label.updateShown_ = function() {
   // if the map/view aren't ready, return false so the conditional delay will keep trying
-  var map = os.MapContainer.getInstance();
-  var view = null;
-  if (map.getMap() && map.getMap().getView()) {
+  var map = os.map.mapContainer;
+  var view;
+  if (map && map.getMap() && map.getMap().getView()) {
     view = map.getMap().getView();
   } else {
     return false;
   }
 
-  var resolution = view.getResolution();
+  var resolution = view ? view.getResolution() : undefined;
   if (!goog.isDef(resolution)) {
     return false;
   }

--- a/src/os/tile/colorabletile.js
+++ b/src/os/tile/colorabletile.js
@@ -33,7 +33,7 @@ os.tile.ColorableTile = function(tileCoord, state, src, crossOrigin, tileLoadFun
    */
   this.olSource_ = null;
 };
-ol.inherits(os.tile.ColorableTile, ol.ImageTile);
+goog.inherits(os.tile.ColorableTile, ol.ImageTile);
 
 
 /**

--- a/src/os/ui/ex/exportdialog.js
+++ b/src/os/ui/ex/exportdialog.js
@@ -5,7 +5,6 @@ goog.require('goog.array');
 goog.require('os.data.event.DataEvent');
 goog.require('os.data.event.DataEventType');
 goog.require('os.events.SelectionType');
-goog.require('os.feature');
 goog.require('os.source');
 goog.require('os.source.PropertyChange');
 goog.require('os.ui');

--- a/src/os/ui/header/scrollheader.js
+++ b/src/os/ui/header/scrollheader.js
@@ -135,7 +135,7 @@ os.ui.header.ScrollHeaderCtrl.prototype.updatePositions_ = function() {
 
   if (!this.isFixed_ && navTop <= 1) {
     this.isFixed_ = true;
-    this.resetHeight_ = this.scrollEl_.scrollTop();
+    this.resetHeight_ = /** @type {number} */ (this.scrollEl_.scrollTop());
     if (!this.supportsSticky_) {
       this.filler_ = $('<div>').css('height', this.offsetHeight_)
           .addClass('scroll-header-filler').insertAfter(this.element_);

--- a/src/os/ui/node/defaultlayernodeui.js
+++ b/src/os/ui/node/defaultlayernodeui.js
@@ -228,7 +228,7 @@ os.ui.node.DefaultLayerNodeUICtrl.prototype.updateFilters_ = function(opt_event)
 
   var layer = this.getLayer();
   if (os.implements(layer, os.filter.IFilterable.ID)) {
-    this['filtersEnabled'] = layer.isFilterable();
+    this['filtersEnabled'] = /** @type {!os.filter.IFilterable} */ (layer).isFilterable();
   } else {
     this['filtersEnabled'] = false;
   }

--- a/src/os/ui/ol/draw/drawcontrols.js
+++ b/src/os/ui/ol/draw/drawcontrols.js
@@ -183,7 +183,8 @@ os.ui.ol.draw.DrawControlsCtrl.prototype.destroyControlMenu_ = function() {
 
 
 /**
- * @return {?ol.Map}
+ * Get the Openlayers map instance for the controller.
+ * @return {ol.PluggableMap}
  */
 os.ui.ol.draw.DrawControlsCtrl.prototype.getMap = function() {
   return this.olMap_ ? this.olMap_.getMap() : null;

--- a/src/os/ui/ol/olmap.js
+++ b/src/os/ui/ol/olmap.js
@@ -2,6 +2,7 @@ goog.provide('os.ui.ol.OLMap');
 
 goog.require('goog.events.EventTarget');
 goog.require('goog.events.MouseWheelHandler');
+goog.require('goog.log');
 goog.require('goog.math.Coordinate');
 goog.require('ol');
 goog.require('ol.Feature');
@@ -71,6 +72,15 @@ os.ui.ol.OLMap = function() {
   os.dispatcher.listen(os.ui.action.EventType.ZOOM, this.onZoom_, false, this);
 };
 goog.inherits(os.ui.ol.OLMap, goog.events.EventTarget);
+
+
+/**
+ * Logger
+ * @type {goog.log.Logger}
+ * @private
+ * @const
+ */
+os.ui.ol.OLMap.LOGGER_ = goog.log.getLogger('os.ui.ol.OLMap');
 
 
 /**
@@ -491,6 +501,42 @@ os.ui.ol.OLMap.prototype.getLayer = function(layerOrFeature, opt_search, opt_rem
 
   return l;
 };
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.ol.OLMap.prototype.getLayers = goog.abstractMethod;
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.ol.OLMap.prototype.addLayer = goog.abstractMethod;
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.ol.OLMap.prototype.removeLayer = goog.abstractMethod;
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.ol.OLMap.prototype.getViewExtent = goog.abstractMethod;
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.ol.OLMap.prototype.is3DEnabled = goog.functions.FALSE;
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.ol.OLMap.prototype.is3DSupported = goog.functions.FALSE;
 
 
 /**


### PR DESCRIPTION
Implicit dependencies were discovered when compiling a library that depends on OpenSphere.

Most of these revolved around the use of `os.MapContainer.getInstance()`, which isn't required in most cases. The `os.map.IMapContainer` interface was added to allow creating custom map containers that will still work with much of OpenSphere. These references haven't been fixed across the board, but this PR handles a number of them.