### PR TITLE
Stop using goog.dom.getTextContent and getRawTextContent.

### DIFF
--- a/conformance_config.textproto
+++ b/conformance_config.textproto
@@ -121,6 +121,20 @@ requirement: {
   value: 'Number.MIN_VALUE'
 }
 
+requirement: {
+  type: BANNED_NAME
+  value: 'goog.dom.getTextContent'
+  error_message: 'goog.dom.getTextContent(node) is not permitted. Use '
+                 'ol.xml.getAllTextContent(node, true) instead.'
+}
+
+requirement: {
+  type: BANNED_NAME
+  value: 'goog.dom.getRawTextContent'
+  error_message: 'goog.dom.getRawTextContent(node) is not permitted. Use '
+                 'ol.xml.getAllTextContent(node, false) instead.'
+}
+
 #requirement: {
 #  type: BANNED_NAME
 #  value: 'goog.bind'

--- a/src/os/tag/tag.js
+++ b/src/os/tag/tag.js
@@ -1,6 +1,8 @@
 goog.provide('os.tag');
+
 goog.require('goog.dom');
 goog.require('goog.string');
+goog.require('ol.xml');
 goog.require('os.xml');
 
 
@@ -69,7 +71,7 @@ os.tag.tagsFromXML = function(node) {
     tags = [];
 
     for (var i = 0, n = children.length; i < n; i++) {
-      tags.push(goog.dom.getTextContent(children[i]));
+      tags.push(ol.xml.getAllTextContent(children[i], true).trim());
     }
   }
 

--- a/src/os/ui/filter/filter.js
+++ b/src/os/ui/filter/filter.js
@@ -265,7 +265,7 @@ os.ui.filter.getColumnName = function(children) {
   var s = '';
 
   if (children && children[0]) {
-    s = goog.dom.getTextContent(children[0]);
+    s = ol.xml.getAllTextContent(children[0], true).trim();
   }
 
   return s;

--- a/src/os/ui/filter/filterfn.js
+++ b/src/os/ui/filter/filterfn.js
@@ -1,8 +1,8 @@
 goog.provide('os.ui.filter.fn');
 
 goog.require('goog.array');
-goog.require('goog.dom');
 goog.require('goog.functions');
+goog.require('ol.xml');
 goog.require('os.string');
 goog.require('os.ui.filter');
 goog.require('os.ui.filter.Expression');
@@ -112,9 +112,9 @@ os.ui.filter.fn.createVarMap = function(node) {
   var propNameNodes = node.querySelectorAll('PropertyName');
   var propNames = [];
   for (var i = 0; i < propNameNodes.length; i++) {
-    var nodeText = goog.dom.getTextContent(propNameNodes[i]);
+    var nodeText = ol.xml.getAllTextContent(propNameNodes[i], true).trim();
     if (nodeText && propNames.indexOf(nodeText) == -1) {
-      propNames.push(nodeText.trim());
+      propNames.push(nodeText);
     }
   }
 

--- a/src/os/ui/text/simplemde.js
+++ b/src/os/ui/text/simplemde.js
@@ -3,6 +3,7 @@ goog.provide('os.ui.text.SimpleMDECtrl');
 goog.provide('os.ui.text.simpleMDEDirective');
 
 goog.require('goog.dom.safe');
+goog.require('ol.xml');
 goog.require('os.ui.Module');
 
 
@@ -286,11 +287,7 @@ os.ui.text.SimpleMDE.removeMarkdown = function(rawText, opt_keepLineBreaks) {
     var cleanText = rawText;
     var node = os.ui.text.SimpleMDE.getHtmlNode(rawText);
     if (node) {
-      if (opt_keepLineBreaks) {
-        cleanText = goog.dom.getRawTextContent(node);
-      } else {
-        cleanText = goog.dom.getTextContent(node);
-      }
+      cleanText = ol.xml.getAllTextContent(node, !opt_keepLineBreaks);
     }
     return os.ui.sanitize(cleanText);
   } else {

--- a/src/os/xml.js
+++ b/src/os/xml.js
@@ -4,6 +4,7 @@ goog.require('goog.dom');
 goog.require('goog.dom.NodeType');
 goog.require('goog.dom.xml');
 goog.require('goog.string');
+goog.require('ol.xml');
 goog.require('os.time');
 
 
@@ -172,8 +173,8 @@ os.xml.readDateTime = function(node) {
   // this should handle any ISO strings and is by far the fastest way to parse dates. if we run into time fields that
   // aren't being parsed correctly, be VERY careful with changes to this function and compare the difference in the
   // browser's CPU profiler. use a large (5MB+) KML with time fields as a test case.
-  var text = goog.dom.getTextContent(node);
-  var date = new Date(text ? text.trim() : undefined);
+  var text = ol.xml.getAllTextContent(node, true).trim();
+  var date = new Date(text || undefined);
   return !isNaN(date.getTime()) ? date : null;
 };
 

--- a/src/plugin/arc/state/v2/arcstate.js
+++ b/src/plugin/arc/state/v2/arcstate.js
@@ -1,4 +1,6 @@
 goog.provide('plugin.arc.state.v2.arcstate');
+
+goog.require('ol.xml');
 goog.require('os.ogc.spatial');
 goog.require('os.state.v2.FilterTag');
 goog.require('os.xml');
@@ -22,7 +24,7 @@ plugin.arc.state.v2.arcstate.load = function(el) {
     var layer = wmsLayers[i];
     var providerEle = layer.querySelector('provider');
     if (providerEle) {
-      var content = goog.dom.getTextContent(providerEle);
+      var content = ol.xml.getAllTextContent(providerEle, true).trim();
       if (content === 'ArcMap') {
         // we found an Arc layer, modify it to match what opensphere expects
         goog.dom.removeNode(providerEle);
@@ -32,7 +34,7 @@ plugin.arc.state.v2.arcstate.load = function(el) {
 
     var urlElement = layer.querySelector('url');
     if (urlElement) {
-      var url = goog.dom.getTextContent(urlElement);
+      var url = ol.xml.getAllTextContent(urlElement, true).trim();
       if (goog.string.endsWith(url, '/export')) {
         // prune off the /export since OL3's TileArcGISRestSource doesn't like it
         var newUrl = url.substring(0, url.length - 7);
@@ -69,7 +71,7 @@ plugin.arc.state.v2.arcstate.save = function(el) {
     // check whether the URL ends with /export
     var urlElement = layer.querySelector('url');
     if (urlElement) {
-      var url = goog.dom.getTextContent(urlElement);
+      var url = ol.xml.getAllTextContent(urlElement, true).trim();
       if (!goog.string.endsWith(url, '/export')) {
         // add /export to the end since 2D expects that
         var newUrl = url + '/export';

--- a/src/plugin/file/kml/kmlparser.js
+++ b/src/plugin/file/kml/kmlparser.js
@@ -382,11 +382,10 @@ plugin.file.kml.KMLParser.prototype.loadExternalStyles = function() {
   var extStylesFound = false;
 
   for (var i = 0, n = styles.length; i < n; i++) {
-    var style = goog.dom.getTextContent(styles[i]);
-
+    var style = ol.xml.getAllTextContent(styles[i], true).trim();
     if (style) {
       // remove the fragment, if url is incorrectly formatted, kml is bad and this url should be skipped
-      var url = style.replace(/#.*/, '').trim();
+      var url = style.replace(/#.*/, '');
       url = encodeURI(url) === url ? url : undefined;
       if (url) {
         extStylesFound = true;
@@ -1550,7 +1549,7 @@ plugin.file.kml.KMLParser.setNodeLabel_ = function(node, el) {
   goog.asserts.assert(el.localName == 'name', 'localName should be name');
 
   // default to null and a default label will be created later
-  node.setLabel(goog.dom.getTextContent(el) || null);
+  node.setLabel(ol.xml.getAllTextContent(el, true).trim() || null);
 };
 
 
@@ -1564,7 +1563,7 @@ plugin.file.kml.KMLParser.setNodeCollapsed_ = function(node, el) {
   goog.asserts.assert(el.localName == 'open', 'localName should be open');
 
   // default to collapsed, so only expand if the text is '1'.
-  node.collapsed = goog.dom.getTextContent(el) !== '1';
+  node.collapsed = ol.xml.getAllTextContent(el, true).trim() !== '1';
 };
 
 
@@ -1577,8 +1576,8 @@ plugin.file.kml.KMLParser.setNodeCollapsed_ = function(node, el) {
 plugin.file.kml.KMLParser.setNodeVisibility_ = function(node, el) {
   goog.asserts.assert(el.localName == 'visibility', 'localName should be visibility');
 
-  var content = goog.dom.getTextContent(el);
-  if (goog.isDefAndNotNull(content)) {
+  var content = ol.xml.getAllTextContent(el, true).trim();
+  if (content) {
     // this only handles turning the node off so we can honor our node defaults. this is specifically for network links,
     // which we always default to being turned off.
     var visibility = ol.format.XSD.readBooleanString(content);


### PR DESCRIPTION
The Closure functions fail when parsing multi-line XML with CDATA to denote the value. For example, the following would be parsed as whitespace:
```
<name>
  <![CDATA[Some Value]]>
</name>
```

This caused problems reading values from formatted KML files, but these are resolved by using `ol.xml.getAllTextContent` instead. This function is also guaranteed to return a string, so I streamlined some following `trim` calls as well.