### PR TITLE
Fix race condition in tour test.

### DIFF
--- a/test/plugin/file/kml/tour/tour.test.js
+++ b/test/plugin/file/kml/tour/tour.test.js
@@ -315,7 +315,7 @@ describe('plugin.file.kml.tour.Tour', function() {
     });
 
     waitsFor(function() {
-      return tour.playlistIndex_ === 2;
+      return tour.playlistIndex_ === 2 && tour.currentPromise_ != null;
     }, 'tour to continue playing');
 
     runs(function() {


### PR DESCRIPTION
Fixes an occasional error in the tour test if the `waitsFor` runs between the index increment and starting the next item.