### PR TITLE
Inform the user when WebGL is being initialized.

### DIFF
--- a/src/os/map/map.js
+++ b/src/os/map/map.js
@@ -23,6 +23,7 @@ os.map.mapContainer = undefined;
  */
 os.MapChange = {
   VIEW3D: 'map:change:view3d',
+  INIT3D: 'map:change:init3d',
   THROTTLE: 'map:change:throttle'
 };
 

--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -1187,6 +1187,20 @@ os.MapContainer.prototype.init = function() {
 
 
 /**
+ * Toggle if the Openlayers canvas is displayed.
+ * @param {boolean} shown If the canvas should be displayed.
+ * @protected
+ */
+os.MapContainer.prototype.toggle2DCanvas = function(shown) {
+  var viewport = this.map_ ? this.map_.getViewport() : undefined;
+  var olCanvas = viewport ? viewport.querySelector('canvas') : undefined;
+  if (olCanvas) {
+    olCanvas.style.visibility = shown ? '' : 'hidden';
+  }
+};
+
+
+/**
  * Initializes settings and adds listeners for settings changes.
  * @protected
  */
@@ -1196,8 +1210,17 @@ os.MapContainer.prototype.initSettings = function() {
 
     var mapMode = os.settings.get(os.config.DisplaySetting.MAP_MODE, os.MapMode.VIEW_3D);
     if (mapMode === os.MapMode.VIEW_3D || mapMode === os.MapMode.AUTO) {
+      // hide the Openlayers canvas while 3D mode is initialized
+      this.toggle2DCanvas(false);
+
       // don't display errors on initialization, and wait until the globe is ready to initialize the camera
-      this.setCesiumEnabled(true, true).then(this.initCameraSettings, this.initCameraSettings, this);
+      this.setCesiumEnabled(true, true).thenAlways(function() {
+        // show the Openlayers canvas again
+        this.toggle2DCanvas(true);
+
+        // initialize the camera/view
+        this.initCameraSettings();
+      }, this);
     } else {
       this.initCameraSettings();
     }

--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -105,11 +105,11 @@ os.MapContainer = function() {
   this.map_ = null;
 
   /**
-   * If the map container is asynchronously initializing a view. Disables toggling the view.
+   * If the WebGL renderer is initializing. Disables toggling the view.
    * @type {boolean}
    * @private
    */
-  this.initializingView_ = false;
+  this.initializingWebGL_ = false;
 
   /**
    * The Openlayers/Cesium synchronizer.
@@ -1250,7 +1250,7 @@ os.MapContainer.prototype.onMapModeChange_ = function(event) {
  * @private
  */
 os.MapContainer.prototype.onToggleView_ = function() {
-  if (this.initializingView_) {
+  if (this.isInitializingWebGL()) {
     return;
   }
 
@@ -1464,6 +1464,28 @@ os.MapContainer.prototype.getAltitude = function() {
 
 
 /**
+ * If the map container is initializing the WebGL renderer.
+ * @return {boolean}
+ */
+os.MapContainer.prototype.isInitializingWebGL = function() {
+  return this.initializingWebGL_;
+};
+
+
+/**
+ * Set if the map container is initializing the WebGL renderer.
+ * @param {boolean} value If WebGL is being initialized.
+ * @protected
+ */
+os.MapContainer.prototype.setInitializingWebGL = function(value) {
+  if (this.initializingWebGL_ != value) {
+    this.initializingWebGL_ = value;
+    this.dispatchEvent(new os.events.PropertyChangeEvent(os.MapChange.INIT3D, value));
+  }
+};
+
+
+/**
  * Enable/disable Cesium.
  * @param {boolean} useCesium If Cesium should be enabled
  * @param {boolean=} opt_silent If errors should be ignored
@@ -1475,23 +1497,17 @@ os.MapContainer.prototype.setCesiumEnabled = function(useCesium, opt_silent) {
 
   // change the view if different than current
   if (useCesium != this.is3DEnabled()) {
-    var viewport = this.map_.getViewport();
-    var olCanvas = viewport ? viewport.querySelector('canvas') : undefined;
-    if (olCanvas) {
-      olCanvas.style.visibility = useCesium ? 'hidden' : '';
-    }
-
     if (useCesium && this.is3DSupported() && !this.failPerformanceCaveat() && !this.olCesium_) {
       // initialize cesium
-      this.initializingView_ = true;
+      this.setInitializingWebGL(true);
 
       return this.initCesium_().then(function() {
         // initialize succeeded - call again to activate Cesium
-        this.initializingView_ = false;
+        this.setInitializingWebGL(false);
         this.setCesiumEnabled(useCesium, opt_silent);
-      }, function() {
+      }, function(reason) {
         // initialize failed - disable 3D support and call again to report the WebGL error
-        this.initializingView_ = false;
+        this.setInitializingWebGL(false);
         this.is3DSupported_ = false;
         this.setCesiumEnabled(useCesium, opt_silent);
       }, this);
@@ -1608,10 +1624,13 @@ os.MapContainer.prototype.initCesium_ = function() {
           this.olCesium_.enableAutoRenderLoop();
           resolve();
         } catch (e) {
-          goog.log.error(os.MapContainer.LOGGER_, 'Failed to create 3D view!', e);
+          goog.log.error(os.MapContainer.LOGGER_, 'Failed to initialize Cesium renderer:', e);
           reject();
         }
-      }, reject, this);
+      }, function(error) {
+        goog.log.error(os.MapContainer.LOGGER_, 'Failed to load Cesium library:', error);
+        reject();
+      }, this);
     }, this);
   }
 

--- a/src/os/olcs/olcs.js
+++ b/src/os/olcs/olcs.js
@@ -81,7 +81,7 @@ os.olcs.DEFAULT_FOG_DENSITY = os.olcs.MAX_FOG_DENSITY / 2;
 
 
 /**
- * Default timeout for loading Cesium.
+ * Default timeout for loading Cesium. Override by setting `cesium.loadTimeout` in the app configuration.
  * @type {number}
  * @const
  */

--- a/src/os/olcs/olcs.js
+++ b/src/os/olcs/olcs.js
@@ -81,6 +81,14 @@ os.olcs.DEFAULT_FOG_DENSITY = os.olcs.MAX_FOG_DENSITY / 2;
 
 
 /**
+ * Default timeout for loading Cesium.
+ * @type {number}
+ * @const
+ */
+os.olcs.DEFAULT_LOAD_TIMEOUT = 30000;
+
+
+/**
  * @define {string} Base path to the Cesium library, from the OpenSphere root.
  */
 goog.define('os.olcs.CESIUM_BASE_PATH', 'vendor/cesium');
@@ -99,7 +107,12 @@ os.olcs.loadCesium = function() {
     // load Cesium
     var cesiumUrl = cesiumPath + '/Cesium.js';
     var trustedUrl = goog.html.TrustedResourceUrl.fromConstant(os.string.createConstant(cesiumUrl));
-    return goog.net.jsloader.safeLoad(trustedUrl);
+
+    // extend default timeout (5 seconds) for slow connections and debugging with unminified version
+    var timeout = /** @type {number} */ (os.settings.get('cesium.loadTimeout', os.olcs.DEFAULT_LOAD_TIMEOUT));
+    return goog.net.jsloader.safeLoad(trustedUrl, {
+      timeout: timeout
+    });
   }
 
   return goog.Promise.resolve();


### PR DESCRIPTION
I noticed two problems with the async Cesium load:
- On slow connections or in debug mode when loading unminified Cesium, the 5 second timeout for `goog.net.jsloader` can be reached.
- It's unclear to the user that something is happening, other than the map going black.

To resolve these, I made the following changes:
- Show a loading spinner with updated tooltip on the map mode control while Cesium is being loaded/initialized.
- Hide the Openlayers canvas when initializing 3D mode on app startup. It seemed odd to show the 2D map then switch to 3D when the user hadn't done anything yet.
- Don't hide the Openlayers canvas during initialization if user toggled. The loading spinner provides feedback that their button click did something and we're working on it, and avoids displaying a blank screen while that happens.
- Increase the load timeout to 30 seconds by default, configurable with `cesium.loadTimeout`.