### PR TITLE
chore(css): Remove vendor prefixes for translate.

### DIFF
--- a/scss/ui/partials/ui/onboarding/_ngonboarding.scss
+++ b/scss/ui/partials/ui/onboarding/_ngonboarding.scss
@@ -32,10 +32,6 @@
 }
 
 .onboarding-popover.onboarding-centered {
-  // sass-lint:disable no-vendor-prefixes
-  -moz-transform: translate(-50%, -50%);
-  -ms-transform: translate(-50%, -50%);
-  -webkit-transform: translate(-50%, -50%);
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);


### PR DESCRIPTION
This is supported in all modern browsers (Chrome from 36, Firefox from 16, even IE 10, Safari 9), see https://caniuse.com/#feat=transforms2d

This is part of the work in #141.