### PR TITLE
feat(time): ensure {time:...} replacer is required

### DIFF
--- a/src/os/time/time.js
+++ b/src/os/time/time.js
@@ -13,6 +13,7 @@ goog.require('goog.events.EventType');
 goog.require('goog.i18n.DateTimeFormat');
 goog.require('os.config.Settings');
 goog.require('os.time.TimeRange');
+goog.require('os.time.TimeRangePresets');
 
 
 /**


### PR DESCRIPTION
`TimeRangePresets` should be required by the application so that the variable replacer for `{time:...}` is properly registered. We weren't using that anywhere but I wanted to and it didn't exist.