### PR TITLE
feat(wms): Added caseSensitive option for params

### DIFF
--- a/src/plugin/ogc/wms/wmslayerconfig.js
+++ b/src/plugin/ogc/wms/wmslayerconfig.js
@@ -110,7 +110,7 @@ plugin.ogc.wms.WMSLayerConfig.prototype.getSource = function(options) {
     var keys = this.params.getKeys();
     for (var i = 0, n = keys.length; i < n; i++) {
       var key = keys[i];
-      params[key.toUpperCase()] = this.params.get(key);
+      params[options['caseSensitive'] ? key : key.toUpperCase()] = this.params.get(key);
     }
   }
 


### PR DESCRIPTION
I was working with a provider who uses all caps in WMS spec params (`SERVICE`, `VERSION`, etc.) and all lower case in non-spec proprietary params (`provider`, `query`, etc.). So I added a `caseSensitive` option that prevents the WMS layer config from assuming that all the parameters can be upper-cased.

EDIT:
I should probably note that this is a little janky. The underlying `ol.source.TileWMS` class will still attempt to bake in the default parameters in upper case. So you can't add case-sensitive parameters for `SERVICE`, `VERSION`, `REQUEST`, `FORMAT`, `TRANSPARENT`, `WIDTH`, `HEIGHT`, `STYLES`, `CRS` (`SRS` for 1.1.1), or `BBOX`. However, anything else will be preserved as sent in the param options.