### PR TITLE
Allow leaving the menu open when an item is selected.

### DIFF
--- a/src/os/ui/menu/menu.js
+++ b/src/os/ui/menu/menu.js
@@ -105,9 +105,10 @@ os.ui.menu.Menu.prototype.onClick_ = function(e) {
  * @param {T} context The menu context.
  * @param {jQuery.PositionOptions} position The position options.
  * @param {Object=} opt_target The menu event target.
+ * @param {boolean=} opt_dispatch Whether or not to dispatch an event. Defaults to true.
  */
-os.ui.menu.Menu.prototype.open = function(context, position, opt_target) {
-  this.close();
+os.ui.menu.Menu.prototype.open = function(context, position, opt_target, opt_dispatch) {
+  this.close(opt_dispatch);
   this.context_ = context || undefined;
   this.position_ = position || {};
   this.target_ = opt_target || this;
@@ -140,7 +141,10 @@ os.ui.menu.Menu.prototype.open = function(context, position, opt_target) {
   this.menu_['position'](this.position_);
   this.listenerDelay_.start();
 
-  this.dispatchEvent(os.ui.menu.MenuEventType.OPEN);
+  var dispatch = opt_dispatch != null ? opt_dispatch : true;
+  if (dispatch) {
+    this.dispatchEvent(os.ui.menu.MenuEventType.OPEN);
+  }
 
   // jQuery menu is outside of the Angular lifecycle, so the menu needs to trigger a digest on its own
   os.ui.apply(os.ui.injector.get('$rootScope'));
@@ -152,7 +156,7 @@ os.ui.menu.Menu.prototype.open = function(context, position, opt_target) {
  */
 os.ui.menu.Menu.prototype.reopen = function() {
   if (this.target_) {
-    this.open(this.context_, this.position_, this.target_);
+    this.open(this.context_, this.position_, this.target_, false);
   }
 };
 
@@ -207,7 +211,9 @@ os.ui.menu.Menu.prototype.onSelect = function(evt, ui) {
         os.metrics.Metrics.getInstance().updateMetric(item.metricKey, 1);
       }
 
-      this.close();
+      if (item.closeOnSelect) {
+        this.close();
+      }
     }
   }
 };

--- a/src/os/ui/menu/menuitem.js
+++ b/src/os/ui/menu/menuitem.js
@@ -37,6 +37,7 @@ os.ui.menu.UnclickableTypes = [
  *  visible: (boolean|undefined),
  *  enabled: (boolean|undefined),
  *  selected: (boolean|undefined),
+ *  closeOnSelect: (boolean|undefined),
  *  icons: (!Array<!string>|undefined),
  *  tooltip: (string|undefined),
  *  shortcut: (string|undefined),
@@ -59,18 +60,19 @@ os.ui.menu.MenuItem = function(options) {
   this.eventType = options.eventType;
   this.metricKey = options.metricKey;
   this.label = options.label;
-  this.visible = goog.isDef(options.visible) ? options.visible : true;
-  this.enabled = goog.isDef(options.enabled) ? options.enabled : true;
+  this.visible = options.visible != null ? options.visible : true;
+  this.enabled = options.enabled != null ? options.enabled : true;
   this.selected = options.selected;
   this.icons = options.icons;
   this.tooltip = options.tooltip;
   this.shortcut = options.shortcut;
   this.sort = options.sort || 0;
+  this.closeOnSelect = options.closeOnSelect != null ? options.closeOnSelect : true;
 
   /**
    * @type {Array<!os.ui.menu.MenuItem<T>>|undefined}
    */
-  this.children = goog.isDef(options.children) ? options.children.map(function(c) {
+  this.children = options.children != null ? options.children.map(function(c) {
     return new os.ui.menu.MenuItem(c);
   }) : undefined;
 
@@ -164,8 +166,8 @@ os.ui.menu.MenuItem.prototype.render = function(context, opt_target) {
   var types = os.ui.menu.MenuItemType;
   var visible = this.visible;
   var enabled = this.enabled;
-  var type = goog.isDef(this.type) ? this.type : types.ITEM;
-  var tooltip = goog.isDef(this.tooltip) ? this.tooltip : '';
+  var type = this.type != null ? this.type : types.ITEM;
+  var tooltip = this.tooltip != null ? this.tooltip : '';
   var html = '';
   var childHtml = '';
 


### PR DESCRIPTION
Other changes:
- Prevent firing open/close events when reopening a menu to refresh the content.
- Clean up `goog.isDef` in support of #165.