### PR TITLE
chore(css): Switch box-shadow to use compass mixins.

### DIFF
--- a/scss/os/overrides/_bootstrap.scss
+++ b/scss/os/overrides/_bootstrap.scss
@@ -349,8 +349,8 @@ td > input {
 }
 
 .modal-borderless {
+  @include box-shadow(rgba(0, 0, 0, 0) 0 3px 7px 0);
   border: 1px solid rgba(0, 0, 0, 0);
-  box-shadow: rgba(0, 0, 0, 0) 0 3px 7px 0;
 }
 
 .modal-body {
@@ -758,8 +758,8 @@ h6 {
 }
 
 .btn-group.open .btn.dropdown-toggle {
+  @include box-shadow(inset 0 2px 4px rgba(0, 0, 0, .15), 0 1px 2px rgba(0, 0, 0, .05));
   background-color: #3a3e41;
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, .15), 0 1px 2px rgba(0, 0, 0, .05);
 }
 
 .dropdown-menu {

--- a/scss/os/partials/_main.scss
+++ b/scss/os/partials/_main.scss
@@ -75,7 +75,7 @@ popover > i,
   }
 
   &.ng-invalid:focus {
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px #888 !important;
+    @include box-shadow(inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px #888 !important);
   }
 }
 

--- a/scss/ui/overrides/_slickgrid.scss
+++ b/scss/ui/overrides/_slickgrid.scss
@@ -126,10 +126,10 @@
 
       // override bootstrap styles on the input so it fits in the cell
       input.editor-text {
+        @include box-shadow(none);
         @include box-sizing(border-box);
         background: transparent;
         border: 0;
-        box-shadow: none;
         height: 100%;
         width: 100%;
       }

--- a/scss/ui/partials/_misc.scss
+++ b/scss/ui/partials/_misc.scss
@@ -412,8 +412,8 @@ div::-moz-focus-inner {
 
 .border-glow {
   @include transition(border 500ms ease);
+  @include box-shadow(inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(82, 168, 236, .6));
   border-color: #72b2ff;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(82, 168, 236, .6);
 }
 
 .insetshadowed {

--- a/scss/ui/partials/ui/_colorpalette.scss
+++ b/scss/ui/partials/ui/_colorpalette.scss
@@ -99,9 +99,9 @@
 
 button.btn-invisible,
 button.btn-invisible[disabled] {
+  @include box-shadow(none);
   background: transparent;
   border: 1px solid transparent;
-  box-shadow: none;
   padding: 0;
 
   &:hover {

--- a/scss/ui/partials/ui/_filter.scss
+++ b/scss/ui/partials/ui/_filter.scss
@@ -29,7 +29,7 @@
   }
 
   .ng-dirty.ng-invalid:focus {
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px #888 !important;
+    @include box-shadow(inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px #888 !important);
   }
 
   .filterbuilder {

--- a/scss/ui/partials/ui/column/_columnmanager.scss
+++ b/scss/ui/partials/ui/column/_columnmanager.scss
@@ -16,8 +16,8 @@
 
   input:focus,
   input[type='text']:focus {
+    @include box-shadow(none);
     border-color: #272b30;
-    box-shadow: none;
     outline: none;
   }
 

--- a/scss/ui/partials/ui/help/_control.scss
+++ b/scss/ui/partials/ui/help/_control.scss
@@ -21,10 +21,10 @@
         }
 
         .control-key {
+          @include box-shadow(0 1px 0 rgba(0, 0, 0, .2), 0 0 0 2px #fff inset);
           background-color: #f7f7f7;
           border: 1px solid #ccc;
           border-radius: 3px;
-          box-shadow: 0 1px 0 rgba(0, 0, 0, .2), 0 0 0 2px #fff inset;
           color: #333;
           display: inline-block;
           font-family: inherit;

--- a/scss/ui/partials/ui/onboarding/_ngonboarding.scss
+++ b/scss/ui/partials/ui/onboarding/_ngonboarding.scss
@@ -1,10 +1,8 @@
 .onboarding-popover {
-  // sass-lint:disable no-vendor-prefixes
-  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, .2);
+  @include box-shadow(0 5px 10px rgba(0, 0, 0, .2));
   background-clip: padding-box;
   background-color: #fff;
   border-radius: 4px;
-  box-shadow: 0 5px 10px rgba(0, 0, 0, .2);
   max-height: 800px;
   max-width: 800px;
   min-height: 50px;


### PR DESCRIPTION
We used them in many places, but not all.

To check this, I compared resulting `combined.css` build results, with the following diff:

```
@@ -9515,12 +9515,14 @@
 }
 
 .slick-grid.editable .slick-cell.editable input.editor-text {
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   background: transparent;
   border: 0;
-  box-shadow: none;
   height: 100%;
   width: 100%;
 }
@@ -10969,8 +10971,10 @@
   -moz-transition: border 500ms ease;
   -o-transition: border 500ms ease;
   transition: border 500ms ease;
-  border-color: #72b2ff;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+  -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+  border-color: #72b2ff;
 }
 
 .insetshadowed {
@@ -11561,9 +11565,11 @@
 
 button.btn-invisible,
 button.btn-invisible[disabled] {
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
   background: transparent;
   border: 1px solid transparent;
-  box-shadow: none;
   padding: 0;
 }
 
@@ -11629,8 +11635,10 @@
 
 .column-manager-container input:focus,
 .column-manager-container input[type='text']:focus {
-  border-color: #272b30;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
   box-shadow: none;
+  border-color: #272b30;
   outline: none;
 }
 
@@ -12025,6 +12033,8 @@
 }
 
 .filterform .ng-dirty.ng-invalid:focus {
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px #888 !important;
+  -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px #888 !important;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px #888 !important;
 }
 
@@ -12365,10 +12375,12 @@
 }
 
 .controls-help .control-column .control-section .control-line .control-key {
+  -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #fff inset;
+  -moz-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #fff inset;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #fff inset;
   background-color: #f7f7f7;
   border: 1px solid #ccc;
   border-radius: 3px;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #fff inset;
   color: #333;
   display: inline-block;
   font-family: inherit;
@@ -12457,10 +12469,11 @@
 
 .onboarding-popover {
   -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
   background-clip: padding-box;
   background-color: #fff;
   border-radius: 4px;
-  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
   max-height: 800px;
   max-width: 800px;
   min-height: 50px;
@@ -14704,8 +14717,10 @@
 }
 
 .modal-borderless {
-  border: 1px solid transparent;
+  -webkit-box-shadow: transparent 0 3px 7px 0;
+  -moz-box-shadow: transparent 0 3px 7px 0;
   box-shadow: transparent 0 3px 7px 0;
+  border: 1px solid transparent;
 }
 
 .modal-body {
@@ -15100,8 +15115,10 @@
 }
 
 .btn-group.open .btn.dropdown-toggle {
-  background-color: #3a3e41;
+  -webkit-box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.05);
+  -moz-box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.05);
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.05);
+  background-color: #3a3e41;
 }
 
 .dropdown-menu {
@@ -17431,6 +17448,8 @@
 }
 
 .ng-dirty.ng-invalid:focus {
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px #888 !important;
+  -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px #888 !important;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px #888 !important;
 }
```

I think that shows we're now providing vendor fallbacks consistently. The few changes in order are associated with mixins coming before overrides.