### PR TITLE
feat(tilelayer): added support for setting the tile class

### DIFF
--- a/src/os/layer/config/abstracttilelayerconfig.js
+++ b/src/os/layer/config/abstracttilelayerconfig.js
@@ -1,6 +1,7 @@
 goog.provide('os.layer.config.AbstractTileLayerConfig');
 
 goog.require('goog.log');
+goog.require('os.TileClass');
 goog.require('os.layer.Tile');
 goog.require('os.layer.config.AbstractLayerConfig');
 goog.require('os.map');
@@ -39,10 +40,16 @@ os.layer.config.AbstractTileLayerConfig = function() {
   this.crossOrigin = null;
 
   /**
-   * @type {?Function}
+   * @type {!Function}
    * @protected
    */
-  this.tileClass = null;
+  this.layerClass = os.layer.Tile;
+
+  /**
+   * @type {!os.TileClass}
+   * @protected
+   */
+  this.tileClass = os.tile.ColorableTile;
 
   /**
    * List of URLs for load balancing.
@@ -131,7 +138,8 @@ os.layer.config.AbstractTileLayerConfig.prototype.initializeConfig = function(op
     options['crossOrigin'] = null;
   }
   // tile class
-  this.tileClass = /** @type {Function} */ (options['tileClass']) || os.layer.Tile;
+  this.layerClass = /** @type {Function} */ (options['layerClass']) || this.layerClass;
+  this.tileClass = /** @type {os.TileClass} */ (options['tileClass']) || this.tileClass;
 };
 
 
@@ -143,9 +151,8 @@ os.layer.config.AbstractTileLayerConfig.prototype.createLayer = function(options
 
   var source = this.getSource(options);
 
-  if (os.implements(source, os.source.IFilterableTileSource.ID)) {
-    // make it use the colorable
-    source.setTileClass(os.tile.ColorableTile);
+  if (this.tileClass && os.implements(source, os.source.IFilterableTileSource.ID)) {
+    source.setTileClass(this.tileClass);
   }
 
   // The extent is set on the source and not the layer in order to properly support wrap-x.
@@ -183,7 +190,7 @@ os.layer.config.AbstractTileLayerConfig.prototype.createLayer = function(options
     source: source
   });
 
-  var tileLayer = new this.tileClass(tileImageOptions);
+  var tileLayer = new this.layerClass(tileImageOptions);
   this.configureLayer(tileLayer, options);
   tileLayer.restore(options);
   return tileLayer;

--- a/src/os/mixin/tileimagemixin.js
+++ b/src/os/mixin/tileimagemixin.js
@@ -10,6 +10,7 @@ goog.provide('os.mixin.TileImage');
 goog.require('ol.TileState');
 goog.require('ol.source.TileImage');
 goog.require('os');
+goog.require('os.TileClass');
 goog.require('os.source.IFilterableTileSource');
 goog.require('os.tile');
 goog.require('os.tile.ColorableTile');
@@ -90,7 +91,7 @@ ol.source.TileImage.prototype.applyTileFilters = function() {
 
 /**
  * Sets the tileClass.
- * @param {function(new: ol.ImageTile, ol.TileCoord, ol.TileState, string, ?string, ol.TileLoadFunctionType)} clazz
+ * @param {!os.TileClass} clazz The tile class
  */
 ol.source.TileImage.prototype.setTileClass = function(clazz) {
   this.tileClass = clazz;

--- a/src/os/tileclass.js
+++ b/src/os/tileclass.js
@@ -1,0 +1,8 @@
+goog.provide('os.TileClass');
+
+/**
+ * @typedef {function(new: ol.ImageTile, ol.TileCoord, ol.TileState, string, ?string, ol.TileLoadFunctionType, olx.TileOptions=)}
+ */
+os.TileClass;
+
+

--- a/src/plugin/arc/layer/arctilelayerconfig.js
+++ b/src/plugin/arc/layer/arctilelayerconfig.js
@@ -29,7 +29,7 @@ plugin.arc.layer.ArcTileLayerConfig.ID = 'arctile';
  */
 plugin.arc.layer.ArcTileLayerConfig.prototype.initializeConfig = function(options) {
   plugin.arc.layer.ArcTileLayerConfig.base(this, 'initializeConfig', options);
-  this.tileClass = options['animate'] ? plugin.arc.layer.AnimatedArcTile : this.tileClass;
+  this.layerClass = options['animate'] ? plugin.arc.layer.AnimatedArcTile : this.layerClass;
 };
 
 

--- a/src/plugin/basemap/basemapconfig.js
+++ b/src/plugin/basemap/basemapconfig.js
@@ -47,7 +47,7 @@ goog.inherits(plugin.basemap.BaseMapConfig, os.layer.config.AbstractLayerConfig)
  */
 plugin.basemap.BaseMapConfig.prototype.createLayer = function(options) {
   var clonedOptions = goog.object.clone(options);
-  clonedOptions['tileClass'] = plugin.basemap.layer.BaseMap;
+  clonedOptions['layerClass'] = plugin.basemap.layer.BaseMap;
 
   var layerType = /** @type {string} */ (clonedOptions['baseType']);
   var layerConfig = os.layer.config.LayerConfigManager.getInstance().getLayerConfig(layerType);

--- a/src/plugin/ogc/wms/wmslayerconfig.js
+++ b/src/plugin/ogc/wms/wmslayerconfig.js
@@ -79,7 +79,7 @@ goog.inherits(plugin.ogc.wms.WMSLayerConfig, os.layer.config.AbstractTileLayerCo
  */
 plugin.ogc.wms.WMSLayerConfig.prototype.initializeConfig = function(options) {
   plugin.ogc.wms.WMSLayerConfig.base(this, 'initializeConfig', options);
-  this.tileClass = options['animate'] ? os.layer.AnimatedTile : this.tileClass;
+  this.layerClass = options['animate'] ? os.layer.AnimatedTile : this.layerClass;
 };
 
 


### PR DESCRIPTION
Moved the misnamed `tileClass` to `layerClass` and added `tileClass` for actually setting the tile class on the source.

BREAKING CHANGE: `confg['tileClass']` -> `config['layerClass']`