### PR TITLE
Ensure features in os.source.Vector have an id.

### DIFF
--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -1783,6 +1783,12 @@ os.source.Vector.prototype.processFeatures = function(features) {
  * @suppress {accessControls} To allow direct access to feature metadata.
  */
 os.source.Vector.prototype.processImmediate = function(feature) {
+  // slickgrid, 3D renderers, and other things depend on features having a unique id. ensure they have one if not
+  // already set.
+  if (feature.id_ === undefined) {
+    feature.setId(ol.getUid(feature));
+  }
+
   // all features are initially visible
   var featureId = /** @type {string} */ (feature.id_);
   this.shownRecordMap[featureId] = true;

--- a/test/os/source/vectorsource.test.js
+++ b/test/os/source/vectorsource.test.js
@@ -131,6 +131,17 @@ describe('os.source.Vector', function() {
     });
   });
 
+  it('should ensure added features have a feature id', function() {
+    var feature = new ol.Feature(new ol.geom.Point([0, 0]));
+    expect(feature.getId()).toBeUndefined();
+
+    source.addFeature(feature);
+    expect(feature.getId()).toBeDefined();
+
+    source.removeFeature(feature);
+    source.unprocessNow();
+  });
+
   it('should select a single feature in the source', function() {
     var feature = features[0];
     expect(source.select(feature)).toBe(true);


### PR DESCRIPTION
Features without an id will run into a few issues, namely that they won't be converted/rendered to Cesium. This ensures all features added to an OS vector source have an id.