### PR TITLE
feat(olcs): Cesium now uses our request stack

### DIFF
--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -75,6 +75,12 @@ Cesium.Deferred = function() {};
  */
 Cesium.Deferred.prototype.resolve = function(value) {};
 
+/**
+ * Resolver for a deferred.
+ * @param {*=} opt_reason
+ */
+Cesium.Deferred.prototype.reject = function(opt_reason) {};
+
 
 /**
  * @type {Cesium.Promise}
@@ -92,6 +98,15 @@ Cesium.Deferred.prototype.promise;
  */
 Cesium.RequestOptions;
 
+/**
+ * @typedef {{
+ *  url: (string|undefined),
+ *  queryParameters: (Object<string, string>|undefined),
+ *  templateValues: (Object<string, *>|undefined),
+ *  headers: (Object<string, string>|undefined),
+ * }}
+ */
+Cesium.ResourceFetchOptions;
 
 /**
  * @param {Cesium.RequestOptions=} opt_options


### PR DESCRIPTION
Note that this does not fully replace Cesium's request stack, but merely only the portions that we are using. We already have a replacement for image loads such as tiles and icons. This allows terrain (loaded as JSON) to follow a similar path.

Pros:
- Terrain requests and other local JSON loads from Cesium no longer need to do the extra one-off of adding third party domains to the `TrustedServers` class in Cesium, as that will be taken care of by the crossOrigin registry in `os.net`.
- Custom request handlers added by plugins will no longer be bypassed by requests originating from Cesium

Cons (maybe?):
- Not a full implementation of Cesium's request stack (most notably we are not doing anything with `options.request` and `RequestScheduler`)