### PR TITLE
Move require to a preload script in opensphere-electron.

### DIFF
--- a/src/electron/electronvendorpre.js
+++ b/src/electron/electronvendorpre.js
@@ -5,7 +5,4 @@ if (navigator.userAgent.toLowerCase().indexOf(' electron/') > -1) {
     window.module = module;
     module = undefined;
   }
-
-  // allow the file:// protocol to be used by the fetch API
-  require('electron').webFrame.registerURLSchemeAsPrivileged('file');
 }


### PR DESCRIPTION
Moved to support disabling `nodeIntegration` in the main BrowserWindow in Electron, per guidance in the [Electron security tutorial](https://electronjs.org/docs/tutorial/security#2-disable-nodejs-integration-for-remote-content).

More details in ngageoint/opensphere-electron#2.

