### PR TITLE
Use a typedef instead of a class for osx.ChecklistItem

### DIFF
--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -201,47 +201,16 @@ osx.legend.LegendOptions;
 osx.legend.PluginOptions;
 
 
-
 /**
- * Item to display in the checklist directive.
- * @constructor
+ * @typedef {{
+ *   enabled: boolean,
+ *   item: *,
+ *   label: string,
+ *   detailText: (string|undefined),
+ *   tooltip: (string|undefined)
+ * }}
  */
-osx.ChecklistItem = function() {};
-
-
-/**
- * If the item is enabled.
- * @type {boolean}
- */
-osx.ChecklistItem.prototype.enabled;
-
-
-/**
- * Data the item maps back to.
- * @type {*}
- */
-osx.ChecklistItem.prototype.item;
-
-
-/**
- * The primary label used for sorting the checklist.
- * @type {string}
- */
-osx.ChecklistItem.prototype.label;
-
-
-/**
- * Displayed next to the label.
- * @type {string}
- */
-osx.ChecklistItem.prototype.detailText;
-
-
-/**
- * Tooltip to display on hover.
- * @type {string}
- */
-osx.ChecklistItem.prototype.tooltip;
+osx.ChecklistItem;
 
 
 /**

--- a/src/os/ui/ex/exportoptions.js
+++ b/src/os/ui/ex/exportoptions.js
@@ -144,11 +144,11 @@ os.ui.ex.ExportOptionsCtrl.prototype.disposeInternal = function() {
  * @private
  */
 os.ui.ex.ExportOptionsCtrl.prototype.createChecklistItem_ = function(source, opt_enabled) {
-  return /** @type {!osx.ChecklistItem} */ ({
+  return {
     enabled: goog.isDef(opt_enabled) ? opt_enabled : false,
     label: source.getTitle(),
     item: source
-  });
+  };
 };
 
 

--- a/src/os/ui/state/statelist.js
+++ b/src/os/ui/state/statelist.js
@@ -97,11 +97,11 @@ os.ui.state.StateListCtrl.prototype.destroy_ = function() {
  * @private
  */
 os.ui.state.StateListCtrl.prototype.createChecklistItem_ = function(descriptor, opt_enabled) {
-  return /** @type {!osx.ChecklistItem} */ ({
+  return {
     enabled: goog.isDef(opt_enabled) ? opt_enabled : false,
     label: descriptor.getTitle(),
     item: descriptor
-  });
+  };
 };
 
 


### PR DESCRIPTION
This is more accurate, and allows removing some type casts.

These type casts hit a bug in [`recast`](https://github.com/benjamn/recast), which affects the Closure Library refactor. They're the only two lines that hit it, so I'm fixing them to avoid the problem.