### PR TITLE
fix(externs): Allow osx.ChecklistItem values to be null.

### DIFF
--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -205,9 +205,9 @@ osx.legend.PluginOptions;
  * @typedef {{
  *   enabled: boolean,
  *   item: *,
- *   label: string,
- *   detailText: (string|undefined),
- *   tooltip: (string|undefined)
+ *   label: (string|null|undefined),
+ *   detailText: (string|null|undefined),
+ *   tooltip: (string|null|undefined)
  * }}
  */
 osx.ChecklistItem;


### PR DESCRIPTION
Fixes errors when building with external plugins that use `statelist.js`.