### PR TITLE
docs(rtd): make line highlight show up better

### DIFF
--- a/docs/_static/css/overrides.css
+++ b/docs/_static/css/overrides.css
@@ -1,0 +1,4 @@
+/* make line highlight visible against new highlight div background */
+.highlight .hll {
+  background-color: #ddeebb;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,9 @@ pygments_style = 'sphinx'
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
+# Copy our static files
+html_static_path = ['_static']
+
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
@@ -82,3 +85,6 @@ man_pages = [
     (master_doc, 'opensphere', u'OpenSphere Documentation',
      [author], 1)
 ]
+
+def setup(app):
+    app.add_stylesheet('css/overrides.css')


### PR DESCRIPTION
The most recent updates to the Sphinx RTD Theme have an issue where the line highlight does not show up well against the code background.

This adds an `overrides.css` file that we can use for fixing that and other minor things like it.