### PR TITLE
fix(cesium): Cesium was not redrawing on map resize

### DIFF
--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -423,6 +423,7 @@ os.MapContainer.prototype.updateSize = function() {
     }, this);
 
     this.map_.setSize([0, 0]);
+    os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
   }
 };
 


### PR DESCRIPTION
This was only occurring on Timeline close as far as I could tell. Browser resize and Timeline open were both redrawing correctly.