### PR TITLE
fix(cesium): move override lower in Cesium stack

### DIFF
--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -3040,7 +3040,17 @@ Cesium.ImageryProvider.prototype.requestImage = function(x, y, level) {};
  */
 Cesium.ImageryProvider.loadImage = function(imageryProvider, url) {};
 
-Cesium.Resource = {};
+/**
+ * @constructor
+ */
+Cesium.Resource = function() {};
+
+/**
+ * @param {Cesium.ResourceFetchOptions} options
+ * @return {Cesium.Promise<*>}
+ */
+Cesium.Resource.prototype._makeRequest = function(options) {};
+
 Cesium.Resource._Implementations = {};
 
 /**
@@ -5053,3 +5063,10 @@ Cesium.EntityView.prototype.update = function(currentTime, bs) {};
  * @constructor
  */
 Cesium.CallbackProperty = function(cb, constant) {};
+
+
+/**
+ * @param {{requestVertexNormals: (boolean|undefined), requestWaterMask: (boolean|undefined)}} options
+ * @return {!Cesium.CesiumTerrainProvider}
+ */
+Cesium.createWorldTerrain = function(options) {};

--- a/src/plugin/cesium/mixin/cesiummixin.js
+++ b/src/plugin/cesium/mixin/cesiummixin.js
@@ -58,7 +58,7 @@ plugin.cesium.mixin.loadCesiumMixins = function() {
    * @param {Cesium.ResourceFetchOptions} options
    * @return {Cesium.Promise<*>}
    */
-  Cesium.Resource.prototype.fetch = function(options) {
+  Cesium.Resource.prototype._makeRequest = function(options) {
     var req = new os.net.Request(options.url || this.url);
     var headers = options.headers || this.headers;
 


### PR DESCRIPTION
Cesium extensions to `Resource` tend to override `_makeRequest` rather than `fetch`. This move allows those items (like `IonResource`) to still have their extension logic run before the request is made, rather than being completely bypassed by mixing in at `fetch`.

You can test this with STK Terrain in Cesium.