### PR TITLE
feat(layer): GOTO is now supported for tile layers

### DIFF
--- a/src/os/layer/tile.js
+++ b/src/os/layer/tile.js
@@ -747,6 +747,13 @@ os.layer.Tile.prototype.getGroupUI = function() {
 os.layer.Tile.prototype.supportsAction = function(type, opt_actionArgs) {
   if (os.action) {
     switch (type) {
+      case os.action.EventType.GOTO:
+        var projExtent = os.map.PROJECTION.getExtent();
+        var layerExtent = os.fn.reduceExtentFromLayers(/** @type {!ol.Extent} */ (ol.extent.createEmpty()), this);
+        var projArea = ol.extent.getArea(projExtent);
+        var layerArea = ol.extent.getArea(layerExtent);
+        return !ol.extent.isEmpty(layerExtent) && ol.extent.containsExtent(projExtent, layerExtent) &&
+            layerArea / projArea < 0.8;
       case os.action.EventType.IDENTIFY:
       case os.action.EventType.REFRESH:
       case os.action.EventType.SHOW_DESCRIPTION:

--- a/src/os/layer/tile.js
+++ b/src/os/layer/tile.js
@@ -752,8 +752,7 @@ os.layer.Tile.prototype.supportsAction = function(type, opt_actionArgs) {
         var layerExtent = os.fn.reduceExtentFromLayers(/** @type {!ol.Extent} */ (ol.extent.createEmpty()), this);
         var projArea = ol.extent.getArea(projExtent);
         var layerArea = ol.extent.getArea(layerExtent);
-        return !ol.extent.isEmpty(layerExtent) && ol.extent.containsExtent(projExtent, layerExtent) &&
-            layerArea / projArea < 0.8;
+        return !ol.extent.isEmpty(layerExtent) && layerArea / projArea < 0.8;
       case os.action.EventType.IDENTIFY:
       case os.action.EventType.REFRESH:
       case os.action.EventType.SHOW_DESCRIPTION:


### PR DESCRIPTION
Go To is now enabled for Tile layers which have a reduceable extent which is contained by the overall projection extent and is less than 80% of the overall projection extent area.

... and it just occurred to me that this probably fails for extents crossing the anti-meridan.