### PR TITLE
fix(data): keep layerIds populated permanently

### DIFF
--- a/src/os/data/layersyncdescriptor.js
+++ b/src/os/data/layersyncdescriptor.js
@@ -108,7 +108,7 @@ os.data.LayerSyncDescriptor.prototype.getLayers = function() {
 
 
 /**
- * @param {Array<Object<string, *>>} opt_options
+ * @param {Array<Object<string, *>>=} opt_options
  */
 os.data.LayerSyncDescriptor.prototype.populateLayerIds = function(opt_options) {
   this.layerIds = (opt_options || this.getOptions()).map(os.data.LayerSyncDescriptor.mapLayerIds_);


### PR DESCRIPTION
This fixes descriptors not showing as enabled for layers automatically added during a projection switch (or any other process which relies on the descriptor enabling itself through layer listeners).