### PR TITLE
fix(wizard): Checked for null case in destroy function

### DIFF
--- a/src/os/ui/wiz/step/abstractwizardstep.js
+++ b/src/os/ui/wiz/step/abstractwizardstep.js
@@ -139,7 +139,7 @@ os.ui.wiz.step.AbstractWizardStep.prototype.activate = function(config, opt_scop
  * @inheritDoc
  */
 os.ui.wiz.step.AbstractWizardStep.prototype.deactivate = function(config) {
-  if (config) {
+  if (config != undefined) {
     this.finalize(config);
   }
 

--- a/src/os/ui/wiz/step/abstractwizardstep.js
+++ b/src/os/ui/wiz/step/abstractwizardstep.js
@@ -139,7 +139,9 @@ os.ui.wiz.step.AbstractWizardStep.prototype.activate = function(config, opt_scop
  * @inheritDoc
  */
 os.ui.wiz.step.AbstractWizardStep.prototype.deactivate = function(config) {
-  this.finalize(config);
+  if (config) {
+    this.finalize(config);
+  }
 
   if (this.scope) {
     delete this.scope['step'];

--- a/src/os/ui/wiz/wizard.js
+++ b/src/os/ui/wiz/wizard.js
@@ -120,7 +120,7 @@ os.ui.wiz.WizardCtrl = function($scope, $element, $timeout, $attrs) {
  */
 os.ui.wiz.WizardCtrl.prototype.destroy_ = function() {
   var step = this['steps'][this['activeIndex']];
-  if (!step.isDeactivated() && this.config) {
+  if (!step.isDeactivated()) {
     step.deactivate(this.config);
   }
 

--- a/src/os/ui/wiz/wizard.js
+++ b/src/os/ui/wiz/wizard.js
@@ -120,7 +120,7 @@ os.ui.wiz.WizardCtrl = function($scope, $element, $timeout, $attrs) {
  */
 os.ui.wiz.WizardCtrl.prototype.destroy_ = function() {
   var step = this['steps'][this['activeIndex']];
-  if (!step.isDeactivated()) {
+  if (!step.isDeactivated() && this.config) {
     step.deactivate(this.config);
   }
 


### PR DESCRIPTION
I think that all that was needed for this was just to check if config is null in the destroy function.

Resolves #263