### PR TITLE
feat(terrain): Support Cesium Ion terrain.

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -89,15 +89,6 @@
             "tileSize": 256,
             "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide. The map includes 15m TerraColor imagery at small and mid-scales (591M down to 72k) and 2.5m SPOT Imagery (288k to 72k) for the world, and USGS 15m Landsat imagery for Antarctica. The map features 0.3m resolution imagery in the continental United States and 0.6m resolution imagery in parts of Western Europe from Digital Globe. Recent 1m USDA NAIP imagery is available in select states of the US. In other parts of the world, 1 meter resolution imagery is available from GeoEye IKONOS, AeroGRID, and IGN Spain. Additionally, imagery at different resolutions has been contributed by the GIS User Community. For more information on this map, including the terms of use, visit us online at http://goto.arcgisonline.com/maps/World_Imagery\n\nSource: Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, AeroGRID, IGN, and the GIS User Community",
             "attributions": ["Esri", "DigitalGlobe", "GeoEye", "Earthstar Geographics", "CNES/Airbus DS", "USDA", "USGS", "AeroGRID", "IGN", "the GIS User Community"]
-          },
-          "terrain": {
-            "baseType": "cesium",
-            "description": "3D terrain provided for Cesium by AGI",
-            "options": {
-              "url": "//assets.agi.com/stk-terrain/world"
-            },
-            "provider": "AGI",
-            "type": "Terrain"
           }
         }
       },

--- a/docs/guides/settings_guide.rst
+++ b/docs/guides/settings_guide.rst
@@ -253,3 +253,97 @@ However, for the overly paranoid:
       }
     }
   }
+
+terrain
+-------
+``admin.providers.basemap.maps.terrain``
+
+OpenSphere supports a number of terrain formats out of the box, and more can be added via plugins. By default, the following are supported:
+
+* STK Terrain Server
+* WMS Tiles (``image/bil`` only)
+* `Cesium World Terrain`_ (requires a `Cesium Ion`_ access token)
+
+Enabling terrain in OpenSphere requires adding a basemap provider to settings with the requisite configuration for the terrain provider type. All providers should set ``"type": "Terrain"`` to identify it as a terrain server, and set ``baseType`` to one of ``cesium``, ``wms``, or ``cesium-ion``. Examples of configuring each are as follows.
+
+STK Terrain Server
+******************
+
+.. code-block:: json
+
+  {
+    "admin": {
+      "providers": {
+        "basemap": {
+          "maps": {
+            "terrain": {
+              "type": "Terrain",
+              "baseType": "cesium",
+              "options": {
+                "url": "<server url>"
+              },
+            }
+          }
+        }
+      }
+    }
+  }
+
+WMS Tiles
+******************
+
+.. code-block:: json
+
+  {
+    "admin": {
+      "providers": {
+        "basemap": {
+          "maps": {
+            "terrain": {
+              "type": "Terrain",
+              "baseType": "wms",
+              "options": {
+                "url": "<server url>"
+              },
+            }
+          }
+        }
+      }
+    }
+  }
+
+Cesium World Terrain
+********************
+
+A `Cesium Ion`_ account is required to use Cesium World Terrain. After signing in to an Ion account:
+
+1. Select a Cesium World Terrain asset from My Assets.
+2. Set the ``options.assetId`` value to the asset ID (displayed in the code example).
+3. Navigate to Access Tokens.
+4. Set the ``options.accessToken`` value to a token with read access for the terrain asset.
+
+Example:
+
+.. code-block:: javascript
+
+  {
+    "admin": {
+      "providers": {
+        "basemap": {
+          "maps": {
+            "terrain": {
+              "type": "Terrain",
+              "baseType": "cesium-ion",
+              "options": {
+                "accessToken": "<ion access token>",
+                "assetId": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+.. _Cesium World Terrain: https://cesium.com/content/cesium-world-terrain/
+.. _Cesium Ion: https://cesium.com/ion/

--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -4787,7 +4787,7 @@ Cesium.ArcGisImageServerTerrainProvider = function(options) {};
 
 /**
  * @typedef {{
- *   url: string,
+ *   url: (Cesium.Resource|string),
  *   credit: (Cesium.Credit|string|undefined),
  *   ellipsoid: (Cesium.Ellipsoid|undefined),
  *   proxy: (Object|undefined),
@@ -5072,7 +5072,43 @@ Cesium.CallbackProperty = function(cb, constant) {};
 
 
 /**
+ * @typedef {{
+ *   accessToken: (string|undefined),
+ *   assetId: (number|undefined)
+ * }}
+ */
+Cesium.WorldTerrainOptions;
+
+
+/**
  * @param {{requestVertexNormals: (boolean|undefined), requestWaterMask: (boolean|undefined)}} options
  * @return {!Cesium.CesiumTerrainProvider}
  */
 Cesium.createWorldTerrain = function(options) {};
+
+
+/**
+ * @typedef {{
+ *   accessToken: (string|undefined),
+ *   server: (Cesium.Resource|string|undefined)
+ * }}
+ */
+Cesium.AssetOptions;
+
+
+/**
+ * @param {Object} endpoint The result of the Cesium ion asset endpoint service.
+ * @param {Cesium.Resource} resource The resource used to retreive the endpoint.
+ * @extends {Cesium.Resource}
+ * @constructor
+ */
+Cesium.IonResource = function(endpoint, resource) {};
+
+
+/**
+ * Create a Cesium Ion resource from an asset id.
+ * @param {number} assetId The asset id.
+ * @param {Cesium.AssetOptions} options The asset options.
+ * @return {Cesium.IonResource}
+ */
+Cesium.IonResource.fromAssetId = function(assetId, options) {};

--- a/src/os/config/displaysettings.js
+++ b/src/os/config/displaysettings.js
@@ -65,7 +65,7 @@ os.config.DisplaySetting = {
 os.config.isTerrainConfigured = function() {
   var options = /** @type {osx.map.TerrainProviderOptions|undefined} */ (os.settings.get(
       os.config.DisplaySetting.TERRAIN_OPTIONS));
-  return !!(options && options.type && options.url);
+  return !!(options && options.type);
 };
 
 

--- a/src/os/webgl/abstractwebglrenderer.js
+++ b/src/os/webgl/abstractwebglrenderer.js
@@ -59,14 +59,6 @@ os.webgl.AbstractWebGLRenderer = function() {
   this.targetFrameRate = 60;
 
   /**
-   * The terrain provider options.
-   * @type {osx.map.TerrainProviderOptions|undefined}
-   * @protected
-   */
-  this.terrainOptions = /** @type {osx.map.TerrainProviderOptions|undefined} */ (os.settings.get(
-      os.config.DisplaySetting.TERRAIN_OPTIONS));
-
-  /**
    * Settings keys monitored by the map container.
    * @type {!Array<string>}
    * @protected
@@ -242,9 +234,6 @@ os.webgl.AbstractWebGLRenderer.prototype.onSettingChange = function(event) {
       }
       break;
     case os.config.DisplaySetting.TERRAIN_OPTIONS:
-      var options = /** @type {osx.map.TerrainProviderOptions|undefined} */ (event.newVal);
-      this.terrainOptions = options;
-
       if (this.getEnabled()) {
         this.updateTerrainProvider();
       }
@@ -300,7 +289,6 @@ os.webgl.AbstractWebGLRenderer.prototype.showSunlight = function(value) {
  */
 os.webgl.AbstractWebGLRenderer.prototype.disableTerrain = function() {
   // disable the terrain provider and switch to the default
-  this.terrainOptions = undefined;
   os.settings.set(os.config.DisplaySetting.ENABLE_TERRAIN, false);
 
   // notify that terrain has been disabled

--- a/src/plugin/basemap/basemapprovider.js
+++ b/src/plugin/basemap/basemapprovider.js
@@ -174,12 +174,10 @@ plugin.basemap.BaseMapProvider.prototype.addBaseMapFromConfig = function(config)
 
           // if multiple terrain descriptors are configured, the last one will win
           var terrainOptions = /** @type {osx.map.TerrainProviderOptions|undefined} */ (conf['options']);
-          if (terrainOptions && terrainOptions.url) {
-            var terrainType = /** @type {string|undefined} */ (conf['baseType']);
-            if (terrainType) {
-              terrainOptions.type = terrainType;
-              os.settings.set(os.config.DisplaySetting.TERRAIN_OPTIONS, terrainOptions);
-            }
+          var terrainType = /** @type {string|undefined} */ (conf['baseType']);
+          if (terrainOptions && terrainType) {
+            terrainOptions.type = terrainType;
+            os.settings.set(os.config.DisplaySetting.TERRAIN_OPTIONS, terrainOptions);
           }
 
           // create a descriptor that will inform the user on where terrain was moved to

--- a/src/plugin/cesium/cesium.js
+++ b/src/plugin/cesium/cesium.js
@@ -13,11 +13,12 @@ goog.require('os.net');
 goog.require('os.proj');
 goog.require('os.string');
 goog.require('plugin.cesium.ImageryProvider');
+goog.require('plugin.cesium.WMSTerrainProvider');
 
 
 /**
  * Constructor for a Cesium terrain provider.
- * @typedef {function(new: Cesium.TerrainProvider, ...)}
+ * @typedef {function(...):Cesium.TerrainProvider}
  */
 plugin.cesium.TerrainProviderFn;
 
@@ -355,4 +356,39 @@ plugin.cesium.updateCesiumLayerProperties = function(olLayer, csLayer) {
   if (hue != null) {
     csLayer.hue = hue * Cesium.Math.RADIANS_PER_DEGREE;
   }
+};
+
+
+/**
+ * Create a Cesium terrain provider instance.
+ * @param {Cesium.CesiumTerrainProviderOptions} options The Cesium terrain options.
+ * @return {!Cesium.CesiumTerrainProvider}
+ */
+plugin.cesium.createCesiumTerrain = function(options) {
+  return new Cesium.CesiumTerrainProvider(options);
+};
+
+
+/**
+ * Create a Cesium World Terrain instance.
+ * @param {Cesium.WorldTerrainOptions} options The Cesium World Terrain options.
+ * @return {!Cesium.CesiumTerrainProvider}
+ */
+plugin.cesium.createWorldTerrain = function(options) {
+  var assetId = options.assetId != null ? options.assetId : 1;
+  return plugin.cesium.createCesiumTerrain({
+    url: Cesium.IonResource.fromAssetId(assetId, {
+      accessToken: options.accessToken
+    })
+  });
+};
+
+
+/**
+ * Create a Cesium WMS terrain provider instance.
+ * @param {!osx.cesium.WMSTerrainProviderOptions} options The WMS terrain options.
+ * @return {!plugin.cesium.WMSTerrainProvider}
+ */
+plugin.cesium.createWMSTerrain = function(options) {
+  return new plugin.cesium.WMSTerrainProvider(options);
 };

--- a/src/plugin/cesium/cesiumrenderer.js
+++ b/src/plugin/cesium/cesiumrenderer.js
@@ -435,27 +435,22 @@ plugin.cesium.CesiumRenderer.prototype.updateTerrainProvider = function() {
   // clean up existing provider
   this.removeTerrainProvider_();
 
-  if (this.terrainOptions) {
-    var terrainType = this.terrainOptions.type;
-    var terrainUrl = this.terrainOptions.url;
+  var terrainOptions = /** @type {osx.map.TerrainProviderOptions|undefined} */ (os.settings.get(
+      os.config.DisplaySetting.TERRAIN_OPTIONS));
+  if (terrainOptions) {
+    var terrainType = terrainOptions.type;
+    if (terrainType && terrainType in this.terrainProviderTypes_) {
+      if (terrainOptions.url) {
+        // instruct Cesium to trust terrain servers (controlled by app configuration)
+        plugin.cesium.addTrustedServer(terrainOptions.url);
+      }
 
-    if (terrainType && terrainType in this.terrainProviderTypes_ && terrainUrl) {
-      // instruct Cesium to trust terrain servers (controlled by app configuration)
-      plugin.cesium.addTrustedServer(terrainUrl);
-
-      this.terrainProvider_ = this.terrainProviderTypes_[terrainType](this.terrainOptions);
+      this.terrainProvider_ = this.terrainProviderTypes_[terrainType](terrainOptions);
       this.terrainProvider_.errorEvent.addEventListener(this.onTerrainError_, this);
-    } else {
-      // report any errors in the configuration
-      if (!terrainType) {
-        goog.log.error(this.log, 'Terrain provider type not configured.');
-      } else if (!(terrainType in this.terrainProviderTypes_)) {
-        goog.log.error(this.log, 'Unknown terrain provider type: ' + terrainType);
-      }
-
-      if (!terrainUrl) {
-        goog.log.error(this.log, 'Terrain provider URL not configured.');
-      }
+    } else if (!terrainType) {
+      goog.log.error(this.log, 'Terrain provider type not configured.');
+    } else if (!(terrainType in this.terrainProviderTypes_)) {
+      goog.log.error(this.log, 'Unknown terrain provider type: ' + terrainType);
     }
   }
 


### PR DESCRIPTION
Removes default terrain config, instead providing instructions on configuring terrain in RTD.

Resolves #229.