### PR TITLE
fix(file): Form file URI's correctly in Windows.

### DIFF
--- a/src/os/file/file.js
+++ b/src/os/file/file.js
@@ -4,6 +4,7 @@ goog.provide('os.file.File');
 goog.require('goog.async.Deferred');
 goog.require('goog.fs.FileReader');
 goog.require('goog.net.jsloader');
+goog.require('goog.userAgent');
 goog.require('os.IPersistable');
 goog.require('os.defines');
 goog.require('os.file.mime.zip');
@@ -366,7 +367,11 @@ os.file.createFromContent = function(fileName, url, originalFile, content) {
  * @return {string}
  */
 os.file.getFileUrl = function(path) {
-  return os.file.FileScheme.FILE + '://' + path;
+  if (goog.userAgent.WINDOWS) {
+    return os.file.FileScheme.FILE + ':///' + path.replace(/\\/g, '/');
+  } else {
+    return os.file.FileScheme.FILE + '://' + path;
+  }
 };
 
 

--- a/test/os/file/file.test.js
+++ b/test/os/file/file.test.js
@@ -19,6 +19,14 @@ describe('os.file.File', function() {
   it('gets file:// URLs from a path', function() {
     var path = '/path/to/some/file.xml';
     expect(os.file.getFileUrl(path)).toBe('file://' + path);
+
+    var isWin = goog.userAgent.WINDOWS;
+    goog.userAgent.WINDOWS = true;
+
+    var winPath = 'C:\\Program Files\\My File.xml';
+    expect(os.file.getFileUrl(winPath)).toBe('file:///C:/Program Files/My File.xml');
+
+    goog.userAgent.WINDOWS = isWin;
   });
 
   it('tests for file:// URLs', function() {


### PR DESCRIPTION
Fixes drag and drop in Windows when running in Electron.