### PR TITLE
refactor(audio): Remove 'None' from audio manager.

### DIFF
--- a/src/os/audio/audiomanager.js
+++ b/src/os/audio/audiomanager.js
@@ -32,10 +32,10 @@ os.audio.AudioManager = function() {
 
   /**
    * Set of sounds
-   * @type {Object<string, string>}
+   * @type {!Object<string, string>}
    * @private
    */
-  this.sounds_ = {'None': null};
+  this.sounds_ = {};
 
   /**
    * Cache of audio objects


### PR DESCRIPTION
BREAKING CHANGE: Code relying on the 'None' option from the audio manager will have to maintain that option locally.