### PR TITLE
build(index): Use local path instead of resolving self.

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ const sharedResources = [
     scripts: ['electronvendorpost.js']
   },
   {
-    source: resolver.resolveModulePath('opensphere/vendor/fonts/typeface-open-sans', __dirname),
+    source: 'vendor/fonts/typeface-open-sans',
     target: 'vendor/fonts/typeface-open-sans',
     files: ['files', 'index.css']
   }


### PR DESCRIPTION
Fixes builds that do not use a Yarn workspace and can't resolve opensphere as a module.