### PR TITLE
fix(query): Only layers affected by entry changes should load

### DIFF
--- a/src/os/ui/query/ui/combinator.js
+++ b/src/os/ui/query/ui/combinator.js
@@ -620,10 +620,8 @@ os.ui.query.ui.CombinatorCtrl.prototype.createEntriesFromTree = function() {
   var tree = this.getRoot();
 
   if (tree) {
-    var entries = this.getEntries_();
-    var newEntries = [];
-    os.ui.query.ui.CombinatorCtrl.parseEntries(tree, newEntries);
-    this.entries_ = os.ui.query.cmd.QueryEntries.merge(newEntries, entries, this.getLayerId_(os.ui.query.ALL_ID));
+    this.entries_ = [];
+    os.ui.query.ui.CombinatorCtrl.parseEntries(tree, this.entries_);
   }
 };
 


### PR DESCRIPTION
## Problem
* Load two queryable layers from WFS/Arc (service doesn't matter)
* Open the filter UI for one of the layers (the use case here is adding an attribute filter but it doesn't actually matter if you do)
* Hit Apply
  * Note that both layers reload rather than just the layer from the filter GUI

Previously, the `QueryEntriesCmd` would merge the new query entries into the set of all entries and always remove all and then add the merged set, which also re-adds the entries for other layers (causing the reload). Now we just remove the entries for the layerIds affected by the incoming entries. For the command revert, old entries are filtered from the full set. The non-merge case (all layer advanced view) still removes/adds all.