### PR TITLE
Fix Controls UI background and Missing Key Text

### DIFF
--- a/src/os/ui/help/controls.js
+++ b/src/os/ui/help/controls.js
@@ -92,7 +92,7 @@ os.ui.help.ControlsCtrl.launch = function() {
  */
 os.ui.help.ControlsCtrl.prototype.getKey = function(key) {
   if (key === goog.events.KeyCodes.META && os.isOSX()) {
-    return '';
+    return 'Command';
   }
 
   return goog.string.toTitleCase(goog.events.KeyNames[key]);

--- a/views/help/controls.html
+++ b/views/help/controls.html
@@ -1,4 +1,4 @@
-<div class="d-flex">
+<div class="d-flex modal-body">
   <div ng-repeat="(key, controlcolumn) in controlsHelp.controls" class="col-6">
     <div ng-repeat="control in controlcolumn" class="m-2">
       <div>


### PR DESCRIPTION
Referencing #184 fixed some of the issues regarding the Controls UI returning empty strings for the mac  Meta key. Added .modal-body to the root element so the background is no longer transparent.