### PR TITLE
fix(kml): miscellaneous ground overlay fixes

### DIFF
--- a/src/plugin/cesium/sync/imagesynchronizer.js
+++ b/src/plugin/cesium/sync/imagesynchronizer.js
@@ -56,6 +56,7 @@ plugin.cesium.sync.ImageSynchronizer.prototype.disposeInternal = function() {
 
 /**
  * @inheritDoc
+ * @suppress {accessControls}
  */
 plugin.cesium.sync.ImageSynchronizer.prototype.synchronize = function() {
   // remove the old KML image
@@ -72,14 +73,22 @@ plugin.cesium.sync.ImageSynchronizer.prototype.synchronize = function() {
   var img = /** @type {string} */ (this.layer.get('url'));
 
   if (img) {
-    var extent = this.layer.getExtent();
-    layers.addImageryProvider(new Cesium.SingleTileImageryProvider({
-      url: img,
-      rectangle: Cesium.Rectangle.fromDegrees(extent[0], extent[1], extent[2], extent[3])
-    }));
-    this.activeLayer_ = layers.get(layers.length - 1);
+    var source = this.layer.getSource();
+    var extent;
 
-    this.activeLayer_.imageryProvider.errorEvent.addEventListener(this.providerError.bind(this));
+    if (source instanceof ol.source.ImageStatic) {
+      extent = /** @type {ol.source.ImageStatic} */ (source).image_.getExtent();
+    }
+
+    if (extent && extent.length === 4 && !ol.extent.isEmpty(extent)) {
+      layers.addImageryProvider(new Cesium.SingleTileImageryProvider({
+        url: img,
+        rectangle: Cesium.Rectangle.fromDegrees(extent[0], extent[1], extent[2], extent[3])
+      }));
+      this.activeLayer_ = layers.get(layers.length - 1);
+
+      this.activeLayer_.imageryProvider.errorEvent.addEventListener(this.providerError.bind(this));
+    }
   }
 };
 

--- a/src/plugin/file/kml/kmlmenu.js
+++ b/src/plugin/file/kml/kmlmenu.js
@@ -187,7 +187,7 @@ plugin.file.kml.menu.onLayerEvent_ = function(event) {
           case plugin.file.kml.menu.EventType.GOTO:
             var extent = node.getExtent();
 
-            if (!ol.extent.isEmpty(extent)) {
+            if (extent && !ol.extent.isEmpty(extent)) {
               os.commandStack.addCommand(new os.command.FlyToExtent(extent));
             }
             break;

--- a/src/plugin/file/kml/kmlparser.js
+++ b/src/plugin/file/kml/kmlparser.js
@@ -1136,6 +1136,8 @@ plugin.file.kml.KMLParser.prototype.readGroundOverlay_ = function(el) {
       Math.max(west, east),
       Math.max(south, north)];
 
+    extent = ol.proj.transformExtent(extent, os.proj.EPSG4326, os.map.PROJECTION);
+
     var image = new os.layer.Image({
       source: new ol.source.ImageStatic({
         url: icon,

--- a/src/plugin/file/kml/ui/kmlnode.js
+++ b/src/plugin/file/kml/ui/kmlnode.js
@@ -386,9 +386,10 @@ plugin.file.kml.ui.KMLNode.prototype.getExtent = function() {
   var extent = null;
 
   if (this.image_) {
-    extent = this.image_.getExtent();
-    if (!extent) {
-      extent = null;
+    var source = this.image_.getSource();
+
+    if (source instanceof ol.source.ImageStatic) {
+      extent = /** @type {ol.source.ImageStatic} */ (source).image_.getExtent();
     }
   } else {
     var features = this.getFeatures();

--- a/src/plugin/file/kml/ui/kmlnode.js
+++ b/src/plugin/file/kml/ui/kmlnode.js
@@ -381,6 +381,7 @@ plugin.file.kml.ui.KMLNode.prototype.getOverlays = function(opt_unchecked) {
 
 /**
  * @inheritDoc
+ * @suppress {accessControls}
  */
 plugin.file.kml.ui.KMLNode.prototype.getExtent = function() {
   var extent = null;


### PR DESCRIPTION
This fixes a couple of bugs:

- Loading KMLs in 3D containing `GroundOverlay` was failing due to the `ImageSynchronizer` looking for the extent in the wrong place.
   - Solution: don't fail on missing extent, and also get the extent from the correct location.
- A similar solution was added to `KMLNode.prototype.getExtent` when reading image layers so that Go To works properly for `GroundOverlay` items
- When parsing `GroundOverlay`, reproject the extent from `EPSG:4326` to the application extent so that we at least make an attempt at going to the correct location and showing the image. Note that this probably needs some follow-on work to make it obey the more strict reprojection rules we have in place for other layers.