### PR TITLE
fix(layerZoomSpinner): Fixed typing a value into a spinner's input

### DIFF
--- a/src/os/ui/spinner.js
+++ b/src/os/ui/spinner.js
@@ -168,28 +168,37 @@ os.ui.SpinnerCtrl.prototype.onDisabledChange_ = function(opt_new, opt_old) {
  * @private
  */
 os.ui.SpinnerCtrl.prototype.onSpin_ = function(e, spinner) {
+  // jQuery UI manages the value between max and min so we don't need to
   this.killEvent_(e);
 
   var faceValue = goog.isDef(spinner['value']) ? spinner['value'] : this.spinner_.spinner('value');
-  var adjustedValue = goog.math.clamp(faceValue, this.scope_['min'], this.scope_['max']); // keep in valid range
-  if (adjustedValue != this.scope_['value'] || faceValue != adjustedValue) {
-    this.scope_['value'] = faceValue; // set to faceValue so UI can adjust
-    this.scope_.$emit(this.scope_['name'] + '.' + e.type, adjustedValue); // keep advertised value in range
-    os.ui.apply(this.scope_);
-  }
+  this.scope_['value'] = faceValue;
+  this.scope_.$emit(this.scope_['name'] + '.' + e.type, faceValue);
+  os.ui.apply(this.scope_);
 };
 
 
 /**
- * Handles the spinner change event for internal value changes (ie, min/max changed)
+ * Handles the spinner change event
  * @param {*} e The event
  * @param {*} spinner The spinner
  * @private
  */
 os.ui.SpinnerCtrl.prototype.onSpinnerChange_ = function(e, spinner) {
-  var value = goog.isDef(spinner['value']) ? spinner['value'] : this.spinner_.spinner('value');
-  if (value != this.scope_['value']) {
-    this.scope_['value'] = value;
+  var faceValue = goog.isDef(spinner['value']) ? spinner['value'] : this.spinner_.spinner('value');
+  if (!goog.isNumber(faceValue)) {
+    faceValue = this.scope_['value'];
+  }
+
+  var adjustedValue = goog.math.clamp(faceValue, this.scope_['min'], this.scope_['max']);
+  if (adjustedValue != this.scope_['value'] || faceValue != adjustedValue) {
+    this.scope_['value'] = adjustedValue;
+    this.scope_.$emit(this.scope_['name'] + '.' + e.type, adjustedValue);
     os.ui.apply(this.scope_);
+  }
+
+  // Ensure ui matches angular's scope
+  if (this.spinner_.spinner('value') != this.scope_['value']) {
+    this.spinner_.spinner('value', this.scope_['value']);
   }
 };

--- a/src/plugin/basemap/ui/basemaplayerui.js
+++ b/src/plugin/basemap/ui/basemaplayerui.js
@@ -42,7 +42,9 @@ plugin.basemap.ui.BaseMapLayerUICtrl = function($scope, $element, $timeout) {
   plugin.basemap.ui.BaseMapLayerUICtrl.base(this, 'constructor', $scope, $element, $timeout);
 
   $scope.$on('minZoom.spin', this.onMinZoomChange.bind(this));
+  $scope.$on('minZoom.spinchange', this.onMinZoomChange.bind(this));
   $scope.$on('maxZoom.spin', this.onMaxZoomChange.bind(this));
+  $scope.$on('maxZoom.spinchange', this.onMaxZoomChange.bind(this));
 
   this.refreshDelay = new goog.async.Delay(this.onRefresh, 1000, this);
 };


### PR DESCRIPTION
This fixes #302. You can now type a value into either spinner box to set the min/max zoom for the current layer(s). The change takes effect once the field looses focus. Values are clamped to the min and max for the field and non-numerical input is ignored.

Issues:
* "Current" buttons still set the layer zoom boundaries correctly but don't update the spinner's value anymore. This will need to be fixed but I'm not sure where I broke this binding.