### PR TITLE
fix(zoom): Replace hard coded map max/min with JS constant for zoom spinners

### DIFF
--- a/src/plugin/basemap/ui/basemaplayerui.js
+++ b/src/plugin/basemap/ui/basemaplayerui.js
@@ -1,7 +1,9 @@
 goog.provide('plugin.basemap.ui.BaseMapLayerUICtrl');
 goog.provide('plugin.basemap.ui.baseMapLayerUIDirective');
 goog.require('goog.async.Delay');
+goog.require('os.MapContainer');
 goog.require('os.defines');
+goog.require('os.map');
 goog.require('os.ui.Module');
 goog.require('os.ui.layer.TileLayerUICtrl');
 goog.require('os.ui.spinnerDirective');
@@ -45,6 +47,9 @@ plugin.basemap.ui.BaseMapLayerUICtrl = function($scope, $element, $timeout) {
   $scope.$on('minZoom.spinchange', this.onMinZoomChange.bind(this));
   $scope.$on('maxZoom.spin', this.onMaxZoomChange.bind(this));
   $scope.$on('maxZoom.spinchange', this.onMaxZoomChange.bind(this));
+
+  this['mapMinZoom'] = os.map.MIN_ZOOM;
+  this['mapMaxZoom'] = os.map.MAX_ZOOM;
 
   this.refreshDelay = new goog.async.Delay(this.onRefresh, 1000, this);
 };
@@ -152,7 +157,7 @@ plugin.basemap.ui.BaseMapLayerUICtrl.prototype.getMinZoom_ = function() {
     }
   }
 
-  return 2;
+  return os.map.MIN_ZOOM;
 };
 
 
@@ -177,7 +182,7 @@ plugin.basemap.ui.BaseMapLayerUICtrl.prototype.getMaxZoom_ = function() {
     }
   }
 
-  return 28;
+  return os.map.MAX_ZOOM;
 };
 
 

--- a/views/plugin/basemap/basemaplayerui.html
+++ b/views/plugin/basemap/basemaplayerui.html
@@ -53,7 +53,7 @@
         <tr title="Sets the minimum zoom level at which the layer will display">
           <td class="text-nowrap">Min Zoom:</td>
           <td class="w-100">
-            <spinner min="2" max="maxZoom" step="1" value="minZoom" name="minZoom"></spinner>
+            <spinner min="::basemap.mapMinZoom" max="maxZoom" step="1" value="minZoom" name="minZoom"></spinner>
           </td>
           <td>
             <button class="btn btn-secondary" ng-click="basemap.setCurrent('minZoom')" title="Sets the min zoom to the current zoom level">Current</button>
@@ -62,7 +62,7 @@
         <tr title="Sets the maximum zoom level at which the layer will display">
           <td class="text-nowrap">Max Zoom:</td>
           <td class="w-100">
-            <spinner min="minZoom" max="28" step="1" value="maxZoom" name="maxZoom"></spinner>
+            <spinner min="minZoom" max="::basemap.mapMaxZoom" step="1" value="maxZoom" name="maxZoom"></spinner>
           </td>
           <td>
             <button class="btn btn-secondary" ng-click="basemap.setCurrent('maxZoom')" title="Sets the max zoom to the current zoom level">Current</button>


### PR DESCRIPTION
* Replaced the hard coded min and max to use the constant already defined elsewhere
* Added extra `goog.require`s for extra needed requirements