### PR TITLE
fix(cesium): Use provided heading in Cesium camera's setHeading.

### DIFF
--- a/src/plugin/cesium/cesiumcamera.js
+++ b/src/plugin/cesium/cesiumcamera.js
@@ -163,7 +163,7 @@ plugin.cesium.Camera.prototype.setHeading = function(heading) {
   this.cam_.setView({
     destionation: carto,
     orientation: {
-      heading: 0,
+      heading: heading,
       pitch: this.cam_.pitch,
       roll: this.cam_.roll
     }


### PR DESCRIPTION
The Cesium camera `setHeading` call was ignoring the `heading` param, always setting heading to 0.