### PR TITLE
refactor(goog): Replace goog.exportProperty with @export.

### DIFF
--- a/conformance_config.textproto
+++ b/conformance_config.textproto
@@ -144,6 +144,14 @@ requirement: {
 
 #requirement: {
 #  type: BANNED_NAME
+#  value: 'goog.exportProperty'
+#  error_message: 'goog.exportProperty is not permitted. Use @export in the JSDoc '
+#                 'to prevent function renaming, or assign the property directly '
+#                 'for aliases.'
+#}
+
+#requirement: {
+#  type: BANNED_NAME
 #  value: 'goog.bind'
 #  error_message: 'goog.bind(func, args) is not permitted. Use func.bind(args) instead.'
 #}

--- a/src/os/bearing/bearingsettings.js
+++ b/src/os/bearing/bearingsettings.js
@@ -109,11 +109,10 @@ os.bearing.BearingSettingsCtrl.prototype.onBearingChange_ = function(event) {
  * Update and store setting.
  * @param {os.ui.location.Format=} opt_new
  * @param {os.ui.location.Format=} opt_old
+ * @export
  */
 os.bearing.BearingSettingsCtrl.prototype.update = function(opt_new, opt_old) {
   if (opt_new && opt_old && opt_new !== opt_old) {
     os.settings.set(os.bearing.BearingSettingsKeys.BEARING_TYPE, opt_new);
   }
 };
-goog.exportProperty(os.bearing.BearingSettingsCtrl.prototype, 'update',
-    os.bearing.BearingSettingsCtrl.prototype.update);

--- a/src/os/config/areasettings.js
+++ b/src/os/config/areasettings.js
@@ -240,7 +240,7 @@ os.config.AreaSettingsCtrl.prototype.confirm_ = function() {
 
 /**
  * Resets to the default colors
- * @protected
+ * @export
  */
 os.config.AreaSettingsCtrl.prototype.reset = function() {
   this['inColor'] = os.query.AreaManager.DEFAULT.IN_COLOR;
@@ -253,5 +253,3 @@ os.config.AreaSettingsCtrl.prototype.reset = function() {
   os.settings.set(os.query.AreaManager.KEYS.EX_WIDTH, os.query.AreaManager.DEFAULT.EX_WIDTH);
   this.confirm_();
 };
-goog.exportProperty(os.config.AreaSettingsCtrl.prototype,
-    'reset', os.config.AreaSettingsCtrl.prototype.reset);

--- a/src/os/config/displaysettings.js
+++ b/src/os/config/displaysettings.js
@@ -347,6 +347,7 @@ os.config.DisplaySettingsCtrl.prototype.updateCameraMode_ = function(opt_new, op
 
 /**
  * Set OpenSphere to use the current map position on reset.
+ * @export
  */
 os.config.DisplaySettingsCtrl.prototype.useCurrentPosition = function() {
   this['cameraState'] = os.MapContainer.getInstance().persistCameraState();
@@ -355,10 +356,6 @@ os.config.DisplaySettingsCtrl.prototype.useCurrentPosition = function() {
     this.updateSetting_(os.config.DisplaySetting.CAMERA_STATE, JSON.stringify(this['cameraState']));
   }
 };
-goog.exportProperty(
-    os.config.DisplaySettingsCtrl.prototype,
-    'useCurrentPosition',
-    os.config.DisplaySettingsCtrl.prototype.useCurrentPosition);
 
 
 /**
@@ -377,6 +374,7 @@ os.config.DisplaySettingsCtrl.prototype.useDefaultPosition_ = function() {
 /**
  * Set OpenSphere to use the current map position on reset.
  * @return {string}
+ * @export
  */
 os.config.DisplaySettingsCtrl.prototype.getZoom = function() {
   if (this['cameraState'] && this['cameraState'].altitude > 0) {
@@ -388,23 +386,16 @@ os.config.DisplaySettingsCtrl.prototype.getZoom = function() {
 
   return os.map.DEFAULT_ZOOM.toFixed(1);
 };
-goog.exportProperty(
-    os.config.DisplaySettingsCtrl.prototype,
-    'getZoom',
-    os.config.DisplaySettingsCtrl.prototype.getZoom);
 
 
 /**
  * Update the fog display.
+ * @export
  */
 os.config.DisplaySettingsCtrl.prototype.updateFog = function() {
   os.settings.set(os.config.DisplaySetting.FOG_ENABLED, this['fogEnabled']);
   os.settings.set(os.config.DisplaySetting.FOG_DENSITY, this['fogDensity']);
 };
-goog.exportProperty(
-    os.config.DisplaySettingsCtrl.prototype,
-    'updateFog',
-    os.config.DisplaySettingsCtrl.prototype.updateFog);
 
 
 /**
@@ -436,35 +427,26 @@ os.config.DisplaySettingsCtrl.prototype.onTerrainChange_ = function(event) {
 /**
  * If terrain is available in the application.
  * @return {boolean}
+ * @export
  */
 os.config.DisplaySettingsCtrl.prototype.supportsTerrain = function() {
   return os.config.isTerrainConfigured();
 };
-goog.exportProperty(
-    os.config.DisplaySettingsCtrl.prototype,
-    'supportsTerrain',
-    os.config.DisplaySettingsCtrl.prototype.supportsTerrain);
 
 
 /**
  * Update the globe sunlight display.
+ * @export
  */
 os.config.DisplaySettingsCtrl.prototype.updateSunlight = function() {
   this.updateSetting_(os.config.DisplaySetting.ENABLE_LIGHTING, this['sunlightEnabled']);
 };
-goog.exportProperty(
-    os.config.DisplaySettingsCtrl.prototype,
-    'updateSunlight',
-    os.config.DisplaySettingsCtrl.prototype.updateSunlight);
 
 
 /**
  * Update the globe terrain display.
+ * @export
  */
 os.config.DisplaySettingsCtrl.prototype.updateTerrain = function() {
   this.updateSetting_(os.config.DisplaySetting.ENABLE_TERRAIN, this['terrainEnabled']);
 };
-goog.exportProperty(
-    os.config.DisplaySettingsCtrl.prototype,
-    'updateTerrain',
-    os.config.DisplaySettingsCtrl.prototype.updateTerrain);

--- a/src/os/config/legendsettings.js
+++ b/src/os/config/legendsettings.js
@@ -234,32 +234,27 @@ os.config.LegendSettingsCtrl.prototype.onOpacityChange_ = function(newVal, oldVa
 /**
  * If the font size can be increased.
  * @return {boolean}
+ * @export
  */
 os.config.LegendSettingsCtrl.prototype.canIncreaseFontSize = function() {
   var sizes = os.config.LegendSettingsCtrl.FONT_SIZES;
   return sizes.indexOf(this['options']['fontSize']) < sizes.length - 1;
 };
-goog.exportProperty(
-    os.config.LegendSettingsCtrl.prototype,
-    'canIncreaseFontSize',
-    os.config.LegendSettingsCtrl.prototype.canIncreaseFontSize);
 
 
 /**
  * If the font size can be increased.
  * @return {boolean}
+ * @export
  */
 os.config.LegendSettingsCtrl.prototype.canDecreaseFontSize = function() {
   return os.config.LegendSettingsCtrl.FONT_SIZES.indexOf(this['options']['fontSize']) > 0;
 };
-goog.exportProperty(
-    os.config.LegendSettingsCtrl.prototype,
-    'canDecreaseFontSize',
-    os.config.LegendSettingsCtrl.prototype.canDecreaseFontSize);
 
 
 /**
  * Increases the font size used in the legend.
+ * @export
  */
 os.config.LegendSettingsCtrl.prototype.increaseFontSize = function() {
   var idx = os.config.LegendSettingsCtrl.FONT_SIZES.indexOf(this['options']['fontSize']);
@@ -269,14 +264,11 @@ os.config.LegendSettingsCtrl.prototype.increaseFontSize = function() {
     os.dispatcher.dispatchEvent(os.legend.EventType.UPDATE);
   }
 };
-goog.exportProperty(
-    os.config.LegendSettingsCtrl.prototype,
-    'increaseFontSize',
-    os.config.LegendSettingsCtrl.prototype.increaseFontSize);
 
 
 /**
  * Decreases the font size used in the legend.
+ * @export
  */
 os.config.LegendSettingsCtrl.prototype.decreaseFontSize = function() {
   var idx = os.config.LegendSettingsCtrl.FONT_SIZES.indexOf(this['options']['fontSize']);
@@ -286,35 +278,25 @@ os.config.LegendSettingsCtrl.prototype.decreaseFontSize = function() {
     os.dispatcher.dispatchEvent(os.legend.EventType.UPDATE);
   }
 };
-goog.exportProperty(
-    os.config.LegendSettingsCtrl.prototype,
-    'decreaseFontSize',
-    os.config.LegendSettingsCtrl.prototype.decreaseFontSize);
 
 
 /**
  * Toggles a boolean value and updates the value in settings.
  * @param {string} type
+ * @export
  */
 os.config.LegendSettingsCtrl.prototype.toggle = function(type) {
   var settingKey = os.legend.DRAW_OPTIONS_KEY + '.' + type;
   os.settings.set(settingKey, this['options'][type]);
   os.dispatcher.dispatchEvent(os.legend.EventType.UPDATE);
 };
-goog.exportProperty(
-    os.config.LegendSettingsCtrl.prototype,
-    'toggle',
-    os.config.LegendSettingsCtrl.prototype.toggle);
 
 
 /**
  * Toggle the font bold setting.
+ * @export
  */
 os.config.LegendSettingsCtrl.prototype.toggleBold = function() {
   this['options']['bold'] = !this['options']['bold'];
   this.toggle('bold');
 };
-goog.exportProperty(
-    os.config.LegendSettingsCtrl.prototype,
-    'toggleBold',
-    os.config.LegendSettingsCtrl.prototype.toggleBold);

--- a/src/os/config/projectionsettings.js
+++ b/src/os/config/projectionsettings.js
@@ -122,10 +122,8 @@ os.config.ProjectionSettingsCtrl.prototype.onProjectionChange_ = function() {
 
 /**
  * Applies the projection change
- * @protected
+ * @export
  */
 os.config.ProjectionSettingsCtrl.prototype.apply = function() {
   os.proj.switch.SwitchProjection.getInstance().start(this['projection']['code']);
 };
-goog.exportProperty(os.config.ProjectionSettingsCtrl.prototype,
-    'apply', os.config.ProjectionSettingsCtrl.prototype.apply);

--- a/src/os/config/themesettings.js
+++ b/src/os/config/themesettings.js
@@ -146,16 +146,13 @@ os.config.ThemeSettingsCtrl.prototype.onSettingsChange_ = function(event) {
  * Save to settings.
  * @param {string} newVal
  * @param {string} oldVal
+ * @export
  */
 os.config.ThemeSettingsCtrl.prototype.onThemeChange = function(newVal, oldVal) {
   if (newVal != this['theme']) {
     os.settings.set(os.config.ThemeSettings.Keys.THEME, this['theme']);
   }
 };
-goog.exportProperty(
-    os.config.ThemeSettingsCtrl.prototype,
-    'onThemeChange',
-    os.config.ThemeSettingsCtrl.prototype.onThemeChange);
 
 
 /**

--- a/src/os/data/basedescriptor.js
+++ b/src/os/data/basedescriptor.js
@@ -367,14 +367,11 @@ os.data.BaseDescriptor.prototype.setColor = function(value) {
 
 /**
  * @inheritDoc
+ * @export
  */
 os.data.BaseDescriptor.prototype.getDescription = function() {
   return this.desc_;
 };
-goog.exportProperty(
-    os.data.BaseDescriptor.prototype,
-    'getDescription',
-    os.data.BaseDescriptor.prototype.getDescription);
 
 
 /**

--- a/src/os/data/layernode.js
+++ b/src/os/data/layernode.js
@@ -210,6 +210,7 @@ os.data.LayerNode.prototype.formatIcons = function() {
 /**
  * Whether or not the layer is loading
  * @return {boolean}
+ * @export
  */
 os.data.LayerNode.prototype.isLoading = function() {
   if (this.layer_) {
@@ -218,10 +219,6 @@ os.data.LayerNode.prototype.isLoading = function() {
 
   return false;
 };
-goog.exportProperty(
-    os.data.LayerNode.prototype,
-    'isLoading',
-    os.data.LayerNode.prototype.isLoading);
 
 
 /**

--- a/src/os/im/action/abstractimportaction.js
+++ b/src/os/im/action/abstractimportaction.js
@@ -66,50 +66,38 @@ os.im.action.AbstractImportAction.prototype.execute = goog.abstractMethod;
 
 /**
  * @inheritDoc
+ * @export
  */
 os.im.action.AbstractImportAction.prototype.getId = function() {
   return this.id;
 };
-goog.exportProperty(
-    os.im.action.AbstractImportAction.prototype,
-    'getId',
-    os.im.action.AbstractImportAction.prototype.getId);
 
 
 /**
  * @inheritDoc
+ * @export
  */
 os.im.action.AbstractImportAction.prototype.getLabel = function() {
   return this.label;
 };
-goog.exportProperty(
-    os.im.action.AbstractImportAction.prototype,
-    'getLabel',
-    os.im.action.AbstractImportAction.prototype.getLabel);
 
 
 /**
  * @inheritDoc
+ * @export
  */
 os.im.action.AbstractImportAction.prototype.getConfigUI = function() {
   return this.configUI;
 };
-goog.exportProperty(
-    os.im.action.AbstractImportAction.prototype,
-    'getConfigUI',
-    os.im.action.AbstractImportAction.prototype.getConfigUI);
 
 
 /**
  * @inheritDoc
+ * @export
  */
 os.im.action.AbstractImportAction.prototype.isUnique = function() {
   return this.unique;
 };
-goog.exportProperty(
-    os.im.action.AbstractImportAction.prototype,
-    'isUnique',
-    os.im.action.AbstractImportAction.prototype.isUnique);
 
 
 /**

--- a/src/os/interaction/contextmenuinteraction.js
+++ b/src/os/interaction/contextmenuinteraction.js
@@ -18,7 +18,7 @@ os.interaction.ContextMenu = function(opt_options) {
 
   // Protractor's mouseDown/mouseUp actions don't work with the Closure event framework (not sure why), so export a
   // function to open the map context menu.
-  goog.exportProperty(window, 'omcm', this.openMapContextMenu.bind(this));
+  window['omcm'] = this.openMapContextMenu.bind(this);
 };
 goog.inherits(os.interaction.ContextMenu, os.ui.ol.interaction.ContextMenu);
 os.implements(os.interaction.ContextMenu, os.I3DSupport.ID);

--- a/src/os/mainctrl.js
+++ b/src/os/mainctrl.js
@@ -978,22 +978,22 @@ os.MainCtrl.prototype.handleURLDrop_ = function(url) {
 
 /**
  * Undo the last command.
+ * @export
  */
 os.MainCtrl.prototype.undoCommand = function() {
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Map.UNDO, 1);
   os.command.CommandProcessor.getInstance().undo();
 };
-goog.exportProperty(os.MainCtrl.prototype, 'undoCommand', os.MainCtrl.prototype.undoCommand);
 
 
 /**
  * Redo the last undone command.
+ * @export
  */
 os.MainCtrl.prototype.redoCommand = function() {
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Map.REDO, 1);
   os.command.CommandProcessor.getInstance().redo();
 };
-goog.exportProperty(os.MainCtrl.prototype, 'redoCommand', os.MainCtrl.prototype.redoCommand);
 
 
 /**

--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -911,9 +911,9 @@ os.MapContainer.prototype.init = function() {
   ol.events.listen(view, ol.ObjectEventType.PROPERTYCHANGE, this.onViewChange_, this);
 
   // export the map's getPixelFromCoordinate/getCoordinateFromPixel methods for tests
-  goog.exportProperty(window, 'pfc', this.map_.getPixelFromCoordinate.bind(this.map_));
-  goog.exportProperty(window, 'cfp', this.map_.getCoordinateFromPixel.bind(this.map_));
-  goog.exportProperty(window, 'fte', this.flyToExtent.bind(this));
+  window['pfc'] = this.map_.getPixelFromCoordinate.bind(this.map_);
+  window['cfp'] = this.map_.getCoordinateFromPixel.bind(this.map_);
+  window['fte'] = this.flyToExtent.bind(this);
 
   // update the map canvas size on browser resize
   this.vsm_.listen(goog.events.EventType.RESIZE, this.updateSize, false, this);

--- a/src/os/mixin/objectmixin.js
+++ b/src/os/mixin/objectmixin.js
@@ -5,6 +5,7 @@ goog.provide('os.mixin.object');
 
 goog.require('ol.Object');
 goog.require('ol.ObjectEventType');
+goog.require('ol.obj');
 
 
 /**
@@ -15,7 +16,9 @@ goog.require('ol.ObjectEventType');
 ol.Object.prototype.getHashKey = function() {
   return ol.getUid(this);
 };
-goog.exportProperty(ol.Object.prototype, '$$hashKey', ol.Object.prototype.getHashKey);
+ol.obj.assign(ol.Object.prototype, {
+  '$$hashKey': ol.Object.prototype.getHashKey
+});
 
 
 /**

--- a/src/os/query/ui/mergeareas.js
+++ b/src/os/query/ui/mergeareas.js
@@ -110,6 +110,7 @@ os.query.ui.MergeAreasCtrl.prototype.disposeInternal = function() {
 
 /**
  * @inheritDoc
+ * @export
  */
 os.query.ui.MergeAreasCtrl.prototype.accept = function() {
   var areas = this.scope['features'];
@@ -155,7 +156,3 @@ os.query.ui.MergeAreasCtrl.prototype.accept = function() {
 
   this.close();
 };
-goog.exportProperty(
-    os.query.ui.MergeAreasCtrl.prototype,
-    'accept',
-    os.query.ui.MergeAreasCtrl.prototype.accept);

--- a/src/os/search/abstractsearchresult.js
+++ b/src/os/search/abstractsearchresult.js
@@ -45,14 +45,11 @@ os.search.AbstractSearchResult.nextId_ = 0;
 /**
  * @inheritDoc
  * @final
+ * @export
  */
 os.search.AbstractSearchResult.prototype.getId = function() {
   return this.id_;
 };
-goog.exportProperty(
-    os.search.AbstractSearchResult.prototype,
-    'getId',
-    os.search.AbstractSearchResult.prototype.getId);
 
 
 /**

--- a/src/os/storage/storage.js
+++ b/src/os/storage/storage.js
@@ -37,7 +37,7 @@ os.storage.clearStorage = function(opt_manualReload) {
       goog.partial(os.storage.resetInternal_, opt_manualReload),
       os.storage.reloadPage_);
 };
-goog.exportProperty(window, 'cls', os.storage.clearStorage);
+window['cls'] = os.storage.clearStorage;
 
 
 /**

--- a/src/os/ui/action/action.js
+++ b/src/os/ui/action/action.js
@@ -116,77 +116,77 @@ os.ui.action.Action.prototype.disposeInternal = function() {
  * Return the event type that invokes this action.
  *
  * @return {!string}
+ * @export
  */
 os.ui.action.Action.prototype.getEventType = function() {
   return this.eventType_;
 };
-goog.exportProperty(os.ui.action.Action.prototype, 'getEventType', os.ui.action.Action.prototype.getEventType);
 
 
 /**
  * Return the metricKey associated with this acation.
  *
  * @return {?string}
+ * @export
  */
 os.ui.action.Action.prototype.getMetricKey = function() {
   return this.metricKey_;
 };
-goog.exportProperty(os.ui.action.Action.prototype, 'getMetricKey', os.ui.action.Action.prototype.getMetricKey);
 
 
 /**
  * Return a short length of text that represents the action to the user.
  *
  * @return {!string}
+ * @export
  */
 os.ui.action.Action.prototype.getTitle = function() {
   return this.title_;
 };
-goog.exportProperty(os.ui.action.Action.prototype, 'getTitle', os.ui.action.Action.prototype.getTitle);
 
 
 /**
  * Return a style name that displays an icon for this action.
  *
  * @return {?string}
+ * @export
  */
 os.ui.action.Action.prototype.getIcon = function() {
   return this.icon_;
 };
-goog.exportProperty(os.ui.action.Action.prototype, 'getIcon', os.ui.action.Action.prototype.getIcon);
 
 
 /**
  * Return a style name that displays an icon for this action.
  *
  * @param {string} icon
+ * @export
  */
 os.ui.action.Action.prototype.setIcon = function(icon) {
   this.icon_ = icon;
 };
-goog.exportProperty(os.ui.action.Action.prototype, 'setIcon', os.ui.action.Action.prototype.setIcon);
 
 
 /**
  * Return a keyboard shortcut to invoke this action.
  *
  * @return {?string}
+ * @export
  */
 os.ui.action.Action.prototype.getHotkey = function() {
   return this.hotkey_;
 };
-goog.exportProperty(os.ui.action.Action.prototype, 'getHotkey', os.ui.action.Action.prototype.getHotkey);
 
 
 /**
  * Return a more detailed description of the action intended for a tooltip, help pop-up, etc.
  *
  * @return {?string}
+ * @export
  */
 os.ui.action.Action.prototype.getDescription = function() {
   return this.description_;
 };
-goog.exportProperty(os.ui.action.Action.prototype, 'getDescription', os.ui.action.Action.prototype.getDescription);
 
 
 /**

--- a/src/os/ui/action/actionmanager.js
+++ b/src/os/ui/action/actionmanager.js
@@ -311,12 +311,11 @@ os.ui.action.ActionManager.prototype.getEnabledActions = function() {
 
 /**
  * @return {boolean} true if this.getEnabledActions().length > 0, false otherwise
+ * @export
  */
 os.ui.action.ActionManager.prototype.hasEnabledActions = function() {
   return this.getEnabledActions().length > 0;
 };
-goog.exportProperty(os.ui.action.ActionManager.prototype, 'hasEnabledActions',
-    os.ui.action.ActionManager.prototype.hasEnabledActions);
 
 
 /**

--- a/src/os/ui/action/menuitem.js
+++ b/src/os/ui/action/menuitem.js
@@ -37,26 +37,20 @@ os.ui.action.MenuItem = function(name, description, opt_menuOptions) {
 
 /**
  * @inheritDoc
+ * @export
  */
 os.ui.action.MenuItem.prototype.getName = function() {
   return this.name_;
 };
-goog.exportProperty(
-    os.ui.action.MenuItem.prototype,
-    'getName',
-    os.ui.action.MenuItem.prototype.getName);
 
 
 /**
  * @inheritDoc
+ * @export
  */
 os.ui.action.MenuItem.prototype.getDescription = function() {
   return this.description_;
 };
-goog.exportProperty(
-    os.ui.action.MenuItem.prototype,
-    'getDescription',
-    os.ui.action.MenuItem.prototype.getDescription);
 
 
 /**

--- a/src/os/ui/action/menuitemaction.js
+++ b/src/os/ui/action/menuitemaction.js
@@ -30,9 +30,8 @@ goog.inherits(os.ui.action.MenuItemAction, os.ui.action.MenuItem);
 /**
  * Retrieve the action
  * @return {!os.ui.action.Action}
+ * @export
  */
 os.ui.action.MenuItemAction.prototype.getAction = function() {
   return this.action_;
 };
-goog.exportProperty(os.ui.action.MenuItemAction.prototype, 'getAction',
-    os.ui.action.MenuItemAction.prototype.getAction);

--- a/src/os/ui/action/menuitemlist.js
+++ b/src/os/ui/action/menuitemlist.js
@@ -39,11 +39,8 @@ os.ui.action.MenuItemList.prototype.addItem = function(menuItem) {
 /**
  * Retrieve the list of menu items (sub-menu)
  * @return {!Array.<os.ui.action.MenuItem>}
+ * @export
  */
 os.ui.action.MenuItemList.prototype.getItems = function() {
   return this.menuItems_;
 };
-goog.exportProperty(
-    os.ui.action.MenuItemList.prototype,
-    'getItems',
-    os.ui.action.MenuItemList.prototype.getItems);

--- a/src/os/ui/action/menuitemseparator.js
+++ b/src/os/ui/action/menuitemseparator.js
@@ -22,10 +22,9 @@ goog.inherits(os.ui.action.MenuItemSeparator, os.ui.action.MenuItem);
 /**
  * Defines this class as a separator
  * @type {boolean}
+ * @export
  */
 os.ui.action.MenuItemSeparator.prototype.isSeparator = true;
-goog.exportProperty(os.ui.action.MenuItemSeparator.prototype, 'isSeparator',
-    os.ui.action.MenuItemSeparator.prototype.isSeparator);
 
 
 
@@ -45,7 +44,6 @@ goog.inherits(os.ui.action.MenuItemSeparatorHeader, os.ui.action.MenuItem);
 /**
  * Defines this class as a separator name
  * @type {boolean}
+ * @export
  */
 os.ui.action.MenuItemSeparatorHeader.prototype.isSeparatorHeader = true;
-goog.exportProperty(os.ui.action.MenuItemSeparatorHeader.prototype, 'isSeparatorHeader',
-    os.ui.action.MenuItemSeparatorHeader.prototype.isSeparatorHeader);

--- a/src/os/ui/actionmenu.js
+++ b/src/os/ui/actionmenu.js
@@ -122,6 +122,7 @@ os.ui.ActionMenuCtrl.prototype.killRightClick_ = function(event) {
  * Invokes a menu action on the provider
  * @param {os.ui.action.Action} action
  * @return {boolean} True if an action was invoked, false otherwise
+ * @export
  */
 os.ui.ActionMenuCtrl.prototype.invoke = function(action) {
   var provider = this.scope['provider'];
@@ -134,7 +135,6 @@ os.ui.ActionMenuCtrl.prototype.invoke = function(action) {
 
   return false;
 };
-goog.exportProperty(os.ui.ActionMenuCtrl.prototype, 'invoke', os.ui.ActionMenuCtrl.prototype.invoke);
 
 
 /**
@@ -344,6 +344,7 @@ os.ui.ActionMenuCtrl.prototype.position = function() {
  * Called when a submenu is initialized. At initialization, the submenu DOM element does not exist yet,
  * so the DOM manipulation is done inside of a timeout which gives sufficient time for the element to
  * be added and its height/position to be read and set based on the viewport boundaries.
+ * @export
  */
 os.ui.ActionMenuCtrl.prototype.positionSubmenu = function() {
   this.timeout(goog.bind(function() {
@@ -389,8 +390,6 @@ os.ui.ActionMenuCtrl.prototype.positionSubmenu = function() {
     }
   }, this), 50, true);
 };
-goog.exportProperty(os.ui.ActionMenuCtrl.prototype, 'positionSubmenu',
-    os.ui.ActionMenuCtrl.prototype.positionSubmenu);
 
 /**
  * Calculate the number of items to show on the screen.

--- a/src/os/ui/adddata.js
+++ b/src/os/ui/adddata.js
@@ -143,24 +143,21 @@ os.ui.AddDataCtrl.prototype.checkServerError_ = function(opt_event) {
 
 /**
  * Dismiss the server alert and do not show it again.
+ * @export
  */
 os.ui.AddDataCtrl.prototype.dismissServerAlert = function() {
   this['showServerAlert'] = false;
 };
-goog.exportProperty(
-    os.ui.AddDataCtrl.prototype,
-    'dismissServerAlert',
-    os.ui.AddDataCtrl.prototype.dismissServerAlert);
 
 
 /**
  * Toggles the add data drop-down menu.
+ * @export
  */
 os.ui.AddDataCtrl.prototype.launchFileImport = function() {
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.AddData.IMPORT, 1);
   os.dispatcher.dispatchEvent(os.ui.im.ImportEventType.FILE);
 };
-goog.exportProperty(os.ui.AddDataCtrl.prototype, 'launchFileImport', os.ui.AddDataCtrl.prototype.launchFileImport);
 
 
 /**
@@ -180,13 +177,10 @@ os.ui.AddDataCtrl.prototype.onParamsChange_ = function(event, params) {
 
 /**
  * Clear the filter function
+ * @export
  */
 os.ui.AddDataCtrl.prototype.clearFilter = function() {
   this.scope['filterName'] = null;
   this.setFilterFunction(null);
   // this.updateSize_(false);
 };
-goog.exportProperty(
-    os.ui.AddDataCtrl.prototype,
-    'clearFilter',
-    os.ui.AddDataCtrl.prototype.clearFilter);

--- a/src/os/ui/adddatabutton.js
+++ b/src/os/ui/adddatabutton.js
@@ -57,10 +57,10 @@ goog.inherits(os.ui.AddDataButtonCtrl, os.ui.menu.MenuButtonCtrl);
 
 /**
  * Opens a file or URL
+ * @export
  */
 os.ui.AddDataButtonCtrl.prototype.open = function() {
   os.dispatcher.dispatchEvent(os.ui.im.ImportEventType.FILE);
 };
-goog.exportProperty(os.ui.AddDataButtonCtrl.prototype, 'open', os.ui.AddDataButtonCtrl.prototype.open);
 
 

--- a/src/os/ui/alert/alertbadge.js
+++ b/src/os/ui/alert/alertbadge.js
@@ -100,14 +100,11 @@ os.ui.alert.AlertBadgeCtrl.prototype.reset = function() {
 
 /**
  * @return {string}
+ * @export
  */
 os.ui.alert.AlertBadgeCtrl.prototype.getClass = function() {
   return os.ui.alert.AlertBadgeCtrl.CLASSES[this['highestAlert']] || 'badge-light';
 };
-goog.exportProperty(
-    os.ui.alert.AlertBadgeCtrl.prototype,
-    'getClass',
-    os.ui.alert.AlertBadgeCtrl.prototype.getClass);
 
 
 /**

--- a/src/os/ui/alert/alertpopup.js
+++ b/src/os/ui/alert/alertpopup.js
@@ -254,6 +254,7 @@ os.ui.alert.AlertPopupCtrl.prototype.displayAlert_ = function(event) {
 
 /**
  * Clear all open alerts.
+ * @export
  */
 os.ui.alert.AlertPopupCtrl.prototype.clearAlerts = function() {
   if (this['alertPopups'] && this.scope_) {
@@ -269,16 +270,13 @@ os.ui.alert.AlertPopupCtrl.prototype.clearAlerts = function() {
     os.ui.apply(this.scope_);
   }
 };
-goog.exportProperty(
-    os.ui.alert.AlertPopupCtrl.prototype,
-    'clearAlerts',
-    os.ui.alert.AlertPopupCtrl.prototype.clearAlerts);
 
 
 /**
  * Dismisses a popup and clears its timeout
  * @param {number} $index The index of the message to dismiss
  * @param {Object} popup The popup to dismiss
+ * @export
  */
 os.ui.alert.AlertPopupCtrl.prototype.dismissAlert = function($index, popup) {
   if (this.popupsEnabled_()) {
@@ -287,10 +285,6 @@ os.ui.alert.AlertPopupCtrl.prototype.dismissAlert = function($index, popup) {
   }
   os.dispatcher.dispatchEvent(new goog.events.Event(os.alert.AlertEventTypes.DISMISS_ALERT, popup));
 };
-goog.exportProperty(
-    os.ui.alert.AlertPopupCtrl.prototype,
-    'dismissAlert',
-    os.ui.alert.AlertPopupCtrl.prototype.dismissAlert);
 
 
 /**

--- a/src/os/ui/alerts.js
+++ b/src/os/ui/alerts.js
@@ -91,28 +91,22 @@ os.ui.alert.AlertsCtrl.prototype.registerAlert_ = function(event) {
 
 /**
  * Clears the alerts being displayed
+ * @export
  */
 os.ui.alert.AlertsCtrl.prototype.clearAlerts = function() {
   this['alertArray'].length = 0;
   os.alertManager.clearAlerts();
 };
-goog.exportProperty(
-    os.ui.alert.AlertsCtrl.prototype,
-    'clearAlerts',
-    os.ui.alert.AlertsCtrl.prototype.clearAlerts);
 
 
 /**
  * Toggles the alert popups
+ * @export
  */
 os.ui.alert.AlertsCtrl.prototype.toggleAlertPopups = function() {
   this['showAlertPopups'] = !this['showAlertPopups'];
   os.settings.set(['showAlertPopups'], this['showAlertPopups']);
 };
-goog.exportProperty(
-    os.ui.alert.AlertsCtrl.prototype,
-    'toggleAlertPopups',
-    os.ui.alert.AlertsCtrl.prototype.toggleAlertPopups);
 
 /**
  * @param {angular.Scope.Event} evt The angular event

--- a/src/os/ui/animationsettings.js
+++ b/src/os/ui/animationsettings.js
@@ -186,15 +186,12 @@ os.ui.AnimationSettingsCtrl.prototype.populate = function() {
 /**
  * If there is a conflict that will change manually defined animation ranges.
  * @return {boolean}
+ * @export
  */
 os.ui.AnimationSettingsCtrl.prototype.hasMultipleRanges = function() {
   var tlc = os.time.TimelineController.getInstance();
   return tlc.getAnimationRanges().length > 1;
 };
-goog.exportProperty(
-    os.ui.AnimationSettingsCtrl.prototype,
-    'hasMultipleRanges',
-    os.ui.AnimationSettingsCtrl.prototype.hasMultipleRanges);
 
 
 /**
@@ -218,7 +215,7 @@ os.ui.AnimationSettingsCtrl.prototype.onLoopDatesChange = function(newValue, old
 
 /**
  * Sets the auto configuration
- * @protected
+ * @export
  */
 os.ui.AnimationSettingsCtrl.prototype.autoConfigure = function() {
   if (this.scope['autoConfig']) {
@@ -240,8 +237,6 @@ os.ui.AnimationSettingsCtrl.prototype.autoConfigure = function() {
     }
   }
 };
-goog.exportProperty(os.ui.AnimationSettingsCtrl.prototype, 'onAutoChange',
-    os.ui.AnimationSettingsCtrl.prototype.autoConfigure);
 
 
 /**
@@ -323,6 +318,7 @@ os.ui.AnimationSettingsCtrl.prototype.getLoopEnd = function() {
 
 /**
  * Apply the settings
+ * @export
  */
 os.ui.AnimationSettingsCtrl.prototype.accept = function() {
   var tlc = os.time.TimelineController.getInstance();
@@ -361,26 +357,24 @@ os.ui.AnimationSettingsCtrl.prototype.accept = function() {
   /** @type {os.ui.timeline.TimelineCtrl} */ (this.scope['timeline']).zoomToExtent([tlc.getStart(), tlc.getEnd()]);
   this.cancel();
 };
-goog.exportProperty(os.ui.AnimationSettingsCtrl.prototype, 'accept', os.ui.AnimationSettingsCtrl.prototype.accept);
 
 
 /**
  * Cancel/Close
+ * @export
  */
 os.ui.AnimationSettingsCtrl.prototype.cancel = function() {
   os.ui.window.close(this.element);
 };
-goog.exportProperty(os.ui.AnimationSettingsCtrl.prototype, 'cancel', os.ui.AnimationSettingsCtrl.prototype.cancel);
 
 
 /**
  * Handles the ui fade checkbox toggle
+ * @export
  */
 os.ui.AnimationSettingsCtrl.prototype.onFadeChange = function() {
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Timeline.FADE, 1);
 };
-goog.exportProperty(os.ui.AnimationSettingsCtrl.prototype, 'onFadeChange',
-    os.ui.AnimationSettingsCtrl.prototype.onFadeChange);
 
 
 /**

--- a/src/os/ui/areas.js
+++ b/src/os/ui/areas.js
@@ -94,15 +94,16 @@ os.ui.AreasCtrl.prototype.destroy = function() {
 
 /**
  * Launches the advanced combination window
+ * @export
  */
 os.ui.AreasCtrl.prototype.launch = function() {
   os.ui.CombinatorCtrl.launch();
 };
-goog.exportProperty(os.ui.AreasCtrl.prototype, 'launch', os.ui.AreasCtrl.prototype.launch);
 
 
 /**
  * Opens the area import menu.
+ * @export
  */
 os.ui.AreasCtrl.prototype.openImportMenu = function() {
   var target = this.element.find('.js-import-group');
@@ -115,15 +116,12 @@ os.ui.AreasCtrl.prototype.openImportMenu = function() {
     });
   }
 };
-goog.exportProperty(
-    os.ui.AreasCtrl.prototype,
-    'openImportMenu',
-    os.ui.AreasCtrl.prototype.openImportMenu);
 
 
 /**
  * Disables export button
  * @return {boolean}
+ * @export
  */
 os.ui.AreasCtrl.prototype.exportDisabled = function() {
   if (this.scope['selected']) {
@@ -132,11 +130,11 @@ os.ui.AreasCtrl.prototype.exportDisabled = function() {
     return true;
   }
 };
-goog.exportProperty(os.ui.AreasCtrl.prototype, 'exportDisabled', os.ui.AreasCtrl.prototype.exportDisabled);
 
 
 /**
  * Pop up area export gui
+ * @export
  */
 os.ui.AreasCtrl.prototype.export = function() {
   var areas = /** @type {Array<os.structs.ITreeNode>} */ (this.scope['selected']).map(
@@ -158,19 +156,15 @@ os.ui.AreasCtrl.prototype.export = function() {
 
   os.ui.ex.AreaExportCtrl.start(areas);
 };
-goog.exportProperty(
-    os.ui.AreasCtrl.prototype,
-    'export',
-    os.ui.AreasCtrl.prototype.export);
 
 
 /**
  * Launches the area import window
+ * @export
  */
 os.ui.AreasCtrl.prototype.import = function() {
   os.query.launchQueryImport();
 };
-goog.exportProperty(os.ui.AreasCtrl.prototype, 'import', os.ui.AreasCtrl.prototype.import);
 
 
 /**

--- a/src/os/ui/browsedata.js
+++ b/src/os/ui/browsedata.js
@@ -116,20 +116,19 @@ os.ui.BrowseDataCtrl.launch = function(facets) {
 
 /**
  * Closes the window
+ * @export
  */
 os.ui.BrowseDataCtrl.prototype.close = function() {
   os.ui.window.close(this.element);
 };
-goog.exportProperty(os.ui.BrowseDataCtrl.prototype, 'close', os.ui.BrowseDataCtrl.prototype.close);
 
 
 /**
  * Loads a file/URL
+ * @export
  */
 os.ui.BrowseDataCtrl.prototype.launchFileImport = function() {
   os.dispatcher.dispatchEvent(os.ui.im.ImportEventType.FILE);
 };
-goog.exportProperty(os.ui.BrowseDataCtrl.prototype, 'launchFileImport',
-    os.ui.BrowseDataCtrl.prototype.launchFileImport);
 
 

--- a/src/os/ui/capture/recordingui.js
+++ b/src/os/ui/capture/recordingui.js
@@ -155,6 +155,7 @@ os.ui.capture.RecordingUI.prototype.close_ = function() {
 
 /**
  * Cancel the recording and close the window.
+ * @export
  */
 os.ui.capture.RecordingUI.prototype.cancel = function() {
   if (this.recorder_) {
@@ -163,14 +164,11 @@ os.ui.capture.RecordingUI.prototype.cancel = function() {
 
   this.close_();
 };
-goog.exportProperty(
-    os.ui.capture.RecordingUI.prototype,
-    'cancel',
-    os.ui.capture.RecordingUI.prototype.cancel);
 
 
 /**
  * Start the recording.
+ * @export
  */
 os.ui.capture.RecordingUI.prototype.record = function() {
   if (this.recorder_) {
@@ -192,30 +190,24 @@ os.ui.capture.RecordingUI.prototype.record = function() {
     this.close_();
   }
 };
-goog.exportProperty(
-    os.ui.capture.RecordingUI.prototype,
-    'record',
-    os.ui.capture.RecordingUI.prototype.record);
 
 
 /**
  * Get the title for a video encoder.
  * @param {os.capture.IVideoEncoder} encoder The encoder
  * @return {string}
+ * @export
  */
 os.ui.capture.RecordingUI.prototype.getEncoderTitle = function(encoder) {
   return encoder && encoder.title || 'Unknown Type';
 };
-goog.exportProperty(
-    os.ui.capture.RecordingUI.prototype,
-    'getEncoderTitle',
-    os.ui.capture.RecordingUI.prototype.getEncoderTitle);
 
 
 /**
  * Get the description for the encoder.
  * @param {os.capture.IVideoEncoder} encoder The encoder
  * @return {string}
+ * @export
  */
 os.ui.capture.RecordingUI.prototype.getEncoderDescription = function(encoder) {
   var description = encoder && encoder.description || '';
@@ -225,10 +217,6 @@ os.ui.capture.RecordingUI.prototype.getEncoderDescription = function(encoder) {
 
   return description;
 };
-goog.exportProperty(
-    os.ui.capture.RecordingUI.prototype,
-    'getEncoderDescription',
-    os.ui.capture.RecordingUI.prototype.getEncoderDescription);
 
 
 /**

--- a/src/os/ui/clear/clear.js
+++ b/src/os/ui/clear/clear.js
@@ -91,27 +91,21 @@ os.ui.clear.ClearCtrl.prototype.cancelInternal_ = function() {
 
 /**
  * Handle user clicking the Cancel button
+ * @export
  */
 os.ui.clear.ClearCtrl.prototype.cancel = function() {
   // reset and close the window
   this.cancelInternal_();
   this.close_();
 };
-goog.exportProperty(
-    os.ui.clear.ClearCtrl.prototype,
-    'cancel',
-    os.ui.clear.ClearCtrl.prototype.cancel);
 
 
 /**
  * Handle user clicking the OK button
+ * @export
  */
 os.ui.clear.ClearCtrl.prototype.accept = function() {
   // clear selected entries and close the window
   os.ui.clearManager.clear();
   this.close_();
 };
-goog.exportProperty(
-    os.ui.clear.ClearCtrl.prototype,
-    'accept',
-    os.ui.clear.ClearCtrl.prototype.accept);

--- a/src/os/ui/color/colorpalette.js
+++ b/src/os/ui/color/colorpalette.js
@@ -98,6 +98,7 @@ os.ui.color.ColorPaletteCtrl.prototype.destroy_ = function() {
 /**
  * Notify parent scope that a color was chosen.
  * @param {string} color The selected color
+ * @export
  */
 os.ui.color.ColorPaletteCtrl.prototype.pick = function(color) {
   this.scope_['value'] = color;
@@ -105,15 +106,12 @@ os.ui.color.ColorPaletteCtrl.prototype.pick = function(color) {
   var eventType = os.ui.color.ColorPaletteCtrl.getEventType(os.ui.color.ColorPaletteEventType.CHANGE, this.name_);
   this.scope_.$emit(eventType, color);
 };
-goog.exportProperty(
-    os.ui.color.ColorPaletteCtrl.prototype,
-    'pick',
-    os.ui.color.ColorPaletteCtrl.prototype.pick);
 
 
 /**
  * Notify parent scope that the color should be reset.
  * @param {string} color The selected color
+ * @export
  */
 os.ui.color.ColorPaletteCtrl.prototype.reset = function(color) {
   this.scope_['value'] = '';
@@ -121,24 +119,17 @@ os.ui.color.ColorPaletteCtrl.prototype.reset = function(color) {
   var eventType = os.ui.color.ColorPaletteCtrl.getEventType(os.ui.color.ColorPaletteEventType.RESET, this.name_);
   this.scope_.$emit(eventType);
 };
-goog.exportProperty(
-    os.ui.color.ColorPaletteCtrl.prototype,
-    'reset',
-    os.ui.color.ColorPaletteCtrl.prototype.reset);
 
 
 /**
  * Get the tooltip to display for a color.
  * @param {string} color The selected color
  * @return {string}
+ * @export
  */
 os.ui.color.ColorPaletteCtrl.prototype.getTitle = function(color) {
   return os.color.toHexString(color);
 };
-goog.exportProperty(
-    os.ui.color.ColorPaletteCtrl.prototype,
-    'getTitle',
-    os.ui.color.ColorPaletteCtrl.prototype.getTitle);
 
 
 /**

--- a/src/os/ui/color/colorpicker.js
+++ b/src/os/ui/color/colorpicker.js
@@ -217,6 +217,7 @@ os.ui.color.ColorPickerCtrl.prototype.onMouseDown_ = function(e) {
 /**
  * Toggle the color picker on/off.
  * @param {boolean=} opt_value
+ * @export
  */
 os.ui.color.ColorPickerCtrl.prototype.togglePopup = function(opt_value) {
   this['showPopup'] = goog.isDef(opt_value) ? opt_value : !this['showPopup'];
@@ -241,10 +242,6 @@ os.ui.color.ColorPickerCtrl.prototype.togglePopup = function(opt_value) {
     this.destroyControlMenu_();
   }
 };
-goog.exportProperty(
-    os.ui.color.ColorPickerCtrl.prototype,
-    'togglePopup',
-    os.ui.color.ColorPickerCtrl.prototype.togglePopup);
 
 
 /**

--- a/src/os/ui/column/columnmanager.js
+++ b/src/os/ui/column/columnmanager.js
@@ -180,6 +180,7 @@ os.ui.column.ColumnManagerCtrl.prototype.destroy_ = function() {
 /**
  * Close the window
  * @param {boolean} enableListen
+ * @export
  */
 os.ui.column.ColumnManagerCtrl.prototype.listenForKeys = function(enableListen) {
   if (enableListen) {
@@ -188,15 +189,12 @@ os.ui.column.ColumnManagerCtrl.prototype.listenForKeys = function(enableListen) 
     this.keyHandler_.unlisten(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent_, false, this);
   }
 };
-goog.exportProperty(
-    os.ui.column.ColumnManagerCtrl.prototype,
-    'listenForKeys',
-    os.ui.column.ColumnManagerCtrl.prototype.listenForKeys);
 
 
 /**
  * Toggles columns to shown.
  * @param {boolean=} opt_all Whether to select all
+ * @export
  */
 os.ui.column.ColumnManagerCtrl.prototype.show = function(opt_all) {
   if (opt_all === true) {
@@ -232,15 +230,12 @@ os.ui.column.ColumnManagerCtrl.prototype.show = function(opt_all) {
   this.validate_();
   this.find(this['searchIndex'] - 1);
 };
-goog.exportProperty(
-    os.ui.column.ColumnManagerCtrl.prototype,
-    'show',
-    os.ui.column.ColumnManagerCtrl.prototype.show);
 
 
 /**
  * Toggles columns to hidden.
  * @param {boolean=} opt_all Whether to select all
+ * @export
  */
 os.ui.column.ColumnManagerCtrl.prototype.hide = function(opt_all) {
   if (opt_all === true) {
@@ -264,14 +259,11 @@ os.ui.column.ColumnManagerCtrl.prototype.hide = function(opt_all) {
   this.scope_.$broadcast(os.ui.slick.SlickGridEvent.INVALIDATE_ROWS);
   this.find(this['searchIndex'] - 1);
 };
-goog.exportProperty(
-    os.ui.column.ColumnManagerCtrl.prototype,
-    'hide',
-    os.ui.column.ColumnManagerCtrl.prototype.hide);
 
 
 /**
  * Save the state
+ * @export
  */
 os.ui.column.ColumnManagerCtrl.prototype.accept = function() {
   var srcColumns = this.scope_['columns'];
@@ -318,22 +310,15 @@ os.ui.column.ColumnManagerCtrl.prototype.accept = function() {
 
   this.close();
 };
-goog.exportProperty(
-    os.ui.column.ColumnManagerCtrl.prototype,
-    'accept',
-    os.ui.column.ColumnManagerCtrl.prototype.accept);
 
 
 /**
  * Close the window
+ * @export
  */
 os.ui.column.ColumnManagerCtrl.prototype.close = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(
-    os.ui.column.ColumnManagerCtrl.prototype,
-    'close',
-    os.ui.column.ColumnManagerCtrl.prototype.close);
 
 
 /**
@@ -382,6 +367,7 @@ os.ui.column.ColumnManagerCtrl.prototype.find_ = function(term, columnName) {
 /**
  * Select the hidden terms
  * @param {number=} opt_startIndex
+ * @export
  */
 os.ui.column.ColumnManagerCtrl.prototype.find = function(opt_startIndex) {
   if (this['term'] != '') {
@@ -390,28 +376,22 @@ os.ui.column.ColumnManagerCtrl.prototype.find = function(opt_startIndex) {
     this.next();
   }
 };
-goog.exportProperty(
-    os.ui.column.ColumnManagerCtrl.prototype,
-    'find',
-    os.ui.column.ColumnManagerCtrl.prototype.find);
 
 
 /**
  * Toggles columns to shown.
+ * @export
  */
 os.ui.column.ColumnManagerCtrl.prototype.clear = function() {
   this['term'] = '';
   this['searchResults'] = [];
   this['searchIndex'] = 0;
 };
-goog.exportProperty(
-    os.ui.column.ColumnManagerCtrl.prototype,
-    'clear',
-    os.ui.column.ColumnManagerCtrl.prototype.clear);
 
 
 /**
  * Toggles columns to shown.
+ * @export
  */
 os.ui.column.ColumnManagerCtrl.prototype.next = function() {
   if (this['searchResults'].length > 0) {
@@ -419,14 +399,11 @@ os.ui.column.ColumnManagerCtrl.prototype.next = function() {
     this.updateSearch_();
   }
 };
-goog.exportProperty(
-    os.ui.column.ColumnManagerCtrl.prototype,
-    'next',
-    os.ui.column.ColumnManagerCtrl.prototype.next);
 
 
 /**
  * Toggles columns to shown.
+ * @export
  */
 os.ui.column.ColumnManagerCtrl.prototype.previous = function() {
   if (this['searchResults'].length > 0) {
@@ -434,10 +411,6 @@ os.ui.column.ColumnManagerCtrl.prototype.previous = function() {
     this.updateSearch_();
   }
 };
-goog.exportProperty(
-    os.ui.column.ColumnManagerCtrl.prototype,
-    'previous',
-    os.ui.column.ColumnManagerCtrl.prototype.previous);
 
 
 /**

--- a/src/os/ui/column/mapping/columnmappingexport.js
+++ b/src/os/ui/column/mapping/columnmappingexport.js
@@ -111,6 +111,7 @@ os.ui.column.mapping.ColumnMappingExportCtrl.prototype.onDestroy_ = function() {
 
 /**
  * Exports the mappings.
+ * @export
  */
 os.ui.column.mapping.ColumnMappingExportCtrl.prototype.accept = function() {
   var method = this['persister'];
@@ -126,19 +127,12 @@ os.ui.column.mapping.ColumnMappingExportCtrl.prototype.accept = function() {
   method.save(title, content, os.file.mime.columnmapping.TYPE);
   this.close();
 };
-goog.exportProperty(
-    os.ui.column.mapping.ColumnMappingExportCtrl.prototype,
-    'accept',
-    os.ui.column.mapping.ColumnMappingExportCtrl.prototype.accept);
 
 
 /**
  * Close the window
+ * @export
  */
 os.ui.column.mapping.ColumnMappingExportCtrl.prototype.close = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(
-    os.ui.column.mapping.ColumnMappingExportCtrl.prototype,
-    'close',
-    os.ui.column.mapping.ColumnMappingExportCtrl.prototype.close);

--- a/src/os/ui/column/mapping/columnmappingnodeui.js
+++ b/src/os/ui/column/mapping/columnmappingnodeui.js
@@ -48,6 +48,7 @@ os.ui.column.mapping.ColumnMappingNodeUICtrl = function($scope, $element) {
 
 /**
  * Prompt the user to remove the analytic from the application
+ * @export
  */
 os.ui.column.mapping.ColumnMappingNodeUICtrl.prototype.tryRemove = function() {
   var cm = /** @type {os.ui.column.mapping.ColumnMappingNode} */ (this.scope_['item']).getColumnMapping();
@@ -73,8 +74,6 @@ os.ui.column.mapping.ColumnMappingNodeUICtrl.prototype.tryRemove = function() {
     }
   }));
 };
-goog.exportProperty(os.ui.column.mapping.ColumnMappingNodeUICtrl.prototype, 'tryRemove',
-    os.ui.column.mapping.ColumnMappingNodeUICtrl.prototype.tryRemove);
 
 
 /**
@@ -89,12 +88,9 @@ os.ui.column.mapping.ColumnMappingNodeUICtrl.prototype.remove_ = function() {
 
 /**
  * Edits the column mapping
+ * @export
  */
 os.ui.column.mapping.ColumnMappingNodeUICtrl.prototype.edit = function() {
   var cm = /** @type {os.ui.column.mapping.ColumnMappingNode} */ (this.scope_['item']).getColumnMapping();
   os.ui.column.mapping.ColumnMappingSettings.launchColumnMappingWindow(cm);
 };
-goog.exportProperty(
-    os.ui.column.mapping.ColumnMappingNodeUICtrl.prototype,
-    'edit',
-    os.ui.column.mapping.ColumnMappingNodeUICtrl.prototype.edit);

--- a/src/os/ui/column/mapping/columnmappingsettings.js
+++ b/src/os/ui/column/mapping/columnmappingsettings.js
@@ -140,18 +140,16 @@ os.ui.column.mapping.ColumnMappingSettingsCtrl.prototype.onMappingsChange_ = fun
 
 /**
  * Launches the create column mapping form.
+ * @export
  */
 os.ui.column.mapping.ColumnMappingSettingsCtrl.prototype.create = function() {
   os.ui.column.mapping.ColumnMappingSettings.launchColumnMappingWindow();
 };
-goog.exportProperty(
-    os.ui.column.mapping.ColumnMappingSettingsCtrl.prototype,
-    'create',
-    os.ui.column.mapping.ColumnMappingSettingsCtrl.prototype.create);
 
 
 /**
  * Launches the export column mappings form.
+ * @export
  */
 os.ui.column.mapping.ColumnMappingSettingsCtrl.prototype.export = function() {
   var selected = /** @type {Array<os.ui.column.mapping.ColumnMappingNode>} */ (this.scope_['selected']);
@@ -192,24 +190,17 @@ os.ui.column.mapping.ColumnMappingSettingsCtrl.prototype.export = function() {
   var template = '<columnmappingexport></columnmappingexport>';
   os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
 };
-goog.exportProperty(
-    os.ui.column.mapping.ColumnMappingSettingsCtrl.prototype,
-    'export',
-    os.ui.column.mapping.ColumnMappingSettingsCtrl.prototype.export);
 
 
 /**
  * Launches the import column mappings form.
+ * @export
  */
 os.ui.column.mapping.ColumnMappingSettingsCtrl.prototype.import = function() {
   var importProcess = new os.ui.im.ImportProcess();
   importProcess.setEvent(new os.ui.im.ImportEvent(os.ui.im.ImportEventType.FILE));
   importProcess.begin();
 };
-goog.exportProperty(
-    os.ui.column.mapping.ColumnMappingSettingsCtrl.prototype,
-    'import',
-    os.ui.column.mapping.ColumnMappingSettingsCtrl.prototype.import);
 
 
 /**

--- a/src/os/ui/column/mapping/mappingexpression.js
+++ b/src/os/ui/column/mapping/mappingexpression.js
@@ -199,6 +199,7 @@ os.ui.column.mapping.MappingExpressionCtrl.prototype.setColumns_ = function(colu
  * @param {Object} item
  * @param {angular.JQLite} ele
  * @return {string|angular.JQLite}
+ * @export
  */
 os.ui.column.mapping.MappingExpressionCtrl.prototype.formatter = function(item, ele) {
   var id = item['text'];
@@ -216,7 +217,3 @@ os.ui.column.mapping.MappingExpressionCtrl.prototype.formatter = function(item, 
   }
   return val;
 };
-goog.exportProperty(
-    os.ui.column.mapping.MappingExpressionCtrl.prototype,
-    'formatter',
-    os.ui.column.mapping.MappingExpressionCtrl.prototype.formatter);

--- a/src/os/ui/columnactions/columnactionprompt.js
+++ b/src/os/ui/columnactions/columnactionprompt.js
@@ -72,37 +72,31 @@ os.ui.columnactions.ColumnActionsCtrl.prototype.onDestroy_ = function() {
  *
  * @param {Object} match
  * @param {string} value
- * @private
+ * @export
  */
-os.ui.columnactions.ColumnActionsCtrl.prototype.executeMatch_ = function(match, value) {
+os.ui.columnactions.ColumnActionsCtrl.prototype.executeMatch = function(match, value) {
   match.execute(value);
 };
-goog.exportProperty(os.ui.columnactions.ColumnActionsCtrl.prototype, 'executeMatch',
-    os.ui.columnactions.ColumnActionsCtrl.prototype.executeMatch_);
 
 
 /**
  *
  * @param {Object} match
  * @return {string}
- * @private
+ * @export
  */
-os.ui.columnactions.ColumnActionsCtrl.prototype.getDescription_ = function(match) {
+os.ui.columnactions.ColumnActionsCtrl.prototype.getDescription = function(match) {
   return match.getDescription();
 };
-goog.exportProperty(os.ui.columnactions.ColumnActionsCtrl.prototype, 'getDescription',
-    os.ui.columnactions.ColumnActionsCtrl.prototype.getDescription_);
 
 
 /**
  * Close the window.
- * @private
+ * @export
  */
-os.ui.columnactions.ColumnActionsCtrl.prototype.close_ = function() {
+os.ui.columnactions.ColumnActionsCtrl.prototype.close = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(os.ui.columnactions.ColumnActionsCtrl.prototype, 'close',
-    os.ui.columnactions.ColumnActionsCtrl.prototype.close_);
 
 
 /**

--- a/src/os/ui/config/abstractsettings.js
+++ b/src/os/ui/config/abstractsettings.js
@@ -89,9 +89,9 @@ os.ui.config.AbstractSettingsCtrl.prototype.onSelected = function(newVal, oldVal
 /**
  * @param {*} item
  * @return {?string}
- * @private
+ * @export
  */
-os.ui.config.AbstractSettingsCtrl.prototype.getUi_ = function(item) {
+os.ui.config.AbstractSettingsCtrl.prototype.getUi = function(item) {
   if (item && item instanceof os.ui.config.SettingNode) {
     var node = /** @type {os.ui.config.SettingNode} */ (item);
     var model = node.getModel();
@@ -101,19 +101,15 @@ os.ui.config.AbstractSettingsCtrl.prototype.getUi_ = function(item) {
 
   return null;
 };
-goog.exportProperty(os.ui.config.AbstractSettingsCtrl.prototype, 'getUi',
-    os.ui.config.AbstractSettingsCtrl.prototype.getUi_);
 
 
 /**
  * Close the window
- * @private
+ * @export
  */
-os.ui.config.AbstractSettingsCtrl.prototype.reset_ = function() {
+os.ui.config.AbstractSettingsCtrl.prototype.reset = function() {
   os.ui.util.resetSettings();
 };
-goog.exportProperty(os.ui.config.AbstractSettingsCtrl.prototype, 'reset',
-    os.ui.config.AbstractSettingsCtrl.prototype.reset_);
 
 
 /**

--- a/src/os/ui/config/settingswindow.js
+++ b/src/os/ui/config/settingswindow.js
@@ -88,10 +88,8 @@ os.ui.config.SettingsWindowCtrl.prototype.onParamsChange_ = function(event, para
 
 /**
  * Close the window
- * @private
+ * @export
  */
-os.ui.config.SettingsWindowCtrl.prototype.close_ = function() {
+os.ui.config.SettingsWindowCtrl.prototype.close = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(os.ui.config.SettingsWindowCtrl.prototype, 'close',
-    os.ui.config.SettingsWindowCtrl.prototype.close_);

--- a/src/os/ui/consent.js
+++ b/src/os/ui/consent.js
@@ -119,16 +119,14 @@ os.ui.Consent.launch = function() {
 
 /**
  * Save the cookie so it wont popup again
+ * @export
  */
 os.ui.Consent.prototype.saveCookie = function() {
   this.update_();
   this.element_.modal('hide');
   this.timer_.start();
   this.peer_.send('consent', '');
-}; goog.exportProperty(
-    os.ui.Consent.prototype,
-    'saveCookie',
-    os.ui.Consent.prototype.saveCookie);
+};
 
 
 /**

--- a/src/os/ui/data/addcolumn.js
+++ b/src/os/ui/data/addcolumn.js
@@ -110,18 +110,16 @@ os.ui.data.AddColumnCtrl.prototype.destroy_ = function() {
 
 /**
  * Closes the window.
+ * @export
  */
 os.ui.data.AddColumnCtrl.prototype.cancel = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(
-    os.ui.data.AddColumnCtrl.prototype,
-    'cancel',
-    os.ui.data.AddColumnCtrl.prototype.cancel);
 
 
 /**
  * Finishes and adds the column.
+ * @export
  */
 os.ui.data.AddColumnCtrl.prototype.finish = function() {
   if (!this.scope_['addColumnForm'].$invalid) {
@@ -151,10 +149,6 @@ os.ui.data.AddColumnCtrl.prototype.finish = function() {
     this.cancel();
   }
 };
-goog.exportProperty(
-    os.ui.data.AddColumnCtrl.prototype,
-    'finish',
-    os.ui.data.AddColumnCtrl.prototype.finish);
 
 
 /**

--- a/src/os/ui/data/adddatactrl.js
+++ b/src/os/ui/data/adddatactrl.js
@@ -147,21 +147,21 @@ os.ui.data.AddDataCtrl.prototype.onDestroy = function() {
 
 /**
  * Close the window
+ * @export
  */
 os.ui.data.AddDataCtrl.prototype.close = function() {
   os.ui.window.close(this.element);
 };
-goog.exportProperty(os.ui.data.AddDataCtrl.prototype, 'close', os.ui.data.AddDataCtrl.prototype.close);
 
 
 /**
  * Check if the base tree is empty (no providers are present).
  * @return {boolean}
+ * @export
  */
 os.ui.data.AddDataCtrl.prototype.isTreeEmpty = function() {
   return this.treeSearch.getSearch().length == 0;
 };
-goog.exportProperty(os.ui.data.AddDataCtrl.prototype, 'isTreeEmpty', os.ui.data.AddDataCtrl.prototype.isTreeEmpty);
 
 
 /**
@@ -180,6 +180,7 @@ os.ui.data.AddDataCtrl.prototype.onChildrenChanged = function(e) {
 
 /**
  * Starts a search
+ * @export
  */
 os.ui.data.AddDataCtrl.prototype.search = function() {
   if (this.root && this.treeSearch && this.searchDelay_) {
@@ -191,7 +192,6 @@ os.ui.data.AddDataCtrl.prototype.search = function() {
     os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.AddData.SEARCH, 1);
   }
 };
-goog.exportProperty(os.ui.data.AddDataCtrl.prototype, 'search', os.ui.data.AddDataCtrl.prototype.search);
 
 
 /**
@@ -223,24 +223,23 @@ os.ui.data.AddDataCtrl.listFilter_ = function(item, i, arr) {
 
 /**
  * Handles group by selection change
-  */
+ * @export
+ */
 os.ui.data.AddDataCtrl.prototype.onGroupByChanged = function() {
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.AddData.GROUP_BY, 1);
   this.search();
 };
-goog.exportProperty(os.ui.data.AddDataCtrl.prototype, 'onGroupByChanged',
-    os.ui.data.AddDataCtrl.prototype.onGroupByChanged);
 
 
 /**
  * Clears the search
+ * @export
  */
 os.ui.data.AddDataCtrl.prototype.clearSearch = function() {
   this['term'] = '';
   this.search();
   this.element.find('.search').focus();
 };
-goog.exportProperty(os.ui.data.AddDataCtrl.prototype, 'clearSearch', os.ui.data.AddDataCtrl.prototype.clearSearch);
 
 
 /**
@@ -270,6 +269,7 @@ os.ui.data.AddDataCtrl.prototype.onSearch_ = function() {
 /**
  * Get the content for the info panel
  * @return {string}
+ * @export
  */
 os.ui.data.AddDataCtrl.prototype.getInfo = function() {
   if (this.isTreeEmpty()) {
@@ -304,4 +304,3 @@ os.ui.data.AddDataCtrl.prototype.getInfo = function() {
 
   return 'Select an item on the left to see more information.';
 };
-goog.exportProperty(os.ui.data.AddDataCtrl.prototype, 'getInfo', os.ui.data.AddDataCtrl.prototype.getInfo);

--- a/src/os/ui/data/descriptornode.js
+++ b/src/os/ui/data/descriptornode.js
@@ -159,6 +159,7 @@ os.ui.data.DescriptorNode.prototype.formatIcons = function() {
 /**
  * Whether or not the descriptor (or the items the descriptor has added) is loading
  * @return {boolean}
+ * @export
  */
 os.ui.data.DescriptorNode.prototype.isLoading = function() {
   if (this.descriptor_) {
@@ -167,10 +168,6 @@ os.ui.data.DescriptorNode.prototype.isLoading = function() {
 
   return false;
 };
-goog.exportProperty(
-    os.ui.data.DescriptorNode.prototype,
-    'isLoading',
-    os.ui.data.DescriptorNode.prototype.isLoading);
 
 
 /**

--- a/src/os/ui/datepanel.js
+++ b/src/os/ui/datepanel.js
@@ -87,6 +87,7 @@ os.ui.DatePanelCtrl = function($scope) {
 
 /**
  * Shows the time slicer or not
+ * @export
  */
 os.ui.DatePanelCtrl.prototype.toggleExtend = function() {
   this['extended'] = !this['extended'];
@@ -95,26 +96,25 @@ os.ui.DatePanelCtrl.prototype.toggleExtend = function() {
     this.applySlice();
   }
 };
-goog.exportProperty(os.ui.DatePanelCtrl.prototype, 'toggleExtend', os.ui.DatePanelCtrl.prototype.toggleExtend);
 
 
 /**
  * Opens timeline
+ * @export
  */
 os.ui.DatePanelCtrl.prototype.expand = function() {
   os.dispatcher.dispatchEvent(new os.ui.events.UIEvent(os.ui.events.UIEventType.TOGGLE_UI, 'timeline'));
 };
-goog.exportProperty(os.ui.DatePanelCtrl.prototype, 'expand', os.ui.DatePanelCtrl.prototype.expand);
 
 
 /**
  * Update the offset if it changes
  * @return {string}
+ * @export
  */
 os.ui.DatePanelCtrl.prototype.getOffset = function() {
   return 'UTC' + (os.time.timeOffsetLabel == 'Z' ? '+0000' : os.time.timeOffsetLabel);
 };
-goog.exportProperty(os.ui.DatePanelCtrl.prototype, 'getOffset', os.ui.DatePanelCtrl.prototype.getOffset);
 
 
 /**
@@ -123,6 +123,7 @@ goog.exportProperty(os.ui.DatePanelCtrl.prototype, 'getOffset', os.ui.DatePanelC
  * @param {number} min
  * @param {number} max
  * @param {number} oldVal
+ * @export
  */
 os.ui.DatePanelCtrl.prototype.onChange = function(varName, min, max, oldVal) {
   if (this[varName] != undefined) {
@@ -136,11 +137,11 @@ os.ui.DatePanelCtrl.prototype.onChange = function(varName, min, max, oldVal) {
   }
   this['active'] = false;
 };
-goog.exportProperty(os.ui.DatePanelCtrl.prototype, 'onChange', os.ui.DatePanelCtrl.prototype.onChange);
 
 
 /**
  * Turns on/off time slice requests
+ * @export
  */
 os.ui.DatePanelCtrl.prototype.applySlice = function() {
   var rangeSet = new goog.math.RangeSet();
@@ -157,38 +158,35 @@ os.ui.DatePanelCtrl.prototype.applySlice = function() {
     this.tlc_.setSliceRanges(rangeSet);
   }
 };
-goog.exportProperty(os.ui.DatePanelCtrl.prototype, 'applySlice', os.ui.DatePanelCtrl.prototype.applySlice);
 
 
 /**
  * Turns on time slice requests if they are in use
+ * @export
  */
 os.ui.DatePanelCtrl.prototype.applySliceIfActive = function() {
   if (this['active']) {
     this.applySlice();
   }
 };
-goog.exportProperty(os.ui.DatePanelCtrl.prototype,
-    'applySliceIfActive',
-    os.ui.DatePanelCtrl.prototype.applySliceIfActive);
 
 
 /**
  * Turns off slicing
+ * @export
  */
 os.ui.DatePanelCtrl.prototype.cancelSlice = function() {
   this.toggleExtend();
 };
-goog.exportProperty(os.ui.DatePanelCtrl.prototype, 'cancelSlice', os.ui.DatePanelCtrl.prototype.cancelSlice);
 
 
 /**
  * Validates slice
  * @return {boolean}
+ * @export
  */
 os.ui.DatePanelCtrl.prototype.sliceValid = function() {
   var start = this['startHour'] * 60 + this['startMinute'];
   var end = this['endHour'] * 60 + this['endMinute'];
   return start < end;
 };
-goog.exportProperty(os.ui.DatePanelCtrl.prototype, 'sliceValid', os.ui.DatePanelCtrl.prototype.sliceValid);

--- a/src/os/ui/datetime/datecontrol.js
+++ b/src/os/ui/datetime/datecontrol.js
@@ -194,6 +194,7 @@ os.ui.datetime.DateControlCtrl.prototype.onEndDateChanged_ = function(newVal, ol
 
 /**
  * Change handler for duration chooser.
+ * @export
  */
 os.ui.datetime.DateControlCtrl.prototype.onDurationChanged = function() {
   if (!this['disabled']) {
@@ -212,10 +213,6 @@ os.ui.datetime.DateControlCtrl.prototype.onDurationChanged = function() {
         'duration changed: ' + this['startDate'].toUTCString() + ' to ' + this['endDate'].toUTCString());
   }
 };
-goog.exportProperty(
-    os.ui.datetime.DateControlCtrl.prototype,
-    'onDurationChanged',
-    os.ui.datetime.DateControlCtrl.prototype.onDurationChanged);
 
 
 /**
@@ -254,6 +251,7 @@ os.ui.datetime.DateControlCtrl.prototype.updateController_ = function() {
 /**
  * Change handler for duration chooser.
  * @param {number} direction
+ * @export
  */
 os.ui.datetime.DateControlCtrl.prototype.shiftDate = function(direction) {
   if (!this['disabled']) {
@@ -261,10 +259,6 @@ os.ui.datetime.DateControlCtrl.prototype.shiftDate = function(direction) {
     this['endDate'] = os.time.offset(this['endDate'], this['duration'], direction, true);
   }
 };
-goog.exportProperty(
-    os.ui.datetime.DateControlCtrl.prototype,
-    'shiftDate',
-    os.ui.datetime.DateControlCtrl.prototype.shiftDate);
 
 
 /**

--- a/src/os/ui/datetime/datetime.js
+++ b/src/os/ui/datetime/datetime.js
@@ -175,6 +175,7 @@ os.ui.datetime.DateTimeCtrl.prototype.onDateChanged_ = function(newVal, oldVal) 
 /**
  * Updates the scope value or reports an error.
  * @param {string=} opt_type
+ * @export
  */
 os.ui.datetime.DateTimeCtrl.prototype.updateValue = function(opt_type) {
   goog.log.fine(os.ui.datetime.DateTimeCtrl.LOGGER_, 'dateTime.updateValue');
@@ -223,12 +224,11 @@ os.ui.datetime.DateTimeCtrl.prototype.updateValue = function(opt_type) {
     }
   }
 };
-goog.exportProperty(os.ui.datetime.DateTimeCtrl.prototype, 'updateValue',
-    os.ui.datetime.DateTimeCtrl.prototype.updateValue);
 
 
 /**
  * Sets this field to the current time.
+ * @export
  */
 os.ui.datetime.DateTimeCtrl.prototype.setNow = function() {
   // set the inputs as dirty for validation
@@ -247,12 +247,11 @@ os.ui.datetime.DateTimeCtrl.prototype.setNow = function() {
     this.scope_['dateTimeForm'].$setDirty();
   }
 };
-goog.exportProperty(os.ui.datetime.DateTimeCtrl.prototype, 'setNow',
-    os.ui.datetime.DateTimeCtrl.prototype.setNow);
 
 
 /**
  * Sets this field to the current time.
+ * @export
  */
 os.ui.datetime.DateTimeCtrl.prototype.reset = function() {
   this.unwatchDate_();
@@ -265,5 +264,3 @@ os.ui.datetime.DateTimeCtrl.prototype.reset = function() {
   this.scope_['invalid'] = false;
   this.watchDate_();
 };
-goog.exportProperty(os.ui.datetime.DateTimeCtrl.prototype, 'reset',
-    os.ui.datetime.DateTimeCtrl.prototype.reset);

--- a/src/os/ui/datetime/startenddate.js
+++ b/src/os/ui/datetime/startenddate.js
@@ -261,6 +261,7 @@ os.ui.datetime.StartEndDateCtrl.getDate = function(date) {
 /**
  * Checks if the start date is in an error state.
  * @return {boolean}
+ * @export
  */
 os.ui.datetime.StartEndDateCtrl.prototype.checkStartForError = function() {
   if (this.scope) {
@@ -282,13 +283,12 @@ os.ui.datetime.StartEndDateCtrl.prototype.checkStartForError = function() {
 
   return false;
 };
-goog.exportProperty(os.ui.datetime.StartEndDateCtrl.prototype, 'checkStartForError',
-    os.ui.datetime.StartEndDateCtrl.prototype.checkStartForError);
 
 
 /**
  * Checks if the end date is in an error state.
  * @return {boolean}
+ * @export
  */
 os.ui.datetime.StartEndDateCtrl.prototype.checkEndForError = function() {
   if (this.scope) {
@@ -314,5 +314,3 @@ os.ui.datetime.StartEndDateCtrl.prototype.checkEndForError = function() {
 
   return false;
 };
-goog.exportProperty(os.ui.datetime.StartEndDateCtrl.prototype, 'checkEndForError',
-    os.ui.datetime.StartEndDateCtrl.prototype.checkEndForError);

--- a/src/os/ui/datetime/wheeldate.js
+++ b/src/os/ui/datetime/wheeldate.js
@@ -332,6 +332,7 @@ os.ui.datetime.WheelDateCtrl.prototype.handleWheelEvent_ = function(event) {
 /**
  * Updates Angular scope's date so the parent can react. This should only fire when the user chooses a date
  * from the calendar, hits enter, or the field loses focus. Mouse wheel changes should be suppressed.
+ * @export
  */
 os.ui.datetime.WheelDateCtrl.prototype.updateScopeDate = function() {
   goog.log.fine(os.ui.datetime.WheelDateCtrl.LOGGER_, 'Wheel date updating scope.');
@@ -346,7 +347,3 @@ os.ui.datetime.WheelDateCtrl.prototype.updateScopeDate = function() {
     }
   }
 };
-goog.exportProperty(
-    os.ui.datetime.WheelDateCtrl.prototype,
-    'updateScopeDate',
-    os.ui.datetime.WheelDateCtrl.prototype.updateScopeDate);

--- a/src/os/ui/ex/exportoptions.js
+++ b/src/os/ui/ex/exportoptions.js
@@ -304,6 +304,7 @@ os.ui.ex.ExportOptionsCtrl.prototype.getSourceItem_ = function(source, opt_remov
 
 /**
  * Update the items being exported. Applications should extend this to handle how export items are determined.
+ * @export
  */
 os.ui.ex.ExportOptionsCtrl.prototype.updateItems = function() {
   this['count'] = 0;
@@ -375,10 +376,6 @@ os.ui.ex.ExportOptionsCtrl.prototype.updateItems = function() {
     os.ui.apply(this.scope);
   }
 };
-goog.exportProperty(
-    os.ui.ex.ExportOptionsCtrl.prototype,
-    'updateItems',
-    os.ui.ex.ExportOptionsCtrl.prototype.updateItems);
 
 /**
  * Check the array to see if any items have a feature level style.

--- a/src/os/ui/feature/featureinfocell.js
+++ b/src/os/ui/feature/featureinfocell.js
@@ -129,18 +129,16 @@ os.ui.feature.FeatureInfoCellCtrl.prototype.init_ = function() {
 
 /**
  * Show the description tab
+ * @export
  */
 os.ui.feature.FeatureInfoCellCtrl.prototype.showDescription = function() {
   this.scope_.$emit(os.ui.feature.FeatureInfoCtrl.SHOW_DESCRIPTION);
 };
-goog.exportProperty(
-    os.ui.feature.FeatureInfoCellCtrl.prototype,
-    'showDescription',
-    os.ui.feature.FeatureInfoCellCtrl.prototype.showDescription);
 
 
 /**
  * View properties
+ * @export
  */
 os.ui.feature.FeatureInfoCellCtrl.prototype.viewProperties = function() {
   var feature = /** @type {!ol.Feature} */ (this.scope_['property']['feature']);
@@ -150,24 +148,17 @@ os.ui.feature.FeatureInfoCellCtrl.prototype.viewProperties = function() {
     os.ui.launchPropertyInfo(id, properties);
   }
 };
-goog.exportProperty(
-    os.ui.feature.FeatureInfoCellCtrl.prototype,
-    'viewProperties',
-    os.ui.feature.FeatureInfoCellCtrl.prototype.viewProperties);
 
 
 /**
  * Pick column action
+ * @export
  */
 os.ui.feature.FeatureInfoCellCtrl.prototype.pickColumnAction = function() {
   os.ui.columnactions.launchColumnActionPrompt(this.scope_['actions'],
       this.scope_['property']['value'],
       this.scope_['ca']);
 };
-goog.exportProperty(
-    os.ui.feature.FeatureInfoCellCtrl.prototype,
-    'pickColumnAction',
-    os.ui.feature.FeatureInfoCellCtrl.prototype.pickColumnAction);
 
 
 /**

--- a/src/os/ui/featureedit.js
+++ b/src/os/ui/featureedit.js
@@ -628,6 +628,7 @@ os.ui.FeatureEditCtrl.prototype.disposeInternal = function() {
 
 /**
  * Accept changes, saving the feature.
+ * @export
  */
 os.ui.FeatureEditCtrl.prototype.accept = function() {
   // create a new feature if necessary
@@ -653,14 +654,11 @@ os.ui.FeatureEditCtrl.prototype.accept = function() {
 
   this.close();
 };
-goog.exportProperty(
-    os.ui.FeatureEditCtrl.prototype,
-    'accept',
-    os.ui.FeatureEditCtrl.prototype.accept);
 
 
 /**
  * Cancel edit and close the window.
+ * @export
  */
 os.ui.FeatureEditCtrl.prototype.cancel = function() {
   var feature = this.options['feature'];
@@ -677,10 +675,6 @@ os.ui.FeatureEditCtrl.prototype.cancel = function() {
 
   this.close();
 };
-goog.exportProperty(
-    os.ui.FeatureEditCtrl.prototype,
-    'cancel',
-    os.ui.FeatureEditCtrl.prototype.cancel);
 
 
 /**
@@ -714,54 +708,42 @@ os.ui.FeatureEditCtrl.prototype.handleKeyEvent = function(event) {
 /**
  * If an ellipse shape is selected.
  * @return {boolean}
+ * @export
  */
 os.ui.FeatureEditCtrl.prototype.isEllipse = function() {
   return os.style.ELLIPSE_REGEXP.test(this['shape']);
 };
-goog.exportProperty(
-    os.ui.FeatureEditCtrl.prototype,
-    'isEllipse',
-    os.ui.FeatureEditCtrl.prototype.isEllipse);
 
 
 /**
  * If the icon picker should be displayed.
  * @return {boolean}
+ * @export
  */
 os.ui.FeatureEditCtrl.prototype.showIcon = function() {
   return this['shape'] === os.style.ShapeType.ICON;
 };
-goog.exportProperty(
-    os.ui.FeatureEditCtrl.prototype,
-    'showIcon',
-    os.ui.FeatureEditCtrl.prototype.showIcon);
 
 
 /**
  * If the icon picker should be displayed.
  * @return {boolean}
+ * @export
  */
 os.ui.FeatureEditCtrl.prototype.showCenterIcon = function() {
   return os.style.CENTER_LOOKUP[this['shape']] && this['centerShape'] === os.style.ShapeType.ICON;
 };
-goog.exportProperty(
-    os.ui.FeatureEditCtrl.prototype,
-    'showCenterIcon',
-    os.ui.FeatureEditCtrl.prototype.showCenterIcon);
 
 
 /**
  * If the feature is dynamic, which means it is a time based track
  * @return {boolean}
+ * @export
  */
 os.ui.FeatureEditCtrl.prototype.isFeatureDynamic = function() {
   var feature = /** @type {ol.Feature|undefined} */ (this.options['feature']);
   return feature instanceof os.feature.DynamicFeature;
 };
-goog.exportProperty(
-    os.ui.FeatureEditCtrl.prototype,
-    'isFeatureDynamic',
-    os.ui.FeatureEditCtrl.prototype.isFeatureDynamic);
 
 
 /**
@@ -829,6 +811,7 @@ os.ui.FeatureEditCtrl.prototype.onMapClick_ = function(mapBrowserEvent) {
 
 /**
  * Updates the temporary feature style.
+ * @export
  */
 os.ui.FeatureEditCtrl.prototype.updatePreview = function() {
   if (this.previewFeature) {
@@ -846,15 +829,12 @@ os.ui.FeatureEditCtrl.prototype.updatePreview = function() {
     }
   }
 };
-goog.exportProperty(
-    os.ui.FeatureEditCtrl.prototype,
-    'updatePreview',
-    os.ui.FeatureEditCtrl.prototype.updatePreview);
 
 
 /**
  * Save which section is open to local storage
  * @param {string} selector
+ * @export
  */
 os.ui.FeatureEditCtrl.prototype.setOpenSection = function(selector) {
   this.element.find('.js-style-content').each(function(i, ele) {
@@ -863,10 +843,6 @@ os.ui.FeatureEditCtrl.prototype.setOpenSection = function(selector) {
     }
   });
 };
-goog.exportProperty(
-    os.ui.FeatureEditCtrl.prototype,
-    'setOpenSection',
-    os.ui.FeatureEditCtrl.prototype.setOpenSection);
 
 
 /**
@@ -1226,6 +1202,7 @@ os.ui.FeatureEditCtrl.prototype.onColumnChange = function(event) {
  * Handle changes to the icon color.
  * @param {string=} opt_new The new color value
  * @param {string=} opt_old The old color value
+ * @export
  */
 os.ui.FeatureEditCtrl.prototype.onIconColorChange = function(opt_new, opt_old) {
   if (opt_new != opt_old && this['labelColor'] == opt_old) {
@@ -1234,17 +1211,13 @@ os.ui.FeatureEditCtrl.prototype.onIconColorChange = function(opt_new, opt_old) {
 
   this.updatePreview();
 };
-goog.exportProperty(
-    os.ui.FeatureEditCtrl.prototype,
-    'onIconColorChange',
-    os.ui.FeatureEditCtrl.prototype.onIconColorChange);
 
 
 /**
  * Handle icon change.
  * @param {angular.Scope.Event} event The Angular event.
  * @param {osx.icon.Icon} value The new value.
- * @protected
+ * @export
  */
 os.ui.FeatureEditCtrl.prototype.onIconChange = function(event, value) {
   event.stopPropagation();
@@ -1253,10 +1226,6 @@ os.ui.FeatureEditCtrl.prototype.onIconChange = function(event, value) {
   this['centerIcon'] = value;
   this.updatePreview();
 };
-goog.exportProperty(
-    os.ui.FeatureEditCtrl.prototype,
-    'onIconChange',
-    os.ui.FeatureEditCtrl.prototype.onIconChange);
 
 
 /**
@@ -1275,6 +1244,7 @@ os.ui.FeatureEditCtrl.prototype.onLabelColorReset = function(event) {
 /**
  * Get the minimum value for the semi-major ellipse axis by converting semi-minor to the semi-major units.
  * @return {number}
+ * @export
  */
 os.ui.FeatureEditCtrl.prototype.getSemiMajorMin = function() {
   var min = 1e-16;
@@ -1285,15 +1255,12 @@ os.ui.FeatureEditCtrl.prototype.getSemiMajorMin = function() {
 
   return min;
 };
-goog.exportProperty(
-    os.ui.FeatureEditCtrl.prototype,
-    'getSemiMajorMin',
-    os.ui.FeatureEditCtrl.prototype.getSemiMajorMin);
 
 
 /**
  * Handle changes to the semi-major or semi-minor axis. This corrects the initial arrow key/scroll value caused by
  * using "1e-16" as the min value to invalidate the form when 0 is used.
+ * @export
  */
 os.ui.FeatureEditCtrl.prototype.onAxisChange = function() {
   if (this['semiMinor'] === 1e-16) {
@@ -1306,10 +1273,6 @@ os.ui.FeatureEditCtrl.prototype.onAxisChange = function() {
 
   this.updatePreview();
 };
-goog.exportProperty(
-    os.ui.FeatureEditCtrl.prototype,
-    'onAxisChange',
-    os.ui.FeatureEditCtrl.prototype.onAxisChange);
 
 
 /**

--- a/src/os/ui/file/anytypeimport.js
+++ b/src/os/ui/file/anytypeimport.js
@@ -61,6 +61,7 @@ os.ui.file.AnyTypeImportCtrl = function($scope, $element) {
 
 /**
  * Open the correct importer
+ * @export
  */
 os.ui.file.AnyTypeImportCtrl.prototype.accept = function() {
   try {
@@ -72,19 +73,12 @@ os.ui.file.AnyTypeImportCtrl.prototype.accept = function() {
 
   this.close();
 };
-goog.exportProperty(
-    os.ui.file.AnyTypeImportCtrl.prototype,
-    'accept',
-    os.ui.file.AnyTypeImportCtrl.prototype.accept);
 
 
 /**
  * Open the correct importer
+ * @export
  */
 os.ui.file.AnyTypeImportCtrl.prototype.close = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(
-    os.ui.file.AnyTypeImportCtrl.prototype,
-    'close',
-    os.ui.file.AnyTypeImportCtrl.prototype.close);

--- a/src/os/ui/file/exportdialog.js
+++ b/src/os/ui/file/exportdialog.js
@@ -133,6 +133,7 @@ os.ui.file.ExportDialogCtrl.prototype.destroy = function() {
 /**
  * Get the label for the exporter.
  * @return {?string}
+ * @export
  */
 os.ui.file.ExportDialogCtrl.prototype.getExporterLabel = function() {
   if (this.scope && this.scope['exporter']) {
@@ -141,15 +142,12 @@ os.ui.file.ExportDialogCtrl.prototype.getExporterLabel = function() {
 
   return null;
 };
-goog.exportProperty(
-    os.ui.file.ExportDialogCtrl.prototype,
-    'getExporterLabel',
-    os.ui.file.ExportDialogCtrl.prototype.getExporterLabel);
 
 
 /**
  * Get the options UI for the exporter.
  * @return {?string}
+ * @export
  */
 os.ui.file.ExportDialogCtrl.prototype.getExporterUI = function() {
   if (this.scope && this.scope['exporter']) {
@@ -158,10 +156,6 @@ os.ui.file.ExportDialogCtrl.prototype.getExporterUI = function() {
 
   return null;
 };
-goog.exportProperty(
-    os.ui.file.ExportDialogCtrl.prototype,
-    'getExporterUI',
-    os.ui.file.ExportDialogCtrl.prototype.getExporterUI);
 
 
 /**
@@ -223,18 +217,16 @@ os.ui.file.ExportDialogCtrl.prototype.onPersisterChange = function(opt_new, opt_
 
 /**
  * Fire the cancel callback and close the window.
+ * @export
  */
 os.ui.file.ExportDialogCtrl.prototype.cancel = function() {
   this.close_();
 };
-goog.exportProperty(
-    os.ui.file.ExportDialogCtrl.prototype,
-    'cancel',
-    os.ui.file.ExportDialogCtrl.prototype.cancel);
 
 
 /**
  * Fire the confirmation callback and close the window.
+ * @export
  */
 os.ui.file.ExportDialogCtrl.prototype.confirm = function() {
   goog.asserts.assert(goog.isDefAndNotNull(this.options.exporter), 'exporter is not defined');
@@ -247,10 +239,6 @@ os.ui.file.ExportDialogCtrl.prototype.confirm = function() {
       this.options.exporter, this.options.persister);
   this.close_();
 };
-goog.exportProperty(
-    os.ui.file.ExportDialogCtrl.prototype,
-    'confirm',
-    os.ui.file.ExportDialogCtrl.prototype.confirm);
 
 
 /**

--- a/src/os/ui/file/fileimport.js
+++ b/src/os/ui/file/fileimport.js
@@ -134,6 +134,7 @@ os.ui.file.FileImportCtrl.prototype.onDestroy_ = function() {
 
 /**
  * Create import command and close the window
+ * @export
  */
 os.ui.file.FileImportCtrl.prototype.accept = function() {
   if (this.scope_['method'] && this['file']) {
@@ -146,10 +147,6 @@ os.ui.file.FileImportCtrl.prototype.accept = function() {
     this.close();
   }
 };
-goog.exportProperty(
-    os.ui.file.FileImportCtrl.prototype,
-    'accept',
-    os.ui.file.FileImportCtrl.prototype.accept);
 
 
 /**
@@ -191,26 +188,20 @@ os.ui.file.FileImportCtrl.prototype.handleError_ = function(errorMsg) {
 
 /**
  * Close the window.
+ * @export
  */
 os.ui.file.FileImportCtrl.prototype.close = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(
-    os.ui.file.FileImportCtrl.prototype,
-    'close',
-    os.ui.file.FileImportCtrl.prototype.close);
 
 
 /**
  * Launch the system file browser.
+ * @export
  */
 os.ui.file.FileImportCtrl.prototype.openFileBrowser = function() {
   this.fileInputEl_.click();
 };
-goog.exportProperty(
-    os.ui.file.FileImportCtrl.prototype,
-    'openFileBrowser',
-    os.ui.file.FileImportCtrl.prototype.openFileBrowser);
 
 
 /**

--- a/src/os/ui/file/importdialog.js
+++ b/src/os/ui/file/importdialog.js
@@ -151,6 +151,7 @@ os.ui.file.ImportDialogCtrl.prototype.onDestroy_ = function() {
 
 /**
  * Create import command and close the window
+ * @export
  */
 os.ui.file.ImportDialogCtrl.prototype.accept = function() {
   if (this.scope_['method']) {
@@ -184,14 +185,11 @@ os.ui.file.ImportDialogCtrl.prototype.accept = function() {
     this.close();
   }
 };
-goog.exportProperty(
-    os.ui.file.ImportDialogCtrl.prototype,
-    'accept',
-    os.ui.file.ImportDialogCtrl.prototype.accept);
 
 
 /**
  * Close the window.
+ * @export
  */
 os.ui.file.ImportDialogCtrl.prototype.close = function() {
   if (this.scope_ && this.scope_['onClose']) {
@@ -200,14 +198,11 @@ os.ui.file.ImportDialogCtrl.prototype.close = function() {
 
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(
-    os.ui.file.ImportDialogCtrl.prototype,
-    'close',
-    os.ui.file.ImportDialogCtrl.prototype.close);
 
 
 /**
  * Launch the system file browser.
+ * @export
  */
 os.ui.file.ImportDialogCtrl.prototype.clearFile = function() {
   if (this.fileInputEl_) {
@@ -222,15 +217,12 @@ os.ui.file.ImportDialogCtrl.prototype.clearFile = function() {
   this['url'] = null;
   this['fileChosen'] = false;
 };
-goog.exportProperty(
-    os.ui.file.ImportDialogCtrl.prototype,
-    'clearFile',
-    os.ui.file.ImportDialogCtrl.prototype.clearFile);
 
 
 /**
  * Get the import types supported by the application.
  * @return {string}
+ * @export
  */
 os.ui.file.ImportDialogCtrl.prototype.getImportDetails = function() {
   var result;
@@ -249,22 +241,15 @@ os.ui.file.ImportDialogCtrl.prototype.getImportDetails = function() {
 
   return result;
 };
-goog.exportProperty(
-    os.ui.file.ImportDialogCtrl.prototype,
-    'getImportDetails',
-    os.ui.file.ImportDialogCtrl.prototype.getImportDetails);
 
 
 /**
  * Launch the system file browser.
+ * @export
  */
 os.ui.file.ImportDialogCtrl.prototype.openFileBrowser = function() {
   this.fileInputEl_.click();
 };
-goog.exportProperty(
-    os.ui.file.ImportDialogCtrl.prototype,
-    'openFileBrowser',
-    os.ui.file.ImportDialogCtrl.prototype.openFileBrowser);
 
 
 /**

--- a/src/os/ui/file/ui/abstractfileimport.js
+++ b/src/os/ui/file/ui/abstractfileimport.js
@@ -118,6 +118,7 @@ os.ui.file.ui.AbstractFileImportCtrl.prototype.createDescriptor = goog.abstractM
 
 /**
  * Create import command and close the window
+ * @export
  */
 os.ui.file.ui.AbstractFileImportCtrl.prototype.accept = function() {
   var descriptor = this.createDescriptor();
@@ -132,19 +133,16 @@ os.ui.file.ui.AbstractFileImportCtrl.prototype.accept = function() {
 
   os.ui.window.close(this.element);
 };
-goog.exportProperty(os.ui.file.ui.AbstractFileImportCtrl.prototype, 'accept',
-    os.ui.file.ui.AbstractFileImportCtrl.prototype.accept);
 
 
 /**
  * Cancel file import
+ * @export
  */
 os.ui.file.ui.AbstractFileImportCtrl.prototype.cancel = function() {
   this.cleanConfig();
   os.ui.window.close(this.element);
 };
-goog.exportProperty(os.ui.file.ui.AbstractFileImportCtrl.prototype, 'cancel',
-    os.ui.file.ui.AbstractFileImportCtrl.prototype.cancel);
 
 
 /**

--- a/src/os/ui/file/ui/csv/configstep.js
+++ b/src/os/ui/file/ui/csv/configstep.js
@@ -181,12 +181,9 @@ os.ui.file.ui.csv.ConfigStepCtrl.prototype.scheduleUpdate_ = function() {
 
 /**
  * Creates a preview using a subset of the source content.
+ * @export
  */
 os.ui.file.ui.csv.ConfigStepCtrl.prototype.updatePreview = function() {
   // don't apply mappings during CSV configuration
   this.config_.updatePreview();
 };
-goog.exportProperty(
-    os.ui.file.ui.csv.ConfigStepCtrl.prototype,
-    'updatePreview',
-    os.ui.file.ui.csv.ConfigStepCtrl.prototype.updatePreview);

--- a/src/os/ui/file/ui/defaultfilenodeui.js
+++ b/src/os/ui/file/ui/defaultfilenodeui.js
@@ -52,6 +52,7 @@ goog.inherits(os.ui.file.ui.DefaultFileNodeUICtrl, os.ui.slick.AbstractNodeUICtr
 
 /**
  * Prompt the user to remove the file from the application
+ * @export
  */
 os.ui.file.ui.DefaultFileNodeUICtrl.prototype.tryRemove = function() {
   os.ui.window.launchConfirm(/** @type {osx.window.ConfirmOptions} */ ({
@@ -64,8 +65,6 @@ os.ui.file.ui.DefaultFileNodeUICtrl.prototype.tryRemove = function() {
     windowOptions: this.getRemoveWindowOptions()
   }));
 };
-goog.exportProperty(os.ui.file.ui.DefaultFileNodeUICtrl.prototype, 'tryRemove',
-    os.ui.file.ui.DefaultFileNodeUICtrl.prototype.tryRemove);
 
 
 /**

--- a/src/os/ui/file/urlimport.js
+++ b/src/os/ui/file/urlimport.js
@@ -88,6 +88,7 @@ os.ui.file.UrlImportCtrl.prototype.onDestroy_ = function() {
 
 /**
  * Create import command and close the window
+ * @export
  */
 os.ui.file.UrlImportCtrl.prototype.accept = function() {
   if (!this.scope_['urlForm']['$invalid'] && this.scope_['method']) {
@@ -104,24 +105,17 @@ os.ui.file.UrlImportCtrl.prototype.accept = function() {
     this.close();
   }
 };
-goog.exportProperty(
-    os.ui.file.UrlImportCtrl.prototype,
-    'accept',
-    os.ui.file.UrlImportCtrl.prototype.accept);
 
 
 /**
  * Close the window.
+ * @export
  */
 os.ui.file.UrlImportCtrl.prototype.close = function() {
   if (this.element_) {
     os.ui.window.close(this.element_);
   }
 };
-goog.exportProperty(
-    os.ui.file.UrlImportCtrl.prototype,
-    'close',
-    os.ui.file.UrlImportCtrl.prototype.close);
 
 
 /**

--- a/src/os/ui/filter/basicfilterbuilder.js
+++ b/src/os/ui/filter/basicfilterbuilder.js
@@ -94,14 +94,13 @@ os.ui.filter.BasicFilterBuilderCtrl.prototype.onDestroy_ = function() {
 /**
  * Adds an expression
  * @param {Node=} opt_node
+ * @export
  */
 os.ui.filter.BasicFilterBuilderCtrl.prototype.add = function(opt_node) {
   var child = os.ui.filter.ui.ExpressionNode.createExpressionNode(opt_node || null, this.scope_['columns']);
   this.root_.addChild(child);
   this.scrollDelay_.start();
 };
-goog.exportProperty(os.ui.filter.BasicFilterBuilderCtrl.prototype, 'add',
-    os.ui.filter.BasicFilterBuilderCtrl.prototype.add);
 
 
 /**

--- a/src/os/ui/filter/between.js
+++ b/src/os/ui/filter/between.js
@@ -68,6 +68,7 @@ os.ui.filter.BetweenCtrl.prototype.onDestroy_ = function() {
 
 /**
  * Run when the user changes the value
+ * @export
  */
 os.ui.filter.BetweenCtrl.prototype.onChange = function() {
   var a = parseFloat(this['min']);
@@ -84,4 +85,3 @@ os.ui.filter.BetweenCtrl.prototype.onChange = function() {
 
   this.scope_['expr']['literal'] = val;
 };
-goog.exportProperty(os.ui.filter.BetweenCtrl.prototype, 'onChange', os.ui.filter.BetweenCtrl.prototype.onChange);

--- a/src/os/ui/filter/expression.js
+++ b/src/os/ui/filter/expression.js
@@ -251,8 +251,8 @@ os.ui.filter.ExpressionCtrl.prototype.filterOps_ = function(op) {
  * Gets the UI for the given item
  * @param {os.ui.filter.op.Op} op
  * @return {?string}
+ * @export
  */
 os.ui.filter.ExpressionCtrl.prototype.getUi = function(op) {
   return op ? op.getUi() : null;
 };
-goog.exportProperty(os.ui.filter.ExpressionCtrl.prototype, 'getUi', os.ui.filter.ExpressionCtrl.prototype.getUi);

--- a/src/os/ui/filter/op/notop.js
+++ b/src/os/ui/filter/op/notop.js
@@ -28,20 +28,20 @@ goog.inherits(os.ui.filter.op.Not, os.ui.filter.op.Op);
 
 /**
  * @inheritDoc
+ * @export
  */
 os.ui.filter.op.Not.prototype.getTitle = function() {
   return this.op.getTitle().replace('is', 'is not');
 };
-goog.exportProperty(os.ui.filter.op.Not.prototype, 'getTitle', os.ui.filter.op.Not.prototype.getTitle);
 
 
 /**
  * @inheritDoc
+ * @export
  */
 os.ui.filter.op.Not.prototype.getShortTitle = function() {
   return 'not ' + this.op.getShortTitle();
 };
-goog.exportProperty(os.ui.filter.op.Not.prototype, 'getShortTitle', os.ui.filter.op.Not.prototype.getShortTitle);
 
 
 /**

--- a/src/os/ui/filter/op/op.js
+++ b/src/os/ui/filter/op/op.js
@@ -78,21 +78,21 @@ os.ui.filter.op.Op.prototype.getLocalName = function() {
 /**
  * Gets the title
  * @return {string} The title
+ * @export
  */
 os.ui.filter.op.Op.prototype.getTitle = function() {
   return this.title_;
 };
-goog.exportProperty(os.ui.filter.op.Op.prototype, 'getTitle', os.ui.filter.op.Op.prototype.getTitle);
 
 
 /**
  * Gets the title
  * @return {string} The title
+ * @export
  */
 os.ui.filter.op.Op.prototype.getShortTitle = function() {
   return this.shortTitle_;
 };
-goog.exportProperty(os.ui.filter.op.Op.prototype, 'getShortTitle', os.ui.filter.op.Op.prototype.getShortTitle);
 
 
 /**

--- a/src/os/ui/filter/textnocolcheck.js
+++ b/src/os/ui/filter/textnocolcheck.js
@@ -63,9 +63,8 @@ os.ui.filter.TextNoColCheckCtrl.prototype.onDestroy_ = function() {
 
 /**
  * Run when the user changes the value
+ * @export
  */
 os.ui.filter.TextNoColCheckCtrl.prototype.onChange = function() {
   this.scope_['expr']['literal'] = this['start'];
 };
-goog.exportProperty(os.ui.filter.TextNoColCheckCtrl.prototype, 'onChange',
-    os.ui.filter.TextNoColCheckCtrl.prototype.onChange);

--- a/src/os/ui/filter/ui/copyfilterpicker.js
+++ b/src/os/ui/filter/ui/copyfilterpicker.js
@@ -101,6 +101,7 @@ os.ui.filter.ui.CopyFilterPickerCtrl.prototype.destroy_ = function() {
 
 /**
  * Validates the picker section.
+ * @export
  */
 os.ui.filter.ui.CopyFilterPickerCtrl.prototype.validate = function() {
   var modelArray = /** @type {Array<Object>} */ (this.scope_['models']);
@@ -137,7 +138,3 @@ os.ui.filter.ui.CopyFilterPickerCtrl.prototype.validate = function() {
   this.scope_['copyFilterPickerForm'].$setValidity('duplicate', !duplicates);
   this.scope_['copyFilterPickerForm'].$setValidity('inUse', !inUse);
 };
-goog.exportProperty(
-    os.ui.filter.ui.CopyFilterPickerCtrl.prototype,
-    'validate',
-    os.ui.filter.ui.CopyFilterPickerCtrl.prototype.validate);

--- a/src/os/ui/filters.js
+++ b/src/os/ui/filters.js
@@ -116,30 +116,28 @@ os.ui.FiltersCtrl.prototype.destroy = function() {
 
 /**
  * Launches the advanced combination window
+ * @export
  */
 os.ui.FiltersCtrl.prototype.launch = function() {
   os.ui.CombinatorCtrl.launch();
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Filters.ADVANCED, 1);
 };
-goog.exportProperty(os.ui.FiltersCtrl.prototype, 'launch', os.ui.FiltersCtrl.prototype.launch);
 
 
 /**
  * Pop up filter export gui
  * @param {os.ui.filter.FilterEvent=} opt_event right click export event
+ * @export
  */
 os.ui.FiltersCtrl.prototype.export = function(opt_event) {
   os.ui.filter.ui.launchFilterExport(this.save_.bind(this));
 };
-goog.exportProperty(
-    os.ui.FiltersCtrl.prototype,
-    'export',
-    os.ui.FiltersCtrl.prototype.export);
 
 
 /**
  * Disables export button
  * @return {boolean}
+ * @export
  */
 os.ui.FiltersCtrl.prototype.exportDisabled = function() {
   // off when no filters present
@@ -150,7 +148,6 @@ os.ui.FiltersCtrl.prototype.exportDisabled = function() {
 
   return true;
 };
-goog.exportProperty(os.ui.FiltersCtrl.prototype, 'exportDisabled', os.ui.FiltersCtrl.prototype.exportDisabled);
 
 
 /**
@@ -206,14 +203,11 @@ os.ui.FiltersCtrl.prototype.flatten_ = function(arr, result, activeOnly) {
 
 /**
  * import filters
+ * @export
  */
 os.ui.FiltersCtrl.prototype.import = function() {
   os.query.launchQueryImport();
 };
-goog.exportProperty(
-    os.ui.FiltersCtrl.prototype,
-    'import',
-    os.ui.FiltersCtrl.prototype.import);
 
 
 /**
@@ -302,25 +296,19 @@ os.ui.FiltersCtrl.prototype.searchIfAddedOrRemoved_ = function(event) {
 
 /**
  * Handles Group By change
+ * @export
  */
 os.ui.FiltersCtrl.prototype.onGroupChange = function() {
   this.search();
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Filters.GROUP_BY, 1);
 };
-goog.exportProperty(
-    os.ui.FiltersCtrl.prototype,
-    'onGroupChange',
-    os.ui.FiltersCtrl.prototype.onGroupChange);
 
 
 /**
  * Handles Group By change
+ * @export
  */
 os.ui.FiltersCtrl.prototype.onSearchTermChange = function() {
   this.search();
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Filters.SEARCH, 1);
 };
-goog.exportProperty(
-    os.ui.FiltersCtrl.prototype,
-    'onSearchTermChange',
-    os.ui.FiltersCtrl.prototype.onSearchTermChange);

--- a/src/os/ui/geo/position.js
+++ b/src/os/ui/geo/position.js
@@ -242,14 +242,11 @@ os.ui.geo.PositionCtrl.prototype.formatLatLon_ = function() {
 
 /**
  * Toggles listening for map click events via the UI, propagating an event upward.
+ * @export
  */
 os.ui.geo.PositionCtrl.prototype.toggleMapEnabled = function() {
   this.setMapEnabled_(!this['mapEnabled']);
 };
-goog.exportProperty(
-    os.ui.geo.PositionCtrl.prototype,
-    'toggleMapEnabled',
-    os.ui.geo.PositionCtrl.prototype.toggleMapEnabled);
 
 
 /**

--- a/src/os/ui/help/controls.js
+++ b/src/os/ui/help/controls.js
@@ -89,6 +89,7 @@ os.ui.help.ControlsCtrl.launch = function() {
  * Get the key text
  * @param {goog.events.KeyCodes} key
  * @return {string}
+ * @export
  */
 os.ui.help.ControlsCtrl.prototype.getKey = function(key) {
   if (key === goog.events.KeyCodes.META && os.isOSX()) {
@@ -97,16 +98,13 @@ os.ui.help.ControlsCtrl.prototype.getKey = function(key) {
 
   return goog.string.toTitleCase(goog.events.KeyNames[key]);
 };
-goog.exportProperty(
-    os.ui.help.ControlsCtrl.prototype,
-    'getKey',
-    os.ui.help.ControlsCtrl.prototype.getKey);
 
 
 /**
  * Get the key text
  * @param {string} other
  * @return {?string}
+ * @export
  */
 os.ui.help.ControlsCtrl.prototype.getMouse = function(other) {
   var mouse = os.ui.help.Controls.MOUSE_IMAGE[other];
@@ -115,16 +113,13 @@ os.ui.help.ControlsCtrl.prototype.getMouse = function(other) {
   }
   return null;
 };
-goog.exportProperty(
-    os.ui.help.ControlsCtrl.prototype,
-    'getMouse',
-    os.ui.help.ControlsCtrl.prototype.getMouse);
 
 
 /**
  * Get the key text
  * @param {string} other
  * @return {?string}
+ * @export
  */
 os.ui.help.ControlsCtrl.prototype.getFont = function(other) {
   var font = os.ui.help.Controls.FONT_CLASS[other];
@@ -133,16 +128,13 @@ os.ui.help.ControlsCtrl.prototype.getFont = function(other) {
   }
   return null;
 };
-goog.exportProperty(
-    os.ui.help.ControlsCtrl.prototype,
-    'getFont',
-    os.ui.help.ControlsCtrl.prototype.getFont);
 
 
 /**
  * Get the key text
  * @param {string} other
  * @return {?string}
+ * @export
  */
 os.ui.help.ControlsCtrl.prototype.getFontClass = function(other) {
   var font = os.ui.help.Controls.FONT_CLASS[other];
@@ -151,10 +143,6 @@ os.ui.help.ControlsCtrl.prototype.getFontClass = function(other) {
   }
   return null;
 };
-goog.exportProperty(
-    os.ui.help.ControlsCtrl.prototype,
-    'getFontClass',
-    os.ui.help.ControlsCtrl.prototype.getFontClass);
 
 
 

--- a/src/os/ui/history/historyviewctrl.js
+++ b/src/os/ui/history/historyviewctrl.js
@@ -95,6 +95,7 @@ os.ui.history.HistoryViewCtrl.prototype.destroy_ = function() {
 
 /**
  * Prompts the user to clear the application history.
+ * @export
  */
 os.ui.history.HistoryViewCtrl.prototype.clearHistory = function() {
   os.ui.window.launchConfirm(/** @type {osx.window.ConfirmOptions} */ ({
@@ -116,10 +117,6 @@ os.ui.history.HistoryViewCtrl.prototype.clearHistory = function() {
     }
   }));
 };
-goog.exportProperty(
-    os.ui.history.HistoryViewCtrl.prototype,
-    'clearHistory',
-    os.ui.history.HistoryViewCtrl.prototype.clearHistory);
 
 
 /**
@@ -135,14 +132,11 @@ os.ui.history.HistoryViewCtrl.prototype.clearHistoryInternal_ = function() {
 
 /**
  * Toggles the history view
+ * @export
  */
 os.ui.history.HistoryViewCtrl.prototype.toggleHistoryView = function() {
   this['showHistoryView'] = !this['showHistoryView'];
 };
-goog.exportProperty(
-    os.ui.history.HistoryViewCtrl.prototype,
-    'toggleHistoryView',
-    os.ui.history.HistoryViewCtrl.prototype.toggleHistoryView);
 
 
 /**
@@ -150,6 +144,7 @@ goog.exportProperty(
  * clicked item and calls os.command.CommandProcessor.setIndex() with the
  * index as the argument.  Also manipulates the DOM to highlight that item.
  * @param {number} index
+ * @export
  */
 os.ui.history.HistoryViewCtrl.prototype.setIndex = function(index) {
   if (this['current'] == index) {
@@ -158,10 +153,6 @@ os.ui.history.HistoryViewCtrl.prototype.setIndex = function(index) {
   this.scope_.$emit('historyProcessing', true);
   this.cp_.setIndex(index);
 };
-goog.exportProperty(
-    os.ui.history.HistoryViewCtrl.prototype,
-    'setIndex',
-    os.ui.history.HistoryViewCtrl.prototype.setIndex);
 
 
 /**

--- a/src/os/ui/icon/iconpalette.js
+++ b/src/os/ui/icon/iconpalette.js
@@ -85,25 +85,19 @@ os.ui.icon.IconPaletteCtrl.prototype.destroy_ = function() {
  * Get the icon src to use in the Image element.
  * @param {string} src The icon src.
  * @return {string} The adjusted icon source.
+ * @export
  */
 os.ui.icon.IconPaletteCtrl.prototype.getIconSrc = function(src) {
   return this.scope_ && this.scope_['iconSrc'] ? this.scope_['iconSrc'](src) : src;
 };
-goog.exportProperty(
-    os.ui.icon.IconPaletteCtrl.prototype,
-    'getIconSrc',
-    os.ui.icon.IconPaletteCtrl.prototype.getIconSrc);
 
 
 /**
  * Notify parent scope that a icon was chosen.
  * @param {string} iconPath The selected iconPath
+ * @export
  */
 os.ui.icon.IconPaletteCtrl.prototype.pick = function(iconPath) {
   this.scope_['selected']['path'] = iconPath;
   os.ui.apply(this.scope);
 };
-goog.exportProperty(
-    os.ui.icon.IconPaletteCtrl.prototype,
-    'pick',
-    os.ui.icon.IconPaletteCtrl.prototype.pick);

--- a/src/os/ui/icon/iconpicker.js
+++ b/src/os/ui/icon/iconpicker.js
@@ -96,14 +96,11 @@ os.ui.icon.IconPickerCtrl.prototype.show = function() {
  * Translates from google uri if needed
  * @param {string} path
  * @return {string}
+ * @export
  */
 os.ui.icon.IconPickerCtrl.prototype.getPath = function(path) {
   return os.ui.file.kml.GMAPS_SEARCH.test(path) ? os.ui.file.kml.replaceGoogleUri(path) : path;
 };
-goog.exportProperty(
-    os.ui.icon.IconPickerCtrl.prototype,
-    'getPath',
-    os.ui.icon.IconPickerCtrl.prototype.getPath);
 
 
 /**

--- a/src/os/ui/icon/iconselector.js
+++ b/src/os/ui/icon/iconselector.js
@@ -94,26 +94,20 @@ os.ui.icon.IconSelectorCtrl.prototype.destroy_ = function() {
 /**
  * Is valid if the user has picked something
  * @return {boolean}
+ * @export
  */
 os.ui.icon.IconSelectorCtrl.prototype.isValid = function() {
   return this.scope_['selected'] && !!this.scope_['selected']['path'];
 };
-goog.exportProperty(
-    os.ui.icon.IconSelectorCtrl.prototype,
-    'isValid',
-    os.ui.icon.IconSelectorCtrl.prototype.isValid);
 
 
 /**
  * Notify parent scope that no icon was selected
+ * @export
  */
 os.ui.icon.IconSelectorCtrl.prototype.cancel = function() {
   this.close_();
 };
-goog.exportProperty(
-    os.ui.icon.IconSelectorCtrl.prototype,
-    'cancel',
-    os.ui.icon.IconSelectorCtrl.prototype.cancel);
 
 
 /**
@@ -127,6 +121,7 @@ os.ui.icon.IconSelectorCtrl.prototype.close_ = function() {
 
 /**
  * Notify parent scope which icon the user picked
+ * @export
  */
 os.ui.icon.IconSelectorCtrl.prototype.okay = function() {
   if (this.scope_['acceptCallback']) {
@@ -134,34 +129,24 @@ os.ui.icon.IconSelectorCtrl.prototype.okay = function() {
   }
   this.close_();
 };
-goog.exportProperty(
-    os.ui.icon.IconSelectorCtrl.prototype,
-    'okay',
-    os.ui.icon.IconSelectorCtrl.prototype.okay);
 
 
 /**
  * Notify parent scope which icon the user picked
  * @param {string} name
+ * @export
  */
 os.ui.icon.IconSelectorCtrl.prototype.setTab = function(name) {
   this.scope_['activeTab'] = name;
 };
-goog.exportProperty(
-    os.ui.icon.IconSelectorCtrl.prototype,
-    'setTab',
-    os.ui.icon.IconSelectorCtrl.prototype.setTab);
 
 
 /**
  * Translates from google uri if needed
  * @param {string} path
  * @return {string}
+ * @export
  */
 os.ui.icon.IconSelectorCtrl.prototype.getPath = function(path) {
   return os.ui.file.kml.GMAPS_SEARCH.test(path) ? os.ui.file.kml.replaceGoogleUri(path) : path;
 };
-goog.exportProperty(
-    os.ui.icon.IconSelectorCtrl.prototype,
-    'getPath',
-    os.ui.icon.IconSelectorCtrl.prototype.getPath);

--- a/src/os/ui/im/abstractmapperctrl.js
+++ b/src/os/ui/im/abstractmapperctrl.js
@@ -123,6 +123,7 @@ os.ui.im.AbstractMapperCtrl.prototype.destroy = function() {
 
 /**
  * Adds the mapping rules/static value to the mapping then closes the window.
+ * @export
  */
 os.ui.im.AbstractMapperCtrl.prototype.accept = function() {
   if (this.scope['mapping']) {
@@ -144,12 +145,11 @@ os.ui.im.AbstractMapperCtrl.prototype.accept = function() {
 
   os.ui.window.close(this.element);
 };
-goog.exportProperty(os.ui.im.AbstractMapperCtrl.prototype,
-    'accept', os.ui.im.AbstractMapperCtrl.prototype.accept);
 
 
 /**
  * Closes the window. Does not save changes to the mapping.
+ * @export
  */
 os.ui.im.AbstractMapperCtrl.prototype.close = function() {
   if (this.scope['finalize']) {
@@ -157,8 +157,6 @@ os.ui.im.AbstractMapperCtrl.prototype.close = function() {
   }
   os.ui.window.close(this.element);
 };
-goog.exportProperty(os.ui.im.AbstractMapperCtrl.prototype,
-    'close', os.ui.im.AbstractMapperCtrl.prototype.close);
 
 
 /**
@@ -220,6 +218,7 @@ os.ui.im.AbstractMapperCtrl.prototype.getColumn = function() {
 /**
  * Updates the mapping rules from a change in the selected column. This should be implemented
  * to test the mappings for the extensions of this class.
+ * @export
  */
 os.ui.im.AbstractMapperCtrl.prototype.update = function() {
   var column = this.getColumn();
@@ -260,8 +259,6 @@ os.ui.im.AbstractMapperCtrl.prototype.update = function() {
     this.validateRules();
   }
 };
-goog.exportProperty(os.ui.im.AbstractMapperCtrl.prototype,
-    'update', os.ui.im.AbstractMapperCtrl.prototype.update);
 
 
 /**

--- a/src/os/ui/im/action/editfilteraction.js
+++ b/src/os/ui/im/action/editfilteraction.js
@@ -98,6 +98,7 @@ goog.inherits(os.ui.im.action.EditFilterActionCtrl, os.ui.filter.ui.EditFiltersC
 
 /**
  * Add a new filter action.
+ * @export
  */
 os.ui.im.action.EditFilterActionCtrl.prototype.addAction = function() {
   if (this['availableActions'].length > 0) {
@@ -114,15 +115,12 @@ os.ui.im.action.EditFilterActionCtrl.prototype.addAction = function() {
     }
   }
 };
-goog.exportProperty(
-    os.ui.im.action.EditFilterActionCtrl.prototype,
-    'addAction',
-    os.ui.im.action.EditFilterActionCtrl.prototype.addAction);
 
 
 /**
  * Remove an action.
  * @param {number} index The import action index.
+ * @export
  */
 os.ui.im.action.EditFilterActionCtrl.prototype.removeAction = function(index) {
   if (index > -1 && index < this['actions'].length) {
@@ -131,15 +129,12 @@ os.ui.im.action.EditFilterActionCtrl.prototype.removeAction = function(index) {
     os.dispatcher.dispatchEvent(os.ui.im.action.EventType.UPDATE);
   }
 };
-goog.exportProperty(
-    os.ui.im.action.EditFilterActionCtrl.prototype,
-    'removeAction',
-    os.ui.im.action.EditFilterActionCtrl.prototype.removeAction);
 
 
 /**
  * Update an action type.
  * @param {number} index The action index.
+ * @export
  */
 os.ui.im.action.EditFilterActionCtrl.prototype.updateAction = function(index) {
   var actionObj = this['actions'][index];
@@ -153,10 +148,6 @@ os.ui.im.action.EditFilterActionCtrl.prototype.updateAction = function(index) {
     os.dispatcher.dispatchEvent(os.ui.im.action.EventType.UPDATE);
   }
 };
-goog.exportProperty(
-    os.ui.im.action.EditFilterActionCtrl.prototype,
-    'updateAction',
-    os.ui.im.action.EditFilterActionCtrl.prototype.updateAction);
 
 
 /**
@@ -183,16 +174,13 @@ os.ui.im.action.EditFilterActionCtrl.prototype.updateAvailableActions = function
 /**
  * Configure an action.
  * @param {os.im.action.IImportAction<T>} action The import action.
+ * @export
  */
 os.ui.im.action.EditFilterActionCtrl.prototype.configAction = function(action) {
   if (this.entry && action) {
     os.ui.im.action.launchActionConfig(action, this.entry.getType());
   }
 };
-goog.exportProperty(
-    os.ui.im.action.EditFilterActionCtrl.prototype,
-    'configAction',
-    os.ui.im.action.EditFilterActionCtrl.prototype.configAction);
 
 
 /**
@@ -220,19 +208,17 @@ os.ui.im.action.EditFilterActionCtrl.prototype.onDestroy = function() {
 
 /**
  * @inheritDoc
+ * @export
  */
 os.ui.im.action.EditFilterActionCtrl.prototype.cancel = function() {
   os.ui.im.action.closeActionConfigWindow();
   os.ui.im.action.EditFilterActionCtrl.base(this, 'cancel');
 };
-goog.exportProperty(
-    os.ui.im.action.EditFilterActionCtrl.prototype,
-    'cancel',
-    os.ui.im.action.EditFilterActionCtrl.prototype.cancel);
 
 
 /**
  * @inheritDoc
+ * @export
  */
 os.ui.im.action.EditFilterActionCtrl.prototype.finish = function() {
   os.ui.im.action.closeActionConfigWindow();
@@ -244,14 +230,11 @@ os.ui.im.action.EditFilterActionCtrl.prototype.finish = function() {
 
   os.ui.im.action.EditFilterActionCtrl.base(this, 'finish');
 };
-goog.exportProperty(
-    os.ui.im.action.EditFilterActionCtrl.prototype,
-    'finish',
-    os.ui.im.action.EditFilterActionCtrl.prototype.finish);
 
 
 /**
  * @inheritDoc
+ * @export
  */
 os.ui.im.action.EditFilterActionCtrl.prototype.isInvalid = function() {
   if (this['actions'].length == 0) {
@@ -260,15 +243,12 @@ os.ui.im.action.EditFilterActionCtrl.prototype.isInvalid = function() {
 
   return os.ui.im.action.EditFilterActionCtrl.base(this, 'isInvalid');
 };
-goog.exportProperty(
-    os.ui.im.action.EditFilterActionCtrl.prototype,
-    'isInvalid',
-    os.ui.im.action.EditFilterActionCtrl.prototype.isInvalid);
 
 
 /**
  * Get the tooltip to display over the Add Action button.
  * @return {string}
+ * @export
  */
 os.ui.im.action.EditFilterActionCtrl.prototype.getAddActionTooltip = function() {
   if (this['availableActions'].length > 0) {
@@ -277,10 +257,6 @@ os.ui.im.action.EditFilterActionCtrl.prototype.getAddActionTooltip = function() 
     return 'All available actions have been added';
   }
 };
-goog.exportProperty(
-    os.ui.im.action.EditFilterActionCtrl.prototype,
-    'getAddActionTooltip',
-    os.ui.im.action.EditFilterActionCtrl.prototype.getAddActionTooltip);
 
 
 /**

--- a/src/os/ui/im/action/filteractionexport.js
+++ b/src/os/ui/im/action/filteractionexport.js
@@ -102,18 +102,16 @@ os.ui.im.action.FilterActionExportCtrl.prototype.disposeInternal = function() {
 
 /**
  * Fire the cancel callback and close the window.
+ * @export
  */
 os.ui.im.action.FilterActionExportCtrl.prototype.cancel = function() {
   this.close_();
 };
-goog.exportProperty(
-    os.ui.im.action.FilterActionExportCtrl.prototype,
-    'cancel',
-    os.ui.im.action.FilterActionExportCtrl.prototype.cancel);
 
 
 /**
  * Validate the export selection.
+ * @export
  */
 os.ui.im.action.FilterActionExportCtrl.prototype.validate = function() {
   this['errorMsg'] = undefined;
@@ -138,14 +136,11 @@ os.ui.im.action.FilterActionExportCtrl.prototype.validate = function() {
       break;
   }
 };
-goog.exportProperty(
-    os.ui.im.action.FilterActionExportCtrl.prototype,
-    'validate',
-    os.ui.im.action.FilterActionExportCtrl.prototype.validate);
 
 
 /**
  * Fire the confirmation callback and close the window.
+ * @export
  */
 os.ui.im.action.FilterActionExportCtrl.prototype.save = function() {
   var entries;
@@ -171,10 +166,6 @@ os.ui.im.action.FilterActionExportCtrl.prototype.save = function() {
 
   this.close_();
 };
-goog.exportProperty(
-    os.ui.im.action.FilterActionExportCtrl.prototype,
-    'save',
-    os.ui.im.action.FilterActionExportCtrl.prototype.save);
 
 
 /**

--- a/src/os/ui/im/action/filteractionimport.js
+++ b/src/os/ui/im/action/filteractionimport.js
@@ -74,6 +74,7 @@ os.ui.im.action.FilterActionImportCtrl.prototype.getFilterTooltip = function(ent
 
 /**
  * @inheritDoc
+ * @export
  */
 os.ui.im.action.FilterActionImportCtrl.prototype.finish = function() {
   var iam = os.im.action.ImportActionManager.getInstance();
@@ -124,19 +125,12 @@ os.ui.im.action.FilterActionImportCtrl.prototype.finish = function() {
 
   os.ui.window.close(this.element);
 };
-goog.exportProperty(
-    os.ui.im.action.FilterActionImportCtrl.prototype,
-    'finish',
-    os.ui.im.action.FilterActionImportCtrl.prototype.finish);
 
 
 /**
  * @inheritDoc
+ * @export
  */
 os.ui.im.action.FilterActionImportCtrl.prototype.getFilterIcon = function() {
   return os.im.action.ICON;
 };
-goog.exportProperty(
-    os.ui.im.action.FilterActionImportCtrl.prototype,
-    'getFilterIcon',
-    os.ui.im.action.FilterActionImportCtrl.prototype.getFilterIcon);

--- a/src/os/ui/im/action/filteractionsui.js
+++ b/src/os/ui/im/action/filteractionsui.js
@@ -104,26 +104,20 @@ os.ui.im.action.FilterActionsCtrl.prototype.refresh = function() {
 
 /**
  * Apply changes.
+ * @export
  */
 os.ui.im.action.FilterActionsCtrl.prototype.apply = function() {
   this.saveEntries();
 };
-goog.exportProperty(
-    os.ui.im.action.FilterActionsCtrl.prototype,
-    'apply',
-    os.ui.im.action.FilterActionsCtrl.prototype.apply);
 
 
 /**
  * Close the window, discarding any pending changes.
+ * @export
  */
 os.ui.im.action.FilterActionsCtrl.prototype.close = function() {
   os.ui.window.close(this.element);
 };
-goog.exportProperty(
-    os.ui.im.action.FilterActionsCtrl.prototype,
-    'close',
-    os.ui.im.action.FilterActionsCtrl.prototype.close);
 
 
 /**
@@ -227,18 +221,16 @@ os.ui.im.action.FilterActionsCtrl.prototype.onRemoveEvent = function(event, entr
 /**
  * If there is at least one selected entry.
  * @return {boolean} If one or more selected entries are available.
+ * @export
  */
 os.ui.im.action.FilterActionsCtrl.prototype.hasSelected = function() {
   return this['selected'] && this['selected'].length > 0;
 };
-goog.exportProperty(
-    os.ui.im.action.FilterActionsCtrl.prototype,
-    'hasSelected',
-    os.ui.im.action.FilterActionsCtrl.prototype.hasSelected);
 
 
 /**
  * Launch the export dialog.
+ * @export
  */
 os.ui.im.action.FilterActionsCtrl.prototype.launchExport = function() {
   os.metrics.Metrics.getInstance().updateMetric(os.im.action.Metrics.EXPORT, 1);
@@ -247,14 +239,11 @@ os.ui.im.action.FilterActionsCtrl.prototype.launchExport = function() {
   var selected = os.ui.im.action.FilterActionNode.toEntries(this['selected']);
   os.ui.im.action.launchFilterActionExport(entries, selected, this.getExportName());
 };
-goog.exportProperty(
-    os.ui.im.action.FilterActionsCtrl.prototype,
-    'launchExport',
-    os.ui.im.action.FilterActionsCtrl.prototype.launchExport);
 
 
 /**
  * Launch the import dialog.
+ * @export
  */
 os.ui.im.action.FilterActionsCtrl.prototype.launchImport = function() {
   os.metrics.Metrics.getInstance().updateMetric(os.im.action.Metrics.IMPORT, 1);
@@ -264,7 +253,3 @@ os.ui.im.action.FilterActionsCtrl.prototype.launchImport = function() {
   });
   os.dispatcher.dispatchEvent(event);
 };
-goog.exportProperty(
-    os.ui.im.action.FilterActionsCtrl.prototype,
-    'launchImport',
-    os.ui.im.action.FilterActionsCtrl.prototype.launchImport);

--- a/src/os/ui/im/filesupport.js
+++ b/src/os/ui/im/filesupport.js
@@ -152,6 +152,7 @@ os.ui.im.FileSupportCtrl.prototype.disposeInternal = function() {
 
 /**
  * Fire the cancel callback and close the window.
+ * @export
  */
 os.ui.im.FileSupportCtrl.prototype.cancel = function() {
   if (this.cancelCallback_) {
@@ -160,11 +161,11 @@ os.ui.im.FileSupportCtrl.prototype.cancel = function() {
 
   this.close_();
 };
-goog.exportProperty(os.ui.im.FileSupportCtrl.prototype, 'cancel', os.ui.im.FileSupportCtrl.prototype.cancel);
 
 
 /**
  * Fire the confirmation callback and close the window.
+ * @export
  */
 os.ui.im.FileSupportCtrl.prototype.confirm = function() {
   if (this['choice'] === os.ui.im.FileSupportChoice.UPLOAD && os.file.upload.uploadFile != null) {
@@ -175,7 +176,6 @@ os.ui.im.FileSupportCtrl.prototype.confirm = function() {
 
   this.close_();
 };
-goog.exportProperty(os.ui.im.FileSupportCtrl.prototype, 'confirm', os.ui.im.FileSupportCtrl.prototype.confirm);
 
 
 /**

--- a/src/os/ui/layer/defaultlayerui.js
+++ b/src/os/ui/layer/defaultlayerui.js
@@ -399,6 +399,7 @@ os.ui.layer.DefaultLayerUICtrl.prototype.onSliderStop = function(callback, key, 
 
 /**
  * Set the refresh state of the source.
+ * @export
  */
 os.ui.layer.DefaultLayerUICtrl.prototype.onRefreshChange = function() {
   var nodes = this.getLayerNodes();
@@ -417,15 +418,12 @@ os.ui.layer.DefaultLayerUICtrl.prototype.onRefreshChange = function() {
     this.createCommand(fn);
   }
 };
-goog.exportProperty(
-    os.ui.layer.DefaultLayerUICtrl.prototype,
-    'onRefreshChange',
-    os.ui.layer.DefaultLayerUICtrl.prototype.onRefreshChange);
 
 
 /**
  * Resets the value of the chosen key to the default.
  * @param {string} key
+ * @export
  */
 os.ui.layer.DefaultLayerUICtrl.prototype.reset = function(key) {
   var defaultValue = this.defaults[key];
@@ -434,15 +432,12 @@ os.ui.layer.DefaultLayerUICtrl.prototype.reset = function(key) {
     this.onSliderStop(callback, key, null, defaultValue);
   }
 };
-goog.exportProperty(
-    os.ui.layer.DefaultLayerUICtrl.prototype,
-    'reset',
-    os.ui.layer.DefaultLayerUICtrl.prototype.reset);
 
 
 /**
  * Opens an accordion and saves it to local storage.
  * @param {string} selector
+ * @export
  */
 os.ui.layer.DefaultLayerUICtrl.prototype.setOpenSection = function(selector) {
   os.settings.set('layercontrols', selector);
@@ -453,7 +448,3 @@ os.ui.layer.DefaultLayerUICtrl.prototype.setOpenSection = function(selector) {
     }
   });
 };
-goog.exportProperty(
-    os.ui.layer.DefaultLayerUICtrl.prototype,
-    'setOpenSection',
-    os.ui.layer.DefaultLayerUICtrl.prototype.setOpenSection);

--- a/src/os/ui/layer/ellipseoptions.js
+++ b/src/os/ui/layer/ellipseoptions.js
@@ -118,6 +118,7 @@ os.ui.layer.EllipseOptionsCtrl.prototype.getShowGroundReference_ = function() {
 
 /**
  * Handle changes to the Show Ellipsoids option.
+ * @export
  */
 os.ui.layer.EllipseOptionsCtrl.prototype.onShowEllipsoidsChange = function() {
   var items = /** @type {Array} */ (this.scope['items']);
@@ -135,14 +136,11 @@ os.ui.layer.EllipseOptionsCtrl.prototype.onShowEllipsoidsChange = function() {
     this.createCommand(fn);
   }
 };
-goog.exportProperty(
-    os.ui.layer.EllipseOptionsCtrl.prototype,
-    'onShowEllipsoidsChange',
-    os.ui.layer.EllipseOptionsCtrl.prototype.onShowEllipsoidsChange);
 
 
 /**
  * Handle changes to the Show Ground Reference option.
+ * @export
  */
 os.ui.layer.EllipseOptionsCtrl.prototype.onShowGroundReferenceChange = function() {
   var items = /** @type {Array} */ (this.scope['items']);
@@ -160,7 +158,3 @@ os.ui.layer.EllipseOptionsCtrl.prototype.onShowGroundReferenceChange = function(
     this.createCommand(fn);
   }
 };
-goog.exportProperty(
-    os.ui.layer.EllipseOptionsCtrl.prototype,
-    'onShowGroundReferenceChange',
-    os.ui.layer.EllipseOptionsCtrl.prototype.onShowGroundReferenceChange);

--- a/src/os/ui/layer/iconstylecontrols.js
+++ b/src/os/ui/layer/iconstylecontrols.js
@@ -71,29 +71,21 @@ os.ui.layer.IconStyleControlsCtrl.prototype.disposeInternal = function() {
 
 /**
  * Toggle the Show Rotation.
- * @protected
+ * @export
  */
 os.ui.layer.IconStyleControlsCtrl.prototype.toggleShowRotation = function() {
   if (this.scope) {
     this.scope.$emit(os.ui.layer.VectorStyleControlsEventType.SHOW_ROTATION_CHANGE, this.scope['showRotation']);
   }
 };
-goog.exportProperty(
-    os.ui.layer.IconStyleControlsCtrl.prototype,
-    'toggleShowRotation',
-    os.ui.layer.IconStyleControlsCtrl.prototype.toggleShowRotation);
 
 
 /**
  * Handles column changes to the rotation
- * @protected
+ * @export
  */
 os.ui.layer.IconStyleControlsCtrl.prototype.onRotationColumnChange = function() {
   if (this.scope) {
     this.scope.$emit(os.ui.layer.VectorStyleControlsEventType.ROTATION_COLUMN_CHANGE, this.scope['rotationColumn']);
   }
 };
-goog.exportProperty(
-    os.ui.layer.IconStyleControlsCtrl.prototype,
-    'onRotationColumnChange',
-    os.ui.layer.IconStyleControlsCtrl.prototype.onRotationColumnChange);

--- a/src/os/ui/layer/labelcontrols.js
+++ b/src/os/ui/layer/labelcontrols.js
@@ -142,6 +142,7 @@ os.ui.layer.LabelControlsCtrl.prototype.getSortOptions = function() {
 
 /**
  * Handles column changes
+ * @export
  */
 os.ui.layer.LabelControlsCtrl.prototype.onColumnChange = function() {
   if (this.scope) {
@@ -151,54 +152,40 @@ os.ui.layer.LabelControlsCtrl.prototype.onColumnChange = function() {
     this.scope.$emit(os.ui.layer.LabelControlsEventType.COLUMN_CHANGE);
   }
 };
-goog.exportProperty(
-    os.ui.layer.LabelControlsCtrl.prototype,
-    'onColumnChange',
-    os.ui.layer.LabelControlsCtrl.prototype.onColumnChange);
 
 
 /**
  * Handles changes to the show labels checkbox.
- * @protected
+ * @export
  */
 os.ui.layer.LabelControlsCtrl.prototype.onShowLabelsChange = function() {
   if (this.scope) {
     this.scope.$emit(os.ui.layer.LabelControlsEventType.SHOW_LABELS_CHANGE, this.scope['showLabels']);
   }
 };
-goog.exportProperty(
-    os.ui.layer.LabelControlsCtrl.prototype,
-    'onShowLabelsChange',
-    os.ui.layer.LabelControlsCtrl.prototype.onShowLabelsChange);
 
 
 /**
  * Add a new label
+ * @export
  */
 os.ui.layer.LabelControlsCtrl.prototype.addLabel = function() {
   this.scope['labels'].push(os.style.label.cloneConfig());
   this.onColumnChange();
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.Layer.LABEL_COLUMN_ADD, 1);
 };
-goog.exportProperty(
-    os.ui.layer.LabelControlsCtrl.prototype,
-    'addLabel',
-    os.ui.layer.LabelControlsCtrl.prototype.addLabel);
 
 
 /**
  * Remove a label
  * @param {os.style.label.LabelConfig} label
+ * @export
  */
 os.ui.layer.LabelControlsCtrl.prototype.removeLabel = function(label) {
   goog.array.remove(this.scope['labels'], label);
   this.onColumnChange();
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.Layer.LABEL_COLUMN_REMOVE, 1);
 };
-goog.exportProperty(
-    os.ui.layer.LabelControlsCtrl.prototype,
-    'removeLabel',
-    os.ui.layer.LabelControlsCtrl.prototype.removeLabel);
 
 
 /**

--- a/src/os/ui/layer/tilelayerui.js
+++ b/src/os/ui/layer/tilelayerui.js
@@ -128,6 +128,7 @@ os.ui.layer.TileLayerUICtrl.prototype.onColorReset = function(event) {
 
 /**
  * Handles style changes.
+ * @export
  */
 os.ui.layer.TileLayerUICtrl.prototype.onStyleChange = function() {
   var items = /** @type {Array} */ (this.scope['items']);
@@ -145,8 +146,6 @@ os.ui.layer.TileLayerUICtrl.prototype.onStyleChange = function() {
     this.createCommand(fn);
   }
 };
-goog.exportProperty(os.ui.layer.TileLayerUICtrl.prototype, 'onStyleChange',
-    os.ui.layer.TileLayerUICtrl.prototype.onStyleChange);
 
 
 /**

--- a/src/os/ui/layer/vectorlayerui.js
+++ b/src/os/ui/layer/vectorlayerui.js
@@ -236,6 +236,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getShapeUIInternal = function() {
 /**
  * Decide when to show the rotation option
  * @return {boolean}
+ * @export
  */
 os.ui.layer.VectorLayerUICtrl.prototype.showRotationOption = function() {
   if (this.scope != null) {
@@ -246,10 +247,6 @@ os.ui.layer.VectorLayerUICtrl.prototype.showRotationOption = function() {
 
   return false;
 };
-goog.exportProperty(
-    os.ui.layer.VectorLayerUICtrl.prototype,
-    'showRotationOption',
-    os.ui.layer.VectorLayerUICtrl.prototype.showRotationOption);
 
 
 /**
@@ -339,6 +336,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.onSizeChange = function(event, value) {
  * Handles changes to the icon.
  * @param {angular.Scope.Event} event The Angular event.
  * @param {osx.icon.Icon} value The new value.
+ * @export
  */
 os.ui.layer.VectorLayerUICtrl.prototype.onIconChange = function(event, value) {
   event.stopPropagation();
@@ -356,14 +354,13 @@ os.ui.layer.VectorLayerUICtrl.prototype.onIconChange = function(event, value) {
     this.createCommand(fn);
   }
 };
-goog.exportProperty(os.ui.layer.VectorLayerUICtrl.prototype, 'onIconChange',
-    os.ui.layer.VectorLayerUICtrl.prototype.onIconChange);
 
 
 /**
  * Handles changes to the shape.
  * @param {angular.Scope.Event} event The Angular event.
  * @param {string} value The new value.
+ * @export
  */
 os.ui.layer.VectorLayerUICtrl.prototype.onShapeChange = function(event, value) {
   event.stopPropagation();
@@ -380,14 +377,13 @@ os.ui.layer.VectorLayerUICtrl.prototype.onShapeChange = function(event, value) {
     this.createCommand(fn);
   }
 };
-goog.exportProperty(os.ui.layer.VectorLayerUICtrl.prototype, 'onShapeChange',
-    os.ui.layer.VectorLayerUICtrl.prototype.onShapeChange);
 
 
 /**
  * Handles changes to the center shape.
  * @param {angular.Scope.Event} event The Angular event.
  * @param {string} value The new value.
+ * @export
  */
 os.ui.layer.VectorLayerUICtrl.prototype.onCenterShapeChange = function(event, value) {
   event.stopPropagation();
@@ -404,8 +400,6 @@ os.ui.layer.VectorLayerUICtrl.prototype.onCenterShapeChange = function(event, va
     this.createCommand(fn);
   }
 };
-goog.exportProperty(os.ui.layer.VectorLayerUICtrl.prototype, 'onCenterShapeChange',
-    os.ui.layer.VectorLayerUICtrl.prototype.onCenterShapeChange);
 
 
 /**
@@ -762,6 +756,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getLockable_ = function() {
 
 /**
  * Set the locked state of the source
+ * @export
  */
 os.ui.layer.VectorLayerUICtrl.prototype.onLockChange = function() {
   var items = /** @type {Array} */ (this.scope['items']);
@@ -777,10 +772,6 @@ os.ui.layer.VectorLayerUICtrl.prototype.onLockChange = function() {
     }
   }
 };
-goog.exportProperty(
-    os.ui.layer.VectorLayerUICtrl.prototype,
-    'onLockChange',
-    os.ui.layer.VectorLayerUICtrl.prototype.onLockChange);
 
 
 /**
@@ -824,6 +815,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.updateReplaceStyle_ = function() {
 
 /**
  * Handle changes to the Replace Feature Style option.
+ * @export
  */
 os.ui.layer.VectorLayerUICtrl.prototype.onReplaceStyleChange = function() {
   var items = /** @type {Array} */ (this.scope['items']);
@@ -841,10 +833,6 @@ os.ui.layer.VectorLayerUICtrl.prototype.onReplaceStyleChange = function() {
     this.createCommand(fn);
   }
 };
-goog.exportProperty(
-    os.ui.layer.VectorLayerUICtrl.prototype,
-    'onReplaceStyleChange',
-    os.ui.layer.VectorLayerUICtrl.prototype.onReplaceStyleChange);
 
 
 /**
@@ -872,6 +860,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getAltitudeMode_ = function() {
 
 /**
  * Set the altitude mode of the source
+ * @export
  */
 os.ui.layer.VectorLayerUICtrl.prototype.onAltitudeModeChange = function() {
   var items = /** @type {Array} */ (this.scope['items']);
@@ -887,14 +876,11 @@ os.ui.layer.VectorLayerUICtrl.prototype.onAltitudeModeChange = function() {
     }
   }
 };
-goog.exportProperty(
-    os.ui.layer.VectorLayerUICtrl.prototype,
-    'onAltitudeModeChange',
-    os.ui.layer.VectorLayerUICtrl.prototype.onAltitudeModeChange);
 
 
 /**
  * Set the unique ID field of the source.
+ * @export
  */
 os.ui.layer.VectorLayerUICtrl.prototype.onUniqueIdChange = function() {
   var nodes = this.getLayerNodes();
@@ -912,10 +898,6 @@ os.ui.layer.VectorLayerUICtrl.prototype.onUniqueIdChange = function() {
     this.createCommand(fn);
   }
 };
-goog.exportProperty(
-    os.ui.layer.VectorLayerUICtrl.prototype,
-    'onUniqueIdChange',
-    os.ui.layer.VectorLayerUICtrl.prototype.onUniqueIdChange);
 
 
 /**

--- a/src/os/ui/layer/vectorstylecontrols.js
+++ b/src/os/ui/layer/vectorstylecontrols.js
@@ -95,21 +95,19 @@ os.ui.layer.VectorStyleControlsCtrl.prototype.disposeInternal = function() {
 
 /**
  * Fire a scope event when the shape is changed by the user.
+ * @export
  */
 os.ui.layer.VectorStyleControlsCtrl.prototype.onShapeChange = function() {
   if (this.scope) {
     this.scope.$emit(os.ui.layer.VectorStyleControlsEventType.SHAPE_CHANGE, this.scope['shape']);
   }
 };
-goog.exportProperty(
-    os.ui.layer.VectorStyleControlsCtrl.prototype,
-    'onShapeChange',
-    os.ui.layer.VectorStyleControlsCtrl.prototype.onShapeChange);
 
 
 /**
  * Check for ellipse with center
  * @return {boolean}
+ * @export
  */
 os.ui.layer.VectorStyleControlsCtrl.prototype.hasCenter = function() {
   if (this.scope && this.scope['shape']) {
@@ -117,15 +115,12 @@ os.ui.layer.VectorStyleControlsCtrl.prototype.hasCenter = function() {
   }
   return false;
 };
-goog.exportProperty(
-    os.ui.layer.VectorStyleControlsCtrl.prototype,
-    'hasCenter',
-    os.ui.layer.VectorStyleControlsCtrl.prototype.hasCenter);
 
 
 /**
  * Fire a scope event when the ellipse center shape is changed by the user.
  * @param {string} shape
+ * @export
  */
 os.ui.layer.VectorStyleControlsCtrl.prototype.onCenterShapeChange = function(shape) {
   if (this.scope) {
@@ -133,7 +128,3 @@ os.ui.layer.VectorStyleControlsCtrl.prototype.onCenterShapeChange = function(sha
     this.scope['centerShape'] = shape;
   }
 };
-goog.exportProperty(
-    os.ui.layer.VectorStyleControlsCtrl.prototype,
-    'onCenterShapeChange',
-    os.ui.layer.VectorStyleControlsCtrl.prototype.onCenterShapeChange);

--- a/src/os/ui/layers.js
+++ b/src/os/ui/layers.js
@@ -173,18 +173,18 @@ os.ui.LayersCtrl.prototype.close = function() {
 
 /**
  * Change event handler for the groupBy control
+ * @export
  */
 os.ui.LayersCtrl.prototype.onGroupByChanged = function() {
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.AddData.GROUP_BY, 1);
   this.search();
 };
-goog.exportProperty(os.ui.LayersCtrl.prototype, 'onGroupByChanged',
-    os.ui.LayersCtrl.prototype.onGroupByChanged);
 
 
 /**
  * @param {*} item
  * @return {?string}
+ * @export
  */
 os.ui.LayersCtrl.prototype.getUi = function(item) {
   if (item && item instanceof os.data.LayerNode) {
@@ -196,13 +196,13 @@ os.ui.LayersCtrl.prototype.getUi = function(item) {
 
   return null;
 };
-goog.exportProperty(os.ui.LayersCtrl.prototype, 'getUi', os.ui.LayersCtrl.prototype.getUi);
 
 
 /**
  * Checks if a window is open in the application
  * @param {string} flag The window id
  * @return {boolean}
+ * @export
  */
 os.ui.LayersCtrl.prototype.isWindowActive = function(flag) {
   var s = angular.element(os.ui.windowSelector.CONTAINER).scope();
@@ -214,12 +214,12 @@ os.ui.LayersCtrl.prototype.isWindowActive = function(flag) {
 
   return !!angular.element('div[label="' + flag + '"].window').length;
 };
-goog.exportProperty(os.ui.LayersCtrl.prototype, 'isWindowActive', os.ui.LayersCtrl.prototype.isWindowActive);
 
 
 /**
  * Opens the specified menu.
  * @param {string} selector The menu target selector.
+ * @export
  */
 os.ui.LayersCtrl.prototype.openMenu = function(selector) {
   var menu = this.menus_[selector];
@@ -237,7 +237,6 @@ os.ui.LayersCtrl.prototype.openMenu = function(selector) {
     }
   }
 };
-goog.exportProperty(os.ui.LayersCtrl.prototype, 'openMenu', os.ui.LayersCtrl.prototype.openMenu);
 
 
 /**
@@ -253,6 +252,7 @@ os.ui.LayersCtrl.prototype.onMenuClose = function(evt) {
 /**
  * Toggles a flag on mainCtrl
  * @param {string} flagName The name of the flag to toggle
+ * @export
  */
 os.ui.LayersCtrl.prototype.toggle = function(flagName) {
   if (!os.ui.menu.windows.openWindow(flagName)) {
@@ -260,11 +260,11 @@ os.ui.LayersCtrl.prototype.toggle = function(flagName) {
     os.dispatcher.dispatchEvent(event);
   }
 };
-goog.exportProperty(os.ui.LayersCtrl.prototype, 'toggle', os.ui.LayersCtrl.prototype.toggle);
 
 
 /**
  * Toggles the Tile layers on/off
+ * @export
  */
 os.ui.LayersCtrl.prototype.toggleTileLayers = function() {
   this.scope['showTiles'] = !this.scope['showTiles'];
@@ -285,21 +285,21 @@ os.ui.LayersCtrl.prototype.toggleTileLayers = function() {
     }
   }
 };
-goog.exportProperty(os.ui.LayersCtrl.prototype, 'toggleTileLayers', os.ui.LayersCtrl.prototype.toggleTileLayers);
 
 
 /**
  * Checks if the Tiles should be displayed
  * @return {boolean}
+ * @export
  */
 os.ui.LayersCtrl.prototype.showTiles = function() {
   return this.scope['showTiles'];
 };
-goog.exportProperty(os.ui.LayersCtrl.prototype, 'showTiles', os.ui.LayersCtrl.prototype.showTiles);
 
 
 /**
  * Toggles the Feature layers on/off
+ * @export
  */
 os.ui.LayersCtrl.prototype.toggleFeatureLayers = function() {
   this.scope['showFeatures'] = !this.scope['showFeatures'];
@@ -322,14 +322,13 @@ os.ui.LayersCtrl.prototype.toggleFeatureLayers = function() {
     }
   }
 };
-goog.exportProperty(os.ui.LayersCtrl.prototype, 'toggleFeatureLayers', os.ui.LayersCtrl.prototype.toggleFeatureLayers);
 
 
 /**
  * Checks if the Features should be displayed
  * @return {boolean}
+ * @export
  */
 os.ui.LayersCtrl.prototype.showFeatures = function() {
   return this.scope['showFeatures'];
 };
-goog.exportProperty(os.ui.LayersCtrl.prototype, 'showFeatures', os.ui.LayersCtrl.prototype.showFeatures);

--- a/src/os/ui/legend.js
+++ b/src/os/ui/legend.js
@@ -446,6 +446,7 @@ os.ui.LegendCtrl.prototype.positionLegend_ = function(opt_e) {
 
 /**
  * Open legend settings.
+ * @export
  */
 os.ui.LegendCtrl.prototype.openSettings = function() {
   os.ui.config.SettingsManager.getInstance().setSelectedPlugin(os.legend.ID);
@@ -453,14 +454,11 @@ os.ui.LegendCtrl.prototype.openSettings = function() {
   var event = new os.ui.events.UIEvent(os.ui.events.UIEventType.TOGGLE_UI, 'settings', true);
   os.dispatcher.dispatchEvent(event);
 };
-goog.exportProperty(
-    os.ui.LegendCtrl.prototype,
-    'openSettings',
-    os.ui.LegendCtrl.prototype.openSettings);
 
 
 /**
  * Open legend settings.
+ * @export
  */
 os.ui.LegendCtrl.prototype.close = function() {
   if (this.scope['closeFlag'] != null) {
@@ -473,7 +471,3 @@ os.ui.LegendCtrl.prototype.close = function() {
     this.scope.$parent.$destroy();
   }
 };
-goog.exportProperty(
-    os.ui.LegendCtrl.prototype,
-    'close',
-    os.ui.LegendCtrl.prototype.close);

--- a/src/os/ui/location/simplelocation.js
+++ b/src/os/ui/location/simplelocation.js
@@ -94,6 +94,7 @@ os.ui.location.SimpleLocationCtrl.prototype.onLatLonChange_ = function() {
 /**
  * Change the display model
  * @param {os.ui.location.Format=} opt_format
+ * @export
  */
 os.ui.location.SimpleLocationCtrl.prototype.format = function(opt_format) {
   if (this.scope_ && this.scope_['latdeg'] != undefined && this.scope_['londeg'] != undefined) {
@@ -114,21 +115,18 @@ os.ui.location.SimpleLocationCtrl.prototype.format = function(opt_format) {
     os.ui.apply(this.scope_);
   }
 };
-goog.exportProperty(os.ui.location.SimpleLocationCtrl.prototype, 'format',
-    os.ui.location.SimpleLocationCtrl.prototype.format);
 
 
 /**
  * Change the display model
  * @param {os.events.SettingChangeEvent} event
+ * @export
  */
 os.ui.location.SimpleLocationCtrl.prototype.locationChanged = function(event) {
   if (event.newVal) {
     this.format(/** @type {os.ui.location.Format} */ (event.newVal));
   }
 };
-goog.exportProperty(os.ui.location.SimpleLocationCtrl.prototype, 'locationChanged',
-    os.ui.location.SimpleLocationCtrl.prototype.locationChanged);
 
 
 /**
@@ -244,14 +242,13 @@ os.ui.location.SimpleLocationControlsCtrl.prototype.formatChanged = function(for
 /**
  * Change the display model
  * @param {os.events.SettingChangeEvent} event
+ * @export
  */
 os.ui.location.SimpleLocationControlsCtrl.prototype.locationControlChanged = function(event) {
   if (event.newVal) {
     this.formatChanged(/** @type {os.ui.location.Format} */ (event.newVal));
   }
 };
-goog.exportProperty(os.ui.location.SimpleLocationControlsCtrl.prototype, 'locationControlChanged',
-    os.ui.location.SimpleLocationControlsCtrl.prototype.locationControlChanged);
 
 
 /**

--- a/src/os/ui/measurebutton.js
+++ b/src/os/ui/measurebutton.js
@@ -104,6 +104,7 @@ os.ui.MeasureButtonCtrl.MEASURE = new os.ui.menu.Menu(new os.ui.menu.MenuItem({
 /**
  * @param {boolean=} opt_value The toggle value
  * @override
+ * @export
  */
 os.ui.MeasureButtonCtrl.prototype.toggle = function(opt_value) {
   var measure = this.getMeasureInteraction_();
@@ -142,7 +143,6 @@ os.ui.MeasureButtonCtrl.prototype.toggle = function(opt_value) {
     }
   }
 };
-goog.exportProperty(os.ui.MeasureButtonCtrl.prototype, 'toggle', os.ui.MeasureButtonCtrl.prototype.toggle);
 
 
 /**

--- a/src/os/ui/menu/menubutton.js
+++ b/src/os/ui/menu/menubutton.js
@@ -86,6 +86,7 @@ os.ui.menu.MenuButtonCtrl.prototype.disposeInternal = function() {
 
 /**
  * Open the menu
+ * @export
  */
 os.ui.menu.MenuButtonCtrl.prototype.openMenu = function() {
   if (this.menu) {
@@ -111,10 +112,6 @@ os.ui.menu.MenuButtonCtrl.prototype.openMenu = function() {
 
   os.ui.apply(this.scope);
 };
-goog.exportProperty(
-    os.ui.menu.MenuButtonCtrl.prototype,
-    'openMenu',
-    os.ui.menu.MenuButtonCtrl.prototype.openMenu);
 
 
 /**
@@ -129,6 +126,7 @@ os.ui.menu.MenuButtonCtrl.prototype.onMenuClose = function() {
 
 /**
  * Toggles a window
+ * @export
  */
 os.ui.menu.MenuButtonCtrl.prototype.toggle = function() {
   if (this.flag && !os.ui.menu.windows.openWindow(this.flag)) {
@@ -136,16 +134,13 @@ os.ui.menu.MenuButtonCtrl.prototype.toggle = function() {
     os.dispatcher.dispatchEvent(event);
   }
 };
-goog.exportProperty(
-    os.ui.menu.MenuButtonCtrl.prototype,
-    'toggle',
-    os.ui.menu.MenuButtonCtrl.prototype.toggle);
 
 
 /**
  * Checks if a window is open in the application
  * @param {string=} opt_flag The ID of the window to check
  * @return {boolean}
+ * @export
  */
 os.ui.menu.MenuButtonCtrl.prototype.isWindowActive = function(opt_flag) {
   var flag = opt_flag || this.flag;
@@ -157,7 +152,3 @@ os.ui.menu.MenuButtonCtrl.prototype.isWindowActive = function(opt_flag) {
 
   return false;
 };
-goog.exportProperty(
-    os.ui.menu.MenuButtonCtrl.prototype,
-    'isWindowActive',
-    os.ui.menu.MenuButtonCtrl.prototype.isWindowActive);

--- a/src/os/ui/menu/spatialmenu.js
+++ b/src/os/ui/menu/spatialmenu.js
@@ -867,6 +867,7 @@ os.ui.menu.spatial.LayerChooserCtrl = function($scope, $element) {
 /**
  * Fire the confirmation callback and close the window.
  * @return {boolean}
+ * @export
  */
 os.ui.menu.spatial.LayerChooserCtrl.prototype.valid = function() {
   var found = goog.array.find(this.scope_['layers'], function(layer) {
@@ -876,13 +877,11 @@ os.ui.menu.spatial.LayerChooserCtrl.prototype.valid = function() {
   // Switch the type to the correct action
   return !found;
 };
-goog.exportProperty(os.ui.menu.spatial.LayerChooserCtrl.prototype,
-    'valid',
-    os.ui.menu.spatial.LayerChooserCtrl.prototype.valid);
 
 
 /**
  * Fire the confirmation callback and close the window.
+ * @export
  */
 os.ui.menu.spatial.LayerChooserCtrl.prototype.accept = function() {
   // Switch the type to the correct action
@@ -898,21 +897,15 @@ os.ui.menu.spatial.LayerChooserCtrl.prototype.accept = function() {
   os.ui.menu.spatial.onMenuEvent(this.scope_['event'], layerIds);
   this.close();
 };
-goog.exportProperty(os.ui.menu.spatial.LayerChooserCtrl.prototype,
-    'accept',
-    os.ui.menu.spatial.LayerChooserCtrl.prototype.accept);
 
 
 /**
  * Close the window.
+ * @export
  */
 os.ui.menu.spatial.LayerChooserCtrl.prototype.close = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(
-    os.ui.menu.spatial.LayerChooserCtrl.prototype,
-    'close',
-    os.ui.menu.spatial.LayerChooserCtrl.prototype.close);
 
 
 /**

--- a/src/os/ui/menubutton.js
+++ b/src/os/ui/menubutton.js
@@ -76,6 +76,7 @@ os.ui.MenuButtonCtrl.prototype.onDestroy = function() {
 
 /**
  * Open the menu
+ * @export
  */
 os.ui.MenuButtonCtrl.prototype.openMenu = function() {
   if (this.menu) {
@@ -95,7 +96,6 @@ os.ui.MenuButtonCtrl.prototype.openMenu = function() {
 
   os.ui.apply(this.scope);
 };
-goog.exportProperty(os.ui.MenuButtonCtrl.prototype, 'openMenu', os.ui.MenuButtonCtrl.prototype.openMenu);
 
 
 /**
@@ -110,6 +110,7 @@ os.ui.MenuButtonCtrl.prototype.onMenuClose = function() {
 
 /**
  * Toggles a window
+ * @export
  */
 os.ui.MenuButtonCtrl.prototype.toggle = function() {
   if (this.flag && !os.ui.menu.windows.openWindow(this.flag)) {
@@ -117,13 +118,13 @@ os.ui.MenuButtonCtrl.prototype.toggle = function() {
     os.dispatcher.dispatchEvent(event);
   }
 };
-goog.exportProperty(os.ui.MenuButtonCtrl.prototype, 'toggle', os.ui.MenuButtonCtrl.prototype.toggle);
 
 
 /**
  * Checks if a window is open in the application
  * @param {string=} opt_flag The ID of the window to check
  * @return {boolean}
+ * @export
  */
 os.ui.MenuButtonCtrl.prototype.isWindowActive = function(opt_flag) {
   var flag = opt_flag || this.flag;
@@ -135,4 +136,3 @@ os.ui.MenuButtonCtrl.prototype.isWindowActive = function(opt_flag) {
 
   return false;
 };
-goog.exportProperty(os.ui.MenuButtonCtrl.prototype, 'isWindowActive', os.ui.MenuButtonCtrl.prototype.isWindowActive);

--- a/src/os/ui/metrics/metriccompletion.js
+++ b/src/os/ui/metrics/metriccompletion.js
@@ -67,6 +67,7 @@ os.ui.metrics.MetricCompletionCtrl.prototype.onDestroy_ = function() {
 
 /**
  * @return {string}
+ * @export
  */
 os.ui.metrics.MetricCompletionCtrl.prototype.getCompleted = function() {
   try {
@@ -88,10 +89,6 @@ os.ui.metrics.MetricCompletionCtrl.prototype.getCompleted = function() {
 
   return '';
 };
-goog.exportProperty(
-    os.ui.metrics.MetricCompletionCtrl.prototype,
-    'getCompleted',
-    os.ui.metrics.MetricCompletionCtrl.prototype.getCompleted);
 
 
 /**

--- a/src/os/ui/metrics/metricdetails.js
+++ b/src/os/ui/metrics/metricdetails.js
@@ -64,6 +64,7 @@ os.ui.metrics.MetricDetailsCtrl.prototype.disposeInternal = function() {
 /**
  * Get the metric label.
  * @return {string}
+ * @export
  */
 os.ui.metrics.MetricDetailsCtrl.prototype.getLabel = function() {
   if (this.scope_ && this.scope_['metric'] instanceof os.ui.metrics.MetricNode) {
@@ -87,15 +88,12 @@ os.ui.metrics.MetricDetailsCtrl.prototype.getLabel = function() {
 
   return '';
 };
-goog.exportProperty(
-    os.ui.metrics.MetricDetailsCtrl.prototype,
-    'getLabel',
-    os.ui.metrics.MetricDetailsCtrl.prototype.getLabel);
 
 
 /**
  * Get the metric description.
  * @return {string}
+ * @export
  */
 os.ui.metrics.MetricDetailsCtrl.prototype.getDescription = function() {
   if (this.scope_ && this.scope_['metric'] instanceof os.ui.metrics.MetricNode) {
@@ -105,7 +103,3 @@ os.ui.metrics.MetricDetailsCtrl.prototype.getDescription = function() {
 
   return '';
 };
-goog.exportProperty(
-    os.ui.metrics.MetricDetailsCtrl.prototype,
-    'getDescription',
-    os.ui.metrics.MetricDetailsCtrl.prototype.getDescription);

--- a/src/os/ui/metrics/metricscontainer.js
+++ b/src/os/ui/metrics/metricscontainer.js
@@ -121,13 +121,11 @@ os.ui.metrics.MetricsContainerCtrl.prototype.initRoot = function() {
 
 /**
  * Save the metrics
- * @private
+ * @export
  */
-os.ui.metrics.MetricsContainerCtrl.prototype.save_ = function() {
+os.ui.metrics.MetricsContainerCtrl.prototype.save = function() {
   os.metrics.Metrics.getInstance().save();
 };
-goog.exportProperty(os.ui.metrics.MetricsContainerCtrl.prototype, 'save',
-    os.ui.metrics.MetricsContainerCtrl.prototype.save_);
 
 
 /**

--- a/src/os/ui/multiurlproviderimport.js
+++ b/src/os/ui/multiurlproviderimport.js
@@ -112,6 +112,7 @@ os.ui.MultiUrlProviderImportCtrl.prototype.getConfigFields = function() {
 
 /**
  * Add a new alternate URL to the list.
+ * @export
  */
 os.ui.MultiUrlProviderImportCtrl.prototype.addAlternateUrl = function() {
   if (!this.scope['config']['alternateUrls']) {
@@ -120,22 +121,15 @@ os.ui.MultiUrlProviderImportCtrl.prototype.addAlternateUrl = function() {
 
   this.scope['config']['alternateUrls'].push('');
 };
-goog.exportProperty(
-    os.ui.MultiUrlProviderImportCtrl.prototype,
-    'addAlternateUrl',
-    os.ui.MultiUrlProviderImportCtrl.prototype.addAlternateUrl);
 
 
 /**
  * Remove an alternate URL from the list at the provided index.
  * @param {number} index The alternate URL index to remove
+ * @export
  */
 os.ui.MultiUrlProviderImportCtrl.prototype.removeAlternateUrl = function(index) {
   if (this.scope['config']['alternateUrls'] && this.scope['config']['alternateUrls'].length > index) {
     this.scope['config']['alternateUrls'].splice(index, 1);
   }
 };
-goog.exportProperty(
-    os.ui.MultiUrlProviderImportCtrl.prototype,
-    'removeAlternateUrl',
-    os.ui.MultiUrlProviderImportCtrl.prototype.removeAlternateUrl);

--- a/src/os/ui/mutebutton.js
+++ b/src/os/ui/mutebutton.js
@@ -47,12 +47,12 @@ os.ui.MuteButtonCtrl = function($scope) {
 
 /**
  * Toggles mute
+ * @export
  */
 os.ui.MuteButtonCtrl.prototype.toggle = function() {
   var am = os.audio.AudioManager.getInstance();
   am.setMute(!am.getMute());
   this.scope['mute'] = am.getMute();
 };
-goog.exportProperty(os.ui.MuteButtonCtrl.prototype, 'toggle', os.ui.MuteButtonCtrl.prototype.toggle);
 
 

--- a/src/os/ui/node/layertype.js
+++ b/src/os/ui/node/layertype.js
@@ -44,6 +44,7 @@ os.ui.node.LayerTypeCtrl = function($scope, $element) {
 
 /**
  * @return {string}
+ * @export
  */
 os.ui.node.LayerTypeCtrl.prototype.getType = function() {
   if (os.settings.get(['ui', 'layers', 'showLayerTypes'], true)) {
@@ -59,5 +60,3 @@ os.ui.node.LayerTypeCtrl.prototype.getType = function() {
   return '';
 };
 
-goog.exportProperty(
-    os.ui.node.LayerTypeCtrl.prototype, 'getType', os.ui.node.LayerTypeCtrl.prototype.getType);

--- a/src/os/ui/ol/draw/drawmenu.js
+++ b/src/os/ui/ol/draw/drawmenu.js
@@ -71,50 +71,38 @@ os.ui.ol.draw.DrawMenuCtrl.prototype.destroy_ = function() {
 
 /**
  * @return {boolean} Whether or not picking by country is enabled
+ * @export
  */
 os.ui.ol.draw.DrawMenuCtrl.prototype.isCountryEnabled = function() {
   return false;
 };
-goog.exportProperty(
-    os.ui.ol.draw.DrawMenuCtrl.prototype,
-    'isCountryEnabled',
-    os.ui.ol.draw.DrawMenuCtrl.prototype.isCountryEnabled);
 
 
 /**
  * Launched adding areas by coordinates
+ * @export
  */
 os.ui.ol.draw.DrawMenuCtrl.prototype.launchAreaByCoordinates = function() {
   os.query.launchCoordinates();
   /** @type {os.ui.ol.draw.DrawControlsCtrl} */ (this['drawControls']).toggleMenu(false);
 };
-goog.exportProperty(
-    os.ui.ol.draw.DrawMenuCtrl.prototype,
-    'launchAreaByCoordinates',
-    os.ui.ol.draw.DrawMenuCtrl.prototype.launchAreaByCoordinates);
 
 
 /**
  * Launched adding areas by coordinates
+ * @export
  */
 os.ui.ol.draw.DrawMenuCtrl.prototype.launchChooseArea = function() {
   os.query.launchChooseArea();
   /** @type {os.ui.ol.draw.DrawControlsCtrl} */ (this['drawControls']).toggleMenu(false);
 };
-goog.exportProperty(
-    os.ui.ol.draw.DrawMenuCtrl.prototype,
-    'launchChooseArea',
-    os.ui.ol.draw.DrawMenuCtrl.prototype.launchChooseArea);
 
 
 /**
  * Adds an area querying the whole world.
+ * @export
  */
 os.ui.ol.draw.DrawMenuCtrl.prototype.queryWorld = function() {
   os.query.queryWorld();
   /** @type {os.ui.ol.draw.DrawControlsCtrl} */ (this['drawControls']).toggleMenu(false);
 };
-goog.exportProperty(
-    os.ui.ol.draw.DrawMenuCtrl.prototype,
-    'queryWorld',
-    os.ui.ol.draw.DrawMenuCtrl.prototype.queryWorld);

--- a/src/os/ui/onboarding/contextonboarding.js
+++ b/src/os/ui/onboarding/contextonboarding.js
@@ -58,11 +58,8 @@ os.ui.onboarding.ContextOnboardingCtrl.prototype.destroy_ = function() {
 
 /**
  * Called on clicking the button to display the onboarding for the element this directive is attached to.
+ * @export
  */
 os.ui.onboarding.ContextOnboardingCtrl.prototype.show = function() {
   os.ui.onboarding.OnboardingManager.getInstance().showContextOnboarding(this.scope_['context']);
 };
-goog.exportProperty(
-    os.ui.onboarding.ContextOnboardingCtrl.prototype,
-    'show',
-    os.ui.onboarding.ContextOnboardingCtrl.prototype.show);

--- a/src/os/ui/onboarding/ngonboarding.js
+++ b/src/os/ui/onboarding/ngonboarding.js
@@ -100,6 +100,7 @@ os.ui.onboarding.NgOnboardingCtrl.prototype.destroy_ = function() {
 
 /**
  * Move to the next step.
+ * @export
  */
 os.ui.onboarding.NgOnboardingCtrl.prototype.next = function() {
   if (!this['lastStep']) {
@@ -108,26 +109,20 @@ os.ui.onboarding.NgOnboardingCtrl.prototype.next = function() {
     this.close();
   }
 };
-goog.exportProperty(
-    os.ui.onboarding.NgOnboardingCtrl.prototype,
-    'next',
-    os.ui.onboarding.NgOnboardingCtrl.prototype.next);
 
 
 /**
  * Move to the previous step.
+ * @export
  */
 os.ui.onboarding.NgOnboardingCtrl.prototype.previous = function() {
   this.scope_['index'] = this.scope_['index'] - 1;
 };
-goog.exportProperty(
-    os.ui.onboarding.NgOnboardingCtrl.prototype,
-    'previous',
-    os.ui.onboarding.NgOnboardingCtrl.prototype.previous);
 
 
 /**
  * Close onboarding.
+ * @export
  */
 os.ui.onboarding.NgOnboardingCtrl.prototype.close = function() {
   this.scope_['enabled'] = false;
@@ -136,23 +131,16 @@ os.ui.onboarding.NgOnboardingCtrl.prototype.close = function() {
     this.scope_['onFinishCallback']();
   }
 };
-goog.exportProperty(
-    os.ui.onboarding.NgOnboardingCtrl.prototype,
-    'close',
-    os.ui.onboarding.NgOnboardingCtrl.prototype.close);
 
 
 /**
  * Close onboarding and prevent others from being displayed.
+ * @export
  */
 os.ui.onboarding.NgOnboardingCtrl.prototype.stopShowing = function() {
   os.settings.set('onboarding.showOnboarding', false);
   this.close();
 };
-goog.exportProperty(
-    os.ui.onboarding.NgOnboardingCtrl.prototype,
-    'stopShowing',
-    os.ui.onboarding.NgOnboardingCtrl.prototype.stopShowing);
 
 
 /**

--- a/src/os/ui/pagingbar.js
+++ b/src/os/ui/pagingbar.js
@@ -151,6 +151,7 @@ os.ui.PagingBarCtrl.prototype.updatePaging_ = function() {
  * Page click handler. Checks to see if the clicked page is enabled and if it's not the same page as is currently
  * active.
  * @param {Object} page
+ * @export
  */
 os.ui.PagingBarCtrl.prototype.onPageClick = function(page) {
   if (!this.scope_['disabled'] && page && !page['disabled'] &&
@@ -160,7 +161,3 @@ os.ui.PagingBarCtrl.prototype.onPageClick = function(page) {
     this.scope_['pageClickFunction'](pageNumber);
   }
 };
-goog.exportProperty(
-    os.ui.PagingBarCtrl.prototype,
-    'onPageClick',
-    os.ui.PagingBarCtrl.prototype.onPageClick);

--- a/src/os/ui/providerimport.js
+++ b/src/os/ui/providerimport.js
@@ -51,6 +51,7 @@ os.ui.ProviderImportCtrl.prototype.initialize = function() {
 
 /**
  * Save button handler
+ * @export
  */
 os.ui.ProviderImportCtrl.prototype.accept = function() {
   if (!this.scope['form']['$invalid'] && !this.scope['testing']) {
@@ -65,11 +66,11 @@ os.ui.ProviderImportCtrl.prototype.accept = function() {
     }
   }
 };
-goog.exportProperty(os.ui.ProviderImportCtrl.prototype, 'accept', os.ui.ProviderImportCtrl.prototype.accept);
 
 
 /**
  * Closes the window
+ * @export
  */
 os.ui.ProviderImportCtrl.prototype.close = function() {
   if (this.dp) {
@@ -78,7 +79,6 @@ os.ui.ProviderImportCtrl.prototype.close = function() {
 
   os.ui.window.close(this.element);
 };
-goog.exportProperty(os.ui.ProviderImportCtrl.prototype, 'close', os.ui.ProviderImportCtrl.prototype.close);
 
 
 /**

--- a/src/os/ui/query/ui/areaimportctrl.js
+++ b/src/os/ui/query/ui/areaimportctrl.js
@@ -69,23 +69,17 @@ os.ui.query.ui.AreaImportCtrl.prototype.disposeInternal = function() {
 
 /**
  * Close the window
+ * @export
  */
 os.ui.query.ui.AreaImportCtrl.prototype.close = function() {
   os.ui.window.close(this.element);
 };
-goog.exportProperty(
-    os.ui.query.ui.AreaImportCtrl.prototype,
-    'close',
-    os.ui.query.ui.AreaImportCtrl.prototype.close);
 
 
 /**
  * Load areas from the selected file(s).
+ * @export
  */
 os.ui.query.ui.AreaImportCtrl.prototype.finish = function() {
   this['loading'] = true;
 };
-goog.exportProperty(
-    os.ui.query.ui.AreaImportCtrl.prototype,
-    'finish',
-    os.ui.query.ui.AreaImportCtrl.prototype.finish);

--- a/src/os/ui/query/ui/editarea.js
+++ b/src/os/ui/query/ui/editarea.js
@@ -75,6 +75,7 @@ goog.inherits(os.ui.query.ui.EditAreaCtrl, os.ui.query.ui.AreaImportCtrl);
 
 /**
  * Finish the dialog
+ * @export
  */
 os.ui.query.ui.EditAreaCtrl.prototype.accept = function() {
   var feature = /** @type {!ol.Feature} */ (this.scope['feature']);
@@ -99,5 +100,4 @@ os.ui.query.ui.EditAreaCtrl.prototype.accept = function() {
 
   this.close();
 };
-goog.exportProperty(os.ui.query.ui.EditAreaCtrl.prototype, 'accept', os.ui.query.ui.EditAreaCtrl.prototype.accept);
 

--- a/src/os/ui/query/ui/modifyarea.js
+++ b/src/os/ui/query/ui/modifyarea.js
@@ -275,18 +275,16 @@ os.ui.query.ui.ModifyAreaCtrl.prototype.getMergedArea_ = function() {
 
 /**
  * Fire the cancel callback and close the window.
+ * @export
  */
 os.ui.query.ui.ModifyAreaCtrl.prototype.cancel = function() {
   this.close_();
 };
-goog.exportProperty(
-    os.ui.query.ui.ModifyAreaCtrl.prototype,
-    'cancel',
-    os.ui.query.ui.ModifyAreaCtrl.prototype.cancel);
 
 
 /**
  * Performs the area modification.
+ * @export
  */
 os.ui.query.ui.ModifyAreaCtrl.prototype.confirm = function() {
   var feature = this.getMergedArea_();
@@ -312,16 +310,13 @@ os.ui.query.ui.ModifyAreaCtrl.prototype.confirm = function() {
 
   this.close_();
 };
-goog.exportProperty(
-    os.ui.query.ui.ModifyAreaCtrl.prototype,
-    'confirm',
-    os.ui.query.ui.ModifyAreaCtrl.prototype.confirm);
 
 
 /**
  * Get the help popover title for an operation.
  * @param {string} op The operation
  * @return {string}
+ * @export
  */
 os.ui.query.ui.ModifyAreaCtrl.prototype.getPopoverTitle = function(op) {
   switch (op) {
@@ -337,16 +332,13 @@ os.ui.query.ui.ModifyAreaCtrl.prototype.getPopoverTitle = function(op) {
 
   return 'Area Help';
 };
-goog.exportProperty(
-    os.ui.query.ui.ModifyAreaCtrl.prototype,
-    'getPopoverTitle',
-    os.ui.query.ui.ModifyAreaCtrl.prototype.getPopoverTitle);
 
 
 /**
  * Get the help popover content for an operation.
  * @param {string} op The operation
  * @return {string}
+ * @export
  */
 os.ui.query.ui.ModifyAreaCtrl.prototype.getPopoverContent = function(op) {
   switch (op) {
@@ -362,10 +354,6 @@ os.ui.query.ui.ModifyAreaCtrl.prototype.getPopoverContent = function(op) {
 
   return 'Area Help';
 };
-goog.exportProperty(
-    os.ui.query.ui.ModifyAreaCtrl.prototype,
-    'getPopoverContent',
-    os.ui.query.ui.ModifyAreaCtrl.prototype.getPopoverContent);
 
 
 /**

--- a/src/os/ui/search/facetedsearch.js
+++ b/src/os/ui/search/facetedsearch.js
@@ -280,12 +280,11 @@ os.ui.search.FacetedSearchCtrl.prototype.sortCategories = function(a, b) {
 
 /**
  * Kicks off the search timer
+ * @export
  */
 os.ui.search.FacetedSearchCtrl.prototype.search = function() {
   this.searchDelay.start();
 };
-goog.exportProperty(os.ui.search.FacetedSearchCtrl.prototype, 'search',
-    os.ui.search.FacetedSearchCtrl.prototype.search);
 
 
 /**
@@ -302,24 +301,22 @@ os.ui.search.FacetedSearchCtrl.prototype.update = function() {
 
 /**
  * Kicks off a more delayed search timer
+ * @export
  */
 os.ui.search.FacetedSearchCtrl.prototype.delaySearch = function() {
   this.longSearchDelay.start();
 };
-goog.exportProperty(os.ui.search.FacetedSearchCtrl.prototype, 'delaySearch',
-    os.ui.search.FacetedSearchCtrl.prototype.delaySearch);
 
 
 /**
  * Clears the search term
+ * @export
  */
 os.ui.search.FacetedSearchCtrl.prototype.clearTerm = function() {
   this.scope['term'] = '';
   os.ui.apply(this.scope);
   this.search();
 };
-goog.exportProperty(os.ui.search.FacetedSearchCtrl.prototype, 'clearTerm',
-    os.ui.search.FacetedSearchCtrl.prototype.clearTerm);
 
 
 /**
@@ -353,13 +350,12 @@ os.ui.search.FacetedSearchCtrl.prototype.clearNode = function(node) {
 
 /**
  * Clear all
+ * @export
  */
 os.ui.search.FacetedSearchCtrl.prototype.clearAll = function() {
   this.clearTerm();
   this.clearFacets();
 };
-goog.exportProperty(os.ui.search.FacetedSearchCtrl.prototype, 'clearAll',
-    os.ui.search.FacetedSearchCtrl.prototype.clearAll);
 
 
 /**
@@ -431,9 +427,8 @@ os.ui.search.FacetedSearchCtrl.prototype.onAutoComplete = function() {
 /**
  * @param {os.search.ISearchResult} result
  * @return {number|string}
+ * @export
  */
 os.ui.search.FacetedSearchCtrl.prototype.track = function(result) {
   return result.getId();
 };
-goog.exportProperty(os.ui.search.FacetedSearchCtrl.prototype, 'track',
-    os.ui.search.FacetedSearchCtrl.prototype.track);

--- a/src/os/ui/search/facetnode.js
+++ b/src/os/ui/search/facetnode.js
@@ -131,6 +131,7 @@ os.ui.search.FacetNode.prototype.format = function(row, cell, value) {
 /**
  * Toggles the state
  * @param {MouseEvent} e the event
+ * @export
  */
 os.ui.search.FacetNode.prototype.toggle = function(e) {
   if (this.parentIndex > -1) {
@@ -142,4 +143,3 @@ os.ui.search.FacetNode.prototype.toggle = function(e) {
     e.stopPropagation();
   }
 };
-goog.exportProperty(os.ui.search.FacetNode.prototype, 'toggle', os.ui.search.FacetNode.prototype.toggle);

--- a/src/os/ui/search/featureresultcard.js
+++ b/src/os/ui/search/featureresultcard.js
@@ -194,44 +194,40 @@ os.ui.search.FeatureResultCardCtrl.prototype.onSourceChange_ = function(event, i
  * Get a field from the result.
  * @param {string} field
  * @return {string}
+ * @export
  */
 os.ui.search.FeatureResultCardCtrl.prototype.getField = function(field) {
   return /** @type {string} */ (this.feature.get(field));
 };
-goog.exportProperty(os.ui.search.FeatureResultCardCtrl.prototype, 'getField',
-    os.ui.search.FeatureResultCardCtrl.prototype.getField);
 
 
 /**
  * Fly to the location on the map.
+ * @export
  */
 os.ui.search.FeatureResultCardCtrl.prototype.goTo = function() {
   this.result.performAction();
 };
-goog.exportProperty(os.ui.search.FeatureResultCardCtrl.prototype, 'goTo',
-    os.ui.search.FeatureResultCardCtrl.prototype.goTo);
 
 
 /**
  * Highlights the feature on mouse over
+ * @export
  */
 os.ui.search.FeatureResultCardCtrl.prototype.over = function() {
   this.feature.set(os.style.StyleType.HIGHLIGHT, os.style.DEFAULT_HIGHLIGHT_CONFIG);
   os.style.setFeatureStyle(this.feature);
   os.style.notifyStyleChange(this.layer, [this.feature]);
 };
-goog.exportProperty(os.ui.search.FeatureResultCardCtrl.prototype, 'over',
-    os.ui.search.FeatureResultCardCtrl.prototype.over);
 
 
 /**
  * Removes the highlight on mouse out
+ * @export
  */
 os.ui.search.FeatureResultCardCtrl.prototype.out = function() {
   this.feature.set(os.style.StyleType.HIGHLIGHT, undefined);
   os.style.setFeatureStyle(this.feature);
   os.style.notifyStyleChange(this.layer, [this.feature]);
 };
-goog.exportProperty(os.ui.search.FeatureResultCardCtrl.prototype, 'out',
-    os.ui.search.FeatureResultCardCtrl.prototype.out);
 

--- a/src/os/ui/search/searchbox.js
+++ b/src/os/ui/search/searchbox.js
@@ -279,16 +279,17 @@ os.ui.search.SearchBoxCtrl.prototype.onClick_ = function(event) {
 
 /**
  * Clear the search.
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.clear = function() {
   this['searchTerm'] = '';
   this.search();
 };
-goog.exportProperty(os.ui.search.SearchBoxCtrl.prototype, 'clear', os.ui.search.SearchBoxCtrl.prototype.clear);
 
 
 /**
  * Perform a search.
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.search = function() {
   if (this['searchTerm'] || this.searchOnClear_) {
@@ -302,7 +303,6 @@ os.ui.search.SearchBoxCtrl.prototype.search = function() {
     os.ui.apply(this.scope);
   }
 };
-goog.exportProperty(os.ui.search.SearchBoxCtrl.prototype, 'search', os.ui.search.SearchBoxCtrl.prototype.search);
 
 
 /**
@@ -379,6 +379,7 @@ os.ui.search.SearchBoxCtrl.prototype.onSearchSuccess_ = function(event) {
 /**
  * Toggles a search on/off.
  * @param {!os.search.ISearch} search The search provider
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.toggleSearch = function(search) {
   // always toggle if multiple types are available, otherwise only allow enabling a search. this prevents disabling all
@@ -395,45 +396,36 @@ os.ui.search.SearchBoxCtrl.prototype.toggleSearch = function(search) {
     });
   }
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'toggleSearch',
-    os.ui.search.SearchBoxCtrl.prototype.toggleSearch);
 
 
 /**
  * Toggles all searches on/off.
  * @param {boolean} value The new enabled value
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.toggleAll = function(value) {
   this['searchOptions'].forEach(function(search) {
     search.setEnabled(value);
   });
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'toggleAll',
-    os.ui.search.SearchBoxCtrl.prototype.toggleAll);
 
 
 /**
  * Get the name of a search.
  * @param {!os.search.ISearch} search The search provider
  * @return {string}
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.getSearchName = function(search) {
   return search.getName();
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'getSearchName',
-    os.ui.search.SearchBoxCtrl.prototype.getSearchName);
 
 
 /**
  * Get the name of a search.
  * @param {!os.search.ISearch} search The search provider
  * @return {string}
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.getSearchIcon = function(search) {
   if (this['allowMultiple']) {
@@ -444,10 +436,6 @@ os.ui.search.SearchBoxCtrl.prototype.getSearchIcon = function(search) {
 
   return '';
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'getSearchIcon',
-    os.ui.search.SearchBoxCtrl.prototype.getSearchIcon);
 
 
 /**
@@ -487,6 +475,7 @@ os.ui.search.SearchBoxCtrl.prototype.setUpGroups = function() {
  * Get the group icon
  * @param {string} group The group
  * @return {string}
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.getGroupIcon = function(group) {
   if (this.allSearchesEnabled(group)) {
@@ -496,10 +485,6 @@ os.ui.search.SearchBoxCtrl.prototype.getGroupIcon = function(group) {
   }
   return 'fa-minus-square-o';
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'getGroupIcon',
-    os.ui.search.SearchBoxCtrl.prototype.getGroupIcon);
 
 
 /**
@@ -541,6 +526,7 @@ os.ui.search.SearchBoxCtrl.prototype.allSearchesDisabled = function(group) {
 /**
  * Enable/disable all the searches in a group
  * @param {string} group The group
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.toggleGroup = function(group) {
   var on = this.allSearchesEnabled(group);
@@ -549,24 +535,17 @@ os.ui.search.SearchBoxCtrl.prototype.toggleGroup = function(group) {
     searches[i].setEnabled(!on);
   }
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'toggleGroup',
-    os.ui.search.SearchBoxCtrl.prototype.toggleGroup);
 
 
 /**
  * Get a searchOptionsGroup
  * @param {string} groupName The group name
  * @return {Array<os.search.ISearch>} The searches associated with groupName
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.getSearchOptionsGroup = function(groupName) {
   return this['searchOptionsGroups'][groupName];
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'getSearchOptionsGroup',
-    os.ui.search.SearchBoxCtrl.prototype.getSearchOptionsGroup);
 
 
 /**
@@ -602,35 +581,30 @@ os.ui.search.SearchBoxCtrl.prototype.singleGroupSelected = function() {
  * If a search provider is enabled.
  * @param {!os.search.ISearch} search The search provider
  * @return {boolean}
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.isSearchEnabled = function(search) {
   return search.isEnabled();
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'isSearchEnabled',
-    os.ui.search.SearchBoxCtrl.prototype.isSearchEnabled);
 
 
 /**
  * If at least one search provider is disabled.
  * @return {boolean}
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.hasDisabledSearch = function() {
   return goog.array.some(this['searchOptions'], function(search) {
     return !search.isEnabled();
   });
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'hasDisabledSearch',
-    os.ui.search.SearchBoxCtrl.prototype.hasDisabledSearch);
 
 
 /**
  * Get the placeholder text to display in the search box.
  * @param {Array<string>=} opt_ids The search ids to consider in the text
  * @return {string}
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.getPlaceholderText = function(opt_ids) {
   if (this['searchOptions'].length > 0) {
@@ -655,15 +629,12 @@ os.ui.search.SearchBoxCtrl.prototype.getPlaceholderText = function(opt_ids) {
 
   return 'No search types available.';
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'getPlaceholderText',
-    os.ui.search.SearchBoxCtrl.prototype.getPlaceholderText);
 
 
 /**
  * Gets the selected search options to display
  * @return {string}
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.getDropdownText = function() {
   if (this['searchOptions'].length > 0) {
@@ -688,16 +659,13 @@ os.ui.search.SearchBoxCtrl.prototype.getDropdownText = function() {
 
   return 'None';
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'getDropdownText',
-    os.ui.search.SearchBoxCtrl.prototype.getDropdownText);
 
 
 /**
  * Get the detail text to display for a recent search.
  * @param {!osx.search.RecentSearch} recent The recent search object
  * @return {string}
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.getRecentDetails = function(recent) {
   var text = '';
@@ -725,16 +693,13 @@ os.ui.search.SearchBoxCtrl.prototype.getRecentDetails = function(recent) {
 
   return text;
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'getRecentDetails',
-    os.ui.search.SearchBoxCtrl.prototype.getRecentDetails);
 
 
 /**
  * Get the tooltip text to display for a recent search.
  * @param {!osx.search.RecentSearch} recent The recent search object
  * @return {string}
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.getRecentTitle = function(recent) {
   var text = 'Load recent search';
@@ -770,15 +735,12 @@ os.ui.search.SearchBoxCtrl.prototype.getRecentTitle = function(recent) {
 
   return text;
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'getRecentTitle',
-    os.ui.search.SearchBoxCtrl.prototype.getRecentTitle);
 
 
 /**
  * Sets the search term/type to a recent one.
  * @param {!osx.search.RecentSearch} recent
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.setFromRecent = function(recent) {
   // set the term to the recent value
@@ -805,14 +767,11 @@ os.ui.search.SearchBoxCtrl.prototype.setFromRecent = function(recent) {
   // save recent searches
   this.saveRecent_();
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'setFromRecent',
-    os.ui.search.SearchBoxCtrl.prototype.setFromRecent);
 
 
 /**
  * Update autocomplete results.
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.refreshAutocomplete = function() {
   this.autocompleteSrc_.data('typeahead').source = [];
@@ -821,15 +780,12 @@ os.ui.search.SearchBoxCtrl.prototype.refreshAutocomplete = function() {
     this.searchManager.autocomplete(this['searchTerm'], 10);
   }
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'refreshAutocomplete',
-    os.ui.search.SearchBoxCtrl.prototype.refreshAutocomplete);
 
 
 /**
  * Toggle search options on/off.
  * @param {angular.Scope.Event} event
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.toggleSearchOptions = function(event) {
   var originalEvent = event.originalEvent;
@@ -876,10 +832,6 @@ os.ui.search.SearchBoxCtrl.prototype.toggleSearchOptions = function(event) {
     }, false, this);
   }
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'toggleSearchOptions',
-    os.ui.search.SearchBoxCtrl.prototype.toggleSearchOptions);
 
 
 /**
@@ -956,16 +908,13 @@ os.ui.search.SearchBoxCtrl.prototype.saveRecent_ = function() {
 /**
  * Run a favorite search
  * @param {os.search.Favorite} favorite
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.favoriteSearch = function(favorite) {
   os.dispatcher.dispatchEvent(new goog.events.Event(os.search.SearchEventType.FAVORITE, favorite));
   this['showSearchOptions'] = false;
   os.ui.apply(this.scope);
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'favoriteSearch',
-    os.ui.search.SearchBoxCtrl.prototype.favoriteSearch);
 
 
 /**
@@ -982,6 +931,7 @@ os.ui.search.SearchBoxCtrl.prototype.onFavoritesUpdate_ = function() {
 /**
  * @param {os.search.Favorite} favorite
  * @return {boolean}
+ * @export
  */
 os.ui.search.SearchBoxCtrl.prototype.isFavoriteActive = function(favorite) {
   // Is the url the same after the hash?
@@ -989,7 +939,3 @@ os.ui.search.SearchBoxCtrl.prototype.isFavoriteActive = function(favorite) {
   var fav = favorite['uri'].split('#');
   return current.length == 2 && fav.length == 2 && current[1] == fav[1];
 };
-goog.exportProperty(
-    os.ui.search.SearchBoxCtrl.prototype,
-    'isFavoriteActive',
-    os.ui.search.SearchBoxCtrl.prototype.isFavoriteActive);

--- a/src/os/ui/search/searchresults.js
+++ b/src/os/ui/search/searchresults.js
@@ -148,9 +148,8 @@ os.ui.search.SearchResultsCtrl.prototype.handleAutocomplete_ = function(event) {
 /**
  * @param {os.search.ISearchResult} result
  * @return {number|string}
+ * @export
  */
 os.ui.search.SearchResultsCtrl.prototype.track = function(result) {
   return result.getId();
 };
-goog.exportProperty(os.ui.search.SearchResultsCtrl.prototype, 'track',
-    os.ui.search.SearchResultsCtrl.prototype.track);

--- a/src/os/ui/server/abstractloadingserver.js
+++ b/src/os/ui/server/abstractloadingserver.js
@@ -286,14 +286,11 @@ os.ui.server.AbstractLoadingServer.prototype.setPing = function(value) {
 
 /**
  * @inheritDoc
+ * @export
  */
 os.ui.server.AbstractLoadingServer.prototype.isLoading = function() {
   return this.isLoading_;
 };
-goog.exportProperty(
-    os.ui.server.AbstractLoadingServer.prototype,
-    'isLoading',
-    os.ui.server.AbstractLoadingServer.prototype.isLoading);
 
 
 /**

--- a/src/os/ui/servers.js
+++ b/src/os/ui/servers.js
@@ -171,6 +171,7 @@ os.ui.ServersCtrl.prototype.apply = function() {
 /**
  * Updates the servers from the UI enabled flag
  * @param {boolean=} opt_prompt
+ * @export
  */
 os.ui.ServersCtrl.prototype.update = function(opt_prompt) {
   if (!this.scope_) {
@@ -216,7 +217,6 @@ os.ui.ServersCtrl.prototype.update = function(opt_prompt) {
     }
   }
 };
-goog.exportProperty(os.ui.ServersCtrl.prototype, 'update', os.ui.ServersCtrl.prototype.update);
 
 
 /**
@@ -295,6 +295,7 @@ os.ui.ServersCtrl.prototype.checkForActiveDescriptors_ = function(provider, opt_
 
 /**
  * Toggles all servers
+ * @export
  */
 os.ui.ServersCtrl.prototype.toggleAll = function() {
   var list = /** @type {Array.<os.data.IDataProvider>} */ (this.scope_['data']);
@@ -307,11 +308,11 @@ os.ui.ServersCtrl.prototype.toggleAll = function() {
     this.update();
   }
 };
-goog.exportProperty(os.ui.ServersCtrl.prototype, 'toggleAll', os.ui.ServersCtrl.prototype.toggleAll);
 
 
 /**
  * Adds a new server
+ * @export
  */
 os.ui.ServersCtrl.prototype.add = function() {
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.Servers.ADD_SERVER, 1);
@@ -319,12 +320,12 @@ os.ui.ServersCtrl.prototype.add = function() {
   importProcess.setEvent(new os.ui.im.ImportEvent(os.ui.im.ImportEventType.URL));
   importProcess.begin();
 };
-goog.exportProperty(os.ui.ServersCtrl.prototype, 'add', os.ui.ServersCtrl.prototype.add);
 
 
 /**
  * Edits/Views a server
  * @param {!os.data.IDataProvider} provider
+ * @export
  */
 os.ui.ServersCtrl.prototype.edit = function(provider) {
   var im = os.ui.im.ImportManager.getInstance();
@@ -346,13 +347,13 @@ os.ui.ServersCtrl.prototype.edit = function(provider) {
     goog.log.error(os.ui.ServersCtrl.LOGGER_, errorMsg);
   }
 };
-goog.exportProperty(os.ui.ServersCtrl.prototype, 'edit', os.ui.ServersCtrl.prototype.edit);
 
 
 /**
  * Removes a server
  * @param {!os.data.IDataProvider} provider
  * @param {boolean=} opt_prompt
+ * @export
  */
 os.ui.ServersCtrl.prototype.remove = function(provider, opt_prompt) {
   if (!goog.isDef(opt_prompt)) {
@@ -372,12 +373,12 @@ os.ui.ServersCtrl.prototype.remove = function(provider, opt_prompt) {
   os.dataManager.removeProvider(provider.getId());
   goog.log.info(os.ui.ServersCtrl.LOGGER_, 'Removed provider "' + provider.getLabel() + '"');
 };
-goog.exportProperty(os.ui.ServersCtrl.prototype, 'remove', os.ui.ServersCtrl.prototype.remove);
 
 
 /**
  * Refreshes a server
  * @param {!os.data.IDataProvider} provider
+ * @export
  */
 os.ui.ServersCtrl.prototype.refresh = function(provider) {
   goog.log.info(os.ui.ServersCtrl.LOGGER_, 'Refreshing provider "' + provider.getLabel() + '"');
@@ -390,4 +391,3 @@ os.ui.ServersCtrl.prototype.refresh = function(provider) {
     provider.load(true);
   }
 };
-goog.exportProperty(os.ui.ServersCtrl.prototype, 'refresh', os.ui.ServersCtrl.prototype.refresh);

--- a/src/os/ui/slick/abstractgroupbytreesearchctrl.js
+++ b/src/os/ui/slick/abstractgroupbytreesearchctrl.js
@@ -124,28 +124,22 @@ os.ui.slick.AbstractGroupByTreeSearchCtrl.prototype.init = function() {
 
 /**
  * Starts a search
+ * @export
  */
 os.ui.slick.AbstractGroupByTreeSearchCtrl.prototype.search = function() {
   this.searchDelay.start();
 };
-goog.exportProperty(
-    os.ui.slick.AbstractGroupByTreeSearchCtrl.prototype,
-    'search',
-    os.ui.slick.AbstractGroupByTreeSearchCtrl.prototype.search);
 
 
 /**
  * Clears the search
+ * @export
  */
 os.ui.slick.AbstractGroupByTreeSearchCtrl.prototype.clearSearch = function() {
   this.scope['term'] = '';
   this.search();
   this.element.find('.search').focus();
 };
-goog.exportProperty(
-    os.ui.slick.AbstractGroupByTreeSearchCtrl.prototype,
-    'clearSearch',
-    os.ui.slick.AbstractGroupByTreeSearchCtrl.prototype.clearSearch);
 
 
 /**

--- a/src/os/ui/slick/abstractnodeui.js
+++ b/src/os/ui/slick/abstractnodeui.js
@@ -40,13 +40,10 @@ os.ui.slick.AbstractNodeUICtrl.prototype.destroy = function() {
 /**
  * Whether or not to show the element
  * @return {boolean}
+ * @export
  */
 os.ui.slick.AbstractNodeUICtrl.prototype.show = function() {
   // selected class may be on the cell or the row
   return this.cellEl.hasClass('hovered') || this.cellEl.hasClass('selected') ||
       this.cellEl.parent().hasClass('selected');
 };
-goog.exportProperty(
-    os.ui.slick.AbstractNodeUICtrl.prototype,
-    'show',
-    os.ui.slick.AbstractNodeUICtrl.prototype.show);

--- a/src/os/ui/slick/loadingnode.js
+++ b/src/os/ui/slick/loadingnode.js
@@ -25,19 +25,17 @@ goog.inherits(os.ui.slick.LoadingNode, os.ui.slick.SlickTreeNode);
 /**
  * Whether or not the node is loading
  * @return {boolean}
+ * @export
  */
 os.ui.slick.LoadingNode.prototype.isLoading = function() {
   return this.loading_;
 };
-goog.exportProperty(
-    os.ui.slick.LoadingNode.prototype,
-    'isLoading',
-    os.ui.slick.LoadingNode.prototype.isLoading);
 
 
 /**
  * Set whether or not the node is loading
  * @param {boolean} value
+ * @export
  */
 os.ui.slick.LoadingNode.prototype.setLoading = function(value) {
   if (value != this.loading_) {
@@ -45,10 +43,6 @@ os.ui.slick.LoadingNode.prototype.setLoading = function(value) {
     this.dispatchEvent(new os.events.PropertyChangeEvent('loading', value, !value));
   }
 };
-goog.exportProperty(
-    os.ui.slick.LoadingNode.prototype,
-    'setLoading',
-    os.ui.slick.LoadingNode.prototype.setLoading);
 
 
 /**

--- a/src/os/ui/slick/slicktreenode.js
+++ b/src/os/ui/slick/slicktreenode.js
@@ -351,14 +351,11 @@ os.ui.slick.SlickTreeNode.prototype.formatValue = function(value) {
 /**
  * API call to get the HTML for the icons
  * @return {!string} The icon HTML
+ * @export
  */
 os.ui.slick.SlickTreeNode.prototype.getIcons = function() {
   return this.formatIcons();
 };
-goog.exportProperty(
-    os.ui.slick.SlickTreeNode.prototype,
-    'getIcons',
-    os.ui.slick.SlickTreeNode.prototype.getIcons);
 
 
 /**

--- a/src/os/ui/state/abstractstateform.js
+++ b/src/os/ui/state/abstractstateform.js
@@ -74,46 +74,38 @@ os.ui.state.AbstractStateFormCtrl.prototype.onDestroy = function() {
 
 /**
  * Save the state
+ * @export
  */
 os.ui.state.AbstractStateFormCtrl.prototype.accept = function() {
   this.close();
 };
-goog.exportProperty(
-    os.ui.state.AbstractStateFormCtrl.prototype,
-    'accept',
-    os.ui.state.AbstractStateFormCtrl.prototype.accept);
 
 
 /**
  * Close the window
+ * @export
  */
 os.ui.state.AbstractStateFormCtrl.prototype.close = function() {
   os.ui.window.close(this.element);
 };
-goog.exportProperty(
-    os.ui.state.AbstractStateFormCtrl.prototype,
-    'close',
-    os.ui.state.AbstractStateFormCtrl.prototype.close);
 
 
 /**
  * Toggle all options
+ * @export
  */
 os.ui.state.AbstractStateFormCtrl.prototype.toggleAll = function() {
   for (var i = 0, n = this['states'].length; i < n; i++) {
     this['states'][i].setEnabled(this['all']);
   }
 };
-goog.exportProperty(
-    os.ui.state.AbstractStateFormCtrl.prototype,
-    'toggleAll',
-    os.ui.state.AbstractStateFormCtrl.prototype.toggleAll);
 
 
 /**
  * Get the state's description.
  * @param {os.state.IState} state The state
  * @return {string} The description
+ * @export
  */
 os.ui.state.AbstractStateFormCtrl.prototype.getDescription = function(state) {
   var description = state.getDescription();
@@ -123,21 +115,14 @@ os.ui.state.AbstractStateFormCtrl.prototype.getDescription = function(state) {
 
   return description;
 };
-goog.exportProperty(
-    os.ui.state.AbstractStateFormCtrl.prototype,
-    'getDescription',
-    os.ui.state.AbstractStateFormCtrl.prototype.getDescription);
 
 
 /**
  * Get the state's title.
  * @param {os.state.IState} state The state
  * @return {string} The title
+ * @export
  */
 os.ui.state.AbstractStateFormCtrl.prototype.getTitle = function(state) {
   return state.getTitle();
 };
-goog.exportProperty(
-    os.ui.state.AbstractStateFormCtrl.prototype,
-    'getTitle',
-    os.ui.state.AbstractStateFormCtrl.prototype.getTitle);

--- a/src/os/ui/state/stateexport.js
+++ b/src/os/ui/state/stateexport.js
@@ -90,6 +90,7 @@ goog.inherits(os.ui.state.StateExportCtrl, os.ui.state.AbstractStateFormCtrl);
 
 /**
  * @inheritDoc
+ * @export
  */
 os.ui.state.StateExportCtrl.prototype.accept = function() {
   var method = this['persister'] || null;
@@ -112,7 +113,3 @@ os.ui.state.StateExportCtrl.prototype.accept = function() {
 
   os.ui.state.StateExportCtrl.base(this, 'accept');
 };
-goog.exportProperty(
-    os.ui.state.StateExportCtrl.prototype,
-    'accept',
-    os.ui.state.StateExportCtrl.prototype.accept);

--- a/src/os/ui/state/stateimport.js
+++ b/src/os/ui/state/stateimport.js
@@ -116,6 +116,7 @@ os.ui.state.StateImportCtrl.prototype.onDestroy = function() {
 
 /**
  * @inheritDoc
+ * @export
  */
 os.ui.state.StateImportCtrl.prototype.accept = function() {
   if (this['showClear']) {
@@ -140,7 +141,3 @@ os.ui.state.StateImportCtrl.prototype.accept = function() {
   os.ui.stateManager.addImportedState(/** @type {!os.file.File} */ (this.config_['file']), options);
   os.ui.state.StateImportCtrl.base(this, 'accept');
 };
-goog.exportProperty(
-    os.ui.state.StateImportCtrl.prototype,
-    'accept',
-    os.ui.state.StateImportCtrl.prototype.accept);

--- a/src/os/ui/textprompt.js
+++ b/src/os/ui/textprompt.js
@@ -106,11 +106,11 @@ os.ui.TextPromptCtrl.prototype.handleKeyEvent_ = function(event) {
 
 /**
  * Close the window
+ * @export
  */
 os.ui.TextPromptCtrl.prototype.close = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(os.ui.TextPromptCtrl.prototype, 'close', os.ui.TextPromptCtrl.prototype.close);
 
 
 /**

--- a/src/os/ui/timeline/abstracttimelinectrl.js
+++ b/src/os/ui/timeline/abstracttimelinectrl.js
@@ -531,6 +531,7 @@ os.ui.timeline.AbstractTimelineCtrl.prototype.updateHistograms_ = function() {
  * @param {os.hist.HistogramData} histogram
  * @param {Object.<string, *>} item
  * @return {string}
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.getHistogramTooltip = function(histogram, item) {
   var tooltip = '';
@@ -540,8 +541,6 @@ os.ui.timeline.AbstractTimelineCtrl.prototype.getHistogramTooltip = function(his
   tooltip += 'Features: <span class="u-text-red">' + item['value'] + '</span>';
   return tooltip;
 };
-goog.exportProperty(os.ui.timeline.AbstractTimelineCtrl.prototype, 'getHistogramTooltip',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.getHistogramTooltip);
 
 
 /**
@@ -739,60 +738,49 @@ os.ui.timeline.AbstractTimelineCtrl.prototype.getItem = function(id) {
 
 /**
  * Skip to the first frame.
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.firstFrame = function() {
   this.tlc.first();
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Timeline.FIRST_FRAME, 1);
 };
-goog.exportProperty(
-    os.ui.timeline.AbstractTimelineCtrl.prototype,
-    'firstFrame',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.firstFrame);
 
 
 /**
  * Skip to the last frame.
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.lastFrame = function() {
   this.tlc.last();
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Timeline.LAST_FRAME, 1);
 };
-goog.exportProperty(
-    os.ui.timeline.AbstractTimelineCtrl.prototype,
-    'lastFrame',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.lastFrame);
 
 
 /**
  * Step ahead one frame.
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.nextFrame = function() {
   this.tlc.next();
   this.tlc.clamp();
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Timeline.NEXT_FRAME, 1);
 };
-goog.exportProperty(
-    os.ui.timeline.AbstractTimelineCtrl.prototype,
-    'nextFrame',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.nextFrame);
 
 
 /**
  * Step back one frame.
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.previousFrame = function() {
   this.tlc.prev();
   this.tlc.clamp();
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Timeline.PREV_FRAME, 1);
 };
-goog.exportProperty(
-    os.ui.timeline.AbstractTimelineCtrl.prototype,
-    'previousFrame',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.previousFrame);
 
 
 /**
  * Resets the timeline controller back to the last saved state.
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.reset = function() {
   if (this.tlcState_) {
@@ -803,14 +791,11 @@ os.ui.timeline.AbstractTimelineCtrl.prototype.reset = function() {
     refreshTimer.start();
   }
 };
-goog.exportProperty(
-    os.ui.timeline.AbstractTimelineCtrl.prototype,
-    'reset',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.reset);
 
 
 /**
  * Start/stop timeline animation.
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.togglePlay = function() {
   this['playing'] = !this['playing'];
@@ -822,36 +807,26 @@ os.ui.timeline.AbstractTimelineCtrl.prototype.togglePlay = function() {
   }
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Timeline.TOGGLE_PLAY, 1);
 };
-goog.exportProperty(
-    os.ui.timeline.AbstractTimelineCtrl.prototype,
-    'togglePlay',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.togglePlay);
 
 
 /**
  * Zoom in
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.zoomIn = function() {
   this.getTimelineCtrl().zoomIn();
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Timeline.ZOOM_IN, 1);
 };
-goog.exportProperty(
-    os.ui.timeline.AbstractTimelineCtrl.prototype,
-    'zoomIn',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.zoomIn);
 
 
 /**
  * Zoom out
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.zoomOut = function() {
   this.getTimelineCtrl().zoomOut();
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Timeline.ZOOM_OUT, 1);
 };
-goog.exportProperty(
-    os.ui.timeline.AbstractTimelineCtrl.prototype,
-    'zoomOut',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.zoomOut);
 
 
 /**
@@ -866,6 +841,7 @@ os.ui.timeline.AbstractTimelineCtrl.prototype.getTimelineCtrl = function() {
 
 /**
  * Start/stop timeline animation.
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.toggleChartType = function() {
   goog.array.rotate(this.histClasses_, 1);
@@ -877,14 +853,11 @@ os.ui.timeline.AbstractTimelineCtrl.prototype.toggleChartType = function() {
   var metricKey = os.metrics.keys.Timeline.CHART_TYPE + os.metrics.SUB_DELIMITER + chartType;
   os.metrics.Metrics.getInstance().updateMetric(metricKey, 1);
 };
-goog.exportProperty(
-    os.ui.timeline.AbstractTimelineCtrl.prototype,
-    'toggleChartType',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.toggleChartType);
 
 
 /**
  * @param {string} selector
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.openMenu = function(selector) {
   var menu = this.menus_[selector];
@@ -930,10 +903,6 @@ os.ui.timeline.AbstractTimelineCtrl.prototype.openMenu = function(selector) {
     });
   }
 };
-goog.exportProperty(
-    os.ui.timeline.AbstractTimelineCtrl.prototype,
-    'openMenu',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.openMenu);
 
 
 /**
@@ -947,15 +916,12 @@ os.ui.timeline.AbstractTimelineCtrl.prototype.onMenuClose = function(evt) {
 
 /**
  * Begins selection on the timeline
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.select = function() {
   this.scope['selecting'] = !this.scope['selecting'];
   angular.element('.brush-select .background').css('display', this.scope['selecting'] ? 'block' : 'none');
 };
-goog.exportProperty(
-    os.ui.timeline.AbstractTimelineCtrl.prototype,
-    'select',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.select);
 
 
 /**
@@ -1701,6 +1667,7 @@ os.ui.timeline.AbstractTimelineCtrl.prototype.moveWindowToData = function() {
 /**
  * Closes the timeline by sending a UI toggle event. This event must be listened for by the timeline's container
  * which should hide/destroy the timeline.
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.close = function() {
   this.tlc.clearAnimateRanges();
@@ -1708,24 +1675,17 @@ os.ui.timeline.AbstractTimelineCtrl.prototype.close = function() {
   var event = new os.ui.events.UIEvent(os.ui.events.UIEventType.TOGGLE_UI, 'timeline');
   os.dispatcher.dispatchEvent(event);
 };
-goog.exportProperty(
-    os.ui.timeline.AbstractTimelineCtrl.prototype,
-    'close',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.close);
 
 
 /**
  * Toggles the expanded/collapsed (normal vs. ribbon) view of the timeline
+ * @export
  */
 os.ui.timeline.AbstractTimelineCtrl.prototype.toggleCollapse = function() {
   os.ui.timeline.AbstractTimelineCtrl.collapsed = !os.ui.timeline.AbstractTimelineCtrl.collapsed;
   this.scope['collapsed'] = os.ui.timeline.AbstractTimelineCtrl.collapsed;
   this.adjust();
 };
-goog.exportProperty(
-    os.ui.timeline.AbstractTimelineCtrl.prototype,
-    'toggleCollapse',
-    os.ui.timeline.AbstractTimelineCtrl.prototype.toggleCollapse);
 
 
 /**

--- a/src/os/ui/timelinepanel.js
+++ b/src/os/ui/timelinepanel.js
@@ -168,6 +168,7 @@ os.ui.TimelinePanelCtrl.prototype.getSettingsTemplate = function() {
 
 /**
  * Launches the timeline settings dialog
+ * @export
  */
 os.ui.TimelinePanelCtrl.prototype.settings = function() {
   var scopeOptions = {
@@ -187,10 +188,6 @@ os.ui.TimelinePanelCtrl.prototype.settings = function() {
 
   os.ui.window.create(windowOptions, this.getSettingsTemplate(), undefined, undefined, undefined, scopeOptions);
 };
-goog.exportProperty(
-    os.ui.TimelinePanelCtrl.prototype,
-    'settings',
-    os.ui.TimelinePanelCtrl.prototype.settings);
 
 
 /**
@@ -204,6 +201,7 @@ os.ui.TimelinePanelCtrl.prototype.getAnimationSettingsTemplate = function() {
 
 /**
  * Launches the animation settings dialog
+ * @export
  */
 os.ui.TimelinePanelCtrl.prototype.animationSettings = function() {
   var scopOptions = {
@@ -224,10 +222,6 @@ os.ui.TimelinePanelCtrl.prototype.animationSettings = function() {
 
   os.ui.window.create(windowOptions, this.getAnimationSettingsTemplate(), undefined, undefined, undefined, scopOptions);
 };
-goog.exportProperty(
-    os.ui.TimelinePanelCtrl.prototype,
-    'animationSettings',
-    os.ui.TimelinePanelCtrl.prototype.animationSettings);
 
 
 /**

--- a/src/os/ui/timelinesettings.js
+++ b/src/os/ui/timelinesettings.js
@@ -290,6 +290,7 @@ os.ui.TimeSettingsCtrl.prototype.timeFromField = function(field) {
 /**
  * Checks for valid
  * @return {boolean}
+ * @export
  */
 os.ui.TimeSettingsCtrl.prototype.valid = function() {
   var loadRanges = this.scope['loadRanges'];
@@ -303,7 +304,6 @@ os.ui.TimeSettingsCtrl.prototype.valid = function() {
 
   return true;
 };
-goog.exportProperty(os.ui.TimeSettingsCtrl.prototype, 'valid', os.ui.TimeSettingsCtrl.prototype.valid);
 
 
 /**
@@ -311,11 +311,11 @@ goog.exportProperty(os.ui.TimeSettingsCtrl.prototype, 'valid', os.ui.TimeSetting
  * @param {string} start
  * @param {string} end
  * @return {boolean}
+ * @export
  */
 os.ui.TimeSettingsCtrl.prototype.isValid = function(start, end) {
   return new Date(start) < new Date(end);
 };
-goog.exportProperty(os.ui.TimeSettingsCtrl.prototype, 'isValid', os.ui.TimeSettingsCtrl.prototype.isValid);
 
 
 /**
@@ -324,6 +324,7 @@ goog.exportProperty(os.ui.TimeSettingsCtrl.prototype, 'isValid', os.ui.TimeSetti
  * @param {Object} end
  * @param {boolean=} opt_ignore
  * @return {boolean}
+ * @export
  */
 os.ui.TimeSettingsCtrl.prototype.isValidSlice = function(start, end, opt_ignore) {
   var valid = true;
@@ -334,4 +335,3 @@ os.ui.TimeSettingsCtrl.prototype.isValidSlice = function(start, end, opt_ignore)
   }
   return /** @type {boolean} */ (valid);
 };
-goog.exportProperty(os.ui.TimeSettingsCtrl.prototype, 'isValidSlice', os.ui.TimeSettingsCtrl.prototype.isValidSlice);

--- a/src/os/ui/tristatecheckbox.js
+++ b/src/os/ui/tristatecheckbox.js
@@ -70,6 +70,7 @@ os.ui.TriStateCheckboxCtrl.prototype.destroy_ = function() {
 /**
  * Toggles the state on the scope
  * @param {MouseEvent} e The event
+ * @export
  */
 os.ui.TriStateCheckboxCtrl.prototype.toggle = function(e) {
   if (this.scope_) {
@@ -85,15 +86,12 @@ os.ui.TriStateCheckboxCtrl.prototype.toggle = function(e) {
     e.stopPropagation();
   }
 };
-goog.exportProperty(
-    os.ui.TriStateCheckboxCtrl.prototype,
-    'toggle',
-    os.ui.TriStateCheckboxCtrl.prototype.toggle);
 
 
 /**
  * Toggles the state on the scope
  * @param {MouseEvent} e The event
+ * @export
  */
 os.ui.TriStateCheckboxCtrl.prototype.onDblClick = function(e) {
   if (!this.element_.hasClass('disabled')) {
@@ -101,10 +99,6 @@ os.ui.TriStateCheckboxCtrl.prototype.onDblClick = function(e) {
     e.stopPropagation();
   }
 };
-goog.exportProperty(
-    os.ui.TriStateCheckboxCtrl.prototype,
-    'onDblClick',
-    os.ui.TriStateCheckboxCtrl.prototype.onDblClick);
 
 
 /**

--- a/src/os/ui/user/settings/locationsettings.js
+++ b/src/os/ui/user/settings/locationsettings.js
@@ -100,11 +100,10 @@ os.ui.user.settings.LocationSettingsCtrl.prototype.onFormatChange_ = function(ev
  * Update and store setting.
  * @param {os.ui.location.Format=} opt_new
  * @param {os.ui.location.Format=} opt_old
+ * @export
  */
 os.ui.user.settings.LocationSettingsCtrl.prototype.update = function(opt_new, opt_old) {
   if (os.settings && opt_new && opt_old && opt_new !== opt_old) {
     os.settings.set(os.ui.location.LocationSetting.POSITION, opt_new);
   }
 };
-goog.exportProperty(os.ui.user.settings.LocationSettingsCtrl.prototype, 'update',
-    os.ui.user.settings.LocationSettingsCtrl.prototype.update);

--- a/src/os/ui/util/scrollfocus.js
+++ b/src/os/ui/util/scrollfocus.js
@@ -175,6 +175,7 @@ os.ui.util.ScrollFocusCtrl.prototype.hasScrollBar_ = function() {
 /**
  * Listener for focus and blur events to activate and deactivate scrolling.
  * @param {goog.events.Event} e The event
+ * @export
  */
 os.ui.util.ScrollFocusCtrl.prototype.setFocus = function(e) {
   if (e.type === 'focus') {
@@ -183,5 +184,3 @@ os.ui.util.ScrollFocusCtrl.prototype.setFocus = function(e) {
     this['hasFocus'] = false;
   }
 };
-goog.exportProperty(os.ui.util.ScrollFocusCtrl.prototype, 'setFocus',
-    os.ui.util.ScrollFocusCtrl.prototype.setFocus);

--- a/src/os/ui/window.js
+++ b/src/os/ui/window.js
@@ -758,6 +758,7 @@ os.ui.WindowCtrl.prototype.hideOverlayWindow_ = function() {
 /**
  * Closes the window
  * @param {boolean=} opt_cancel If the cancel event should be fired
+ * @export
  */
 os.ui.WindowCtrl.prototype.close = function(opt_cancel) {
   this.closing_ = true;
@@ -784,11 +785,11 @@ os.ui.WindowCtrl.prototype.close = function(opt_cancel) {
   // remove the element from the DOM
   el.remove();
 };
-goog.exportProperty(os.ui.WindowCtrl.prototype, 'close', os.ui.WindowCtrl.prototype.close);
 
 
 /**
  * Toggles the window content
+ * @export
  */
 os.ui.WindowCtrl.prototype.toggle = function() {
   if (!this.scope['modal']) {
@@ -813,11 +814,11 @@ os.ui.WindowCtrl.prototype.toggle = function() {
     }
   }
 };
-goog.exportProperty(os.ui.WindowCtrl.prototype, 'toggle', os.ui.WindowCtrl.prototype.toggle);
 
 
 /**
  * Hide (not close) the window and raise an event
+ * @export
  */
 os.ui.WindowCtrl.prototype.hide = function() {
   if (this.scope['id']) {
@@ -826,7 +827,6 @@ os.ui.WindowCtrl.prototype.hide = function() {
     os.dispatcher.dispatchEvent(event);
   }
 };
-goog.exportProperty(os.ui.WindowCtrl.prototype, 'hide', os.ui.WindowCtrl.prototype.hide);
 
 
 /**
@@ -982,12 +982,9 @@ os.ui.WindowCtrl.prototype.constrainWindow_ = function() {
  * Handle header button click
  * @param {!Event} event
  * @param {!os.ui.window.HeaderBtnConfig} headerBtnCfg
+ * @export
  */
 os.ui.WindowCtrl.prototype.onHeaderBtnClick = function(event, headerBtnCfg) {
   var winEl = $(event.target).parents(os.ui.windowSelector.WINDOW);
   headerBtnCfg.onClick(winEl);
 };
-goog.exportProperty(
-    os.ui.WindowCtrl.prototype,
-    'onHeaderBtnClick',
-    os.ui.WindowCtrl.prototype.onHeaderBtnClick);

--- a/src/os/ui/window/confirm.js
+++ b/src/os/ui/window/confirm.js
@@ -144,6 +144,7 @@ os.ui.window.ConfirmCtrl.prototype.onDestroy_ = function() {
 
 /**
  * Fire the cancel callback and close the window.
+ * @export
  */
 os.ui.window.ConfirmCtrl.prototype.cancel = function() {
   if (this.scope_['cancelCallback']) {
@@ -152,11 +153,11 @@ os.ui.window.ConfirmCtrl.prototype.cancel = function() {
 
   this.close_();
 };
-goog.exportProperty(os.ui.window.ConfirmCtrl.prototype, 'cancel', os.ui.window.ConfirmCtrl.prototype.cancel);
 
 
 /**
  * Fire the confirmation callback and close the window.
+ * @export
  */
 os.ui.window.ConfirmCtrl.prototype.confirm = function() {
   if (this.scope_['confirmCallback']) {
@@ -172,7 +173,6 @@ os.ui.window.ConfirmCtrl.prototype.confirm = function() {
 
   this.close_();
 };
-goog.exportProperty(os.ui.window.ConfirmCtrl.prototype, 'confirm', os.ui.window.ConfirmCtrl.prototype.confirm);
 
 
 /**

--- a/src/os/ui/window/geohelp.js
+++ b/src/os/ui/window/geohelp.js
@@ -78,11 +78,8 @@ os.ui.window.GeoHelpCtrl.prototype.destroy_ = function() {
 
 /**
  * Close the window
+ * @export
  */
 os.ui.window.GeoHelpCtrl.prototype.close = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(
-    os.ui.window.GeoHelpCtrl.prototype,
-    'close',
-    os.ui.window.GeoHelpCtrl.prototype.close);

--- a/src/os/ui/window/timehelp.js
+++ b/src/os/ui/window/timehelp.js
@@ -78,11 +78,8 @@ os.ui.window.TimeHelpCtrl.prototype.destroy_ = function() {
 
 /**
  * Close the window
+ * @export
  */
 os.ui.window.TimeHelpCtrl.prototype.close = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(
-    os.ui.window.TimeHelpCtrl.prototype,
-    'close',
-    os.ui.window.TimeHelpCtrl.prototype.close);

--- a/src/os/ui/windowlauncher.js
+++ b/src/os/ui/windowlauncher.js
@@ -64,6 +64,7 @@ os.ui.WindowLauncherCtrl.prototype.destroy_ = function() {
 /**
  * Sets the descriptor as active.
  * @param {MouseEvent} e The event
+ * @export
  */
 os.ui.WindowLauncherCtrl.prototype.click = function(e) {
   if (this.scope_) {
@@ -71,7 +72,3 @@ os.ui.WindowLauncherCtrl.prototype.click = function(e) {
     item.getDescriptor().setActive(true);
   }
 };
-goog.exportProperty(
-    os.ui.WindowLauncherCtrl.prototype,
-    'click',
-    os.ui.WindowLauncherCtrl.prototype.click);

--- a/src/os/ui/wiz/geometrystep.js
+++ b/src/os/ui/wiz/geometrystep.js
@@ -437,6 +437,7 @@ os.ui.wiz.GeometryStepCtrl.prototype.destroy_ = function() {
 
 /**
  * Verifies the provided form data is valid and complete.
+ * @export
  */
 os.ui.wiz.GeometryStepCtrl.prototype.validate = function() {
   this['sample'] = null;
@@ -538,10 +539,6 @@ os.ui.wiz.GeometryStepCtrl.prototype.validate = function() {
       (!this.scope_['step']['showEllipse'] || this.scope_['ellipseForm'].$valid));
   this.scope_.$broadcast('resizePreview');
 };
-goog.exportProperty(
-    os.ui.wiz.GeometryStepCtrl.prototype,
-    'validate',
-    os.ui.wiz.GeometryStepCtrl.prototype.validate);
 
 
 /**
@@ -572,11 +569,8 @@ os.ui.wiz.GeometryStepCtrl.prototype.testMappingAndEmpty_ = function(mapping, fi
 
 /**
  * Launches the geo formatting help dialog.
+ * @export
  */
 os.ui.wiz.GeometryStepCtrl.prototype.launchHelp = function() {
   os.ui.window.launchGeoHelp();
 };
-goog.exportProperty(
-    os.ui.wiz.GeometryStepCtrl.prototype,
-    'launchHelp',
-    os.ui.wiz.GeometryStepCtrl.prototype.launchHelp);

--- a/src/os/ui/wiz/step/abstractwizardstep.js
+++ b/src/os/ui/wiz/step/abstractwizardstep.js
@@ -188,14 +188,11 @@ os.ui.wiz.step.AbstractWizardStep.prototype.getTemplate = function() {
 
 /**
  * @inheritDoc
+ * @export
  */
 os.ui.wiz.step.AbstractWizardStep.prototype.getTitle = function() {
   return this.title;
 };
-goog.exportProperty(
-    os.ui.wiz.step.AbstractWizardStep.prototype,
-    'getTitle',
-    os.ui.wiz.step.AbstractWizardStep.prototype.getTitle);
 
 
 /**

--- a/src/os/ui/wiz/step/timeinstantui.js
+++ b/src/os/ui/wiz/step/timeinstantui.js
@@ -239,12 +239,11 @@ os.ui.wiz.step.TimeInstantUICtrl.prototype.updateResult_ = function() {
 
 /**
  * Handles user UI changes.
+ * @export
  */
 os.ui.wiz.step.TimeInstantUICtrl.prototype.change = function() {
   this.updateSample_();
 };
-goog.exportProperty(os.ui.wiz.step.TimeInstantUICtrl.prototype, 'change',
-    os.ui.wiz.step.TimeInstantUICtrl.prototype.change);
 
 
 /**
@@ -302,6 +301,7 @@ os.ui.wiz.step.TimeInstantUICtrl.prototype.autoDetectTime_ = function() {
 
 /**
  * Handles user UI changes to the date type.
+ * @export
  */
 os.ui.wiz.step.TimeInstantUICtrl.prototype.onDateType = function() {
   this.autoDetectDate_();
@@ -310,34 +310,31 @@ os.ui.wiz.step.TimeInstantUICtrl.prototype.onDateType = function() {
   }
   this.updateSample_();
 };
-goog.exportProperty(os.ui.wiz.step.TimeInstantUICtrl.prototype, 'onDateType',
-    os.ui.wiz.step.TimeInstantUICtrl.prototype.onDateType);
 
 
 /**
  * Handles user UI changes to the date column.
+ * @export
  */
 os.ui.wiz.step.TimeInstantUICtrl.prototype.onDateColumn = function() {
   this.autoDetectDate_();
   this.updateSample_();
 };
-goog.exportProperty(os.ui.wiz.step.TimeInstantUICtrl.prototype, 'onDateColumn',
-    os.ui.wiz.step.TimeInstantUICtrl.prototype.onDateColumn);
 
 
 /**
  * Handles user UI changes to the time column.
+ * @export
  */
 os.ui.wiz.step.TimeInstantUICtrl.prototype.onTimeColumn = function() {
   this.autoDetectTime_();
   this.updateSample_();
 };
-goog.exportProperty(os.ui.wiz.step.TimeInstantUICtrl.prototype, 'onTimeColumn',
-    os.ui.wiz.step.TimeInstantUICtrl.prototype.onTimeColumn);
 
 
 /**
  * Handles user UI changes to the date format picker.
+ * @export
  */
 os.ui.wiz.step.TimeInstantUICtrl.prototype.onDateFormat = function() {
   if (this['dateFormat'] && this['dateFormat'] != 'Custom') {
@@ -345,12 +342,11 @@ os.ui.wiz.step.TimeInstantUICtrl.prototype.onDateFormat = function() {
     this.updateSample_();
   }
 };
-goog.exportProperty(os.ui.wiz.step.TimeInstantUICtrl.prototype, 'onDateFormat',
-    os.ui.wiz.step.TimeInstantUICtrl.prototype.onDateFormat);
 
 
 /**
  * Handles user UI changes to the time format picker.
+ * @export
  */
 os.ui.wiz.step.TimeInstantUICtrl.prototype.onTimeFormat = function() {
   if (this['timeFormat'] && this['timeFormat'] != 'Custom') {
@@ -358,5 +354,3 @@ os.ui.wiz.step.TimeInstantUICtrl.prototype.onTimeFormat = function() {
     this.updateSample_();
   }
 };
-goog.exportProperty(os.ui.wiz.step.TimeInstantUICtrl.prototype, 'onTimeFormat',
-    os.ui.wiz.step.TimeInstantUICtrl.prototype.onTimeFormat);

--- a/src/os/ui/wiz/step/timestep.js
+++ b/src/os/ui/wiz/step/timestep.js
@@ -231,11 +231,8 @@ os.ui.wiz.step.TimeStepCtrl.prototype.validate_ = function() {
 
 /**
  * Launches the date/time formatting help dialog.
+ * @export
  */
 os.ui.wiz.step.TimeStepCtrl.prototype.launchHelp = function() {
   os.ui.window.launchTimeHelp();
 };
-goog.exportProperty(
-    os.ui.wiz.step.TimeStepCtrl.prototype,
-    'launchHelp',
-    os.ui.wiz.step.TimeStepCtrl.prototype.launchHelp);

--- a/src/os/ui/wiz/wizard.js
+++ b/src/os/ui/wiz/wizard.js
@@ -182,6 +182,7 @@ os.ui.wiz.WizardCtrl.prototype.activateStep_ = function(step, opt_skipCompile) {
 
 /**
  * Check if all steps are complete and finish the wizard, or display an error.
+ * @export
  */
 os.ui.wiz.WizardCtrl.prototype.accept = function() {
   var step = this['steps'][this['activeIndex']];
@@ -191,49 +192,48 @@ os.ui.wiz.WizardCtrl.prototype.accept = function() {
     this.setStepState(step, os.ui.wiz.StepState.ERROR);
   }
 };
-goog.exportProperty(os.ui.wiz.WizardCtrl.prototype, 'accept', os.ui.wiz.WizardCtrl.prototype.accept);
 
 
 /**
  * If the accept button should be enabled.
  * @return {boolean}
+ * @export
  */
 os.ui.wiz.WizardCtrl.prototype.canAccept = function() {
   // only enable the accept button if we're on the last step and it's valid
   return this.isLastStep() && this.getStepState(this['activeIndex']) != os.ui.wiz.StepState.ERROR;
 };
-goog.exportProperty(os.ui.wiz.WizardCtrl.prototype, 'canAccept', os.ui.wiz.WizardCtrl.prototype.canAccept);
 
 
 /**
  * If the next button should be enabled.
  * @return {boolean}
+ * @export
  */
 os.ui.wiz.WizardCtrl.prototype.canContinue = function() {
   // only enable the next button if we're not on the last step and the current step is valid
   return !this.isLastStep() && this.getStepState(this['activeIndex']) != os.ui.wiz.StepState.ERROR;
 };
-goog.exportProperty(os.ui.wiz.WizardCtrl.prototype, 'canContinue', os.ui.wiz.WizardCtrl.prototype.canContinue);
 
 
 /**
  * If the accept button should be enabled.
  * @return {boolean}
+ * @export
  */
 os.ui.wiz.WizardCtrl.prototype.isLastStep = function() {
   return this['activeIndex'] == this['steps'].length - 1;
 };
-goog.exportProperty(os.ui.wiz.WizardCtrl.prototype, 'isLastStep', os.ui.wiz.WizardCtrl.prototype.isLastStep);
 
 
 /**
  * Performs wizard cancellation actions and closes the window.
+ * @export
  */
 os.ui.wiz.WizardCtrl.prototype.cancel = function() {
   this.cancelInternal();
   os.ui.window.close(this.element);
 };
-goog.exportProperty(os.ui.wiz.WizardCtrl.prototype, 'cancel', os.ui.wiz.WizardCtrl.prototype.cancel);
 
 
 /**
@@ -258,6 +258,7 @@ os.ui.wiz.WizardCtrl.prototype.finish = function() {
  * Move to the next step in the wizard.
  * @param {boolean=} opt_skipCompile If true, compilation of the next step will be skipped. Use this when moving
  *   multiple steps at a time.
+ * @export
  */
 os.ui.wiz.WizardCtrl.prototype.next = function(opt_skipCompile) {
   if (this['activeIndex'] < this['steps'].length - 1) {
@@ -282,13 +283,13 @@ os.ui.wiz.WizardCtrl.prototype.next = function(opt_skipCompile) {
     this.afterStepping_();
   }
 };
-goog.exportProperty(os.ui.wiz.WizardCtrl.prototype, 'next', os.ui.wiz.WizardCtrl.prototype.next);
 
 
 /**
  * Move to the previous step in the wizard.
  * @param {boolean=} opt_skipCompile If true, compilation of the next step will be skipped. Use this when moving
  *   multiple steps at a time.
+ * @export
  */
 os.ui.wiz.WizardCtrl.prototype.prev = function(opt_skipCompile) {
   if (this['activeIndex'] > 0) {
@@ -301,7 +302,6 @@ os.ui.wiz.WizardCtrl.prototype.prev = function(opt_skipCompile) {
     this.afterStepping_();
   }
 };
-goog.exportProperty(os.ui.wiz.WizardCtrl.prototype, 'prev', os.ui.wiz.WizardCtrl.prototype.prev);
 
 
 /**
@@ -327,6 +327,7 @@ os.ui.wiz.WizardCtrl.prototype.afterStepping_ = function() {
 /**
  * Move to a specific step in the wizard.
  * @param {number} index
+ * @export
  */
 os.ui.wiz.WizardCtrl.prototype.setStepIndex = function(index) {
   index = goog.math.clamp(index, 0, this['steps'].length - 1);
@@ -347,16 +348,13 @@ os.ui.wiz.WizardCtrl.prototype.setStepIndex = function(index) {
     }
   }
 };
-goog.exportProperty(
-    os.ui.wiz.WizardCtrl.prototype,
-    'setStepIndex',
-    os.ui.wiz.WizardCtrl.prototype.setStepIndex);
 
 
 /**
  * Determine if the provided step is set as the active step.
  * @param {os.ui.wiz.step.IWizardStep|number} step The step or the index in the steps array
  * @return {boolean}
+ * @export
  */
 os.ui.wiz.WizardCtrl.prototype.isActive = function(step) {
   if (goog.isNumber(step)) {
@@ -365,16 +363,13 @@ os.ui.wiz.WizardCtrl.prototype.isActive = function(step) {
     return this['steps'][this['activeIndex']] === step;
   }
 };
-goog.exportProperty(
-    os.ui.wiz.WizardCtrl.prototype,
-    'isActive',
-    os.ui.wiz.WizardCtrl.prototype.isActive);
 
 
 /**
  * Get the icon to display next to the step in the wizard.
  * @param {os.ui.wiz.step.IWizardStep|number} step The step or the index in the steps array
  * @return {!string}
+ * @export
  */
 os.ui.wiz.WizardCtrl.prototype.getStepIcon = function(step) {
   if (goog.isNumber(step)) {
@@ -397,16 +392,13 @@ os.ui.wiz.WizardCtrl.prototype.getStepIcon = function(step) {
 
   return '';
 };
-goog.exportProperty(
-    os.ui.wiz.WizardCtrl.prototype,
-    'getStepIcon',
-    os.ui.wiz.WizardCtrl.prototype.getStepIcon);
 
 
 /**
  * Get the state of the provided step
  * @param {os.ui.wiz.step.IWizardStep|number} step The step or the index in the steps array
  * @return {!string}
+ * @export
  */
 os.ui.wiz.WizardCtrl.prototype.getStepState = function(step) {
   if (goog.isNumber(step)) {
@@ -415,10 +407,6 @@ os.ui.wiz.WizardCtrl.prototype.getStepState = function(step) {
 
   return this['stepStates'][step.getTitle()];
 };
-goog.exportProperty(
-    os.ui.wiz.WizardCtrl.prototype,
-    'getStepState',
-    os.ui.wiz.WizardCtrl.prototype.getStepState);
 
 
 /**

--- a/src/plugin/basemap/ui/basemaplayerui.js
+++ b/src/plugin/basemap/ui/basemaplayerui.js
@@ -188,6 +188,7 @@ plugin.basemap.ui.BaseMapLayerUICtrl.prototype.getMaxZoom_ = function() {
 
 /**
  * @param {string} key The scope value to set
+ * @export
  */
 plugin.basemap.ui.BaseMapLayerUICtrl.prototype.setCurrent = function(key) {
   var map = os.MapContainer.getInstance();
@@ -215,6 +216,4 @@ plugin.basemap.ui.BaseMapLayerUICtrl.prototype.setCurrent = function(key) {
     }
   }
 };
-goog.exportProperty(plugin.basemap.ui.BaseMapLayerUICtrl.prototype, 'setCurrent',
-    plugin.basemap.ui.BaseMapLayerUICtrl.prototype.setCurrent);
 

--- a/src/plugin/cesium/mixin/cesiummixin.js
+++ b/src/plugin/cesium/mixin/cesiummixin.js
@@ -135,7 +135,7 @@ plugin.cesium.mixin.loadCesiumMixins = function() {
     this.context_ = null;
     return undefined;
   };
-  goog.exportProperty(Cesium.PickId.prototype, 'destroy', Cesium.PickId.prototype.destroy);
+  Cesium.PickId.prototype['destroy'] = Cesium.PickId.prototype.destroy;
 
 
   /**
@@ -180,5 +180,5 @@ plugin.cesium.mixin.loadCesiumMixins = function() {
     this._pickObjects[key] = object;
     return new Cesium.PickId(this, key, Cesium.Color.fromRgba(key));
   };
-  goog.exportProperty(Cesium.Context.prototype, 'createPickId', Cesium.Context.prototype.createPickId);
+  Cesium.Context.prototype['createPickId'] = Cesium.Context.prototype.createPickId;
 };

--- a/src/plugin/descriptor/descriptorresultcard.js
+++ b/src/plugin/descriptor/descriptorresultcard.js
@@ -108,6 +108,7 @@ plugin.descriptor.ResultCardCtrl.prototype.getDescriptor = function() {
  * Get a field from the result.
  * @param {string} field
  * @return {*}
+ * @export
  */
 plugin.descriptor.ResultCardCtrl.prototype.getField = function(field) {
   var d = this.getDescriptor();
@@ -156,12 +157,11 @@ plugin.descriptor.ResultCardCtrl.prototype.getField = function(field) {
 
   return '';
 };
-goog.exportProperty(plugin.descriptor.ResultCardCtrl.prototype, 'getField',
-    plugin.descriptor.ResultCardCtrl.prototype.getField);
 
 
 /**
  * Toggles the descriptor
+ * @export
  */
 plugin.descriptor.ResultCardCtrl.prototype.toggle = function() {
   var d = this.getDescriptor();
@@ -174,17 +174,14 @@ plugin.descriptor.ResultCardCtrl.prototype.toggle = function() {
     }
   }
 };
-goog.exportProperty(plugin.descriptor.ResultCardCtrl.prototype, 'toggle',
-    plugin.descriptor.ResultCardCtrl.prototype.toggle);
 
 
 /**
  * Toggles the description text length
  * @param {boolean} full
+ * @export
  */
 plugin.descriptor.ResultCardCtrl.prototype.showFullDescription = function(full) {
   this.scope_['showFullDescription'] = full;
   os.ui.apply(this.scope_);
 };
-goog.exportProperty(plugin.descriptor.ResultCardCtrl.prototype, 'showFullDescription',
-    plugin.descriptor.ResultCardCtrl.prototype.showFullDescription);

--- a/src/plugin/featureaction/ui/featureactionsui.js
+++ b/src/plugin/featureaction/ui/featureactionsui.js
@@ -68,19 +68,17 @@ plugin.im.action.feature.ui.FeatureActionsCtrl.prototype.onSourceRemoved_ = func
 
 /**
  * @inheritDoc
+ * @export
  */
 plugin.im.action.feature.ui.FeatureActionsCtrl.prototype.close = function() {
   plugin.im.action.feature.ui.FeatureActionsCtrl.base(this, 'close');
   os.dataManager.unlisten(os.data.event.DataEventType.SOURCE_REMOVED, this.onSourceRemoved_, false, this);
 };
-goog.exportProperty(
-    plugin.im.action.feature.ui.FeatureActionsCtrl.prototype,
-    'close',
-    plugin.im.action.feature.ui.FeatureActionsCtrl.prototype.close);
 
 
 /**
  * @inheritDoc
+ * @export
  */
 plugin.im.action.feature.ui.FeatureActionsCtrl.prototype.apply = function() {
   plugin.im.action.feature.ui.FeatureActionsCtrl.base(this, 'apply');
@@ -106,10 +104,6 @@ plugin.im.action.feature.ui.FeatureActionsCtrl.prototype.apply = function() {
     }
   }
 };
-goog.exportProperty(
-    plugin.im.action.feature.ui.FeatureActionsCtrl.prototype,
-    'apply',
-    plugin.im.action.feature.ui.FeatureActionsCtrl.prototype.apply);
 
 
 /**

--- a/src/plugin/featureaction/ui/featurelabelactionconfig.js
+++ b/src/plugin/featureaction/ui/featurelabelactionconfig.js
@@ -216,6 +216,7 @@ plugin.im.action.feature.ui.LabelConfigCtrl.prototype.onCustomNameChange = funct
 
 /**
  * Update the custom column and add it to the column list if necessary.
+ * @export
  */
 plugin.im.action.feature.ui.LabelConfigCtrl.prototype.updateCustomColumn = function() {
   goog.array.remove(this.scope['columns'], this.customColumn);
@@ -240,10 +241,6 @@ plugin.im.action.feature.ui.LabelConfigCtrl.prototype.updateCustomColumn = funct
   this.validate();
   os.ui.apply(this.scope);
 };
-goog.exportProperty(
-    plugin.im.action.feature.ui.LabelConfigCtrl.prototype,
-    'updateCustomColumn',
-    plugin.im.action.feature.ui.LabelConfigCtrl.prototype.updateCustomColumn);
 
 
 /**

--- a/src/plugin/featureaction/ui/featurestyleactionconfig.js
+++ b/src/plugin/featureaction/ui/featurestyleactionconfig.js
@@ -326,6 +326,7 @@ plugin.im.action.feature.ui.StyleConfigCtrl.prototype.updateCenterIcon_ = functi
 /**
  * When to show the icon rotation option
  * @return {boolean}
+ * @export
  */
 plugin.im.action.feature.ui.StyleConfigCtrl.prototype.showRotationOption = function() {
   if (this.scope != null) {
@@ -337,10 +338,6 @@ plugin.im.action.feature.ui.StyleConfigCtrl.prototype.showRotationOption = funct
 
   return false;
 };
-goog.exportProperty(
-    plugin.im.action.feature.ui.StyleConfigCtrl.prototype,
-    'showRotationOption',
-    plugin.im.action.feature.ui.StyleConfigCtrl.prototype.showRotationOption);
 
 
 /**

--- a/src/plugin/file/kml/ui/kmllayernode.js
+++ b/src/plugin/file/kml/ui/kmllayernode.js
@@ -88,14 +88,11 @@ plugin.file.kml.ui.KMLLayerNode.prototype.onChildChange = function(e) {
 
 /**
  * @inheritDoc
+ * @export
  */
 plugin.file.kml.ui.KMLLayerNode.prototype.isLoading = function() {
   return this.childLoadCount_ > 0 || plugin.file.kml.ui.KMLLayerNode.base(this, 'isLoading');
 };
-goog.exportProperty(
-    plugin.file.kml.ui.KMLLayerNode.prototype,
-    'isLoading',
-    plugin.file.kml.ui.KMLLayerNode.prototype.isLoading);
 
 
 /**

--- a/src/plugin/file/kml/ui/kmlnode.js
+++ b/src/plugin/file/kml/ui/kmlnode.js
@@ -440,14 +440,11 @@ plugin.file.kml.ui.KMLNode.prototype.getId = function() {
 /**
  * Whether or not the KML node is loading.
  * @return {boolean}
+ * @export
  */
 plugin.file.kml.ui.KMLNode.prototype.isLoading = function() {
   return this.loading;
 };
-goog.exportProperty(
-    plugin.file.kml.ui.KMLNode.prototype,
-    'isLoading',
-    plugin.file.kml.ui.KMLNode.prototype.isLoading);
 
 
 /**

--- a/src/plugin/file/kml/ui/kmltournodeui.js
+++ b/src/plugin/file/kml/ui/kmltournodeui.js
@@ -101,65 +101,50 @@ plugin.file.kml.ui.KMLTourNodeUICtrl.prototype.onTourEvent = function(event) {
 /**
  * If the tour is playing.
  * @return {boolean}
+ * @export
  */
 plugin.file.kml.ui.KMLTourNodeUICtrl.prototype.isPlaying = function() {
   return this.tour_ != null && this.tour_['playing'];
 };
-goog.exportProperty(
-    plugin.file.kml.ui.KMLTourNodeUICtrl.prototype,
-    'isPlaying',
-    plugin.file.kml.ui.KMLTourNodeUICtrl.prototype.isPlaying);
 
 
 /**
  * @inheritDoc
+ * @export
  */
 plugin.file.kml.ui.KMLTourNodeUICtrl.prototype.show = function() {
   return plugin.file.kml.ui.KMLTourNodeUICtrl.base(this, 'show') || this.isPlaying();
 };
-goog.exportProperty(
-    plugin.file.kml.ui.KMLTourNodeUICtrl.prototype,
-    'show',
-    plugin.file.kml.ui.KMLTourNodeUICtrl.prototype.show);
 
 
 /**
  * Play the tour.
+ * @export
  */
 plugin.file.kml.ui.KMLTourNodeUICtrl.prototype.play = function() {
   if (this.tour_) {
     this.tour_.play();
   }
 };
-goog.exportProperty(
-    plugin.file.kml.ui.KMLTourNodeUICtrl.prototype,
-    'play',
-    plugin.file.kml.ui.KMLTourNodeUICtrl.prototype.play);
 
 
 /**
  * Pause the tour.
+ * @export
  */
 plugin.file.kml.ui.KMLTourNodeUICtrl.prototype.pause = function() {
   if (this.tour_) {
     this.tour_.pause();
   }
 };
-goog.exportProperty(
-    plugin.file.kml.ui.KMLTourNodeUICtrl.prototype,
-    'pause',
-    plugin.file.kml.ui.KMLTourNodeUICtrl.prototype.pause);
 
 
 /**
  * Reset the tour.
+ * @export
  */
 plugin.file.kml.ui.KMLTourNodeUICtrl.prototype.reset = function() {
   if (this.tour_) {
     this.tour_.reset();
   }
 };
-goog.exportProperty(
-    plugin.file.kml.ui.KMLTourNodeUICtrl.prototype,
-    'reset',
-    plugin.file.kml.ui.KMLTourNodeUICtrl.prototype.reset);

--- a/src/plugin/file/kml/ui/kmltreeexportui.js
+++ b/src/plugin/file/kml/ui/kmltreeexportui.js
@@ -133,18 +133,16 @@ plugin.file.kml.ui.KMLTreeExportCtrl.prototype.destroy = function() {
 
 /**
  * Fire the cancel callback and close the window.
+ * @export
  */
 plugin.file.kml.ui.KMLTreeExportCtrl.prototype.cancel = function() {
   this.close_();
 };
-goog.exportProperty(
-    plugin.file.kml.ui.KMLTreeExportCtrl.prototype,
-    'cancel',
-    plugin.file.kml.ui.KMLTreeExportCtrl.prototype.cancel);
 
 
 /**
  * Fire the confirmation callback and close the window.
+ * @export
  */
 plugin.file.kml.ui.KMLTreeExportCtrl.prototype.confirm = function() {
   goog.asserts.assert(goog.isDefAndNotNull(this.scope), 'scope is not defined');
@@ -160,10 +158,6 @@ plugin.file.kml.ui.KMLTreeExportCtrl.prototype.confirm = function() {
     this.close_();
   }
 };
-goog.exportProperty(
-    plugin.file.kml.ui.KMLTreeExportCtrl.prototype,
-    'confirm',
-    plugin.file.kml.ui.KMLTreeExportCtrl.prototype.confirm);
 
 
 /**

--- a/src/plugin/file/kml/ui/placemarkedit.js
+++ b/src/plugin/file/kml/ui/placemarkedit.js
@@ -90,6 +90,7 @@ plugin.file.kml.ui.PlacemarkEditCtrl.prototype.disposeInternal = function() {
 
 /**
  * @inheritDoc
+ * @export
  */
 plugin.file.kml.ui.PlacemarkEditCtrl.prototype.accept = function() {
   // create a new feature if necessary
@@ -112,7 +113,3 @@ plugin.file.kml.ui.PlacemarkEditCtrl.prototype.accept = function() {
 
   this.close();
 };
-goog.exportProperty(
-    plugin.file.kml.ui.PlacemarkEditCtrl.prototype,
-    'accept',
-    plugin.file.kml.ui.PlacemarkEditCtrl.prototype.accept);

--- a/src/plugin/file/shp/ui/shpfilesstep.js
+++ b/src/plugin/file/shp/ui/shpfilesstep.js
@@ -170,6 +170,7 @@ plugin.file.shp.ui.SHPFilesStepCtrl.prototype.validate_ = function() {
 /**
  * Launches a file browser for the specified file type.
  * @param {string} type The file type
+ * @export
  */
 plugin.file.shp.ui.SHPFilesStepCtrl.prototype.onBrowse = function(type) {
   if (type == 'dbf' && this.dbfFileEl_) {
@@ -178,10 +179,6 @@ plugin.file.shp.ui.SHPFilesStepCtrl.prototype.onBrowse = function(type) {
     this.shpFileEl_.click();
   }
 };
-goog.exportProperty(
-    plugin.file.shp.ui.SHPFilesStepCtrl.prototype,
-    'onBrowse',
-    plugin.file.shp.ui.SHPFilesStepCtrl.prototype.onBrowse);
 
 
 /**
@@ -308,6 +305,7 @@ plugin.file.shp.ui.SHPFilesStepCtrl.prototype.handleError_ = function(type, erro
 /**
  * Clears the file associated with the specified type.
  * @param {string} type The file type
+ * @export
  */
 plugin.file.shp.ui.SHPFilesStepCtrl.prototype.onClear = function(type) {
   if (type == 'dbf') {
@@ -324,10 +322,6 @@ plugin.file.shp.ui.SHPFilesStepCtrl.prototype.onClear = function(type) {
   this.updateErrorText_(type);
   this.validate_();
 };
-goog.exportProperty(
-    plugin.file.shp.ui.SHPFilesStepCtrl.prototype,
-    'onClear',
-    plugin.file.shp.ui.SHPFilesStepCtrl.prototype.onClear);
 
 
 /**
@@ -345,6 +339,7 @@ plugin.file.shp.ui.SHPFilesStepCtrl.prototype.getTypeString_ = function(type) {
 /**
  * Loads the provided URL to see if it's a valid SHP/DBF file.
  * @param {string} type The file type
+ * @export
  */
 plugin.file.shp.ui.SHPFilesStepCtrl.prototype.loadUrl = function(type) {
   var method = new os.ui.file.method.UrlMethod();
@@ -354,10 +349,6 @@ plugin.file.shp.ui.SHPFilesStepCtrl.prototype.loadUrl = function(type) {
   method.listen(os.events.EventType.CANCEL, goog.partial(this.onUrlError_, type), false, this);
   method.loadUrl();
 };
-goog.exportProperty(
-    plugin.file.shp.ui.SHPFilesStepCtrl.prototype,
-    'loadUrl',
-    plugin.file.shp.ui.SHPFilesStepCtrl.prototype.loadUrl);
 
 
 /**

--- a/src/plugin/heatmap/heatmaplayerui.js
+++ b/src/plugin/heatmap/heatmaplayerui.js
@@ -79,7 +79,7 @@ plugin.heatmap.HeatmapLayerUICtrl.prototype.initUI = function() {
 
 /**
  * Handles changes to the gradient
- * @protected
+ * @export
  */
 plugin.heatmap.HeatmapLayerUICtrl.prototype.onGradientChange = function() {
   var value = this.scope['gradient']['gradient'];
@@ -94,10 +94,6 @@ plugin.heatmap.HeatmapLayerUICtrl.prototype.onGradientChange = function() {
 
   this.createCommand(fn);
 };
-goog.exportProperty(
-    plugin.heatmap.HeatmapLayerUICtrl.prototype,
-    'onGradientChange',
-    plugin.heatmap.HeatmapLayerUICtrl.prototype.onGradientChange);
 
 
 /**

--- a/src/plugin/ogc/ui/choosetimecolumn.js
+++ b/src/plugin/ogc/ui/choosetimecolumn.js
@@ -103,6 +103,7 @@ plugin.ogc.ui.ChooseTimeColumnCtrl.prototype.disposeInternal = function() {
 
 /**
  * Save the time columns to the descriptor
+ * @export
  */
 plugin.ogc.ui.ChooseTimeColumnCtrl.prototype.save = function() {
   this.featureType_.setStartDateColumnName(this['start']);
@@ -113,10 +114,6 @@ plugin.ogc.ui.ChooseTimeColumnCtrl.prototype.save = function() {
   }
   this.close_();
 };
-goog.exportProperty(
-    plugin.ogc.ui.ChooseTimeColumnCtrl.prototype,
-    'save',
-    plugin.ogc.ui.ChooseTimeColumnCtrl.prototype.save);
 
 
 /**

--- a/src/plugin/ogc/ui/ogclayernodeui.js
+++ b/src/plugin/ogc/ui/ogclayernodeui.js
@@ -66,6 +66,7 @@ goog.inherits(plugin.ogc.ui.OGCLayerNodeUICtrl, os.ui.node.DefaultLayerNodeUICtr
 
 /**
  * Launch the time column chooser for the layer
+ * @export
  */
 plugin.ogc.ui.OGCLayerNodeUICtrl.prototype.chooseTime = function() {
   var deferred = new goog.async.Deferred();
@@ -75,5 +76,3 @@ plugin.ogc.ui.OGCLayerNodeUICtrl.prototype.chooseTime = function() {
   }, this);
   plugin.ogc.ui.ChooseTimeColumnCtrl.launch(this.getLayerId(), deferred);
 };
-goog.exportProperty(plugin.ogc.ui.OGCLayerNodeUICtrl.prototype, 'chooseTime',
-    plugin.ogc.ui.OGCLayerNodeUICtrl.prototype.chooseTime);

--- a/src/plugin/osm/nom/nominatimsearchresultcard.js
+++ b/src/plugin/osm/nom/nominatimsearchresultcard.js
@@ -80,11 +80,8 @@ goog.inherits(plugin.osm.nom.ResultCardCtrl, os.ui.search.FeatureResultCardCtrl)
 /**
  * Get the title to display on the card.
  * @return {string} The title.
+ * @export
  */
 plugin.osm.nom.ResultCardCtrl.prototype.getTitle = function() {
   return /** @type {string} */ (this.feature.get(plugin.osm.nom.ResultField.DISPLAY_NAME) || 'Unknown Result');
 };
-goog.exportProperty(
-    plugin.osm.nom.ResultCardCtrl.prototype,
-    'getTitle',
-    plugin.osm.nom.ResultCardCtrl.prototype.getTitle);

--- a/src/plugin/places/ui/placesnodeui.js
+++ b/src/plugin/places/ui/placesnodeui.js
@@ -58,6 +58,7 @@ goog.inherits(plugin.places.ui.PlacesNodeUICtrl, os.ui.node.DefaultLayerNodeUICt
 
 /**
  * Add a new folder.
+ * @export
  */
 plugin.places.ui.PlacesNodeUICtrl.prototype.addFolder = function() {
   var node = /** @type {plugin.file.kml.ui.KMLLayerNode} */ (this.scope['item']);
@@ -70,14 +71,11 @@ plugin.places.ui.PlacesNodeUICtrl.prototype.addFolder = function() {
     }
   }
 };
-goog.exportProperty(
-    plugin.places.ui.PlacesNodeUICtrl.prototype,
-    'addFolder',
-    plugin.places.ui.PlacesNodeUICtrl.prototype.addFolder);
 
 
 /**
  * Add a new place.
+ * @export
  */
 plugin.places.ui.PlacesNodeUICtrl.prototype.addPlace = function() {
   var node = /** @type {plugin.file.kml.ui.KMLLayerNode} */ (this.scope['item']);
@@ -90,10 +88,6 @@ plugin.places.ui.PlacesNodeUICtrl.prototype.addPlace = function() {
     }
   }
 };
-goog.exportProperty(
-    plugin.places.ui.PlacesNodeUICtrl.prototype,
-    'addPlace',
-    plugin.places.ui.PlacesNodeUICtrl.prototype.addPlace);
 
 
 /**

--- a/src/plugin/places/ui/placesui.js
+++ b/src/plugin/places/ui/placesui.js
@@ -120,18 +120,16 @@ plugin.places.ui.PlacesCtrl.prototype.onPlacesReady_ = function(event) {
 /**
  * If the places root node is available.
  * @return {boolean}
+ * @export
  */
 plugin.places.ui.PlacesCtrl.prototype.hasRoot = function() {
   return this.placesRoot_ != null;
 };
-goog.exportProperty(
-    plugin.places.ui.PlacesCtrl.prototype,
-    'hasRoot',
-    plugin.places.ui.PlacesCtrl.prototype.hasRoot);
 
 
 /**
  * Export places to a KMZ.
+ * @export
  */
 plugin.places.ui.PlacesCtrl.prototype.export = function() {
   if (this.placesRoot_) {
@@ -141,27 +139,21 @@ plugin.places.ui.PlacesCtrl.prototype.export = function() {
     os.alertManager.sendAlert('Nothing to export.', os.alert.AlertEventSeverity.WARNING);
   }
 };
-goog.exportProperty(
-    plugin.places.ui.PlacesCtrl.prototype,
-    'export',
-    plugin.places.ui.PlacesCtrl.prototype.export);
 
 
 /**
  * Import places from a file/URL.
+ * @export
  */
 plugin.places.ui.PlacesCtrl.prototype.import = function() {
   plugin.places.PlacesManager.getInstance().startImport();
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.Places.IMPORT, 1);
 };
-goog.exportProperty(
-    plugin.places.ui.PlacesCtrl.prototype,
-    'import',
-    plugin.places.ui.PlacesCtrl.prototype.import);
 
 
 /**
  * Create a new folder and add it to the tree.
+ * @export
  */
 plugin.places.ui.PlacesCtrl.prototype.addFolder = function() {
   var parent = this['selected'] && this['selected'].length == 1 ? this['selected'][0] : this.placesRoot_;
@@ -176,14 +168,11 @@ plugin.places.ui.PlacesCtrl.prototype.addFolder = function() {
   }
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.Places.ADD_FOLDER, 1);
 };
-goog.exportProperty(
-    plugin.places.ui.PlacesCtrl.prototype,
-    'addFolder',
-    plugin.places.ui.PlacesCtrl.prototype.addFolder);
 
 
 /**
  * Create a new place and add it to the tree.
+ * @export
  */
 plugin.places.ui.PlacesCtrl.prototype.addPlace = function() {
   var parent = this['selected'] && this['selected'].length == 1 ? this['selected'][0] : this.placesRoot_;
@@ -198,14 +187,11 @@ plugin.places.ui.PlacesCtrl.prototype.addPlace = function() {
   }
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.Places.ADD_PLACE, 1);
 };
-goog.exportProperty(
-    plugin.places.ui.PlacesCtrl.prototype,
-    'addPlace',
-    plugin.places.ui.PlacesCtrl.prototype.addPlace);
 
 
 /**
  * Fully expands the tree from the provided node. Uses the first node if multiple are selected.
+ * @export
  */
 plugin.places.ui.PlacesCtrl.prototype.expandAll = function() {
   var node = this['selected'] && this['selected'].length > 0 ? this['selected'][0] : this.placesRoot_;
@@ -215,14 +201,11 @@ plugin.places.ui.PlacesCtrl.prototype.expandAll = function() {
   }
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.Places.EXPAND_ALL, 1);
 };
-goog.exportProperty(
-    plugin.places.ui.PlacesCtrl.prototype,
-    'expandAll',
-    plugin.places.ui.PlacesCtrl.prototype.expandAll);
 
 
 /**
  * Fully collapses the tree from the provided node. Uses the first node if multiple are selected.
+ * @export
  */
 plugin.places.ui.PlacesCtrl.prototype.collapseAll = function() {
   var node = this['selected'] && this['selected'].length > 0 ? this['selected'][0] : this.placesRoot_;
@@ -232,7 +215,3 @@ plugin.places.ui.PlacesCtrl.prototype.collapseAll = function() {
   }
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.Places.COLLAPSE_ALL, 1);
 };
-goog.exportProperty(
-    plugin.places.ui.PlacesCtrl.prototype,
-    'collapseAll',
-    plugin.places.ui.PlacesCtrl.prototype.collapseAll);

--- a/src/plugin/places/ui/saveplaces.js
+++ b/src/plugin/places/ui/saveplaces.js
@@ -145,18 +145,16 @@ plugin.places.ui.SavePlacesCtrl.prototype.disposeInternal = function() {
 
 /**
  * Close the window.
+ * @export
  */
 plugin.places.ui.SavePlacesCtrl.prototype.cancel = function() {
   os.ui.window.close(this.element);
 };
-goog.exportProperty(
-    plugin.places.ui.SavePlacesCtrl.prototype,
-    'cancel',
-    plugin.places.ui.SavePlacesCtrl.prototype.cancel);
 
 
 /**
  * Save selection to places and close the window.
+ * @export
  */
 plugin.places.ui.SavePlacesCtrl.prototype.confirm = function() {
   plugin.places.saveFromSource(this['config']);
@@ -168,10 +166,6 @@ plugin.places.ui.SavePlacesCtrl.prototype.confirm = function() {
 
   this.cancel();
 };
-goog.exportProperty(
-    plugin.places.ui.SavePlacesCtrl.prototype,
-    'confirm',
-    plugin.places.ui.SavePlacesCtrl.prototype.confirm);
 
 
 /**

--- a/src/plugin/suncalc/suncalc.js
+++ b/src/plugin/suncalc/suncalc.js
@@ -79,11 +79,11 @@ plugin.suncalc.SunCalcCtrl.prototype.destroy_ = function() {
 
 /**
  * Close
+ * @export
  */
 plugin.suncalc.SunCalcCtrl.prototype.close = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(plugin.suncalc.SunCalcCtrl.prototype, 'close', plugin.suncalc.SunCalcCtrl.prototype.close);
 
 
 /**
@@ -230,6 +230,7 @@ plugin.suncalc.SunCalcCtrl.addTextColor_ = function(item) {
 /**
  * @param {number|string} t The time
  * @return {string} The formatted time
+ * @export
  */
 plugin.suncalc.SunCalcCtrl.prototype.formatTime = function(t) {
   if (goog.isNumber(t)) {
@@ -238,13 +239,12 @@ plugin.suncalc.SunCalcCtrl.prototype.formatTime = function(t) {
 
   return t;
 };
-goog.exportProperty(plugin.suncalc.SunCalcCtrl.prototype, 'formatTime',
-    plugin.suncalc.SunCalcCtrl.prototype.formatTime);
 
 
 /**
  * @param {number} t The time
  * @return {string} The formatted date
+ * @export
  */
 plugin.suncalc.SunCalcCtrl.prototype.formatDate = function(t) {
   if (goog.isDef(t)) {
@@ -254,6 +254,4 @@ plugin.suncalc.SunCalcCtrl.prototype.formatDate = function(t) {
 
   return '';
 };
-goog.exportProperty(plugin.suncalc.SunCalcCtrl.prototype, 'formatDate',
-    plugin.suncalc.SunCalcCtrl.prototype.formatDate);
 

--- a/src/plugin/track/confirmtrack.js
+++ b/src/plugin/track/confirmtrack.js
@@ -60,6 +60,7 @@ plugin.track.ConfirmTrackCtrl = function($scope) {
  * Get the name of a track.
  * @param {!ol.Feature} track The track
  * @return {string} The name
+ * @export
  */
 plugin.track.ConfirmTrackCtrl.prototype.getTrackName = function(track) {
   var trackName = /** @type {string|undefined} */ (track.get(plugin.file.kml.KMLField.NAME));
@@ -69,10 +70,6 @@ plugin.track.ConfirmTrackCtrl.prototype.getTrackName = function(track) {
 
   return trackName;
 };
-goog.exportProperty(
-    plugin.track.ConfirmTrackCtrl.prototype,
-    'getTrackName',
-    plugin.track.ConfirmTrackCtrl.prototype.getTrackName);
 
 
 /**

--- a/src/plugin/track/tracknodeui.js
+++ b/src/plugin/track/tracknodeui.js
@@ -57,6 +57,7 @@ goog.inherits(plugin.track.ui.TrackNodeUICtrl, os.ui.node.DefaultLayerNodeUICtrl
 
 /**
  * Add a new folder.
+ * @export
  */
 plugin.track.ui.TrackNodeUICtrl.prototype.addFolder = function() {
   var node = /** @type {plugin.file.kml.ui.KMLLayerNode} */ (this.scope['item']);
@@ -69,21 +70,14 @@ plugin.track.ui.TrackNodeUICtrl.prototype.addFolder = function() {
     }
   }
 };
-goog.exportProperty(
-    plugin.track.ui.TrackNodeUICtrl.prototype,
-    'addFolder',
-    plugin.track.ui.TrackNodeUICtrl.prototype.addFolder);
 
 
 /**
  * If the node can be edited.
  * @return {boolean}
+ * @export
  */
 plugin.track.ui.TrackNodeUICtrl.prototype.canEdit = function() {
   var node = /** @type {plugin.file.kml.ui.KMLLayerNode} */ (this.scope['item']);
   return node != null && node.isEditable();
 };
-goog.exportProperty(
-    plugin.track.ui.TrackNodeUICtrl.prototype,
-    'canEdit',
-    plugin.track.ui.TrackNodeUICtrl.prototype.canEdit);

--- a/src/plugin/vectortools/joinwindow.js
+++ b/src/plugin/vectortools/joinwindow.js
@@ -182,15 +182,16 @@ plugin.vectortools.JoinCtrl.prototype.onUpdateDelay = function() {
 
 /**
  * Close the window.
+ * @export
  */
 plugin.vectortools.JoinCtrl.prototype.close = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(plugin.vectortools.JoinCtrl.prototype, 'close', plugin.vectortools.JoinCtrl.prototype.close);
 
 
 /**
  * Builds and executes the command to perform the join then closes the window.
+ * @export
  */
 plugin.vectortools.JoinCtrl.prototype.accept = function() {
   var sources = this['joinSources'].map(function(item) {
@@ -220,7 +221,6 @@ plugin.vectortools.JoinCtrl.prototype.accept = function() {
   os.command.CommandProcessor.getInstance().addCommand(cmd);
   this.close();
 };
-goog.exportProperty(plugin.vectortools.JoinCtrl.prototype, 'accept', plugin.vectortools.JoinCtrl.prototype.accept);
 
 
 /**

--- a/src/plugin/vectortools/mappingcounter.js
+++ b/src/plugin/vectortools/mappingcounter.js
@@ -97,10 +97,8 @@ plugin.vectortools.MappingCounterCtrl.prototype.onColumnMappingsChange_ = functi
 
 /**
  * Launches the settings window for managing column mappings.
+ * @export
  */
 plugin.vectortools.MappingCounterCtrl.prototype.launchColumnMappings = function() {
   os.ui.menu.windows.openSettingsTo(os.ui.column.mapping.ColumnMappingSettings.ID);
 };
-goog.exportProperty(plugin.vectortools.MappingCounterCtrl.prototype,
-    'launchColumnMappings',
-    plugin.vectortools.MappingCounterCtrl.prototype.launchColumnMappings);

--- a/src/plugin/vectortools/mergewindow.js
+++ b/src/plugin/vectortools/mergewindow.js
@@ -159,19 +159,19 @@ plugin.vectortools.MergeCtrl.prototype.onUpdateDelay = function() {
 
 /**
  * Close dialog
+ * @export
  */
 plugin.vectortools.MergeCtrl.prototype.close = function() {
   os.ui.window.close(this.element_);
 };
-goog.exportProperty(plugin.vectortools.MergeCtrl.prototype, 'close', plugin.vectortools.MergeCtrl.prototype.close);
 
 
 /**
  * Adds the command to perform the merge.
+ * @export
  */
 plugin.vectortools.MergeCtrl.prototype.accept = function() {
   var merge = new plugin.vectortools.MergeLayer(this.sourceIds_, this['name']);
   os.command.CommandProcessor.getInstance().addCommand(merge);
   this.close();
 };
-goog.exportProperty(plugin.vectortools.MergeCtrl.prototype, 'accept', plugin.vectortools.MergeCtrl.prototype.accept);

--- a/views/windows/animationsettings.html
+++ b/views/windows/animationsettings.html
@@ -38,7 +38,7 @@
 
       <div class="row mb-1">
         <label class="checkbox">
-          <input name="auto" type="checkbox" ng-model="autoConfig" ng-change="animationCtrl.onAutoChange()">
+          <input name="auto" type="checkbox" ng-model="autoConfig" ng-change="animationCtrl.autoConfigure()">
           Auto configure the window, skip, and tiles
         </label>
       </div>


### PR DESCRIPTION
This replaces `goog.exportProperty` in all source files using the following rules:
- Use `@export` for functions that needed to avoid compiler renaming.
- Remove `@protected` from exported functions.
- Remove `@private` from exported functions and remove the trailing `_` from the function name. In all cases, the private function was not being used internally.
- Replace aliases created with `goog.exportProperty` with an equivalent property assignment.

Special cases:
- We add `$$hashKey` to `ol.Object` for Angular. `ol.Object` has `@struct` so the compiler won't allow direct property access. I worked around this by using `ol.obj.assign` to make the assignment.
- `os.ui.AnimationSettingsCtrl.prototype.autoConfigure` was exporting to a different function name. That was not necessary, so the template was updated to use `autoConfigure`.