### PR TITLE
fix(cesium): fix some bugs in Cesium's explicit rendering

### DIFF
--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -3839,6 +3839,20 @@ Cesium.Scene.prototype.postRender;
 
 
 /**
+ * @type {Cesium.Event}
+ * @const
+ */
+Cesium.Scene.prototype.preUpdate;
+
+
+/**
+ * @type {Cesium.Event}
+ * @const
+ */
+Cesium.Scene.prototype.postUpdate;
+
+
+/**
  * @type {Cesium.ScreenSpaceCameraController}
  */
 Cesium.Scene.prototype.screenSpaceCameraController;

--- a/src/plugin/cesium/mixin/cesiummixin.js
+++ b/src/plugin/cesium/mixin/cesiummixin.js
@@ -4,6 +4,7 @@
  */
 goog.provide('plugin.cesium.mixin');
 
+goog.require('os.MapEvent');
 goog.require('os.net.Request');
 
 
@@ -76,6 +77,11 @@ plugin.cesium.mixin.loadCesiumMixins = function() {
       deferred.resolve(response);
     }).thenCatch(function(reason) {
       deferred.reject(reason);
+    }).thenAlways(function() {
+      // The old olcs render loop fired a repaint when requests returned. While that shouldn't
+      // be necessary with Cesium's new explicit rendering, there are still cases like async
+      // Billboard/Icon loading which do not appear to be triggering a render request.
+      os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
     });
 
     return deferred.promise;

--- a/src/plugin/cesium/mixin/renderloopmixin.js
+++ b/src/plugin/cesium/mixin/renderloopmixin.js
@@ -21,6 +21,8 @@ goog.require('os.time.TimelineEventType');
     os.dispatcher.listen(os.MapEvent.GL_REPAINT, this.notifyRepaintRequired, false, this);
     os.time.TimelineController.getInstance().listen(os.time.TimelineEventType.SHOW,
         this.notifyRepaintRequired, false, this);
+
+    this.scene_.postUpdate.addEventListener(this.onPostUpdate_, this);
     origEnable.call(this);
   };
 
@@ -35,10 +37,24 @@ goog.require('os.time.TimelineEventType');
     os.dispatcher.unlisten(os.MapEvent.GL_REPAINT, this.notifyRepaintRequired, false, this);
     os.time.TimelineController.getInstance().unlisten(os.time.TimelineEventType.SHOW,
         this.notifyRepaintRequired, false, this);
+    this.scene_.postUpdate.removeEventListener(this.onPostUpdate_, this);
     origDisable.call(this);
   };
 
   var origNotify = olcs.AutoRenderLoop.prototype.notifyRepaintRequired;
+
+
+  var lastRepaintEventTime = 0;
+
+  /**
+   * @private
+   */
+  olcs.AutoRenderLoop.prototype.onPostUpdate_ = function() {
+    // render for at least a whole second after a GL_REPAINT event is fired
+    if (goog.now() - lastRepaintEventTime < 1000) {
+      this.scene_.requestRender();
+    }
+  };
 
   /**
    * Overridden because we only care about mouse events if a button is down
@@ -57,5 +73,6 @@ goog.require('os.time.TimelineEventType');
     }
 
     origNotify.call(this);
+    lastRepaintEventTime = goog.now();
   };
 })();


### PR DESCRIPTION
The old ol-cesium render loop fired rendering when Cesium's request stack finished a request. This has been restored. Additionally, when the render loop is fired via a GL_REPAINT event, the loop continuously renders for a whole second at the target framerate rather than simply rendering once. This covers the async load of an icon and asynchronously loading it to the GPU.

This would be "less hacky" if there was an event when `BillBoard`s or other classes from cesium fired an event when their `ready` flag flips to `true`. I figured pulling back in some logic similar to the older `AutoRenderLoop` class from `ol-cesium` was preferable to polling that flag.