### PR TITLE
Cascade windows with the same id

### DIFF
--- a/src/os/ui/query/ui/modifyarea.js
+++ b/src/os/ui/query/ui/modifyarea.js
@@ -394,8 +394,7 @@ os.ui.query.ui.launchModifyArea = function(config) {
   var windowId = 'modifyArea';
   if (os.ui.window.exists(windowId)) {
     // update the existing window
-    var win = document.querySelector('.window#' + windowId);
-    var scope = angular.element(win).find('.modify-area-window').scope();
+    var scope = $('.js-window#' + windowId + ' .modal-body').scope();
     if (scope) {
       goog.object.extend(scope, config);
       os.ui.apply(scope);

--- a/src/plugin/file/kml/ui/kmlui.js
+++ b/src/plugin/file/kml/ui/kmlui.js
@@ -101,38 +101,29 @@ plugin.file.kml.ui.updateFolder = function(options) {
  */
 plugin.file.kml.ui.createOrEditPlace = function(options) {
   var windowId = 'placemarkEdit';
-  if (options['feature']) {
-    var featureId = options['feature'].getId();
-    windowId = os.ui.sanitizeId(windowId + '-' + featureId);
-  }
+  var scopeOptions = {
+    'options': options
+  };
 
-  if (os.ui.window.exists(windowId)) {
-    os.ui.window.bringToFront(windowId);
-  } else {
-    var scopeOptions = {
-      'options': options
-    };
+  var label = (options['feature'] ? 'Edit' : 'Add') + ' Place';
+  var windowOptions = {
+    'id': windowId,
+    'label': label,
+    'icon': 'fa fa-map-marker',
+    'x': 'center',
+    'y': 'center',
+    'width': 700,
+    'min-width': 400,
+    'max-width': 2000,
+    'height': 'auto',
+    'min-height': 300,
+    'max-height': 2000,
+    'modal': false,
+    'show-close': true
+  };
 
-    var label = (options['feature'] ? 'Edit' : 'Add') + ' Place';
-    var windowOptions = {
-      'id': windowId,
-      'label': label,
-      'icon': 'fa fa-map-marker',
-      'x': 'center',
-      'y': 'center',
-      'width': 700,
-      'min-width': 400,
-      'max-width': 2000,
-      'height': 'auto',
-      'min-height': 300,
-      'max-height': 2000,
-      'modal': false,
-      'show-close': true
-    };
-
-    var template = '<placemarkedit></placemarkedit>';
-    os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
-  }
+  var template = '<placemarkedit></placemarkedit>';
+  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
 };
 
 


### PR DESCRIPTION
This causes saved windows with the same `id` to be cascaded. The cascade behavior was designed to mimic macOS:

- Find top-most like window and add x/y offset to that position.
- If the new window hits the right edge of the screen, change x position of new window to 0.
- If it hits the bottom edge of the screen, change y position of the new window to 0 (under the top bar).

In OpenSphere, this results in windows being positioned on top of the top nav because the window container contains the navs. This feels a little odd, but the best way to resolve that would be changing the window container to the map container. That seemed like a potentially unwanted change, and perhaps not fit for this PR.