### PR TITLE
fix(area): modify area command should remove original geometry

### DIFF
--- a/src/os/ui/query/cmd/areamodifycmd.js
+++ b/src/os/ui/query/cmd/areamodifycmd.js
@@ -1,5 +1,6 @@
 goog.provide('os.ui.query.cmd.AreaModify');
 goog.require('os.command.ICommand');
+goog.require('os.interpolate');
 goog.require('os.ol.feature');
 goog.require('os.ui.query.cmd.AbstractArea');
 
@@ -53,6 +54,7 @@ os.ui.query.cmd.AreaModify.prototype.execute = function() {
     this.state = os.command.State.EXECUTING;
 
     // update the geometry and re-add the area to trigger a refresh
+    this.area.set(os.interpolate.ORIGINAL_GEOM_FIELD, undefined);
     this.area.setGeometry(this.newGeometry);
     os.ui.areaManager.remove(this.area);
     os.ui.areaManager.add(this.area);
@@ -72,6 +74,7 @@ os.ui.query.cmd.AreaModify.prototype.revert = function() {
   this.state = os.command.State.REVERTING;
 
   // revert to the original geometry and re-add the area to trigger a refresh
+  this.area.set(os.interpolate.ORIGINAL_GEOM_FIELD, undefined);
   this.area.setGeometry(this.oldGeometry);
   os.ui.areaManager.remove(this.area);
   os.ui.areaManager.add(this.area);


### PR DESCRIPTION
If the original geometry is not removed, the interpolation will work off of that and overwrite the
new geometry.

I gave some thought to potentially making the JSTS operations work off the original geometry so that the resulting polygons could be simpler, but I believe that may affect its accuracy in some situations so I left it out.