### PR TITLE
Add WMTS server support

### DIFF
--- a/src/os/mainctrl.js
+++ b/src/os/mainctrl.js
@@ -163,6 +163,7 @@ goog.require('plugin.suncalc.Plugin');
 goog.require('plugin.track.TrackPlugin');
 goog.require('plugin.vectortools.VectorToolsPlugin');
 goog.require('plugin.weather.WeatherPlugin');
+goog.require('plugin.wmts.Plugin');
 goog.require('plugin.xyz.XYZPlugin');
 
 
@@ -517,6 +518,7 @@ os.MainCtrl.prototype.addPlugins = function() {
   os.ui.pluginManager.addPlugin(new plugin.weather.WeatherPlugin());
   os.ui.pluginManager.addPlugin(new plugin.overview.OverviewPlugin());
   os.ui.pluginManager.addPlugin(new plugin.arc.ArcPlugin());
+  os.ui.pluginManager.addPlugin(new plugin.wmts.Plugin());
   os.ui.pluginManager.addPlugin(plugin.places.PlacesPlugin.getInstance());
   os.ui.pluginManager.addPlugin(plugin.position.PositionPlugin.getInstance());
   os.ui.pluginManager.addPlugin(plugin.vectortools.VectorToolsPlugin.getInstance());

--- a/src/os/proj/proj.js
+++ b/src/os/proj/proj.js
@@ -183,3 +183,23 @@ os.proj.getBestSupportedProjection = function(options) {
       '. projections=' + supportedProjections.toString());
   return null;
 };
+
+/**
+ * Given a projection, returns the equivalent projection with the shortest code.
+ * @param {ol.ProjectionLike} proj
+ * @return {ol.proj.Projection}
+ * @suppress {accessControls}
+ */
+os.proj.getBestEquivalent = function(proj) {
+  var projection = ol.proj.get(proj);
+  var projMap = ol.proj.projections.cache_;
+  var shortest = '';
+  for (var key in projMap) {
+    if (key !== 'CRS:84' && ol.proj.equivalent(projMap[key], projection) &&
+        (!shortest || key.length < shortest.length)) {
+      shortest = key;
+    }
+  }
+
+  return ol.proj.get(shortest);
+};

--- a/src/os/proj/projswitch.js
+++ b/src/os/proj/projswitch.js
@@ -243,7 +243,7 @@ os.proj.switch.SwitchProjection.prototype.addLayer = function(layer) {
   }
 
   if (!this.newProjection_) {
-    this.newProjection_ = layer.getSource().getProjection();
+    this.newProjection_ = os.proj.getBestEquivalent(layer.getSource().getProjection());
   }
 
   if (this.layers_.indexOf(layer) === -1) {
@@ -272,7 +272,7 @@ os.proj.switch.SwitchProjection.prototype.start = function(projection) {
   }
 
   if (!this.newProjection_) {
-    var p = ol.proj.get(projection);
+    var p = os.proj.getBestEquivalent(projection);
 
     if (p) {
       this.newProjection_ = p;

--- a/src/plugin/arc/layer/animatedarctilelayer.js
+++ b/src/plugin/arc/layer/animatedarctilelayer.js
@@ -13,6 +13,7 @@ goog.require('os.time.TimelineController');
  */
 plugin.arc.layer.AnimatedArcTile = function(options) {
   plugin.arc.layer.AnimatedArcTile.base(this, 'constructor', options);
+  this.setTimeFunction(os.layer.AnimatedTile.updateParams);
 };
 goog.inherits(plugin.arc.layer.AnimatedArcTile, os.layer.AnimatedTile);
 

--- a/src/plugin/cesium/cesium.js
+++ b/src/plugin/cesium/cesium.js
@@ -229,12 +229,6 @@ plugin.cesium.tileLayerToImageryLayer = function(olLayer, viewProj) {
   var source = olLayer.getSource();
   var provider = null;
 
-  // handle special cases before the general synchronization
-  if (source instanceof ol.source.WMTS) {
-    // WMTS uses different TileGrid which is not currently supported
-    return null;
-  }
-
   if (source instanceof ol.source.TileImage) {
     var projection = source.getProjection();
 
@@ -243,8 +237,8 @@ plugin.cesium.tileLayerToImageryLayer = function(olLayer, viewProj) {
       projection = viewProj;
     }
 
-    var is3857 = projection === ol.proj.get(os.proj.EPSG3857);
-    var is4326 = projection === ol.proj.get(os.proj.EPSG4326);
+    var is3857 = ol.proj.equivalent(projection, ol.proj.get(os.proj.EPSG3857));
+    var is4326 = ol.proj.equivalent(projection, ol.proj.get(os.proj.EPSG4326));
     if (is3857 || is4326) {
       provider = new plugin.cesium.ImageryProvider(source, viewProj);
     } else {

--- a/src/plugin/cesium/sync/tilesynchronizer.js
+++ b/src/plugin/cesium/sync/tilesynchronizer.js
@@ -380,11 +380,12 @@ plugin.cesium.sync.TileSynchronizer.prototype.getTimeParameter_ = function(offse
   goog.asserts.assertInstanceof(this.layer, os.layer.AnimatedTile);
 
   var dateFormat = this.layer.getDateFormat();
+  var timeFormat = this.layer.getTimeFormat();
   var duration = this.tlc.getDuration();
   var start = this.tlc.getCurrent() - this.tlc.getOffset();
   var end = this.tlc.getCurrent();
 
-  return os.layer.AnimatedTile.getTimeParameter(dateFormat,
+  return os.layer.AnimatedTile.getTimeParameter(dateFormat, timeFormat,
       os.time.offset(new Date(start), duration, offset).getTime(),
       os.time.offset(new Date(end), duration, offset).getTime(),
       duration);

--- a/src/plugin/ogc/wms/wmslayerconfig.js
+++ b/src/plugin/ogc/wms/wmslayerconfig.js
@@ -79,7 +79,8 @@ goog.inherits(plugin.ogc.wms.WMSLayerConfig, os.layer.config.AbstractTileLayerCo
  */
 plugin.ogc.wms.WMSLayerConfig.prototype.initializeConfig = function(options) {
   plugin.ogc.wms.WMSLayerConfig.base(this, 'initializeConfig', options);
-  this.layerClass = options['animate'] ? os.layer.AnimatedTile : this.layerClass;
+  this.animate = !!options['animate'];
+  this.layerClass = this.animate ? os.layer.AnimatedTile : this.layerClass;
 };
 
 
@@ -92,8 +93,17 @@ plugin.ogc.wms.WMSLayerConfig.prototype.configureLayer = function(layer, options
   layer.setStyles(/** @type {?Array<osx.ogc.TileStyle>} */ (options['styles'] || null));
 
   if (this.animate) {
-    if (layer instanceof os.layer.AnimatedTile && options['dateFormat']) {
-      /** @type {os.layer.AnimatedTile} */ (layer).setDateFormat(/** @type {string} */ (options['dateFormat']));
+    if (layer instanceof os.layer.AnimatedTile) {
+      var animatedLayer = /** @type {os.layer.AnimatedTile} */ (layer);
+      animatedLayer.setTimeFunction(os.layer.AnimatedTile.updateParams);
+
+      if (options['dateFormat']) {
+        animatedLayer.setDateFormat(/** @type {string} */ (options['dateFormat']));
+      }
+
+      if (options['timeFormat']) {
+        animatedLayer.setTimeFormat(/** @type {string} */ (options['timeFormat']));
+      }
     }
   }
 };

--- a/src/plugin/wmts/mime.js
+++ b/src/plugin/wmts/mime.js
@@ -1,0 +1,9 @@
+goog.provide('plugin.wmts.mime');
+
+goog.require('os.file.mime.xml');
+
+
+os.file.mime.register(
+    plugin.wmts.ID,
+    os.file.mime.xml.createDetect(/^Capabilities$/, /\/wmts\//),
+    0, os.file.mime.xml.TYPE);

--- a/src/plugin/wmts/wmts.js
+++ b/src/plugin/wmts/wmts.js
@@ -1,0 +1,7 @@
+goog.provide('plugin.wmts');
+
+/**
+ * @type {string}
+ * @const
+ */
+plugin.wmts.ID = 'wmts';

--- a/src/plugin/wmts/wmtsimport.js
+++ b/src/plugin/wmts/wmtsimport.js
@@ -1,0 +1,66 @@
+goog.provide('plugin.wmts.ImportCtrl');
+goog.provide('plugin.wmts.importDirective');
+goog.require('os.defines');
+goog.require('os.ui.Module');
+goog.require('os.ui.SingleUrlProviderImportCtrl');
+goog.require('os.ui.window');
+goog.require('plugin.wmts.Server');
+
+
+/**
+ * The geoserver import directive
+ * @return {angular.Directive}
+ */
+plugin.wmts.importDirective = function() {
+  return {
+    restrict: 'E',
+    replace: true,
+    templateUrl: os.ROOT + 'views/forms/singleurl.html',
+    controller: plugin.wmts.ImportCtrl,
+    controllerAs: 'ctrl'
+  };
+};
+
+
+/**
+ * Add the directive to the module
+ */
+os.ui.Module.directive('wmtsserver', [plugin.wmts.importDirective]);
+
+
+
+/**
+ * Controller for the geoserver import dialog
+ * @param {!angular.Scope} $scope
+ * @param {!angular.JQLite} $element
+ * @extends {os.ui.SingleUrlProviderImportCtrl}
+ * @constructor
+ * @ngInject
+ */
+plugin.wmts.ImportCtrl = function($scope, $element) {
+  plugin.wmts.ImportCtrl.base(this, 'constructor', $scope, $element);
+
+  var file = /** @type {os.file.File} */ ($scope['config']['file']);
+  $scope['config']['url'] = file ? file.getUrl() : this.getUrl();
+  $scope['config']['type'] = plugin.wmts.ID;
+  $scope['urlExample'] = 'http://www.example.com/path/to/wmts';
+};
+goog.inherits(plugin.wmts.ImportCtrl, os.ui.SingleUrlProviderImportCtrl);
+
+
+/**
+ * @inheritDoc
+ */
+plugin.wmts.ImportCtrl.prototype.getDataProvider = function() {
+  var dp = new plugin.wmts.Server();
+  dp.configure(this.scope['config']);
+  return dp;
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.wmts.ImportCtrl.prototype.getUrl = function() {
+  return this.dp ? /** @type {plugin.ogc.GeoServer} */ (this.dp).getUrl() : '';
+};

--- a/src/plugin/wmts/wmtsimport.js
+++ b/src/plugin/wmts/wmtsimport.js
@@ -8,7 +8,7 @@ goog.require('plugin.wmts.Server');
 
 
 /**
- * The geoserver import directive
+ * The WMTS Server import directive
  * @return {angular.Directive}
  */
 plugin.wmts.importDirective = function() {
@@ -30,7 +30,7 @@ os.ui.Module.directive('wmtsserver', [plugin.wmts.importDirective]);
 
 
 /**
- * Controller for the geoserver import dialog
+ * Controller for the WMTS import dialog
  * @param {!angular.Scope} $scope
  * @param {!angular.JQLite} $element
  * @extends {os.ui.SingleUrlProviderImportCtrl}
@@ -62,5 +62,5 @@ plugin.wmts.ImportCtrl.prototype.getDataProvider = function() {
  * @inheritDoc
  */
 plugin.wmts.ImportCtrl.prototype.getUrl = function() {
-  return this.dp ? /** @type {plugin.ogc.GeoServer} */ (this.dp).getUrl() : '';
+  return this.dp ? /** @type {plugin.wmts.Server} */ (this.dp).getUrl() : '';
 };

--- a/src/plugin/wmts/wmtslayerconfig.js
+++ b/src/plugin/wmts/wmtslayerconfig.js
@@ -1,0 +1,109 @@
+goog.provide('plugin.wmts.LayerConfig');
+
+goog.require('ol.array');
+goog.require('ol.source.WMTS');
+goog.require('os.layer.config.AbstractTileLayerConfig');
+
+
+/**
+ * Creates a WMTS layer.
+ * @extends {os.layer.config.AbstractTileLayerConfig}
+ * @constructor
+ */
+plugin.wmts.LayerConfig = function() {
+  plugin.wmts.LayerConfig.base(this, 'constructor');
+
+  /**
+   * @type {boolean}
+   * @protected
+   */
+  this.animate = false;
+};
+goog.inherits(plugin.wmts.LayerConfig, os.layer.config.AbstractTileLayerConfig);
+
+
+/**
+ * @inheritDoc
+ */
+plugin.wmts.LayerConfig.prototype.initializeConfig = function(options) {
+  plugin.wmts.LayerConfig.base(this, 'initializeConfig', options);
+  this.animate = !!options['animate'];
+  this.layerClass = this.animate ? os.layer.AnimatedTile : this.layerClass;
+
+  delete options['minZoom'];
+  delete options['maxZoom'];
+  delete options['minResolution'];
+  delete options['maxResolution'];
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.wmts.LayerConfig.prototype.configureLayer = function(layer, options) {
+  plugin.wmts.LayerConfig.base(this, 'configureLayer', layer, options);
+
+  if (this.animate) {
+    if (layer instanceof os.layer.AnimatedTile) {
+      var animatedLayer = /** @type {os.layer.AnimatedTile} */ (layer);
+      animatedLayer.setTimeFunction(plugin.wmts.LayerConfig.timeFunction_);
+
+      if (options['dateFormat']) {
+        animatedLayer.setDateFormat(/** @type {string} */ (options['dateFormat']));
+      }
+
+      if (options['timeFormat']) {
+        animatedLayer.setTimeFormat(/** @type {string} */ (options['timeFormat']));
+      }
+    }
+  }
+};
+
+
+/**
+ * @param {string} timeValue
+ * @this {os.layer.AnimatedTile}
+ * @private
+ */
+plugin.wmts.LayerConfig.timeFunction_ = function(timeValue) {
+  var source = /** @type {ol.source.WMTS} */ (this.getSource());
+  var dimensions = source.getDimensions();
+  dimensions['time'] = timeValue;
+  source.updateDimensions(dimensions);
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.wmts.LayerConfig.prototype.getSource = function(options) {
+  var list = options['wmtsOptions'];
+
+  if (!list || !Array.isArray(list)) {
+    throw new Error('wmtsOptions must be set on the layer config for WMTS layers');
+  }
+
+  var projection = this.projection;
+  var wmtsOptions = ol.array.find(list, function(opts) {
+    return ol.proj.equivalent(ol.proj.get(opts.projection), ol.proj.get(projection));
+  });
+
+  // ensure the time key in URL templates matches the case in the dimension set
+  if (wmtsOptions.dimensions) {
+    var timeKey;
+    for (var key in wmtsOptions.dimensions) {
+      if (/time/i.test(key)) {
+        timeKey = key;
+      }
+    }
+
+    if (timeKey) {
+      wmtsOptions.urls = wmtsOptions.urls.map(function(url) {
+        return url.replace(/\{time}/ig, '{' + timeKey + '}');
+      });
+    }
+  }
+
+  this.urls = wmtsOptions.urls;
+  return new ol.source.WMTS(wmtsOptions);
+};

--- a/src/plugin/wmts/wmtsplugin.js
+++ b/src/plugin/wmts/wmtsplugin.js
@@ -1,7 +1,5 @@
 goog.provide('plugin.wmts.Plugin');
 
-// goog.require('plugin.ogc.ui.ogcserverDirective');
-// goog.require('plugin.wmts.mime');
 goog.require('os.data.ConfigDescriptor');
 goog.require('os.data.DataManager');
 goog.require('os.data.ProviderEntry');
@@ -11,7 +9,8 @@ goog.require('os.ui.im.ImportManager');
 goog.require('plugin.wmts');
 goog.require('plugin.wmts.LayerConfig');
 goog.require('plugin.wmts.Server');
-
+goog.require('plugin.wmts.importDirective');
+goog.require('plugin.wmts.mime');
 
 
 /**
@@ -43,6 +42,6 @@ plugin.wmts.Plugin.prototype.init = function() {
   dm.registerDescriptorType(os.data.ConfigDescriptor.ID, os.data.ConfigDescriptor);
 
   // register the server forms for adding/editing servers
-  // var im = os.ui.im.ImportManager.getInstance();
-  // im.registerImportUI(plugin.wmts.ID, new os.ui.ProviderImportUI('wmtsserver'));
+  var im = os.ui.im.ImportManager.getInstance();
+  im.registerImportUI(plugin.wmts.ID, new os.ui.ProviderImportUI('wmtsserver'));
 };

--- a/src/plugin/wmts/wmtsplugin.js
+++ b/src/plugin/wmts/wmtsplugin.js
@@ -1,0 +1,48 @@
+goog.provide('plugin.wmts.Plugin');
+
+// goog.require('plugin.ogc.ui.ogcserverDirective');
+// goog.require('plugin.wmts.mime');
+goog.require('os.data.ConfigDescriptor');
+goog.require('os.data.DataManager');
+goog.require('os.data.ProviderEntry');
+goog.require('os.plugin.AbstractPlugin');
+goog.require('os.ui.ProviderImportUI');
+goog.require('os.ui.im.ImportManager');
+goog.require('plugin.wmts');
+goog.require('plugin.wmts.LayerConfig');
+goog.require('plugin.wmts.Server');
+
+
+
+/**
+ * Provides WMTS support
+ * @extends {os.plugin.AbstractPlugin}
+ * @constructor
+ */
+plugin.wmts.Plugin = function() {
+  plugin.wmts.Plugin.base(this, 'constructor');
+  this.id = plugin.wmts.ID;
+};
+goog.inherits(plugin.wmts.Plugin, os.plugin.AbstractPlugin);
+
+
+/**
+ * @inheritDoc
+ */
+plugin.wmts.Plugin.prototype.init = function() {
+  var dm = os.dataManager;
+
+  dm.registerProviderType(new os.data.ProviderEntry(
+    plugin.wmts.ID, plugin.wmts.Server, 'WMTS Server',
+    'WMTS servers provide map tiles through the Web Map Tile Service specification'));
+
+  // register the layer configurations
+  var lcm = os.layer.config.LayerConfigManager.getInstance();
+  lcm.registerLayerConfig(plugin.wmts.ID, plugin.wmts.LayerConfig);
+
+  dm.registerDescriptorType(os.data.ConfigDescriptor.ID, os.data.ConfigDescriptor);
+
+  // register the server forms for adding/editing servers
+  // var im = os.ui.im.ImportManager.getInstance();
+  // im.registerImportUI(plugin.wmts.ID, new os.ui.ProviderImportUI('wmtsserver'));
+};

--- a/src/plugin/wmts/wmtsserver.js
+++ b/src/plugin/wmts/wmtsserver.js
@@ -1,0 +1,600 @@
+goog.provide('plugin.wmts.Server');
+
+goog.require('goog.Uri');
+goog.require('goog.Uri.QueryData');
+goog.require('goog.array');
+goog.require('goog.dom');
+goog.require('goog.dom.xml');
+goog.require('goog.log');
+goog.require('goog.log.Logger');
+goog.require('ol.format.WMTSCapabilities');
+goog.require('os.alert.AlertEventSeverity');
+goog.require('os.alert.AlertManager');
+goog.require('os.color');
+goog.require('os.data.ConfigDescriptor');
+goog.require('os.data.DataProviderEvent');
+goog.require('os.data.DataProviderEventType');
+goog.require('os.data.IDataProvider');
+goog.require('os.file');
+goog.require('os.layer.LayerType');
+goog.require('os.net.HandlerType');
+goog.require('os.net.Request');
+goog.require('os.ui.Icons');
+goog.require('os.ui.data.DescriptorNode');
+goog.require('os.ui.server.AbstractLoadingServer');
+goog.require('os.ui.slick.SlickTreeNode');
+goog.require('plugin.wmts');
+
+
+/**
+ * The OGC server provider
+ *
+ * @implements {os.data.IDataProvider}
+ * @extends {os.ui.server.AbstractLoadingServer}
+ * @constructor
+ */
+plugin.wmts.Server = function() {
+  plugin.wmts.Server.base(this, 'constructor');
+  this.log = plugin.wmts.Server.LOGGER_;
+  this.providerType = os.ogc.ID;
+
+  /**
+   * @type {Array.<string>}
+   * @private
+   */
+  this.abstracts_ = [];
+
+  /**
+   * @type {?Array.<!os.ui.slick.SlickTreeNode>}
+   * @private
+   */
+  this.toAdd_ = null;
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.lowerCase_ = false;
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.originalUrl_ = '';
+
+  /**
+   * @type {goog.Uri.QueryData}
+   * @private
+   */
+  this.params_ = null;
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.dateFormat_ = '';
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.timeFormat_ = '';
+};
+goog.inherits(plugin.wmts.Server, os.ui.server.AbstractLoadingServer);
+
+
+/**
+ * The logger.
+ * @const
+ * @type {goog.debug.Logger}
+ * @private
+ */
+plugin.wmts.Server.LOGGER_ = goog.log.getLogger('plugin.wmts.Server');
+
+
+/**
+ * Default color for descriptors.
+ * @const
+ * @type {string}
+ */
+plugin.wmts.Server.DEFAULT_COLOR = 'rgba(255,255,255,1)';
+
+
+/**
+ * @type {string}
+ * @const
+ */
+plugin.wmts.Server.DEFAULT_VERSION = '1.0.0';
+
+
+/**
+ * @return {Array.<string>}
+ */
+plugin.wmts.Server.prototype.getAbstracts = function() {
+  return this.abstracts_;
+};
+
+
+/**
+ * @return {boolean}
+ */
+plugin.wmts.Server.prototype.getLowerCase = function() {
+  return this.lowerCase_;
+};
+
+
+/**
+ * @param {boolean} value
+ */
+plugin.wmts.Server.prototype.setLowerCase = function(value) {
+  this.lowerCase_ = value;
+};
+
+
+/**
+ * @return {string}
+ */
+plugin.wmts.Server.prototype.getOriginalUrl = function() {
+  return this.originalUrl_ || this.getUrl();
+};
+
+
+/**
+ * @param {string} value
+ */
+plugin.wmts.Server.prototype.setOriginalUrl = function(value) {
+  this.originalUrl_ = value;
+};
+
+
+/**
+ * @return {goog.Uri.QueryData}
+ */
+plugin.wmts.Server.prototype.getParams = function() {
+  return this.params_;
+};
+
+
+/**
+ * @param {goog.Uri.QueryData} value
+ */
+plugin.wmts.Server.prototype.setParams = function(value) {
+  this.params_ = value;
+};
+
+
+/**
+ * @return {string}
+ */
+plugin.wmts.Server.prototype.getDateFormat = function() {
+  return this.dateFormat_;
+};
+
+
+/**
+ * @param {string} dateFormat The date format
+ */
+plugin.wmts.Server.prototype.setDateFormat = function(dateFormat) {
+  this.dateFormat_ = dateFormat;
+};
+
+
+/**
+ * @return {string}
+ */
+plugin.wmts.Server.prototype.getTimeFormat = function() {
+  return this.timeFormat_;
+};
+
+
+/**
+ * @param {string} timeFormat The time format
+ */
+plugin.wmts.Server.prototype.setTimeFormat = function(timeFormat) {
+  this.timeFormat_ = timeFormat;
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.wmts.Server.prototype.configure = function(config) {
+  plugin.wmts.Server.base(this, 'configure', config);
+
+  this.setUrl(/** @type {string} */ (config['url']));
+  this.setOriginalUrl(/** @type {string} */ (config['url']));
+  this.setLowerCase(/** @type {boolean} */ (config['lowerCase']));
+  this.setDateFormat(/** @type {string} */ (config['dateFormat']));
+  this.setTimeFormat(/** @type {string} */ (config['timeFormat']));
+
+  this.setParams('params' in config ? new goog.Uri.QueryData(/** @type {string} */ (config['wmsParams'])) : null);
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.wmts.Server.prototype.finish = function() {
+  if (this.isLoaded()) {
+    if (this.toAdd_) {
+      this.addChildren(this.toAdd_);
+      this.toAdd_ = null;
+    }
+
+    if (!this.getPing()) {
+      this.markAllDescriptors();
+    }
+
+    plugin.wmts.Server.base(this, 'finish');
+  }
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.wmts.Server.prototype.load = function(opt_ping) {
+  plugin.wmts.Server.base(this, 'load', opt_ping);
+  this.setChildren(null);
+  this.loadCapabilities();
+};
+
+
+/**
+ * Builds query data from the WMS params.
+ * @return {goog.Uri.QueryData}
+ * @private
+ */
+plugin.wmts.Server.prototype.getQueryData_ = function() {
+  var queryData = this.params_ ? this.params_.clone() : new goog.Uri.QueryData();
+  queryData.setIgnoreCase(true);
+
+  queryData.set('request', 'GetCapabilities');
+
+  var version = plugin.wmts.Server.DEFAULT_VERSION;
+  if (queryData.containsKey('version')) {
+    version = queryData.get('version');
+  }
+
+  queryData.set('version', version);
+  return queryData;
+};
+
+
+/**
+ * Loads WMS GetCapabilities from the configured server.
+ * @protected
+ */
+plugin.wmts.Server.prototype.loadCapabilities = function() {
+  var url = this.getOriginalUrl();
+  if (url) {
+    goog.log.info(plugin.wmts.Server.LOGGER_, this.getLabel() + ' requesting WMTS GetCapabilities');
+    this.testUrl(url);
+  } else {
+    this.finish();
+  }
+};
+
+
+/**
+ * Test a WMS URL to check if its GetCapabilities is valid.
+ * @param {string} url The WMS URL
+ * @param {function(goog.events.Event)=} opt_success The success handler
+ * @param {function(goog.events.Event)=} opt_error The error handler
+ * @protected
+ */
+plugin.wmts.Server.prototype.testUrl = function(url, opt_success, opt_error) {
+  var uri = new goog.Uri(url);
+  var queryData = this.getQueryData_();
+  uri.setQueryData(queryData);
+
+  var onSuccess = opt_success || this.handleCapabilities;
+  var onError = opt_error || this.onOGCError;
+
+  var request = new os.net.Request(uri);
+  request.setHeader('Accept', '*/*');
+  request.listen(goog.net.EventType.SUCCESS, onSuccess, false, this);
+  request.listen(goog.net.EventType.ERROR, onError, false, this);
+  request.setValidator(os.ogc.getException);
+
+  goog.log.fine(plugin.wmts.Server.LOGGER_, 'Loading WMTS GetCapabilities from URL: ' + uri.toString());
+  this.setLoading(true);
+  request.load();
+};
+
+
+/**
+ * @param {goog.events.Event} event
+ * @protected
+ */
+plugin.wmts.Server.prototype.handleCapabilities = function(event) {
+  goog.log.info(plugin.wmts.Server.LOGGER_, this.getLabel() +
+      ' WMTS GetCapabilities request completed. Parsing data...');
+
+  var req = /** @type {os.net.Request} */ (event.target);
+  req.unlisten(goog.net.EventType.SUCCESS, this.handleCapabilities);
+  req.unlisten(goog.net.EventType.ERROR, this.onOGCError);
+  var response = /** @type {string} */ (req.getResponse());
+
+  this.parseCapabilities(response, req.getUri().toString());
+};
+
+
+/**
+ * @param {string} response
+ * @param {string} uri
+ */
+plugin.wmts.Server.prototype.parseCapabilities = function(response, uri) {
+  var link = '<a target="_blank" href="' + uri + '">WMTS Capabilities</a>';
+  if (response) {
+    var doc = undefined;
+    var result = undefined;
+    try {
+      doc = goog.dom.xml.loadXml(response);
+      result = new ol.format.WMTSCapabilities().read(doc);
+    } catch (e) {
+      this.logError('The response XML for ' + link + ' is invalid!');
+      return;
+    }
+
+    if (result) {
+      if (!this.getLabel()) {
+        try {
+          this.setLabel(/** @type {string} */ (goog.object.getValueByKeys(result, 'ServiceIdentification', 'Title')));
+        } catch (e) {
+        }
+      }
+
+      var serviceAbstract = goog.object.getValueByKeys(result, 'ServiceIdentification', 'Abstract');
+      if (serviceAbstract && typeof serviceAbstract === 'string') {
+        this.abstracts_.push(serviceAbstract);
+      }
+
+      var layers = goog.object.getValueByKeys(result, 'Contents', 'Layer');
+
+      this.toAdd_ = [];
+      layers.forEach(function(layer) {
+        var id = layer['Identifier'];
+        var fullId = this.getId() + os.ui.data.BaseProvider.ID_DELIMITER + id;
+
+        var hasTimeExtent = 'Dimension' in layer ?
+            ol.array.find(layer['Dimension'], plugin.wmts.Server.hasTimeExtent_) : false;
+
+        var config = {
+          'id': fullId,
+          'type': plugin.wmts.ID,
+          'description': layer['Abstract'],
+          'provider': this.getLabel(),
+          'title': layer['Title'],
+          'extent': layer['WGS84BoundingBox'],
+          'extentProjection': 'EPSG:4326',
+          'layerType': os.layer.LayerType.TILES,
+          'icons': os.ui.Icons.TILES + (hasTimeExtent ? os.ui.Icons.TIME : ''),
+          'animate': hasTimeExtent,
+          'dateFormat': this.getDateFormat() || null,
+          'timeFormat': this.getTimeFormat() || null,
+          'delayUpdateActive': true
+        };
+
+        var crossOrigin = null;
+        config['wmtsOptions'] = layer['TileMatrixSetLink'].map(function(setLink) {
+          var options = ol.source.WMTS.optionsFromCapabilities(/** @type {!Object} */ (result), {
+            'layer': id,
+            'matrixSet': setLink['TileMatrixSet']
+          });
+          options.crossOrigin = os.net.getCrossOrigin(options.urls[0]);
+          if (!crossOrigin) {
+            crossOrigin = options.crossOrigin;
+          }
+          return options;
+        });
+
+        config['crossOrigin'] = crossOrigin;
+        config['projections'] = config['wmtsOptions'].map(plugin.wmts.Server.wmtsOptionsToProjection_);
+
+        var descriptor = /** @type {os.data.ConfigDescriptor} */ (os.dataManager.getDescriptor(fullId));
+        if (!descriptor) {
+          descriptor = new os.data.ConfigDescriptor();
+        }
+
+        descriptor.setBaseConfig(config);
+        var node = new os.ui.data.DescriptorNode();
+        node.setDescriptor(descriptor);
+        this.toAdd_.push(node);
+        this.addDescriptor(descriptor);
+      }, this);
+    }
+
+    this.finish();
+  } else {
+    this.logError(link + ' response is empty!');
+  }
+};
+
+
+/**
+ * @param {Object} dimension
+ * @return {boolean}
+ * @private
+ */
+plugin.wmts.Server.hasTimeExtent_ = function(dimension) {
+  return /time/i.test(dimension['Identifier']);
+};
+
+
+/**
+ * @param {?olx.source.WMTSOptions} wmtsOptions
+ * @return {?string}
+ */
+plugin.wmts.Server.wmtsOptionsToProjection_ = function(wmtsOptions) {
+  return wmtsOptions && wmtsOptions['projection'] ?
+    /** @type {ol.proj.Projection} */ (wmtsOptions['projection']).getCode() : null;
+};
+
+/**
+ * Adds the descriptor.
+ * @param {!os.data.IDataDescriptor} descriptor
+ */
+plugin.wmts.Server.prototype.addDescriptor = function(descriptor) {
+  descriptor.setDataProvider(this);
+  os.dataManager.addDescriptor(descriptor);
+};
+
+
+/**
+ * @param {goog.events.Event} event
+ * @protected
+ */
+plugin.wmts.Server.prototype.onOGCError = function(event) {
+  var req = /** @type {os.net.Request} */ (event.target);
+  var errors = req.getErrors();
+  var uri = req.getUri();
+  goog.dispose(req);
+
+  var href = uri.toString();
+  var service = uri.getQueryData().get('service');
+  var msg = 'Request failed for <a target="_blank" href="' + href + '">' + service + ' Capabilities</a>: ';
+
+  if (errors) {
+    msg += errors.join(' ');
+  }
+
+  this.logError(msg);
+};
+
+
+/**
+ * @param {string} msg The error message.
+ * @protected
+ */
+plugin.wmts.Server.prototype.logError = function(msg) {
+  if (!this.getError()) {
+    var errorMsg = 'Server [' + this.getLabel() + ']: ' + msg;
+
+    if (!this.getPing()) {
+      os.alert.AlertManager.getInstance().sendAlert(errorMsg, os.alert.AlertEventSeverity.ERROR);
+    }
+
+    goog.log.error(plugin.wmts.Server.LOGGER_, errorMsg);
+
+    this.setErrorMessage(errorMsg);
+    this.setLoading(false);
+  }
+};
+
+
+/**
+ * @param {os.structs.ITreeNode=} opt_node
+ * @protected
+ */
+plugin.wmts.Server.prototype.markAllDescriptors = function(opt_node) {
+  var node = opt_node || this;
+
+  if (node instanceof os.ui.data.DescriptorNode) {
+    var dn = /** @type {os.ui.data.DescriptorNode} */ (node);
+    var descriptor = /** @type {os.data.ConfigDescriptor} */ (dn.getDescriptor());
+    descriptor.updateActiveFromTemp();
+  }
+
+  var nodeChildren = node.getChildren();
+  if (nodeChildren && nodeChildren.length > 0) {
+    var i = nodeChildren.length;
+    while (i--) {
+      this.markAllDescriptors(nodeChildren[i]);
+    }
+  }
+};
+
+
+/**
+ * Finds and removes the descriptor.
+ * @param {os.ui.ogc.IOGCDescriptor} descriptor
+ */
+plugin.wmts.Server.prototype.removeDescriptor = function(descriptor) {
+  var children = this.getChildren();
+  if (!children || children.length == 0) {
+    return;
+  }
+
+  var node = this.findNode_(descriptor, children);
+  if (node) {
+    var par = node.getParent();
+    par.removeChild(node);
+    // work our way up the tree to remove parent nodes if we just removed the last item.
+    while (!par.getChildren() || par.getChildren().length == 0) {
+      node = par;
+      par = par.getParent();
+      par.removeChild(node);
+    }
+  }
+
+  descriptor.setActive(false);
+};
+
+
+/**
+ * @param {os.ui.ogc.IOGCDescriptor} descriptor
+ * @param {?Array.<!os.structs.ITreeNode>} children
+ * @return {?os.structs.ITreeNode}
+ * @private
+ */
+plugin.wmts.Server.prototype.findNode_ = function(descriptor, children) {
+  var child;
+  for (var i = 0, n = children.length; i < n; i++) {
+    child = children[i];
+    var grandChildren = child.getChildren();
+
+    if (grandChildren && grandChildren.length >= 0) {
+      var node = this.findNode_(descriptor, grandChildren);
+      if (node) {
+        return node;
+      }
+    } else {
+      child = /** @type {os.ui.slick.SlickTreeNode} */ (child);
+      if (child.getDescriptor() == descriptor || child.getDescriptor().getId() == descriptor.getId()) {
+        return child;
+      }
+    }
+  }
+  return null;
+};
+
+
+/**
+ * @type {RegExp}
+ * @const
+ * @private
+ */
+plugin.wmts.Server.URI_REGEXP_ = /wmts/i;
+
+
+/**
+ * @type {RegExp}
+ * @const
+ * @private
+ */
+plugin.wmts.Server.CONTENT_REGEXP_ = /https?:\/\/www.opengis.net\/wmts\/1.0/;
+
+
+/**
+ * @param {os.file.File} file
+ * @return {number}
+ */
+plugin.wmts.Server.isOGCResponse = function(file) {
+  var score = 0;
+
+  if (file && !os.file.isLocal(file)) {
+    var uri = file.getUrl();
+
+    if (uri) {
+      score += plugin.wmts.Server.URI_REGEXP_.test(uri) ? 3 : 0;
+    }
+
+    var content = file.getContent();
+    if (typeof content === 'string') {
+      score += plugin.wmts.Server.CONTENT_REGEXP_.test(content) ? 3 : 0;
+    }
+  }
+
+  return score;
+};

--- a/test/os/layer/animatedtile.test.js
+++ b/test/os/layer/animatedtile.test.js
@@ -14,7 +14,7 @@ describe('os.layer.AnimatedTile', function() {
 
     layer = new os.layer.AnimatedTile({
       source: new ol.source.TileWMS(/** @type {olx.source.TileWMSOptions} */ ({
-        params: { 'LAYERS': 'dontcare' }
+        params: {'LAYERS': 'dontcare'}
       }))
     });
   });
@@ -57,18 +57,18 @@ describe('os.layer.AnimatedTile', function() {
   it('should get time parameters correctly for tiles', function() {
     // days should have a / and the next day's date
     expect(os.layer.AnimatedTile.getTimeParameter(
-        'YYYY-MM-DD', 1472947200000, 1473033600000, os.time.Duration.DAY)).toBe('2016-09-04/2016-09-05');
+        'YYYY-MM-DD', '{start}/{end}', 1472947200000, 1473033600000, os.time.Duration.DAY)).toBe('2016-09-04/2016-09-05');
 
     // weeks should be fully qualified
     expect(os.layer.AnimatedTile.getTimeParameter(
-        'YYYY-MM-DD', 1472947200000, 1473552000000, os.time.Duration.WEEK)).toBe('2016-09-04/2016-09-11');
+        'YYYY-MM-DD', '{start}/{end}', 1472947200000, 1473552000000, os.time.Duration.WEEK)).toBe('2016-09-04/2016-09-11');
 
     // months should increment to the first day of next month
     expect(os.layer.AnimatedTile.getTimeParameter(
-        'YYYY-MM-DD', 1472688000000, 1475280000000, os.time.Duration.MONTH)).toBe('2016-09-01/2016-10-01');
+        'YYYY-MM-DD', '{start}/{end}', 1472688000000, 1475280000000, os.time.Duration.MONTH)).toBe('2016-09-01/2016-10-01');
 
     // custom should add a day, i.e. this case would show as 2016/09/01 - 2016/09/06 on the date chooser
     expect(os.layer.AnimatedTile.getTimeParameter(
-        'YYYY-MM-DD', 1472688000000, 1473206399000, os.time.Duration.CUSTOM)).toBe('2016-09-01/2016-09-07');
+        'YYYY-MM-DD', '{start}/{end}', 1472688000000, 1473206399000, os.time.Duration.CUSTOM)).toBe('2016-09-01/2016-09-07');
   });
 });


### PR DESCRIPTION
Adds support for WMTS servers, such as [NASA GIBS](https://earthdata.nasa.gov/about/science-system-description/eosdis-components/global-imagery-browse-services-gibs). Time dimensions are supported.

This also fixes a couple of issues with projection switching. When choosing the best projection for a layer, it must choose one enumerated for support by the server. This means that the layer can choose something like `urn:ogc:def:crs:OGC:1.3:CRS84`. However, the projection switch should change the overall map projection to `EPSG:4326`, since things like default map layers are done by string codes in settings.

- [x]  WMTS servers from config
- [x]  WMTS servers from users
- [x]  Auto detect date/time format from dimension default if not set
-----------
### Testing
Config:
```
      "wmts-test": {
        "type": "wmts",
        "label": "NASA GIBS WMTS",
        "url": "https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi"
      }
```
For user added URLs, [use this](https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi?request=GetCapabilities).

GeoServer's WMTS implementation would also be a good test since it supports multiple projections in the same capabilities document.