### PR TITLE
fix(ogc): Get WMS/WFS custom params from the URL

### DIFF
--- a/src/os/ui/ogc/ogcserver.js
+++ b/src/os/ui/ogc/ogcserver.js
@@ -411,8 +411,34 @@ os.ui.ogc.OGCServer.prototype.configure = function(config) {
   this.setLowerCase(/** @type {boolean} */ (config['lowerCase']));
   this.setWpsUrl(/** @type {string} */ (config['wps']));
 
-  this.setWfsParams('wfsParams' in config ? new goog.Uri.QueryData(/** @type {string} */ (config['wfsParams'])) : null);
-  this.setWmsParams('wmsParams' in config ? new goog.Uri.QueryData(/** @type {string} */ (config['wmsParams'])) : null);
+  var wfsUrl = this.getWfsUrl();
+
+  if ('wfsParams' in config) {
+    this.setWfsParams(new goog.Uri.QueryData(/** @type {string} */ (config['wfsParams'])));
+  } else if (wfsUrl) {
+    // attempt to generate custom WFS params from the wfsUrl
+    var wfsUri = new goog.Uri(wfsUrl);
+    var queryData = wfsUri.getQueryData();
+    queryData.setIgnoreCase(true);
+    queryData.remove('request');
+    this.setWfsParams(queryData.getCount() ? queryData : null);
+  } else {
+    this.setWfsParams(null);
+  }
+
+  var wmsUrl = this.getWmsUrl();
+  if ('wmsParams' in config) {
+    this.setWmsParams(new goog.Uri.QueryData(/** @type {string} */ (config['wmsParams'])));
+  } else if (wmsUrl) {
+    // attempt to generate custom WMS params from the wmsUrl
+    var wmsUri = new goog.Uri(wmsUrl);
+    queryData = wmsUri.getQueryData();
+    queryData.setIgnoreCase(true);
+    queryData.remove('request');
+    this.setWmsParams(queryData.getCount() ? queryData : null);
+  } else {
+    this.setWmsParams(null);
+  }
 };
 
 


### PR DESCRIPTION
Unless they are already defined on the config.

fixes #325

You can use https://planetarymaps.usgs.gov/cgi-bin/mapserv?map=/maps/mars/mars_simp_cyl.map&service=WMS&request=GetCapabilities for testing