### PR TITLE
Constrain search results within map container.

### DIFF
--- a/scss/os/_searchresults.scss
+++ b/scss/os/_searchresults.scss
@@ -1,6 +1,8 @@
 .c-searchresults {
+  bottom: 0;
   max-width: 35rem;
   right: 0;
+  top: 0;
   z-index: $u-zindex-base + 1;
 }
 

--- a/views/main.html
+++ b/views/main.html
@@ -1,7 +1,7 @@
 <div id="js-window__container" class="h-100 w-100 position-absolute js-main d-flex">
   <div class="dd-target c-main d-flex flex-column flex-fill w-100" url-drag-drop dd-element=".os-app">
     <nav-top options="navOptions"></nav-top>
-    <div id="js-main" class="d-flex flex-row flex-fill">
+    <div id="js-main" class="d-flex flex-row flex-fill position-relative">
       <div list list-id="main-content" list-prefix="<div>" list-suffix="</div>"></div>
       <map></map>
     </div>


### PR DESCRIPTION
Search results should always occupy the full height of the map container, and scroll if they exceed the map container height.

Fixed with `top/bottom: 0` on the results panel, and an explicit `position: relative` on the map container.