### PR TITLE
fix(layermenu): Updates tooltip to the correct text

### DIFF
--- a/src/os/ui/menu/layermenu.js
+++ b/src/os/ui/menu/layermenu.js
@@ -198,7 +198,7 @@ os.ui.menu.layer.setup = function() {
       children: [{
         label: 'Export...',
         eventType: os.action.EventType.EXPORT,
-        tooltip: 'Repositions the map to show the layer',
+        tooltip: 'Exports data from this layer',
         icons: ['<i class="fa fa-fw fa-download"></i>'],
         beforeRender: os.ui.menu.layer.visibleIfSupported,
         handler: os.ui.menu.layer.onExport_,


### PR DESCRIPTION
Tooltip for Export was a copy/paste mistake for Go To. Fixed.

![layer context menu tooltip](https://user-images.githubusercontent.com/44378016/50310597-b9602180-045f-11e9-97f5-71b2f89b969a.png)
