### PR TITLE
fix(wfs): use custom params in DescribeFeatureLoader

### DIFF
--- a/src/os/ogc/wfs/describefeatureloader.js
+++ b/src/os/ogc/wfs/describefeatureloader.js
@@ -87,6 +87,10 @@ os.ogc.wfs.DescribeFeatureLoader.prototype.setUrl = function(value) {
           this.typename_ = /** @type {string} */ (qd.get('typename'));
         }
       }
+
+      if (!this.params_.getKeys().length) {
+        this.setParams(qd);
+      }
     }
   } else {
     this.url_ = value;


### PR DESCRIPTION
This passes custom params set on the WFS server to the `DescribeFeatureType` call.