### PR TITLE
fix(zip): call close on all zip readers

### DIFF
--- a/src/os/file/mime/zip.js
+++ b/src/os/file/mime/zip.js
@@ -48,6 +48,7 @@ os.file.mime.zip.detectZip = function(buffer, opt_file) {
         try {
           zip.createReader(reader, function(reader) {
             reader.getEntries(function(entries) {
+              reader.close();
               resolve(entries);
             });
           }, function(error) {

--- a/src/os/parse/asynczipparser.js
+++ b/src/os/parse/asynczipparser.js
@@ -1,0 +1,111 @@
+goog.provide('os.parse.AsyncZipParser');
+
+goog.require('os.parse.AsyncParser');
+
+
+/**
+ * @extends {os.parse.AsyncParser<T>}
+ * @template T
+ * @constructor
+ */
+os.parse.AsyncZipParser = function() {
+  os.parse.AsyncZipParser.base(this, 'constructor');
+
+  /**
+   * @protected
+   * @type {!Array<!zip.Reader>}
+   */
+  this.zipReaders = [];
+
+  /**
+   * @protected
+   */
+  this.boundZipHandler = this.handleZipReader.bind(this);
+
+  /**
+   * @protected
+   */
+  this.boundZipErrorHandler = this.handleZipReaderError.bind(this);
+
+  /**
+   * @protected
+   */
+  this.boundZipEntriesHandler = this.handleZipEntries.bind(this);
+};
+goog.inherits(os.parse.AsyncZipParser, os.parse.AsyncParser);
+
+
+/**
+ * Logger
+ * @type {goog.log.Logger}
+ * @private
+ * @const
+ */
+os.parse.AsyncZipParser.LOGGER_ = goog.log.getLogger('os.parse.AsyncZipParser');
+
+
+/**
+ * @inheritDoc
+ */
+os.parse.AsyncZipParser.prototype.disposeInternal = function() {
+  this.closeZipReaders();
+  os.parse.AsyncZipParser.base(this, 'disposeInternal');
+};
+
+
+/**
+ * @protected
+ */
+os.parse.AsyncZipParser.prototype.closeZipReaders = function() {
+  this.zipReaders.forEach(function(reader) {
+    reader.close();
+  });
+
+  this.zipReaders.length = 0;
+};
+
+
+/**
+ * @protected
+ * @param {ArrayBuffer} source
+ */
+os.parse.AsyncZipParser.prototype.createZipReader = function(source) {
+  zip.createReader(new zip.ArrayBufferReader(source), this.boundZipHandler, this.boundZipErrorHandler);
+};
+
+
+
+/**
+ * @param {!zip.Reader} reader
+ * @protected
+ */
+os.parse.AsyncZipParser.prototype.handleZipReader = function(reader) {
+  this.zipReaders.push(reader);
+  reader.getEntries(this.boundZipEntriesHandler);
+};
+
+
+/**
+ * @protected
+ */
+os.parse.AsyncZipParser.prototype.handleZipReaderError = function() {
+  goog.log.error(os.parse.AsyncZipParser.LOGGER_, 'There was an error processing the zip file!');
+  this.onError();
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.parse.AsyncZipParser.prototype.onError = function() {
+  this.closeZipReaders();
+  os.parse.AsyncZipParser.base(this, 'onError');
+};
+
+
+/**
+ * @param {Array<!zip.Entry>} entries
+ * @protected
+ */
+os.parse.AsyncParser.prototype.handleZipEntries = goog.abstractMethod;
+

--- a/src/plugin/area/kmlareaparser.js
+++ b/src/plugin/area/kmlareaparser.js
@@ -4,7 +4,7 @@ goog.require('ol.xml');
 goog.require('os.data.ColumnDefinition');
 goog.require('os.file.mime.text');
 goog.require('os.file.mime.zip');
-goog.require('os.parse.AsyncParser');
+goog.require('os.parse.AsyncZipParser');
 goog.require('os.parse.IParser');
 goog.require('os.ui.im.mergeAreaOptionDirective');
 
@@ -13,7 +13,7 @@ goog.require('os.ui.im.mergeAreaOptionDirective');
 /**
  * Simple KML parser that extracts areas from a KML. Has asynchronous support for KMZ files.
  * @implements {os.parse.IParser.<ol.Feature>}
- * @extends {os.parse.AsyncParser}
+ * @extends {os.parse.AsyncZipParser}
  * @template T
  * @constructor
  */
@@ -51,24 +51,8 @@ plugin.area.KMLAreaParser = function() {
    * @private
    */
   this.log_ = plugin.area.KMLAreaParser.LOGGER_;
-
-  /**
-   * @type {!Array<!zip.Reader>}
-   * @protected
-   */
-  this.zipReaders = [];
-
-  /**
-   * @private
-   */
-  this.boundZipHandler_ = this.handleZipReader.bind(this);
-
-  /**
-   * @private
-   */
-  this.boundZipErrorHandler_ = this.handleZipReaderError.bind(this);
 };
-goog.inherits(plugin.area.KMLAreaParser, os.parse.AsyncParser);
+goog.inherits(plugin.area.KMLAreaParser, os.parse.AsyncZipParser);
 
 
 /**
@@ -91,7 +75,7 @@ plugin.area.KMLAreaParser.prototype.setSource = function(source) {
     this.document_ = goog.dom.xml.loadXml(source);
   } else if (source instanceof ArrayBuffer) {
     if (os.file.mime.zip.isZip(source)) {
-      this.handleZIP_(source);
+      this.createZipReader(source);
       return;
     } else {
       var s = os.file.mime.text.getText(source);
@@ -133,41 +117,12 @@ plugin.area.KMLAreaParser.prototype.setSource = function(source) {
 
 
 /**
- * @param {ArrayBuffer} source
- * @private
- */
-plugin.area.KMLAreaParser.prototype.handleZIP_ = function(source) {
-  zip.createReader(new zip.ArrayBufferReader(source), this.boundZipHandler_, this.boundZipErrorHandler_);
-};
-
-
-/**
- * @param {!zip.Reader} reader
- * @protected
- */
-plugin.area.KMLAreaParser.prototype.handleZipReader = function(reader) {
-  this.zipReaders.push(reader);
-  reader.getEntries(this.processZIPEntries_.bind(this));
-};
-
-
-/**
- * @protected
- */
-plugin.area.KMLAreaParser.prototype.handleZipReaderError = function() {
-  this.onError();
-  goog.log.error(this.log_, 'Error reading zip file!');
-};
-
-
-/**
  * HACK ALERT! zip.js has a zip.TextWriter() class that directly turns the zip entry into the string we want.
  * Unfortunately, it doesn't work in FF24 for some reason, but luckily, the BlobWriter does. Here, we read
  * the zip as a Blob, then feed it to a FileReader in the next callback in order to extract the text.
- * @param {Array.<!zip.Entry>} entries
- * @private
+ * @inheritDoc
  */
-plugin.area.KMLAreaParser.prototype.processZIPEntries_ = function(entries) {
+plugin.area.KMLAreaParser.prototype.handleZipEntries = function(entries) {
   var mainEntry = null;
   var firstEntry = null;
   var mainKml = /(doc|index)\.kml$/i;


### PR DESCRIPTION
This fixes leaking zip workers each time they are used.

### Test
For each of these, you're going to open dev tools and watch the "Threads" count to ensure that zip workers are not leaked in addition to ensuring that the feature you're using is working properly.

 * Mime stack
   * Load zip files that are not supported layer types (not KMZ or zipped SHP)
 * KMZ
   * Load KMZ files
   * Load KMZ files with external stylesheets in the zip
   * Load KMZ files with external stylesheets that load as a KMZ
   * Load KMZ files with network links that are KMZ files
   * Import KMZ areas into the Areas tab
 * SHP
   * Load zipped SHP files

fixes #373