### PR TITLE
fix(csv_import): Fix csv import ellipse radius incorrect units

### DIFF
--- a/src/os/geo/geo.js
+++ b/src/os/geo/geo.js
@@ -42,21 +42,6 @@ os.geo.VINCENTY_ELLIPSOIDS = {
 
 
 /**
- * Multipliers to convert units to nautical miles.
- * @type {Object.<string, number>}
- * @const
- */
-os.geo.UNIT_MULTIPLIERS = {
-  'ft': 1 / 6076.0,
-  'yd': 1 / 2025.333333333333,
-  'mi': 5280 / 6076,
-  'm': 1 / 1852.0,
-  'km': 1 / 1.852,
-  'nmi': 1.0
-};
-
-
-/**
  * @type {!RegExp}
  * @const
  */

--- a/src/os/im/mapping/radiusmapping.js
+++ b/src/os/im/mapping/radiusmapping.js
@@ -3,6 +3,7 @@ goog.require('os.Fields');
 goog.require('os.geo');
 goog.require('os.im.mapping.MappingRegistry');
 goog.require('os.im.mapping.RenameMapping');
+goog.require('os.math.Units');
 
 
 
@@ -111,7 +112,7 @@ os.im.mapping.RadiusMapping.prototype.execute = function(item) {
     var current = os.math.parseNumber(os.im.mapping.getItemField(item, this.field));
     if (!isNaN(current)) {
       if (this.units) {
-        current = current * os.geo.UNIT_MULTIPLIERS[this.units];
+        current = os.math.convertUnits(current, os.style.DEFAULT_UNITS, this.units);
       }
 
       os.im.mapping.setItemField(item, this.toField, current);
@@ -145,7 +146,7 @@ os.im.mapping.RadiusMapping.prototype.autoDetect = function(items) {
             if (typeof units == 'string') {
               units = units.toLowerCase();
 
-              if (units in os.geo.UNIT_MULTIPLIERS) {
+              if (goog.object.getValues(os.math.Units).indexOf(units) !== -1) {
                 m.setUnits(units);
               }
             }

--- a/src/os/math/units.js
+++ b/src/os/math/units.js
@@ -16,7 +16,8 @@ os.math.Units = {
   METERS: 'm',
   NAUTICAL_MILES: 'nmi',
   MILES: 'mi',
-  FEET: 'ft'
+  FEET: 'ft',
+  YARD: 'yd'
 };
 
 
@@ -49,7 +50,8 @@ os.math.UnitLabels = {
   'Meters': os.math.Units.METERS,
   'Nautical Miles': os.math.Units.NAUTICAL_MILES,
   'Miles': os.math.Units.MILES,
-  'Feet': os.math.Units.FEET
+  'Feet': os.math.Units.FEET,
+  'Yard': os.math.Units.YARD
 };
 
 
@@ -91,6 +93,12 @@ os.math.METERS_TO_KILOMETERS = .001;
 
 
 /**
+ * @type {number}
+ */
+os.math.METERS_TO_YARDS = 1.09361;
+
+
+/**
  * function to simplify unit conversion
  * @param {number} value
  * @param {string} newUnit
@@ -119,6 +127,9 @@ os.math.convertUnits = function(value, newUnit, opt_oldUnit) {
       case os.math.Units.FEET:
         value = value / os.math.METERS_TO_FEET;
         break;
+      case os.math.Units.YARD:
+        value = value / os.math.METERS_TO_YARDS;
+        break;
       default:
         return NaN;
     }
@@ -137,6 +148,9 @@ os.math.convertUnits = function(value, newUnit, opt_oldUnit) {
       break;
     case os.math.Units.FEET:
       multiplier = os.math.METERS_TO_FEET;
+      break;
+    case os.math.Units.YARD:
+      multiplier = os.math.METERS_TO_YARDS;
       break;
     case os.math.Units.NAUTICAL_MILES:
       multiplier = os.math.METERS_TO_NAUTICAL_MILES;

--- a/src/os/ui/wiz/geometrystep.js
+++ b/src/os/ui/wiz/geometrystep.js
@@ -411,7 +411,7 @@ os.ui.wiz.GeometryStepCtrl = function($scope) {
   /**
    * @type {Array<string>}
    */
-  this['units'] = goog.object.getKeys(os.geo.UNIT_MULTIPLIERS);
+  this['units'] = goog.object.getValues(os.math.Units);
 
   /**
    * @type {Array<string>}

--- a/src/os/unit/unitmanager.js
+++ b/src/os/unit/unitmanager.js
@@ -171,7 +171,7 @@ os.unit.UnitManager.prototype.convert = function(unitType, valueToConvert, multF
   // Convert to the default multiplier within the 'to' units
   var toMultiplier = toUnit.getMultiplier(multToKey);
   var toDefaultMultiplier = toUnit.getDefaultMultiplier();
-  if (toMultiplier !== toDefaultMultiplier) {
+  if (toMultiplier && toMultiplier !== toDefaultMultiplier) {
     valueToConvert /= toMultiplier.getMultiplier();
   }
   return valueToConvert;

--- a/test/os/im/mapping/radiusmapping.test.js
+++ b/test/os/im/mapping/radiusmapping.test.js
@@ -1,0 +1,70 @@
+goog.require('ol.Feature');
+goog.require('ol.geom.Point');
+goog.require('os.Fields');
+goog.require('os.im.mapping.RadiusMapping');
+goog.require('os.math');
+goog.require('os.math.Units');
+
+describe('os.im.mapping.RadiusMapping', function() {
+  it('should auto detect radius string types', function() {
+    // test with a feature (WFS layer or csv import)
+    // does not contain the correct fields
+    var feature = new ol.Feature();
+    feature.set('value1', 'nope');
+    feature.set('value2', 'nope');
+    feature.set('value3', 'nope');
+    feature.set('value4', 'nope');
+
+    // should return null because the correct fields do not exist in either object
+    var rm = new os.im.mapping.RadiusMapping();
+    var m = rm.autoDetect([feature]);
+    expect(m).toBeNull();
+
+    // add a radius column but no units
+    feature.set('RADIUS', '5000');
+    m = rm.autoDetect([feature]);
+
+    // should return a legit RadiusMapping object with the field set and unit field at default
+    expect(m).not.toBeNull();
+    expect(m.field).toBe('RADIUS');
+    expect(m.unitsField).toBe('RADIUS_UNITS');
+
+    // test with both radius and units columns
+    feature.set('RADIUS_UNITS', 'km');
+    m = rm.autoDetect([feature]);
+
+    // should return a legit RadiusMapping object with the field set and unit field at RADUIS_UNITS
+    expect(m).not.toBeNull();
+    expect(m.field).toBe('RADIUS');
+    expect(m.unitsField).toBe('RADIUS_UNITS');
+    expect(m.getUnits()).toBe('km');
+  });
+
+  it('should map radius to a feature', function() {
+    var feature = new ol.Feature(new ol.geom.Point([0, 0]));
+    feature.set('RADIUS', '50');
+
+    var m = new os.im.mapping.RadiusMapping();
+    var rm = m.autoDetect([feature]);
+    rm.execute(feature);
+
+    // feature should have RADIUS defaulted to nmi
+    expect(os.im.mapping.getItemField(feature, os.Fields.RADIUS)).toBeCloseTo(92598.23703685642, 10);
+  });
+
+  it('should normalize radius column names', function() {
+    var feature = new ol.Feature(new ol.geom.Point([0, 0]));
+    feature.set('CEP', '50');
+    feature.set('CEP_UNITS', 'yd');
+
+    var m = new os.im.mapping.RadiusMapping();
+    var rm = m.autoDetect([feature]);
+    rm.execute(feature);
+
+    // feature should have RADIUS remain the same and new derived column
+    expect(os.im.mapping.getItemField(feature, os.Fields.RADIUS)).toBeCloseTo(45.720137891935885, 10);
+    expect(os.im.mapping.getItemField(feature, os.Fields.RADIUS_UNITS)).toBe('yd');
+    expect(os.im.mapping.getItemField(feature, 'CEP')).toBe('50');
+    expect(os.im.mapping.getItemField(feature, 'CEP_UNITS')).toBe('yd');
+  });
+});


### PR DESCRIPTION
When you import a csv file and set the ellipse geometry to have a radius, the unit conversion is a bit strange, this should fix it.
I also noticed that the radius conversion for yards was missing, so I added (affects altitude also)