### PR TITLE
Add custom providers through config

### DIFF
--- a/src/os/data/configdescriptor.js
+++ b/src/os/data/configdescriptor.js
@@ -1,6 +1,7 @@
 goog.provide('os.data.ConfigDescriptor');
 
 goog.require('goog.object');
+goog.require('os.array');
 goog.require('os.command.LayerAdd');
 goog.require('os.data.IReimport');
 goog.require('os.data.LayerSyncDescriptor');
@@ -21,7 +22,7 @@ os.data.ConfigDescriptor = function() {
   this.descriptorType = os.data.ConfigDescriptor.ID;
 
   /**
-   * @type {?Object<string, *>}
+   * @type {?(Array<Object<string, *>>|Object<string, *>)}
    * @protected
    */
   this.baseConfig = null;
@@ -41,7 +42,27 @@ os.data.ConfigDescriptor.ID = 'config';
  * @inheritDoc
  */
 os.data.ConfigDescriptor.prototype.getId = function() {
-  return /** @type {string} */ (this.get('id')) || os.data.ConfigDescriptor.base(this, 'getId');
+  var ids = /** @type {string} */ (os.data.ConfigDescriptor.getAll_(this.baseConfig, 'id'));
+
+  if (Array.isArray(ids)) {
+    if (ids.length > 1) {
+      var done = false;
+      for (var x = 0, xx = ids[0].length; x < xx && !done; x++) {
+        var char = ids[0].charAt(x);
+        for (var i = 1, ii = ids.length; i < ii && !done; i++) {
+          if (ids[i].charAt(x) !== char) {
+            done = true;
+          }
+        }
+      }
+
+      ids = ids[0].substring(0, x - 1);
+    } else if (ids.length) {
+      ids = ids[0];
+    }
+  }
+
+  return ids || os.data.ConfigDescriptor.base(this, 'getId');
 };
 
 
@@ -49,7 +70,7 @@ os.data.ConfigDescriptor.prototype.getId = function() {
  * @inheritDoc
  */
 os.data.ConfigDescriptor.prototype.getTitle = function() {
-  return /** @type {string} */ (this.get('title')) || os.data.ConfigDescriptor.base(this, 'getTitle');
+  return /** @type {string} */ (this.getFirst('title')) || os.data.ConfigDescriptor.base(this, 'getTitle');
 };
 
 
@@ -57,7 +78,18 @@ os.data.ConfigDescriptor.prototype.getTitle = function() {
  * @inheritDoc
  */
 os.data.ConfigDescriptor.prototype.getType = function() {
-  return /** @type {string} */ (this.get('layerType')) || os.data.ConfigDescriptor.base(this, 'getType');
+  var types = /** @type {Array<string>|string} */ (os.data.ConfigDescriptor.getAll_(this.baseConfig, 'layerType'));
+
+  if (Array.isArray(types)) {
+    if (types.indexOf(os.layer.LayerType.TILES) > -1 &&
+        types.indexOf(os.layer.LayerType.FEATURES) > -1) {
+      types = os.layer.LayerType.GROUPS;
+    } else {
+      types = types[0];
+    }
+  }
+
+  return types || os.data.ConfigDescriptor.base(this, 'getType');
 };
 
 
@@ -65,7 +97,7 @@ os.data.ConfigDescriptor.prototype.getType = function() {
  * @inheritDoc
  */
 os.data.ConfigDescriptor.prototype.getProvider = function() {
-  return /** @type {string} */ (this.get('provider')) || os.data.ConfigDescriptor.base(this, 'getProvider');
+  return /** @type {string} */ (this.getFirst('provider') || os.data.ConfigDescriptor.base(this, 'getProvider'));
 };
 
 
@@ -73,7 +105,9 @@ os.data.ConfigDescriptor.prototype.getProvider = function() {
  * @inheritDoc
  */
 os.data.ConfigDescriptor.prototype.getDescription = function() {
-  return /** @type {string} */ (this.get('description')) || os.data.ConfigDescriptor.base(this, 'getDescription');
+  var val = /** @type {Array<string>|string} */ (os.data.ConfigDescriptor.getAll_(this.baseConfig, 'description'));
+  val = Array.isArray(val) ? val.join('\n\n') : val;
+  return val || os.data.ConfigDescriptor.base(this, 'getDescription');
 };
 
 
@@ -81,7 +115,20 @@ os.data.ConfigDescriptor.prototype.getDescription = function() {
  * @inheritDoc
  */
 os.data.ConfigDescriptor.prototype.getTags = function() {
-  return /** @type {Array<string>} */ (this.get('tags')) || os.data.ConfigDescriptor.base(this, 'getTags');
+  var tagSets = /** @type {Array<string>} */ (os.data.ConfigDescriptor.getAll_(this.baseConfig, 'tags'));
+  var tags = null;
+
+  if (Array.isArray(tagSets)) {
+    tags = tagSets.reduce(function(all, set) {
+      return all.concat(set);
+    }, []);
+  } else {
+    tags = tagSets;
+  }
+
+  tags = tags || os.data.ConfigDescriptor.base(this, 'getTags');
+  os.array.removeDuplicates(tags);
+  return tags;
 };
 
 
@@ -89,7 +136,8 @@ os.data.ConfigDescriptor.prototype.getTags = function() {
  * @inheritDoc
  */
 os.data.ConfigDescriptor.prototype.getDescriptorType = function() {
-  return /** @type {string} */ (this.get('descriptorType')) || os.data.ConfigDescriptor.base(this, 'getDescriptorType');
+  return /** @type {string} */ (this.getFirst('descriptorType') ||
+      os.data.ConfigDescriptor.base(this, 'getDescriptorType'));
 };
 
 
@@ -97,7 +145,13 @@ os.data.ConfigDescriptor.prototype.getDescriptorType = function() {
  * @inheritDoc
  */
 os.data.ConfigDescriptor.prototype.getIcons = function() {
-  return /** @type {string} */ (this.get('icons')) || os.data.ConfigDescriptor.base(this, 'getIcons');
+  var icons = /** @type {Array<string>|string} */ (os.data.ConfigDescriptor.getAll_(this.baseConfig, 'icons'));
+  icons = Array.isArray(icons) ? icons.join('') : icons;
+  icons = icons || os.data.ConfigDescriptor.base(this, 'getIcons');
+  icons = os.string.removeDuplicates(icons, os.ui.Icons.TILES);
+  icons = os.string.removeDuplicates(icons, os.ui.Icons.FEATURES);
+  icons = os.string.removeDuplicates(icons, os.ui.Icons.TIME);
+  return icons;
 };
 
 
@@ -116,11 +170,30 @@ os.data.ConfigDescriptor.prototype.getSearchType = function() {
 
 
 /**
- * @param {!string} key
+ * @param {string} key
  * @return {*}
+ * @protected
  */
-os.data.ConfigDescriptor.prototype.get = function(key) {
-  return key in this.baseConfig ? this.baseConfig[key] : null;
+os.data.ConfigDescriptor.prototype.getFirst = function(key) {
+  var val = os.data.ConfigDescriptor.getAll_(this.baseConfig, key);
+  return Array.isArray(val) && val.length ? val[0] : val;
+};
+
+
+/**
+ * @param {Array|Object} objOrArr
+ * @param {string} key
+ * @return {*}
+ * @private
+ */
+os.data.ConfigDescriptor.getAll_ = function(objOrArr, key) {
+  if (Array.isArray(objOrArr)) {
+    return objOrArr.map(function(item) {
+      return os.data.ConfigDescriptor.getAll_(item, key);
+    });
+  } else {
+    return key in objOrArr ? objOrArr[key] : null;
+  }
 };
 
 
@@ -152,13 +225,32 @@ os.data.ConfigDescriptor.prototype.getLayerOptions = function() {
  * @inheritDoc
  */
 os.data.ConfigDescriptor.prototype.matchesURL = function(url) {
-  if (url) {
-    var myUrl = this.get('url');
+  return os.data.ConfigDescriptor.matchesURL_(this.baseConfig, url);
+};
+
+
+/**
+ * @param {Array|Object} objOrArr
+ * @param {string} url
+ * @return {boolean}
+ * @private
+ */
+os.data.ConfigDescriptor.matchesURL_ = function(objOrArr, url) {
+  if (Array.isArray(objOrArr)) {
+    return objOrArr.reduce(function(prev, curr) {
+      if (prev) {
+        return prev;
+      }
+
+      return os.data.ConfigDescriptor.matchesURL_(curr, url);
+    }, false);
+  } else if (url) {
+    var myUrl = /** @type {string} */ (os.data.ConfigDescriptor.getAll_(objOrArr, 'url'));
     if (url == myUrl) {
       return true;
     }
 
-    var myUrls = this.get('urls');
+    var myUrls = /** @type {Array<string>} */ (os.data.ConfigDescriptor.getAll_(objOrArr, 'urls'));
     if (Array.isArray(myUrls) && myUrls.indexOf(url) > -1) {
       return true;
     }
@@ -172,7 +264,7 @@ os.data.ConfigDescriptor.prototype.matchesURL = function(url) {
  * @inheritDoc
  */
 os.data.ConfigDescriptor.prototype.canReimport = function() {
-  var importUrl = this.getBaseConfig()['importUrl'];
+  var importUrl = this.getFirst('importUrl');
   return !!importUrl;
 };
 
@@ -183,7 +275,7 @@ os.data.ConfigDescriptor.prototype.canReimport = function() {
 os.data.ConfigDescriptor.prototype.reimport = function() {
   var config = this.getBaseConfig();
   var evt = new os.ui.im.ImportEvent(os.ui.im.ImportEventType.URL,
-      /** @type {string} */ (config['importUrl'] || config['url']));
+      /** @type {string} */ (this.getFirst('importUrl') || this.getFirst('url')));
 
   var process = new os.im.ImportProcess();
   process.setEvent(evt);
@@ -196,11 +288,7 @@ os.data.ConfigDescriptor.prototype.reimport = function() {
  * @inheritDoc
  */
 os.data.ConfigDescriptor.prototype.getNodeUI = function() {
-  if (this.baseConfig && this.baseConfig['nodeUi']) {
-    return /** @type {string} */ (this.baseConfig['nodeUi']);
-  } else {
-    return '<defaultlayernodeui></defaultlayernodeui>';
-  }
+  return /** @type {string} */ (this.getFirst('nodeUi')) || '<defaultlayernodeui></defaultlayernodeui>';
 };
 
 
@@ -212,18 +300,31 @@ os.data.ConfigDescriptor.prototype.persist = function(opt_obj) {
     opt_obj = {};
   }
 
+  opt_obj['base'] = this.persistBase_(this.baseConfig);
+  return os.data.ConfigDescriptor.base(this, 'persist', opt_obj);
+};
+
+
+/**
+ * @param {Array<Object<string, *>>|Object<string, *>} obj
+ * @return {Array<Object<string, *>>|Object<string, *>}
+ * @private
+ */
+os.data.ConfigDescriptor.prototype.persistBase_ = function(obj) {
+  if (Array.isArray(obj)) {
+    return obj.map(this.persistBase_, this);
+  }
   // we are going to shallow-copy everything that is not an instance object
   var base = {};
-  for (var key in this.baseConfig) {
-    var thing = this.baseConfig[key];
+  for (var key in obj) {
+    var thing = obj[key];
 
-    if (goog.typeOf(thing) !== 'object' || thing.prototype === Object.prototype) {
+    if (goog.typeOf(thing) !== 'object' || thing.constructor === Object) {
       base[key] = thing;
     }
   }
 
-  opt_obj['base'] = base;
-  return os.data.ConfigDescriptor.base(this, 'persist', opt_obj);
+  return base;
 };
 
 

--- a/src/os/data/configdescriptor.js
+++ b/src/os/data/configdescriptor.js
@@ -127,7 +127,9 @@ os.data.ConfigDescriptor.prototype.getTags = function() {
   }
 
   tags = tags || os.data.ConfigDescriptor.base(this, 'getTags');
-  os.array.removeDuplicates(tags);
+  if (tags) {
+    os.array.removeDuplicates(tags);
+  }
   return tags;
 };
 

--- a/src/os/layer/animatedtile.js
+++ b/src/os/layer/animatedtile.js
@@ -6,6 +6,8 @@ goog.require('os.layer.Tile');
 goog.require('os.query.TemporalFormatter');
 goog.require('os.time');
 goog.require('os.time.TimelineController');
+goog.require('os.ui.Icons');
+goog.require('os.ui.IconsSVG');
 goog.require('os.ui.ScreenOverlayCtrl');
 
 
@@ -92,6 +94,24 @@ os.layer.AnimatedTile.prototype.disposeInternal = function() {
       os.ui.window.close(os.ui.window.getById(this.legendId_));
     }
   }
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.layer.AnimatedTile.prototype.getSVGIconsInternal = function() {
+  var icons = os.layer.AnimatedTile.base(this, 'getSVGIconsInternal');
+  icons.push(os.ui.IconsSVG.TIME);
+  return icons;
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.layer.AnimatedTile.prototype.getIconsInternal = function() {
+  return os.layer.AnimatedTile.base(this, 'getIconsInternal') + os.ui.Icons.TIME;
 };
 
 

--- a/src/os/layer/tile.js
+++ b/src/os/layer/tile.js
@@ -572,8 +572,26 @@ os.layer.Tile.prototype.getIcons = function() {
     color = os.color.toRgbArray(layerColor);
   }
 
-  html += color ? os.ui.createIconSet(this.getId(), [os.ui.IconsSVG.TILES], null, color) : os.ui.Icons.TILES;
+  html += color ? os.ui.createIconSet(this.getId(), this.getSVGIconsInternal(), null, color) : this.getIconsInternal();
   return html;
+};
+
+
+/**
+ * @return {Array<string>}
+ * @protected
+ */
+os.layer.Tile.prototype.getSVGIconsInternal = function() {
+  return [os.ui.IconsSVG.TILES];
+};
+
+
+/**
+ * @return {string}
+ * @protected
+ */
+os.layer.Tile.prototype.getIconsInternal = function() {
+  return os.ui.Icons.TILES;
 };
 
 

--- a/src/os/mainctrl.js
+++ b/src/os/mainctrl.js
@@ -141,6 +141,7 @@ goog.require('plugin.audio.AudioPlugin');
 goog.require('plugin.basemap.BaseMapPlugin');
 goog.require('plugin.capture.CapturePlugin');
 goog.require('plugin.cesium.Plugin');
+goog.require('plugin.config.Plugin');
 goog.require('plugin.descriptor.SearchPlugin');
 goog.require('plugin.file.csv.CSVPlugin');
 goog.require('plugin.file.geojson.GeoJSONPlugin');
@@ -507,6 +508,7 @@ os.MainCtrl.prototype.addPlugins = function() {
   os.ui.pluginManager.addPlugin(new plugin.area.AreaPlugin());
   os.ui.pluginManager.addPlugin(new plugin.audio.AudioPlugin());
   os.ui.pluginManager.addPlugin(plugin.capture.CapturePlugin.getInstance());
+  os.ui.pluginManager.addPlugin(plugin.config.Plugin.getInstance());
   os.ui.pluginManager.addPlugin(new plugin.ogc.OGCPlugin());
   os.ui.pluginManager.addPlugin(new plugin.xyz.XYZPlugin());
   os.ui.pluginManager.addPlugin(new plugin.basemap.BaseMapPlugin());

--- a/src/os/string/string.js
+++ b/src/os/string/string.js
@@ -193,3 +193,26 @@ os.string.split = function(str, opt_removeSpaces, opt_precedence) {
 os.string.createConstant = function(str) {
   return goog.string.Const.create__googStringSecurityPrivate_(str);
 };
+
+
+/**
+ * This keeps the last instance of the substring and removes all others
+ * @param {?string} str The full string
+ * @param {?string} substr The substring whose duplicates to remove
+ * @return {string}
+ */
+os.string.removeDuplicates = function(str, substr) {
+  var result = str || '';
+  if (str && substr) {
+    var parts = str.split(substr);
+    if (parts.length > 1) {
+      var b = parts.pop();
+      var a = parts.pop();
+      result = parts.join('') + a + substr + b;
+    } else if (parts.length == 1) {
+      result = parts[0];
+    }
+  }
+
+  return result;
+};

--- a/src/os/ui/data/descriptorprovider.js
+++ b/src/os/ui/data/descriptorprovider.js
@@ -111,6 +111,7 @@ os.ui.data.DescriptorProvider.prototype.findNode = function(descriptor) {
  * @inheritDoc
  */
 os.ui.data.DescriptorProvider.prototype.configure = function(config) {
+  os.ui.data.DescriptorProvider.base(this, 'configure', config);
   this.setState(os.structs.TriState.OFF);
   this.setEditable(false);
   this.setEnabled(true);

--- a/src/os/ui/ogc/ogcdescriptor.js
+++ b/src/os/ui/ogc/ogcdescriptor.js
@@ -228,15 +228,6 @@ os.ui.ogc.OGCDescriptor.prototype.setActive = function(value) {
 /**
  * @inheritDoc
  */
-os.ui.ogc.OGCDescriptor.prototype.getAliases = function() {
-  var aliases = [this.getId()];
-  return aliases;
-};
-
-
-/**
- * @inheritDoc
- */
 os.ui.ogc.OGCDescriptor.prototype.getAttribution = function() {
   return this.attribution_;
 };

--- a/src/plugin/config/config.js
+++ b/src/plugin/config/config.js
@@ -1,0 +1,8 @@
+goog.provide('plugin.config');
+
+
+/**
+ * @type {string}
+ * @const
+ */
+plugin.config.ID = 'config';

--- a/src/plugin/config/configplugin.js
+++ b/src/plugin/config/configplugin.js
@@ -1,0 +1,35 @@
+goog.provide('plugin.config.Plugin');
+
+goog.require('os.data.ConfigDescriptor');
+goog.require('os.data.DataManager');
+goog.require('os.data.ProviderEntry');
+goog.require('os.plugin.AbstractPlugin');
+goog.require('plugin.config');
+goog.require('plugin.config.Provider');
+
+
+/**
+ * Provides config support
+ * @extends {os.plugin.AbstractPlugin}
+ * @constructor
+ */
+plugin.config.Plugin = function() {
+  plugin.config.Plugin.base(this, 'constructor');
+  this.id = plugin.config.ID;
+};
+goog.inherits(plugin.config.Plugin, os.plugin.AbstractPlugin);
+goog.addSingletonGetter(plugin.config.Plugin);
+
+
+/**
+ * @inheritDoc
+ */
+plugin.config.Plugin.prototype.init = function() {
+  var dm = os.dataManager;
+
+  dm.registerProviderType(new os.data.ProviderEntry(
+    plugin.config.ID, plugin.config.Provider, 'config Provider',
+    'config servers provide layers through layer configs'));
+
+  dm.registerDescriptorType(os.data.ConfigDescriptor.ID, os.data.ConfigDescriptor);
+};

--- a/src/plugin/config/configprovider.js
+++ b/src/plugin/config/configprovider.js
@@ -1,0 +1,120 @@
+goog.provide('plugin.config.Provider');
+
+goog.require('os.MapEvent');
+goog.require('os.data.BaseDescriptor');
+goog.require('os.data.ConfigDescriptor');
+goog.require('os.data.DataManager');
+goog.require('os.data.DataProviderEvent');
+goog.require('os.data.DataProviderEventType');
+goog.require('os.data.IDataProvider');
+goog.require('os.map');
+goog.require('os.proj.switch');
+goog.require('os.ui.data.DescriptorNode');
+goog.require('os.ui.data.DescriptorProvider');
+goog.require('plugin.basemap');
+goog.require('plugin.basemap.BaseMapDescriptor');
+goog.require('plugin.basemap.TerrainDescriptor');
+goog.require('plugin.basemap.layer.BaseMap');
+
+
+
+/**
+ * The base map provider provides access to pre-configured map layers
+ *
+ * @implements {os.data.IDataProvider}
+ * @extends {os.ui.data.DescriptorProvider}
+ * @constructor
+ * @see {@link plugin.basemap.BaseMapPlugin} for configuration instructions
+ */
+plugin.config.Provider = function() {
+  plugin.config.Provider.base(this, 'constructor');
+
+  this.setId(plugin.config.ID);
+
+  /**
+   * @type {Object|Array<Object>}
+   * @private
+   */
+  this.layers_;
+};
+goog.inherits(plugin.config.Provider, os.ui.data.DescriptorProvider);
+
+
+/**
+ * @inheritDoc
+ */
+plugin.config.Provider.prototype.configure = function(config) {
+  plugin.config.Provider.base(this, 'configure', config);
+  this.setToolTip(/** @type {?string} */ (config['tooltip'] || config['description']));
+  this.layers_ = /** @type {Object} */ (config['layers']);
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.config.Provider.prototype.load = function(ping) {
+  this.dispatchEvent(new os.data.DataProviderEvent(os.data.DataProviderEventType.LOADING, this));
+  this.setChildren(null);
+
+  if (this.layers_) {
+    for (var id in this.layers_) {
+      var conf = this.layers_[id];
+      var fullId = this.getId() + os.data.BaseDescriptor.ID_DELIMITER + id;
+      var descriptor = os.dataManager.getDescriptor(fullId);
+
+      if (!descriptor) {
+        descriptor = new os.data.ConfigDescriptor();
+      }
+
+      this.fixId(fullId, conf);
+      this.addIcons(conf);
+
+      descriptor.setBaseConfig(conf);
+      os.dataManager.addDescriptor(descriptor);
+      this.addDescriptor(descriptor, false, false);
+    }
+  }
+
+  this.dispatchEvent(new os.data.DataProviderEvent(os.data.DataProviderEventType.LOADED, this));
+};
+
+
+/**
+ * @param {string} fullId
+ * @param {Object|Array} conf
+ * @protected
+ */
+plugin.config.Provider.prototype.fixId = function(fullId, conf) {
+  if (Array.isArray(conf)) {
+    conf.forEach(this.fixId.bind(this, fullId));
+  } else {
+    conf['id'] = fullId + os.data.BaseDescriptor.ID_DELIMITER + conf['id'];
+  }
+};
+
+
+/**
+ * @param {Object|Array} conf
+ */
+plugin.config.Provider.prototype.addIcons = function(conf) {
+  if (Array.isArray(conf)) {
+    conf.forEach(this.addIcons, this);
+  } else if (!conf['icons']) {
+    var icons = '';
+
+    var layerType = conf['layerType'];
+    if (layerType === os.layer.LayerType.TILES || layerType === os.layer.LayerType.GROUPS) {
+      icons += os.ui.Icons.TILES;
+    }
+    if (layerType === os.layer.LayerType.FEATURES || layerType === os.layer.LayerType.GROUPS) {
+      icons += os.ui.Icons.FEATURES;
+    }
+
+    if (conf['animate']) {
+      icons += os.ui.Icons.TIME;
+    }
+
+    conf['icons'] = icons;
+  }
+};

--- a/src/plugin/ogc/wfs/wfslayerconfig.js
+++ b/src/plugin/ogc/wfs/wfslayerconfig.js
@@ -238,8 +238,21 @@ plugin.ogc.wfs.WFSLayerConfig.prototype.addMappings = function(layer, options) {
   var importer = /** @type {os.im.Importer} */ (source.getImporter());
 
   var execMappings = [];
+
+
+  var timeFields = options['timeFields'];
+  if (timeFields) {
+    if (!Array.isArray(timeFields)) {
+      timeFields = [timeFields];
+    }
+
+    this.featureType.setStartDateColumnName(timeFields[0]);
+    this.featureType.setEndDateColumnName(timeFields[1] || timeFields[0]);
+  }
+
   var startField = this.featureType.getStartDateColumnName();
   var endField = this.featureType.getEndDateColumnName();
+
   if (animate && startField) {
     if (startField === 'validTime' && this.url.indexOf('/ogc/wfsServer') > -1) {
       // validTime means that the feature type is dynamic, which means we need to find the actual start/end fields

--- a/test/os/data/configdescriptor.test.js
+++ b/test/os/data/configdescriptor.test.js
@@ -36,82 +36,90 @@ describe('os.data.ConfigDescriptor', function() {
     'icons': '<feature><time>'
   };
 
-  it('should get id from config', function() {
-    var d = new os.data.ConfigDescriptor();
-    d.setBaseConfig(tileConfig);
-    expect(d.getId()).toBe(tileConfig.id);
-  });
+  var bareConfig = {
+    'id': 'config#descriptor#bare',
+    'type': 'GeoJSON',
+    'url': 'http://localhost/bogus/test.geojson'
+  };
 
-  it('should get title from config', function() {
-    var d = new os.data.ConfigDescriptor();
-    d.setBaseConfig(tileConfig);
-    expect(d.getTitle()).toBe(tileConfig.title);
-  });
+  [bareConfig, tileConfig].forEach(function(config) {
+    it('should get id from config', function() {
+      var d = new os.data.ConfigDescriptor();
+      d.setBaseConfig(config);
+      expect(d.getId()).toEqual(config.id);
+    });
 
-  it('should get type from config', function() {
-    var d = new os.data.ConfigDescriptor();
-    d.setBaseConfig(tileConfig);
-    expect(d.getType()).toBe(tileConfig.layerType);
-  });
+    it('should get title from config', function() {
+      var d = new os.data.ConfigDescriptor();
+      d.setBaseConfig(config);
+      expect(d.getTitle()).toEqual(config.title);
+    });
 
-  it('should get provider from config', function() {
-    var d = new os.data.ConfigDescriptor();
-    d.setBaseConfig(tileConfig);
-    expect(d.getProvider()).toBe(tileConfig.provider);
-  });
+    it('should get type from config', function() {
+      var d = new os.data.ConfigDescriptor();
+      d.setBaseConfig(config);
+      expect(d.getType()).toEqual(config.layerType);
+    });
 
-  it('should get description from config', function() {
-    var d = new os.data.ConfigDescriptor();
-    d.setBaseConfig(tileConfig);
-    expect(d.getDescription()).toBe(tileConfig.description);
-  });
+    it('should get provider from config', function() {
+      var d = new os.data.ConfigDescriptor();
+      d.setBaseConfig(config);
+      expect(d.getProvider()).toEqual(config.provider);
+    });
 
-  it('should get tags from config', function() {
-    var d = new os.data.ConfigDescriptor();
-    d.setBaseConfig(tileConfig);
-    expect(d.getTags()).toEqual(tileConfig.tags);
-  });
+    it('should get description from config', function() {
+      var d = new os.data.ConfigDescriptor();
+      d.setBaseConfig(config);
+      expect(d.getDescription()).toEqual(config.description);
+    });
 
-  it('should get descriptor type from config', function() {
-    var d = new os.data.ConfigDescriptor();
-    d.setBaseConfig(tileConfig);
-    expect(d.getDescriptorType()).toBe(tileConfig.descriptorType);
-  });
+    it('should get tags from config', function() {
+      var d = new os.data.ConfigDescriptor();
+      d.setBaseConfig(config);
+      expect(d.getTags()).toEqual(config.tags);
+    });
 
-  it('should get icons from config', function() {
-    var d = new os.data.ConfigDescriptor();
-    d.setBaseConfig(tileConfig);
-    expect(d.getIcons()).toBe(tileConfig.icons);
-  });
+    it('should get descriptor type from config', function() {
+      var d = new os.data.ConfigDescriptor();
+      d.setBaseConfig(config);
+      expect(d.getDescriptorType()).toBe(config.descriptorType || 'config');
+    });
 
-  it('should get search type from config', function() {
-    var d = new os.data.ConfigDescriptor();
-    d.setBaseConfig(tileConfig);
-    expect(d.getSearchType()).toBe(tileConfig.layerType.toLowerCase().replace(/s$/, ''));
-  });
+    it('should get icons from config', function() {
+      var d = new os.data.ConfigDescriptor();
+      d.setBaseConfig(config);
+      expect(d.getIcons()).toBe(config.icons || '');
+    });
 
-  it('should match URLs', function() {
-    var d = new os.data.ConfigDescriptor();
-    d.setBaseConfig(tileConfig);
-    expect(d.matchesURL('https://nope.com')).toBe(false);
-    expect(d.matchesURL(tileConfig.url)).toBe(true);
-    expect(d.matchesURL('http://localhost/bogus')).toBe(false);
-  });
+    it('should get search type from config', function() {
+      var d = new os.data.ConfigDescriptor();
+      d.setBaseConfig(config);
+      expect(d.getSearchType() || '').toBe((config.layerType || '').toLowerCase().replace(/s$/, ''));
+    });
 
-  it('should persist properly', function() {
-    var d = new os.data.ConfigDescriptor();
-    d.setBaseConfig(tileConfig);
-    var obj = d.persist();
-    expect(obj.base).toEqual(tileConfig);
-  });
+    it('should match URLs', function() {
+      var d = new os.data.ConfigDescriptor();
+      d.setBaseConfig(config);
+      expect(d.matchesURL('https://nope.com')).toBe(false);
+      expect(d.matchesURL(config.url)).toBe(true);
+      expect(d.matchesURL('http://localhost/bogus')).toBe(false);
+    });
 
-  it('should restore properly', function() {
-    var d = new os.data.ConfigDescriptor();
-    d.setBaseConfig(tileConfig);
-    var obj = d.persist();
-    d = new os.data.ConfigDescriptor();
-    d.restore(obj);
-    expect(d.getBaseConfig()).toEqual(tileConfig);
+    it('should persist properly', function() {
+      var d = new os.data.ConfigDescriptor();
+      d.setBaseConfig(config);
+      var obj = d.persist();
+      expect(obj.base).toEqual(config);
+    });
+
+    it('should restore properly', function() {
+      var d = new os.data.ConfigDescriptor();
+      d.setBaseConfig(config);
+      var obj = d.persist();
+      d = new os.data.ConfigDescriptor();
+      d.restore(obj);
+      expect(d.getBaseConfig()).toEqual(config);
+    });
   });
 
   // Multi Layer Tests

--- a/test/os/data/configdescriptor.test.js
+++ b/test/os/data/configdescriptor.test.js
@@ -1,0 +1,196 @@
+goog.require('os.data.ConfigDescriptor');
+goog.require('os.layer.LayerType');
+
+describe('os.data.ConfigDescriptor', function() {
+  var tileConfig = {
+    'id': 'config#descriptor#tiles',
+    'type': 'WMS',
+    'layerType': 'Tile Layers',
+    'crossOrigin': 'none',
+    'description': 'This is a test of a tile layer',
+    'descriptorType': 'testType',
+    'maxZoom': 9,
+    'minZoom': 2,
+    'params': {
+      'LAYERS': 'blue_marble'
+    },
+    'projection': 'EPSG:4326',
+    'provider': 'Some Service',
+    'proxy': false,
+    'title': 'Blue Marble Test',
+    'tags': ['test', 'tile'],
+    'url': 'http://localhost/bogus/wms',
+    'icons': '<tile><time>'
+  };
+
+  var featureConfig = {
+    'id': 'config#descriptor#features',
+    'type': 'GeoJSON',
+    'layerType': 'Feature Layers',
+    'crossOrigin': 'anonymous',
+    'description': 'This is a test of a GeoJSON layer.',
+    'provider': 'Some Service\'s GeoJSON stuff',
+    'title': 'GeoJSON Test',
+    'tags': ['test', 'feature'],
+    'url': 'http://localhost/bogus/test.geojson',
+    'icons': '<feature><time>'
+  };
+
+  it('should get id from config', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig(tileConfig);
+    expect(d.getId()).toBe(tileConfig.id);
+  });
+
+  it('should get title from config', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig(tileConfig);
+    expect(d.getTitle()).toBe(tileConfig.title);
+  });
+
+  it('should get type from config', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig(tileConfig);
+    expect(d.getType()).toBe(tileConfig.layerType);
+  });
+
+  it('should get provider from config', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig(tileConfig);
+    expect(d.getProvider()).toBe(tileConfig.provider);
+  });
+
+  it('should get description from config', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig(tileConfig);
+    expect(d.getDescription()).toBe(tileConfig.description);
+  });
+
+  it('should get tags from config', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig(tileConfig);
+    expect(d.getTags()).toEqual(tileConfig.tags);
+  });
+
+  it('should get descriptor type from config', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig(tileConfig);
+    expect(d.getDescriptorType()).toBe(tileConfig.descriptorType);
+  });
+
+  it('should get icons from config', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig(tileConfig);
+    expect(d.getIcons()).toBe(tileConfig.icons);
+  });
+
+  it('should get search type from config', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig(tileConfig);
+    expect(d.getSearchType()).toBe(tileConfig.layerType.toLowerCase().replace(/s$/, ''));
+  });
+
+  it('should match URLs', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig(tileConfig);
+    expect(d.matchesURL('https://nope.com')).toBe(false);
+    expect(d.matchesURL(tileConfig.url)).toBe(true);
+    expect(d.matchesURL('http://localhost/bogus')).toBe(false);
+  });
+
+  it('should persist properly', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig(tileConfig);
+    var obj = d.persist();
+    expect(obj.base).toEqual(tileConfig);
+  });
+
+  it('should restore properly', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig(tileConfig);
+    var obj = d.persist();
+    d = new os.data.ConfigDescriptor();
+    d.restore(obj);
+    expect(d.getBaseConfig()).toEqual(tileConfig);
+  });
+
+  // Multi Layer Tests
+  it('should get id from multiple configs', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig([tileConfig, featureConfig]);
+    expect(d.getId()).toBe('config#descriptor#');
+  });
+
+  it('should get title from multiple configs', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig([tileConfig, featureConfig]);
+    expect(d.getTitle()).toBe(tileConfig.title);
+  });
+
+  it('should get type from multiple configs', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig([tileConfig, featureConfig]);
+    expect(d.getType()).toBe(os.layer.LayerType.GROUPS);
+  });
+
+  it('should get provider from multiple configs', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig([tileConfig, featureConfig]);
+    expect(d.getProvider()).toBe(tileConfig.provider);
+  });
+
+  it('should get description from multiple configs', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig([tileConfig, featureConfig]);
+    expect(d.getDescription()).toBe(tileConfig.description + '\n\n' + featureConfig.description);
+  });
+
+  it('should get tags from multiple configs', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig([tileConfig, featureConfig]);
+    expect(d.getTags()).toEqual(['test', 'tile', 'feature']);
+  });
+
+  it('should get descriptor type from multiple configs', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig([tileConfig, featureConfig]);
+    expect(d.getDescriptorType()).toBe(tileConfig.descriptorType);
+  });
+
+  it('should get icons from multiple configs', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig([tileConfig, featureConfig]);
+    expect(d.getIcons()).toBe(tileConfig.icons + featureConfig.icons);
+  });
+
+  it('should get search type from multiple configs', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig([tileConfig, featureConfig]);
+    expect(d.getSearchType()).toBe(os.layer.LayerType.GROUPS.toLowerCase().replace(/s$/, ''));
+  });
+
+  it('should match URLs in multiple configs', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig([tileConfig, featureConfig]);
+    expect(d.matchesURL('https://nope.com')).toBe(false);
+    expect(d.matchesURL(tileConfig.url)).toBe(true);
+    expect(d.matchesURL(featureConfig.url)).toBe(true);
+    expect(d.matchesURL('http://localhost/bogus')).toBe(false);
+  });
+
+  it('should persist multiple configs properly', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig([tileConfig, featureConfig]);
+    var obj = d.persist();
+    expect(obj.base).toEqual([tileConfig, featureConfig]);
+  });
+
+  it('should restore from configs properly', function() {
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig([tileConfig, featureConfig]);
+    var obj = d.persist();
+    d = new os.data.ConfigDescriptor();
+    d.restore(obj);
+    expect(d.getBaseConfig()).toEqual([tileConfig, featureConfig]);
+  });
+});

--- a/test/os/string/string.test.js
+++ b/test/os/string/string.test.js
@@ -81,4 +81,40 @@ describe('os.string', function() {
     expect(r4[1]).toBe('d,e;f;g');
     expect(r4[2]).toBe('h');
   });
+
+  it('should test removing duplicates', function() {
+    var tests = [{
+      original: 'abcabcabc',
+      item: 'a',
+      expected: 'bcbcabc'
+    }, {
+      original: '',
+      item: 'whatever',
+      expected: ''
+    }, {
+      original: null,
+      item: 'whatever',
+      expected: ''
+    }, {
+      original: 'whatever',
+      item: null,
+      expected: 'whatever'
+    }, {
+      original: 'whatever',
+      item: 'bogus',
+      expected: 'whatever'
+    }, {
+      original: 'abc',
+      item: 'a',
+      expected: 'abc'
+    }, {
+      original: 'onetwothreeonetwothree',
+      item: 'two',
+      expected: 'onethreeonetwothree'
+    }];
+
+    tests.forEach(function(test) {
+      expect(os.string.removeDuplicates(test.original, test.item)).toBe(test.expected);
+    });
+  });
 });


### PR DESCRIPTION
This allows admins to configure a provider and its layers completely through config.

Sample Config (For Electron. The KMLs do not support CORS well. Download and translate to local URLs to avoid that and test in a browser.)
```
{
  "admin": {
    "providers": {
      "config-test-1": {
        "type": "config",
        "label": "Test Provider",
        "description": "This is a test of the config provider PR",
        "layers": {
          "single-layer-test": {
            "id": "features",
            "type": "KML",
            "title": "Single Layer Test",
            "description": "Tests single layer configs by using the Google KML Samples file",
            "url": "https://developers.google.com/kml/documentation/KML_Samples.kml",
            "layerType": "Feature Layers"
          },
          "multi-layer-test": [{
            "id": "tiles",
            "type": "XYZ",
            "title": "Layer Group Test",
            "url": "http://mesonet.agron.iastate.edu/cache/tile.py/1.0.0/ridge::USCOMP-N0Q-201901301540/{z}/{x}/{y}.png",
            "projection": "EPSG:3857",
            "tileSize" : 256,
            "layerType": "Tile Layers",
            "proxy": false
          }, {
            "id": "features",
            "type": "KML",
            "title": "Layer Group Test",
            "description": "Tests the multi layer config by using a XYZ and KML layer",
            "animate": true,
            "url": "https://developers.google.com/kml/documentation/whale_shark.kml",
            "layerType": "Feature Layers"
          }]
        }
      }
    }
  }
}
```