### PR TITLE
Improve window lookup performance

### DIFF
--- a/src/os/ui/savedwindow.js
+++ b/src/os/ui/savedwindow.js
@@ -80,6 +80,21 @@ os.ui.SavedWindowCtrl.prototype.onChange = function(event, ui) {
 
 
 /**
+ * @inheritDoc
+ */
+os.ui.SavedWindowCtrl.prototype.getWindowKeys = function() {
+  var keys = os.ui.SavedWindowCtrl.base(this, 'getWindowKeys');
+
+  var key = this.scope ? /** @type {string|undefined} */ (this.scope['key']) : undefined;
+  if (key) {
+    keys.push(key);
+  }
+
+  return keys;
+};
+
+
+/**
  * Gets the window config
  * @param {string} key The window key
  * @return {Object}


### PR DESCRIPTION
Avoids unnecessary DOM queries that may happen very frequently. This was very apparent when looking at an animation CPU trace, where these window lookups were responsible for ~8% of the CPU usage. Fixed by maintaining a map of open windows by id (or key, for saved windows). Improves performance for both `os.ui.window.exists` and `os.ui.window.getById` without impacting the API.