### PR TITLE
Only set label if defined in config.

### DIFF
--- a/src/os/ui/data/baseprovider.js
+++ b/src/os/ui/data/baseprovider.js
@@ -75,8 +75,12 @@ os.ui.data.BaseProvider.TYPE = 'default';
  * @inheritDoc
  */
 os.ui.data.BaseProvider.prototype.configure = function(config) {
-  this.setEnabled(/** @type {boolean} */ (config['enabled']));
-  this.setLabel(/** @type {string} */ (config['label']));
+  this.setEnabled(!!config['enabled']);
+
+  var label = /** @type {string|undefined} */ (config['label']);
+  if (label) {
+    this.setLabel(label);
+  }
 };
 
 


### PR DESCRIPTION
`StateProvider` and a few others were manually setting a label, then calling the parent `configure`. This would wipe out the label in `BaseProvider` if it wasn't set in config.