### PR TITLE
Ensure feature type gets loaded for Arc layers.

### DIFF
--- a/src/os/ui/filters.js
+++ b/src/os/ui/filters.js
@@ -235,6 +235,9 @@ os.ui.FiltersCtrl.prototype.onEditFilter_ = function(event, entry) {
   }
   if (cols) {
     os.filter.BaseFilterManager.edit(entry.getType(), cols, this.editEntry.bind(this), entry);
+  } else {
+    os.alertManager.sendAlert('This layer is missing required information to edit filters.',
+        os.alert.AlertEventSeverity.WARNING);
   }
 };
 

--- a/src/plugin/arc/layer/arclayerdescriptor.js
+++ b/src/plugin/arc/layer/arclayerdescriptor.js
@@ -22,7 +22,6 @@ goog.require('os.ui.ControlType');
 goog.require('os.ui.Icons');
 goog.require('os.ui.ogc.IFeatureTypeDescriptor');
 goog.require('os.ui.query.CombinatorCtrl');
-goog.require('plugin.arc.ArcFeatureType');
 
 
 
@@ -261,13 +260,9 @@ plugin.arc.layer.ArcLayerDescriptor.prototype.configureDescriptor = function(con
     }
   }
 
-  var startField = null;
-  var endField = null;
   var timeInfo = /** @type {Object} */ (config['timeInfo']);
   if (timeInfo) {
     try {
-      startField = /** @type {string} */ (timeInfo['startTimeField']);
-      endField = /** @type {string} */ (timeInfo['endTimeField']);
       this.setMinDate(/** @type {number} */ (timeInfo['timeExtent'][0]));
       this.setMaxDate(/** @type {number} */ (timeInfo['timeExtent'][1]));
     } catch (e) {
@@ -312,36 +307,9 @@ plugin.arc.layer.ArcLayerDescriptor.prototype.configureDescriptor = function(con
     this.setFeaturesEnabled(true);
   }
 
-  var fields = /** @type {Array} */ (config['fields']);
-  if (fields && goog.isArray(fields) && fields.length > 0) {
-    this.featureType_ = new plugin.arc.ArcFeatureType();
-    var columns = [];
-
-    for (var i = 0, ii = fields.length; i < ii; i++) {
-      var field = fields[i];
-      var name = /** @type {string} */ (field['name']);
-      var type = plugin.arc.getColumnType(/** @type {string} */ (field['type']));
-      var c = /** @type {os.ogc.FeatureTypeColumn} */ ({
-        'name': name,
-        'type': type
-      });
-      columns.push(c);
-
-      if (name === startField) {
-        this.featureType_.setStartDateColumnName(startField);
-      } else if (name === endField) {
-        this.featureType_.setEndDateColumnName(endField);
-      } else if (name === 'esriFieldTypeGeometry') {
-        this.featureType_.setGeometryColumnName(name);
-      }
-    }
-
-    columns.sort(function(a, b) {
-      return goog.string.numerateCompare(a.name, b.name);
-    });
-    this.featureType_.setColumns(columns);
-  } else {
-    // if there aren't any fields, assume features aren't supported
+  this.featureType_ = plugin.arc.createFeatureType(config);
+  if (!this.featureType_) {
+    // if a feature type could not be created, assume features aren't supported
     this.setFeaturesEnabled(false);
   }
 


### PR DESCRIPTION
This loads the Arc layer metadata and creates a feature type in the layer config, if one isn't already provided in the layer options (via the descriptor).

The filters tab will also display a warning to the user if they try editing and columns are unavailable, instead of doing nothing.

Fixes #382.