### PR TITLE
Toggle legend on/off with the legend button

### DIFF
--- a/src/os/ui/legend.js
+++ b/src/os/ui/legend.js
@@ -117,6 +117,9 @@ os.ui.LegendCtrl = function($scope, $element) {
    */
   this.layerListeners_ = {};
 
+  // register the legend as a window so it can be toggled by os.ui.menu.windows.toggleWindow
+  os.ui.window.registerWindow('legend', this.element[0]);
+
   this.init();
 };
 goog.inherits(os.ui.LegendCtrl, os.data.SourceManager);
@@ -135,6 +138,9 @@ os.ui.LegendCtrl.CONTAINER_SELECTOR = '#map-container';
  */
 os.ui.LegendCtrl.prototype.disposeInternal = function() {
   os.ui.LegendCtrl.base(this, 'disposeInternal');
+
+  // remove from the open window registry
+  os.ui.window.unregisterWindow('legend', this.element[0]);
 
   os.dispatcher.unlisten(os.legend.EventType.UPDATE, this.onUpdateDelay, false, this);
 

--- a/src/os/ui/window.js
+++ b/src/os/ui/window.js
@@ -306,8 +306,17 @@ os.ui.window.close = function(el) {
   if (el) {
     var scope = el.is(os.ui.windowSelector.WINDOW) ?
         el.children().scope() : el.parents(os.ui.windowSelector.WINDOW).children().scope();
-    if (scope) {
+    if (scope && scope['windowCtrl']) {
+      // scope for a window directive, so call the close function
       /** @type {os.ui.WindowCtrl} */ (scope['windowCtrl']).close();
+    } else {
+      // check if the element has a close flag on its scope.
+      scope = el.children().first().scope();
+
+      if (scope && scope['closeFlag']) {
+        scope['closeFlag'] = false;
+        os.ui.apply(scope);
+      }
     }
   }
 };

--- a/views/legend.html
+++ b/views/legend.html
@@ -1,5 +1,5 @@
-<div class="u-hover-container js-legend__render-container" ng-class="legend.widget && 'position-fixed'">
-  <div class="text-right" ng-if="legend.widget">
+<div class="u-hover-container js-legend__render-container position-fixed">
+  <div class="text-right">
     <button class="btn btn-sm btn-outline-secondary border-0 bg-transparent animate-fade u-hover-show" title="Open settings"
         ng-click="legend.openSettings()">
       <i class="fa fa-gear"></i>


### PR DESCRIPTION
- The legend button in the bottom nav will now toggle the legend on/off.
- Fixed the legend being positioned incorrectly the first time it's opened each session.
- Removed the concept of "widget mode" for the legend. This was used to differentiate between the floating legend (normal case) and the embedded legend that was previously used in Settings > Legend.
- Added an additional window close path to use the scope `closeFlag` on non-traditional windows like the legend.