### PR TITLE
fix(kml): fix leak of disposed KML nodes

### DIFF
--- a/src/plugin/file/kml/kmlsource.js
+++ b/src/plugin/file/kml/kmlsource.js
@@ -436,18 +436,12 @@ plugin.file.kml.KMLSource.prototype.onImportComplete = function(opt_event) {
  * @inheritDoc
  */
 plugin.file.kml.KMLSource.prototype.clearQueue = function() {
-  var toRemove = [];
   for (var key in this.nodeMap_) {
     var node = this.nodeMap_[key];
     if (node && node.isDisposed()) {
-      toRemove.push(key);
+      this.nodeMap_[key] = undefined;
     }
   }
-
-  var nmap = this.nodeMap_;
-  toRemove.forEach(function(key) {
-    nmap[key] = undefined;
-  });
 
   plugin.file.kml.KMLSource.base(this, 'clearQueue');
 };

--- a/src/plugin/file/kml/kmlsource.js
+++ b/src/plugin/file/kml/kmlsource.js
@@ -7,6 +7,7 @@ goog.require('goog.object');
 goog.require('ol.array');
 goog.require('os.events.PropertyChangeEvent');
 goog.require('os.layer.Image');
+goog.require('os.object');
 goog.require('os.source.PropertyChange');
 goog.require('os.source.Request');
 goog.require('os.structs.TriState');
@@ -442,6 +443,8 @@ plugin.file.kml.KMLSource.prototype.clearQueue = function() {
       this.nodeMap_[key] = undefined;
     }
   }
+
+  this.nodeMap_ = os.object.prune(this.nodeMap_);
 
   plugin.file.kml.KMLSource.base(this, 'clearQueue');
 };


### PR DESCRIPTION
`KMLSource` keeps a map of node IDs to nodes. In the event that the KML is refreshed (or a portion of the tree is refreshed via a network link), nodes that were left out of the resulting merge by the `KMLParser` were already disposed but were still being added back into the map here, causing a leak.