### PR TITLE
feat(wfs): add support for KVP-formatted POST payloads

### DIFF
--- a/src/plugin/ogc/wfs/wfslayerconfig.js
+++ b/src/plugin/ogc/wfs/wfslayerconfig.js
@@ -162,7 +162,11 @@ plugin.ogc.wfs.WFSLayerConfig.prototype.getRequest = function(options) {
   }
 
   request.setValidator(os.ogc.getException);
-  request.setDataFormatter(new os.ogc.wfs.WFSFormatter());
+
+  if (options['postFormat'] !== 'kvp') {
+    request.setDataFormatter(new os.ogc.wfs.WFSFormatter());
+  }
+
   return request;
 };
 


### PR DESCRIPTION
As far as I can tell, there is not anything in the `GetCapabilities` response (for v1.1.0) which determines if the service supports `application/x-www-form-urlencoded` in the POST payload for `GetFeature` requests. Therefore, I have merely added a config parameter for now.