### PR TITLE
Sync tree/timeline visibility states for KML overlays

### DIFF
--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -375,6 +375,21 @@ osx.window.ConfirmColumnOptions;
 
 
 /**
+ * @typedef {{
+ *   id: string,
+ *   name: string,
+ *   image: string,
+ *   size: Array<string|number>,
+ *   xy: Array<string|number>,
+ *
+ *   showClose: (boolean|undefined),
+ *   showHide: (boolean|undefined)
+ * }}
+ */
+osx.window.ScreenOverlayOptions;
+
+
+/**
  * Namespace.
  * @type {Object}
  */

--- a/src/os/layer/animatedtile.js
+++ b/src/os/layer/animatedtile.js
@@ -141,7 +141,7 @@ os.layer.AnimatedTile.prototype.setLayerVisible = function(value) {
     if (value && !this.legendId_) {
       // show the legend
       os.ui.launchScreenOverlay(legendOpts);
-      this.legendId_ = legendOpts['id'];
+      this.legendId_ = legendOpts.id;
     } else if (!value && this.legendId_) {
       // close the legend, you can turn it back on by toggling on/off the descriptor or layer node in add layers
       if (os.ui.window.getById(this.legendId_)) {
@@ -156,19 +156,11 @@ os.layer.AnimatedTile.prototype.setLayerVisible = function(value) {
 /**
  * If the layer contains legend information (supported in WMS - see os.ui.ogc.wms.WMSLayerParserV130)
  * then let's pop-up a screen overlay similar to what is done for KML
- * @return {?{Object}} options
+ * @return {?osx.window.ScreenOverlayOptions} options
  */
 os.layer.AnimatedTile.prototype.getLegendOptions = function() {
   if (this.getLayerOptions() && this.getLayerOptions()['legends'] && this.getLayerOptions()['legends'][0]) {
     var legend = this.getLayerOptions()['legends'][0];
-    var size = null;
-    var xy = null;
-    if (legend['size']) {
-      // add 30 to the height to account for the header
-      size = {x: legend['size'][0], y: legend['size'][1] + 30};
-      var screenSize = os.MapContainer.getInstance().getMap().getSize();
-      xy = {x: screenSize[0] - size['x'] - 250, y: screenSize[1] - size['y'] - 75};
-    }
 
     var imageURL = '';
     if (legend['OnlineResource']) {
@@ -180,16 +172,33 @@ os.layer.AnimatedTile.prototype.getLegendOptions = function() {
       return null;
     }
 
-    var overlay = {'image': imageURL,
-      'name': this.getTitle() + ' - Legend',
-      'id': goog.string.hashCode(imageURL),
-      'show-close': true,
-      'xy': xy,
-      'size': size};
-    return overlay;
-  } else {
-    return null;
+    var size = [250, 75];
+    var xy = [0, 0];
+    if (legend['size']) {
+      // add 30 to the height to account for the header
+      size = [
+        legend['size'][0],
+        legend['size'][1] + 30
+      ];
+
+      var screenSize = os.MapContainer.getInstance().getMap().getSize();
+      xy = [
+        screenSize[0] - size[0] - 250,
+        screenSize[1] - size[1] - 75
+      ];
+    }
+
+    return /** @type {!osx.window.ScreenOverlayOptions} */ ({
+      id: goog.string.hashCode(imageURL),
+      name: this.getTitle() + ' - Legend',
+      image: imageURL,
+      showClose: true,
+      size: size,
+      xy: xy
+    });
   }
+
+  return null;
 };
 
 

--- a/src/os/ui/screenoverlay.js
+++ b/src/os/ui/screenoverlay.js
@@ -31,24 +31,26 @@ os.ui.Module.directive('screenoverlay', [os.ui.screenOverlayDrective]);
 
 
 /**
- * Launch a dialog with the overlay image
- * @param {osx.window.ConfirmOptions} options The window options
+ * Launch a dialog with the overlay image.
+ * @param {!osx.window.ScreenOverlayOptions} options The overlay options.
  */
 os.ui.launchScreenOverlay = function(options) {
   var scopeOptions = {
     'image': options.image
   };
 
-  var height = options['size'] && options['size']['y'] > 75 ? options['size']['y'] : 75;
-  var width = options['size'] && options['size']['x'] > 250 ? options['size']['x'] : 250;
-  var xLoc = options['xy'] ? options['xy']['x'] : 25;
-  var yLoc = options['xy'] ? options['xy']['y'] : 50;
+  var size = options.size || [250, 75];
+  var width = Math.max(size[0], 250);
+  var height = Math.max(size[1], 75);
+
+  var xLoc = options.xy ? options.xy[0] : 25;
+  var yLoc = options.xy ? options.xy[1] : 50;
 
   var mapSize = os.MapContainer.getInstance().getMap().getSize();
 
   var windowOptions = {
     'id': options.id,
-    'label': options.name || 'KML Screen Overlay',
+    'label': options.name || 'Screen Overlay',
     'icon': '',
     'x': xLoc,
     'y': yLoc,
@@ -59,8 +61,8 @@ os.ui.launchScreenOverlay = function(options) {
     'min-height': 75,
     'max-height': mapSize[1],
     'modal': false,
-    'show-hide': options['show-hide'] ? options['show-hide'] : false,
-    'show-close': options['show-close'] ? options['show-close'] : false,
+    'show-hide': !!options.showHide,
+    'show-close': !!options.showClose,
     'no-scroll': true,
     'overlay': true
   };

--- a/src/plugin/file/kml/kml.js
+++ b/src/plugin/file/kml/kml.js
@@ -275,7 +275,6 @@ os.object.merge(plugin.file.kml.LINK_PARSERS, plugin.file.kml.OL_LINK_PARSERS(),
 /**
  * @type {Object<string, Object<string, ol.XmlParser>>}
  * @const
- * @suppress {accessControls}
  */
 plugin.file.kml.ICON_STYLE_PARSERS = ol.xml.makeStructureNS(
     plugin.file.kml.OL_NAMESPACE_URIS(), {
@@ -510,6 +509,28 @@ plugin.file.kml.LAT_LON_BOX_PARSERS = ol.xml.makeStructureNS(
 plugin.file.kml.LAT_LON_QUAD_PARSERS = ol.xml.makeStructureNS(
     plugin.file.kml.OL_NAMESPACE_URIS(), {
       'coordinates': ol.xml.makeReplacer(ol.format.KML.readFlatCoordinates_)
+    });
+
+
+/**
+ * Property parsers for ScreenOverlay.
+ * @type {Object<string, Object<string, ol.XmlParser>>}
+ * @const
+ */
+plugin.file.kml.SCREEN_OVERLAY_PARSERS = ol.xml.makeStructureNS(
+    plugin.file.kml.OL_NAMESPACE_URIS(), {
+      'name': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString),
+      'visibility': ol.xml.makeObjectPropertySetter(ol.format.XSD.readBoolean),
+      'Icon': ol.xml.makeObjectPropertySetter(ol.format.KML.readIcon_),
+      'color': ol.xml.makeObjectPropertySetter(plugin.file.kml.readColor_),
+      'drawOrder': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
+      'overlayXY': ol.xml.makeObjectPropertySetter(ol.format.KML.readVec2_),
+      'screenXY': ol.xml.makeObjectPropertySetter(ol.format.KML.readVec2_),
+      'rotationXY': ol.xml.makeObjectPropertySetter(ol.format.KML.readVec2_),
+      'size': ol.xml.makeObjectPropertySetter(ol.format.KML.readVec2_),
+      'rotation': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
+      'TimeStamp': ol.xml.makeObjectPropertySetter(plugin.file.kml.readTime, os.data.RecordField.TIME),
+      'TimeSpan': ol.xml.makeObjectPropertySetter(plugin.file.kml.readTime, os.data.RecordField.TIME)
     });
 
 

--- a/src/plugin/file/kml/kml.js
+++ b/src/plugin/file/kml/kml.js
@@ -5,6 +5,7 @@
 goog.provide('plugin.file.kml');
 
 goog.require('goog.asserts');
+goog.require('ol.extent');
 goog.require('ol.format.KML');
 goog.require('ol.format.XSD');
 goog.require('ol.geom.GeometryCollection');
@@ -411,6 +412,105 @@ os.object.merge(plugin.file.kml.GX_TRACK_PARSERS, ol.format.KML.GX_TRACK_PARSERS
  * Add/replace Track/MultiTrack parsers for Placemark nodes.
  */
 os.object.merge(plugin.file.kml.PLACEMARK_TRACK_PARSERS, plugin.file.kml.OL_PLACEMARK_PARSERS(), true);
+
+
+/**
+ * Read a LatLonBox node and add extent/rotation to the last object on the stack.
+ * @param {Node} node Node.
+ * @param {Array<*>} objectStack Object stack.
+ * @private
+ */
+plugin.file.kml.readLatLonBox_ = function(node, objectStack) {
+  var object = ol.xml.pushParseAndPop({}, plugin.file.kml.LAT_LON_BOX_PARSERS, node, objectStack);
+  if (!object) {
+    return;
+  }
+
+  var targetObject = /** @type {Object} */ (objectStack[objectStack.length - 1]);
+  var extent = [
+    parseFloat(object['west']),
+    parseFloat(object['south']),
+    parseFloat(object['east']),
+    parseFloat(object['north'])
+  ];
+  targetObject['extent'] = extent;
+  targetObject['rotation'] = parseFloat(object['rotation'] || 0);
+};
+
+
+/**
+ * Read a LatLonQuad node and add extent to the last object on the stack.
+ * @param {Node} node Node.
+ * @param {Array<*>} objectStack Object stack.
+ * @private
+ */
+plugin.file.kml.readLatLonQuad_ = function(node, objectStack) {
+  var flatCoords = ol.xml.pushParseAndPop([], plugin.file.kml.LAT_LON_QUAD_PARSERS, node, objectStack);
+  if (flatCoords && flatCoords.length) {
+    var coordinates = ol.geom.flat.inflate.coordinates(flatCoords, 0, flatCoords.length, 3);
+    if (coordinates.length === 4) {
+      // TODO: how can we properly represent this with openlayers and cesium?
+      // the ImageStatic layer only supports a box but LatLonQuad can be skewed
+      var extent = ol.extent.createEmpty();
+      coordinates.forEach(function(coordinate) {
+        ol.extent.extendCoordinate(extent, coordinate);
+      });
+
+      var targetObject = /** @type {Object} */ (objectStack[objectStack.length - 1]);
+      targetObject['extent'] = extent;
+    }
+  }
+};
+
+
+/**
+ * Property parsers for GroundOverlay.
+ * @type {Object<string, Object<string, ol.XmlParser>>}
+ * @const
+ */
+plugin.file.kml.GROUND_OVERLAY_PARSERS = ol.xml.makeStructureNS(
+    plugin.file.kml.OL_NAMESPACE_URIS(), {
+      'Icon': ol.xml.makeObjectPropertySetter(ol.format.KML.readIcon_),
+      'color': ol.xml.makeObjectPropertySetter(plugin.file.kml.readColor_),
+      'drawOrder': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
+      'altitude': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
+      'altitudeMode': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString),
+      'LatLonBox': plugin.file.kml.readLatLonBox_,
+      'LatLonQuad': plugin.file.kml.readLatLonQuad_,
+      'TimeStamp': ol.xml.makeObjectPropertySetter(plugin.file.kml.readTime, os.data.RecordField.TIME),
+      'TimeSpan': ol.xml.makeObjectPropertySetter(plugin.file.kml.readTime, os.data.RecordField.TIME)
+    }, ol.xml.makeStructureNS(
+        plugin.file.kml.OL_GX_NAMESPACE_URIS(), {
+          // also include gx:LatLonQuad to support 2.2 extension values
+          'LatLonQuad': plugin.file.kml.readLatLonQuad_
+        }
+    ));
+
+
+/**
+ * Property parsers for LatLonBox.
+ * @type {Object<string, Object<string, ol.XmlParser>>}
+ * @const
+ */
+plugin.file.kml.LAT_LON_BOX_PARSERS = ol.xml.makeStructureNS(
+    plugin.file.kml.OL_NAMESPACE_URIS(), {
+      'north': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
+      'south': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
+      'east': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
+      'west': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
+      'rotation': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal)
+    });
+
+
+/**
+ * Property parsers for LatLonQuad.
+ * @type {Object<string, Object<string, ol.XmlParser>>}
+ * @const
+ */
+plugin.file.kml.LAT_LON_QUAD_PARSERS = ol.xml.makeStructureNS(
+    plugin.file.kml.OL_NAMESPACE_URIS(), {
+      'coordinates': ol.xml.makeReplacer(ol.format.KML.readFlatCoordinates_)
+    });
 
 
 /**

--- a/src/plugin/file/kml/kmlsource.js
+++ b/src/plugin/file/kml/kmlsource.js
@@ -354,7 +354,7 @@ plugin.file.kml.KMLSource.prototype.addNodes = function(nodes, opt_recurse) {
         images.push(image);
       }
 
-      var overlay = node.getOverlay();
+      var overlay = node.getOverlayId();
       if (overlay) {
         id = /** @type {string} */ (node.getId());
         this.nodeMap_[id] = node;

--- a/src/plugin/file/kml/kmlsource.js
+++ b/src/plugin/file/kml/kmlsource.js
@@ -539,6 +539,13 @@ plugin.file.kml.KMLSource.prototype.processImmediate = function(feature) {
 
   plugin.file.kml.KMLSource.base(this, 'processImmediate', feature);
 
+  if (this.animationOverlay) {
+    var node = this.getFeatureNode(feature);
+    if (node) {
+      node.setAnimationState(false);
+    }
+  }
+
   this.scheduleUpdateFromNodes();
 };
 

--- a/src/plugin/file/kml/kmlsource.js
+++ b/src/plugin/file/kml/kmlsource.js
@@ -576,22 +576,6 @@ plugin.file.kml.KMLSource.prototype.updateVisibilityFromNodes = function() {
     }
   }
 
-  for (var i = 0, n = this.images.length; i < n; i++) {
-    var image = this.images[i];
-    var id = /** @type {string} */ (image.getId());
-    node = this.nodeMap_[id];
-
-    if (node) {
-      if (node.getState() == os.structs.TriState.ON) {
-        image.setLayerVisible(true);
-      } else if (node.getState() == os.structs.TriState.OFF) {
-        image.setLayerVisible(false);
-      }
-    } else {
-      goog.log.warning(this.log, 'Image [' + id + '] is not in the KML tree!');
-    }
-  }
-
   if (toShow.length) {
     this.showFeatures(toShow);
   }
@@ -768,14 +752,13 @@ plugin.file.kml.KMLSource.prototype.restore = function(config) {
  */
 plugin.file.kml.KMLSource.prototype.createAnimationOverlay = function() {
   plugin.file.kml.KMLSource.base(this, 'createAnimationOverlay');
-  var features = this.getFeatures();
 
-  // Hide all annotations
+  // hide all features
+  var features = this.getFeatures();
   for (var i = 0, n = features.length; i < n; i++) {
-    var feature = features[i];
-    var annotation = this.getFeatureNode(feature).getAnnotation();
-    if (annotation) {
-      annotation.setVisible(false);
+    var node = this.getFeatureNode(features[i]);
+    if (node) {
+      node.setAnimationState(false);
     }
   }
 };
@@ -788,14 +771,12 @@ plugin.file.kml.KMLSource.prototype.createAnimationOverlay = function() {
  */
 plugin.file.kml.KMLSource.prototype.updateAnimationOverlay = function() {
   if (this.animationOverlay) {
+    // hide features from the previous animation frame
     var overlayFeatures = this.animationOverlay.getFeatures();
-
-    // hide annotations in overlay
     for (var i = 0, n = overlayFeatures.length; i < n; i++) {
-      var feature = overlayFeatures[i];
-      var annotation = this.getFeatureNode(feature).getAnnotation();
-      if (annotation) {
-        annotation.setVisible(false);
+      var node = this.getFeatureNode(overlayFeatures[i]);
+      if (node) {
+        node.setAnimationState(false);
       }
     }
   }
@@ -803,14 +784,12 @@ plugin.file.kml.KMLSource.prototype.updateAnimationOverlay = function() {
   plugin.file.kml.KMLSource.base(this, 'updateAnimationOverlay');
 
   if (this.animationOverlay) {
+    // show features in the current animation frame
     var overlayFeatures = this.animationOverlay.getFeatures();
-
-    // show annotations in overlay
     for (var i = 0, n = overlayFeatures.length; i < n; i++) {
-      var feature = overlayFeatures[i];
-      var annotation = this.getFeatureNode(feature).getAnnotation();
-      if (annotation) {
-        annotation.setVisible(true);
+      var node = this.getFeatureNode(overlayFeatures[i]);
+      if (node) {
+        node.setAnimationState(true);
       }
     }
   }
@@ -824,14 +803,13 @@ plugin.file.kml.KMLSource.prototype.updateAnimationOverlay = function() {
  */
 plugin.file.kml.KMLSource.prototype.disposeAnimationOverlay = function() {
   plugin.file.kml.KMLSource.base(this, 'disposeAnimationOverlay');
-  var features = this.getFeatures();
 
-  // Show all annotations
+  // show all features
+  var features = this.getFeatures();
   for (var i = 0, n = features.length; i < n; i++) {
-    var feature = features[i];
-    var annotation = this.getFeatureNode(feature).getAnnotation();
-    if (annotation) {
-      annotation.setVisible(true);
+    var node = this.getFeatureNode(features[i]);
+    if (node) {
+      node.setAnimationState(true);
     }
   }
 };


### PR DESCRIPTION
Annotations and KML ground/screen overlays will now respect both timeline and tree visibility states.

Summary of changes:
- Refactors overlay parsers to use the `ol.xml` API, and parses additional fields like time.
- Adds an animation state flag to KML nodes, so overlay visibility can be resolved between tree/timeline states.
- Fixes a bug where a `ScreenOverlay` with `visibility = 0` would not be added to the KML tree.

This file has a number of ground/screen overlays with a mix of timeless, time instant, and time range. Rename to `.kmz` to load it.

[Overlays.zip](https://github.com/ngageoint/opensphere/files/2927066/Overlays.zip)