### PR TITLE
fix(menu): remove superfluous boolean checks

### DIFF
--- a/src/os/ui/menu/menubutton.js
+++ b/src/os/ui/menu/menubutton.js
@@ -91,10 +91,7 @@ os.ui.menu.MenuButtonCtrl.prototype.disposeInternal = function() {
 os.ui.menu.MenuButtonCtrl.prototype.openMenu = function() {
   if (this.menu) {
     // To be consistent with bs4, if the menu is open and you click it again, close the menu
-    if (this.scope['menu'] ||
-        this.element.hasClass('active') ||
-        this.element.hasClass('active-remove') ||
-        this.element.hasClass('active-remove-active')) {
+    if (this.scope['menu']) {
       this.scope['menu'] = false;
       this.element.blur();
       this.menu.close();


### PR DESCRIPTION
`this.scope['menu']` drives the `active` class within the templates. Therefore, checking for the existence of the class (or any of its derivatives) is superfluous and in some cases incorrect (due to some of them not being synchronously removed).

fixes #385