### PR TITLE
Fix various windows that did not collapse properly.

### DIFF
--- a/src/os/ui/buffer/bufferdialog.js
+++ b/src/os/ui/buffer/bufferdialog.js
@@ -14,6 +14,7 @@ goog.require('os.ui.buffer.bufferFormDirective');
 os.ui.buffer.bufferDialogDirective = function() {
   return {
     restrict: 'E',
+    replace: true,
     templateUrl: os.ROOT + 'views/buffer/bufferdialog.html',
     controller: os.ui.buffer.BufferDialogCtrl,
     controllerAs: 'buffer'

--- a/src/os/ui/buffer/bufferform.js
+++ b/src/os/ui/buffer/bufferform.js
@@ -19,6 +19,7 @@ goog.require('os.ui.im.basicInfoDirective');
 os.ui.buffer.bufferFormDirective = function() {
   return {
     restrict: 'E',
+    replace: true,
     scope: {
       'config': '=',
       'showSourcePicker': '=',

--- a/src/os/ui/filter/ui/filterexport.js
+++ b/src/os/ui/filter/ui/filterexport.js
@@ -24,6 +24,7 @@ os.ui.filter.ui.FilterExportChoice = {
 os.ui.filter.ui.filterExportDirective = function() {
   return {
     restrict: 'E',
+    replace: true,
     scope: {
       'confirm': '=',
       'mode': '='

--- a/src/os/ui/state/stateimport.js
+++ b/src/os/ui/state/stateimport.js
@@ -18,6 +18,7 @@ goog.require('os.ui.state.AbstractStateFormCtrl');
 os.ui.state.stateImportDirective = function() {
   return {
     restrict: 'E',
+    replace: true,
     scope: true,
     templateUrl: os.ROOT + 'views/window/stateimportexport.html',
     controller: os.ui.state.StateImportCtrl,

--- a/src/plugin/area/kmlareaimportui.js
+++ b/src/plugin/area/kmlareaimportui.js
@@ -99,6 +99,7 @@ plugin.area.KMLAreaImportUI.prototype.onPreviewReady_ = function(config, event) 
 plugin.area.kmlAreaDirective = function() {
   return {
     restrict: 'E',
+    replace: true,
     templateUrl: os.ROOT + 'views/plugin/kml/kmlarea.html',
     controller: plugin.area.KMLAreaCtrl,
     controllerAs: 'areaFiles'

--- a/src/plugin/area/shpareaimportui.js
+++ b/src/plugin/area/shpareaimportui.js
@@ -85,6 +85,7 @@ plugin.area.SHPAreaImportUI.prototype.launchUI = function(file, opt_config) {
 plugin.area.shpAreaDirective = function() {
   return {
     restrict: 'E',
+    replace: true,
     templateUrl: os.ROOT + 'views/plugin/shp/shparea.html',
     controller: plugin.area.SHPAreaCtrl,
     controllerAs: 'areaFiles'

--- a/src/plugin/places/ui/saveplaces.js
+++ b/src/plugin/places/ui/saveplaces.js
@@ -15,6 +15,7 @@ goog.require('plugin.places');
 plugin.places.ui.savePlacesDirective = function() {
   return {
     restrict: 'E',
+    replace: true,
     scope: {
       'initSources': '&'
     },

--- a/views/buffer/bufferdialog.html
+++ b/views/buffer/bufferdialog.html
@@ -1,4 +1,4 @@
-<div>
+<div class="d-flex flex-column">
   <div class="modal-body">
     <div ng-form="bufferDialogForm">
       <bufferform config="config" init-sources="sources" show-source-picker="buffer.showSourcePicker" warning-message="buffer.warningMessage"></bufferform>

--- a/views/file/anytypeimport.html
+++ b/views/file/anytypeimport.html
@@ -1,4 +1,4 @@
-<div>
+<div class="d-flex flex-column">
   <div class="modal-body">
     <div>
       <div class="row">

--- a/views/filter/filterexport.html
+++ b/views/filter/filterexport.html
@@ -1,4 +1,4 @@
-<div>
+<div class="d-flex flex-column">
   <div class="modal-body">
     <form name="exportForm">
       <div class="d-flex flex-fill form-group">

--- a/views/plugin/kml/kmlarea.html
+++ b/views/plugin/kml/kmlarea.html
@@ -1,4 +1,4 @@
-<div>
+<div class="d-flex flex-column">
   <div class="modal-body">
     <form name="areaForm">
       <basicinfo config="config" columns="config.merge ? null : config.columns" help="areaFiles.help"></basicinfo>

--- a/views/plugin/places/saveplaces.html
+++ b/views/plugin/places/saveplaces.html
@@ -1,4 +1,4 @@
-<div>
+<div class="d-flex flex-column">
   <div class="modal-body">
     <div ng-form="savePlacesForm">
       <div>

--- a/views/plugin/shp/shparea.html
+++ b/views/plugin/shp/shparea.html
@@ -1,4 +1,4 @@
-<div>
+<div class="d-flex flex-column">
   <div class="modal-body">
     <div ng-if="!config.zipFile">
       <shpfilesstep></shpfilesstep>

--- a/views/query/area/userarea.html
+++ b/views/query/area/userarea.html
@@ -1,4 +1,4 @@
-<div>
+<div class="d-flex flex-column">
   <div class="modal-body">
     <form class="user-area-form form-compact no-margin" ng-class="formClass" name="userAreaForm" ng-submit="ctrl.confirm()" novalidate>
       <div ng-form="areaTypeForm" class="form-compressed"

--- a/views/query/editarea.html
+++ b/views/query/editarea.html
@@ -1,4 +1,4 @@
-<div>
+<div class="d-flex flex-column">
   <div class="modal-body">
     <form name="areaForm" ng-submit="ctrl.accept()">
       <basicinfo config="config" columns="columns"></basicinfo>

--- a/views/query/mergeareas.html
+++ b/views/query/mergeareas.html
@@ -1,4 +1,4 @@
-<div>
+<div class="d-flex flex-column">
   <div class="modal-body">
     <form name="areaForm" ng-submit="ctrl.accept()">
       <basicinfo config="config" columns="columns" help="ctrl.help"></basicinfo>

--- a/views/query/modifyarea.html
+++ b/views/query/modifyarea.html
@@ -1,4 +1,4 @@
-<div>
+<div class="d-flex flex-column">
   <div class="modal-body">
     <form name="areaForm" novalidate>
       <div class="row mt-1" title="{{modarea.help.area1}}">

--- a/views/windows/browsedata.html
+++ b/views/windows/browsedata.html
@@ -1,4 +1,4 @@
-<div>
+<div class="d-flex flex-column">
   <div class="modal-body">
     <div class="bd-header">
       <div class="float-left">


### PR DESCRIPTION
Window content must be a flex container for it to fill the window. This was a mix of the root element in the template not having `d-flex flex-column` and the directive not using `replace: true` which would create another DOM level that was not a flex item.

Resolves #422.