### PR TITLE
fix(cesium): limit tilt range to [0, pi] and keep roll across updates

### DIFF
--- a/src/plugin/cesium/cesiumcamera.js
+++ b/src/plugin/cesium/cesiumcamera.js
@@ -183,7 +183,7 @@ plugin.cesium.Camera.prototype.getTilt = function() {
  * @inheritDoc
  */
 plugin.cesium.Camera.prototype.setTilt = function(tilt) {
-  this.tilt_ = tilt;
+  this.tilt_ = goog.math.clamp(tilt, 0, Math.PI);
   this.updateCamera_();
 };
 
@@ -431,7 +431,7 @@ plugin.cesium.Camera.prototype.updateCamera_ = function() {
   var orientation = {
     pitch: this.tilt_ - Cesium.Math.PI_OVER_TWO,
     heading: -view.getRotation(),
-    roll: undefined
+    roll: this.cam_.roll
   };
   this.cam_.setView({
     destination: destination,


### PR DESCRIPTION
This fixes the case where you shift+left|right a while and then shift+up|down to change the tilt (on master weird jumps and other things occur).

resolves #369