### PR TITLE
fix(CSVExport): Prevent hidden columns from being included in export

### DIFF
--- a/src/os/ex/abstractexporter.js
+++ b/src/os/ex/abstractexporter.js
@@ -90,6 +90,14 @@ os.ex.AbstractExporter.prototype.supportsMultiple = function() {
 /**
  * @inheritDoc
  */
+os.ex.AbstractExporter.prototype.supportsTime = function() {
+  return false;
+};
+
+
+/**
+ * @inheritDoc
+ */
 os.ex.AbstractExporter.prototype.reset = function() {
   this.fields = null;
   this.items = null;

--- a/src/os/ex/iexportmethod.js
+++ b/src/os/ex/iexportmethod.js
@@ -77,6 +77,13 @@ os.ex.IExportMethod.prototype.supportsMultiple;
 
 
 /**
+ * If the export method supports exporting time from the data source.
+ * @return {boolean}
+ */
+os.ex.IExportMethod.prototype.supportsTime;
+
+
+/**
  * Begins the export process.
  */
 os.ex.IExportMethod.prototype.process;

--- a/src/os/source/source.js
+++ b/src/os/source/source.js
@@ -227,9 +227,10 @@ os.source.getHoldRecordTime = function(item) {
  * Get the fields to export for features in the source.
  * @param {os.source.Vector} source The source
  * @param {boolean=} opt_internal If internal fields should be included
+ * @param {boolean=} opt_includeTime If the time field should be included
  * @return {Array<string>} The fields to export
  */
-os.source.getExportFields = function(source, opt_internal) {
+os.source.getExportFields = function(source, opt_internal, opt_includeTime) {
   var fields = null;
 
   if (source) {
@@ -251,7 +252,8 @@ os.source.getExportFields = function(source, opt_internal) {
         if (column['visible'] &&
             !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(field)) &&
             !ol.array.includes(fields, field) &&
-            (opt_internal || !os.feature.isInternalField(field))) {
+            (opt_internal || !os.feature.isInternalField(field) ||
+            (opt_includeTime && field == os.data.RecordField.TIME))) {
           fields.push(field);
         }
       }

--- a/src/os/ui/ex/exportdialog.js
+++ b/src/os/ui/ex/exportdialog.js
@@ -57,6 +57,12 @@ os.ui.ex.ExportCtrl = function($scope, $element, $compile) {
   $scope['allowMultiple'] = false;
 
   /**
+   * If time is allowed by the export method.
+   * @type {boolean}
+   */
+  $scope['allowTime'] = false;
+
+  /**
    * If label export is supported by the export method.
    * @type {boolean}
    */
@@ -86,8 +92,8 @@ goog.inherits(os.ui.ex.ExportCtrl, os.ui.file.ExportDialogCtrl);
  */
 os.ui.ex.ExportCtrl.prototype.getCustomOptions = function() {
   return '<h5 class="mt-3 text-center">Sources to Export</h5>' +
-      '<exportoptions init-sources="initSources" allow-multiple="allowMultiple" show-labels="showLabels">' +
-      '</exportoptions>';
+      '<exportoptions init-sources="initSources" allow-multiple="allowMultiple" show-labels="showLabels"' +
+      ' allow-time="allowTime"></exportoptions>';
 };
 
 
@@ -100,6 +106,7 @@ os.ui.ex.ExportCtrl.prototype.onExporterChange = function(opt_new, opt_old) {
   if (opt_new) {
     this.scope['allowMultiple'] = opt_new.supportsMultiple();
     this.scope['showLabels'] = opt_new.supportsLabelExport();
+    this.scope['allowTime'] = opt_new.supportsTime();
   }
 };
 
@@ -125,7 +132,7 @@ os.ui.ex.ExportCtrl.prototype.onExportOptionsChange_ = function(event, items, so
   // update the export columns
   if (sources) {
     for (var i = 0; i < sources.length; i++) {
-      var sourceFields = os.source.getExportFields(sources[i]);
+      var sourceFields = os.source.getExportFields(sources[i], false, this.scope['allowTime']);
       if (sourceFields) {
         for (var j = 0; j < sourceFields.length; j++) {
           if (!ol.array.includes(this.options.fields, sourceFields[j])) {

--- a/src/plugin/file/csv/csvexporter.js
+++ b/src/plugin/file/csv/csvexporter.js
@@ -13,6 +13,7 @@ goog.require('os.ui.file.csv.AbstractCSVExporter');
 goog.require('plugin.file.csv.ui.csvExportDirective');
 
 
+
 /**
  * The CSV exporter.
  * @extends {os.ui.file.csv.AbstractCSVExporter.<ol.Feature>}
@@ -28,6 +29,12 @@ plugin.file.csv.CSVExporter = function() {
    * @private
    */
   this.exportEllipses_ = false;
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.alwaysIncludeWkt_ = true;
 };
 goog.inherits(plugin.file.csv.CSVExporter, os.ui.file.csv.AbstractCSVExporter);
 
@@ -49,6 +56,7 @@ plugin.file.csv.CSVExporter.FIELDS = {
   START_TIME: 'START_TIME',
   END_TIME: 'END_TIME'
 };
+
 
 
 /**
@@ -109,62 +117,12 @@ plugin.file.csv.CSVExporter.prototype.getUI = function() {
 plugin.file.csv.CSVExporter.prototype.processItem = function(item) {
   var result = item == null ? null : {};
 
-  var geom = item ? /** @type {ol.geom.SimpleGeometry|undefined} */ (item.getGeometry()) : null;
-  if (geom != null) {
-    geom = /** @type {ol.geom.SimpleGeometry|undefined} */ (geom.clone().toLonLat());
-
-    try {
-      // only populate these fields for point geometries, which will return an array of numbers. unfortunately we can't
-      // detect a point geometry with instanceof because of external tools
-      var coords = geom.getCoordinates();
-      if (coords && typeof coords[0] === 'number') {
-        result[os.Fields.LAT] = String(coords[1]);
-        result[os.Fields.LON] = String(coords[0]);
-        result[os.Fields.LAT_DDM] = os.geo.toDegreesDecimalMinutes(coords[1], false, false);
-        result[os.Fields.LON_DDM] = os.geo.toDegreesDecimalMinutes(coords[0], true, false);
-        result[os.Fields.LAT_DMS] = os.geo.toSexagesimal(coords[1], false, false);
-        result[os.Fields.LON_DMS] = os.geo.toSexagesimal(coords[0], true, false);
-        result[os.Fields.MGRS] = osasm.toMGRS(coords);
-      }
-    } catch (e) {
-      // didn't have a getCoordinates function... carry on
-    }
-
-    // all geometry fields should at least be on the result to make PapaParse happier
-    if (!(os.Fields.LAT in result)) {
-      result[os.Fields.LAT] = '';
-      result[os.Fields.LON] = '';
-      result[os.Fields.LAT_DDM] = '';
-      result[os.Fields.LON_DDM] = '';
-      result[os.Fields.LAT_DMS] = '';
-      result[os.Fields.LON_DMS] = '';
-      result[os.Fields.MGRS] = '';
-    }
-
-    result[os.Fields.GEOMETRY] = os.ol.wkt.FORMAT.writeFeature(item, {
-      dataProjection: os.proj.EPSG4326,
-      featureProjection: os.map.PROJECTION});
-
-    var time = /** @type {os.time.ITime|undefined} */ (item.get(os.data.RecordField.TIME));
-    if (time) {
-      if (os.instanceOf(time, os.time.TimeRange.NAME)) {
-        // time ranges need to be put into two separate fields so that we can reimport our own exports
-        result[plugin.file.csv.CSVExporter.FIELDS.START_TIME] = time.getStartISOString();
-        result[plugin.file.csv.CSVExporter.FIELDS.END_TIME] = time.getEndISOString();
-      } else {
-        result[os.Fields.TIME] = time.toISOString();
-      }
-    }
-    if (this.exportEllipses_) {
-      result[os.Fields.SEMI_MAJOR] = item.get(os.Fields.SEMI_MAJOR);
-      result[os.Fields.SEMI_MINOR] = item.get(os.Fields.SEMI_MINOR);
-    }
-  }
-
   if (this.fields) {
     for (var i = 0, n = this.fields.length; i < n; i++) {
       var field = this.fields[i];
-      if (!(field in result)) {
+      if (field === os.data.RecordField.TIME) {
+        this.writeTime(item, result);
+      } else if (!(field in result)) {
         var value = item.get(this.fields[i]);
         if (value == null) {
           value = '';
@@ -177,5 +135,78 @@ plugin.file.csv.CSVExporter.prototype.processItem = function(item) {
     }
   }
 
+  this.writeGeometry(item, result);
+
   return result;
+};
+
+
+/**
+ * Get whether to always include WKT geometry in the export
+ * @return {boolean} If true, WKT geometry will always be included in the export
+ */
+plugin.file.csv.CSVExporter.prototype.getAlwaysIncludeWkt = function() {
+  return this.alwaysIncludeWkt_;
+};
+
+
+/**
+ * Set wheather to always include WKT geometry in the export
+ * @param {boolean} newValue Set to true if WKT geometry should always be included in the export
+ */
+plugin.file.csv.CSVExporter.prototype.setAlwaysIncludeWkt = function(newValue) {
+  this.alwaysIncludeWkt_ = newValue;
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.file.csv.CSVExporter.prototype.supportsTime = function() {
+  return true;
+};
+
+
+/**
+ * Conditionally writes the time field(s) to the result object
+ * @param {T} item The items
+ * @param {Object.<string, string>} result The Papa item
+ * @protected
+ * @template T
+ */
+plugin.file.csv.CSVExporter.prototype.writeTime = function(item, result) {
+  var time = item ? /** @type {os.time.ITime|undefined} */ (item.get(os.data.RecordField.TIME)) : null;
+  if (time != null) {
+    if (os.instanceOf(time, os.time.TimeRange.NAME)) {
+      // time ranges need to be put into two separate fields so that we can reimport our own exports
+      result[plugin.file.csv.CSVExporter.FIELDS.START_TIME] = time.getStartISOString();
+      result[plugin.file.csv.CSVExporter.FIELDS.END_TIME] = time.getEndISOString();
+    } else {
+      result[os.Fields.TIME] = time.toISOString();
+    }
+  }
+};
+
+
+/**
+ * Conditionally writes the geometry field to the result object
+ * @param {T} item The items
+ * @param {Object.<string, string>} result The Papa item
+ * @protected
+ * @template T
+ */
+plugin.file.csv.CSVExporter.prototype.writeGeometry = function(item, result) {
+  var geom = item ? /** @type {ol.geom.SimpleGeometry|undefined} */ (item.getGeometry()) : null;
+  if (this.alwaysIncludeWkt_ && geom != null) {
+    geom = /** @type {ol.geom.SimpleGeometry|undefined} */ (geom.clone().toLonLat());
+    result[os.Fields.GEOMETRY] = os.ol.wkt.FORMAT.writeFeature(item, {
+      dataProjection: os.proj.EPSG4326,
+      featureProjection: os.map.PROJECTION
+    });
+
+    if (this.exportEllipses_) {
+      result[os.Fields.SEMI_MAJOR] = item.get(os.Fields.SEMI_MAJOR);
+      result[os.Fields.SEMI_MINOR] = item.get(os.Fields.SEMI_MINOR);
+    }
+  }
 };

--- a/src/plugin/file/csv/ui/csvexportui.js
+++ b/src/plugin/file/csv/ui/csvexportui.js
@@ -2,10 +2,15 @@ goog.provide('plugin.file.csv.ui.CSVExportCtrl');
 goog.provide('plugin.file.csv.ui.csvExportDirective');
 goog.require('os.defines');
 goog.require('os.ui.Module');
+goog.require('os.ui.icon.IconPickerCtrl');
+goog.require('os.ui.icon.iconPickerDirective');
+
 
 
 /**
- * The csvexport directive
+ * The csvexport directive for use in exportdialog.js
+ *
+ * This is not a stand alone UI, it's meant to augment exportdialog.js
  * @return {angular.Directive}
  */
 plugin.file.csv.ui.csvExportDirective = function() {
@@ -52,7 +57,13 @@ plugin.file.csv.ui.CSVExportCtrl = function($scope) {
    */
   $scope['exportEllipses'] = this.exporter_.getExportEllipses();
 
+  /**
+   * @type {boolean}
+   */
+  $scope['alwaysIncludeWkt'] = this.exporter_.getAlwaysIncludeWkt();
+
   $scope.$watch('exportEllipses', this.updateExporter_.bind(this));
+  $scope.$watch('alwaysIncludeWkt', this.updateExporter_.bind(this));
   $scope.$on('$destroy', this.destroy_.bind(this));
 
   this.updateExporter_();
@@ -76,5 +87,6 @@ plugin.file.csv.ui.CSVExportCtrl.prototype.destroy_ = function() {
 plugin.file.csv.ui.CSVExportCtrl.prototype.updateExporter_ = function() {
   if (this.exporter_ && this.scope_) {
     this.exporter_.setExportEllipses(this.scope_['exportEllipses']);
+    this.exporter_.setAlwaysIncludeWkt(this.scope_['alwaysIncludeWkt']);
   }
 };

--- a/test/plugin/file/csv/csvexporter.test.js
+++ b/test/plugin/file/csv/csvexporter.test.js
@@ -21,7 +21,7 @@ describe('plugin.file.csv.CSVExporter', function() {
     ex.reset();
   });
 
-  it('does not process null features', function() {
+  it('should not process null features', function() {
     var result = ex.processItem(null);
     expect(result).toBeNull();
   });
@@ -39,40 +39,25 @@ describe('plugin.file.csv.CSVExporter', function() {
     expect(result.numKey).toBe(props.numKey);
   });
 
-  it('converts features with a point geometry to JSON', function() {
+  it('should convert features with a point geometry to JSON', function() {
     var result = ex.processItem(pointFeature);
 
-    expect(result[os.Fields.LAT].length).not.toBe(0);
-    expect(result[os.Fields.LON].length).not.toBe(0);
-    expect(result[os.Fields.LAT_DMS].length).not.toBe(0);
-    expect(result[os.Fields.LON_DMS].length).not.toBe(0);
-    expect(result[os.Fields.MGRS].length).not.toBe(0);
     expect(result[os.Fields.GEOMETRY].length).not.toBe(0);
   });
 
-  it('converts features with a linestring geometry to JSON', function() {
+  it('should convert features with a linestring geometry to JSON', function() {
     var result = ex.processItem(lineFeature);
 
-    expect(result[os.Fields.LAT].length).toBe(0);
-    expect(result[os.Fields.LON].length).toBe(0);
-    expect(result[os.Fields.LAT_DMS].length).toBe(0);
-    expect(result[os.Fields.LON_DMS].length).toBe(0);
-    expect(result[os.Fields.MGRS].length).toBe(0);
     expect(result[os.Fields.GEOMETRY].length).not.toBe(0);
   });
 
-  it('converts features with a polygon geometry to JSON', function() {
+  it('should convert features with a polygon geometry to JSON', function() {
     var result = ex.processItem(polygonFeature);
 
-    expect(result[os.Fields.LAT].length).toBe(0);
-    expect(result[os.Fields.LON].length).toBe(0);
-    expect(result[os.Fields.LAT_DMS].length).toBe(0);
-    expect(result[os.Fields.LON_DMS].length).toBe(0);
-    expect(result[os.Fields.MGRS].length).toBe(0);
     expect(result[os.Fields.GEOMETRY].length).not.toBe(0);
   });
 
-  it('translates fields to JSON', function() {
+  it('should translate fields to JSON', function() {
     var props = {
       strKey: 'a',
       numKey: 5,
@@ -104,7 +89,7 @@ describe('plugin.file.csv.CSVExporter', function() {
     ex.setItems(null);
   });
 
-  it('exports time instants correctly', function() {
+  it('should export time instants correctly', function() {
     var props = {
       recordTime: new os.time.TimeInstant(999999)
     };
@@ -117,7 +102,7 @@ describe('plugin.file.csv.CSVExporter', function() {
     expect(result[os.Fields.TIME]).toBe('1970-01-01 00:16:39Z');
   });
 
-  it('exports time ranges correctly', function() {
+  it('should export time ranges correctly', function() {
     var props = {
       recordTime: new os.time.TimeRange(999999, 9999999)
     };
@@ -129,5 +114,22 @@ describe('plugin.file.csv.CSVExporter', function() {
 
     expect(result[plugin.file.csv.CSVExporter.FIELDS.START_TIME]).toBe('1970-01-01 00:16:39Z');
     expect(result[plugin.file.csv.CSVExporter.FIELDS.END_TIME]).toBe('1970-01-01 02:46:39Z');
+  });
+
+  it('should export GEOMETRY when alwaysIncludeWkt is true', function() {
+    ex.setAlwaysIncludeWkt(true);
+
+    var result = ex.processItem(pointFeature);
+
+    expect(result[os.Fields.GEOMETRY].length).not.toBe(0);
+  });
+
+  it('should not export GEOMETRY when alwaysIncludeWkt is false', function() {
+    // Though there's nothing stopping the user from exporting their own WKT field
+    ex.setAlwaysIncludeWkt(false);
+
+    var result = ex.processItem(pointFeature);
+
+    expect(result[os.Fields.GEOMETRY]).toBeUndefined();
   });
 });

--- a/views/plugin/csv/csvexport.html
+++ b/views/plugin/csv/csvexport.html
@@ -4,5 +4,10 @@
       <input id="js-csvexport__ellipses" class="custom-control-input" type="checkbox" name="exportEllipses" ng-model="exportEllipses">
       <label for="js-csvexport__ellipses" class="custom-control-label">Export Ellipses</label>
     </div>
+    <div class="custom-control custom-checkbox mx-1"
+      title="This will include geometry data (as WKT) in the export, if any, even if the field is hidden.">
+      <input id="js-csvexport__alwaysIncludeWkt" class="custom-control-input" type="checkbox" name="alwaysIncludeWkt" ng-model="alwaysIncludeWkt">
+      <label for="js-csvexport__alwaysIncludeWkt" class="custom-control-label">Always Include Geometry (WKT)</label>
+    </div>
   </div>
 </ng-form>


### PR DESCRIPTION
Geometry and time fields were previously always included in exports. This commit adds an option to
keep them out of the export if they're hidden.

BREAKING CHANGE: Even though this defaults to the old behavior I haven't had time to ensure this doesn't break other uses of it

WIP:

- [x] I'd like some review on my naming. `alwaysIncludeGeometryAndTime` might be too verbose
    * Replaced with `alwaysIncludeLatLonTime` since not all geometry is included with this option
- [x] I'd like a little bit of feedback on my documentation
    * Adding notes that this is not a stand alone UI
- [x] Is there anywhere else that could benefit from this option?
- [x] I still need to write tests in `test/plugin/file/csv/csvexporter.test.js` that utilize `includeGeometry`
