### PR TITLE
Avoid null dereference when canvas coordinate can't be resolved.

### DIFF
--- a/src/plugin/cesium/cesiumrenderer.js
+++ b/src/plugin/cesium/cesiumrenderer.js
@@ -286,7 +286,9 @@ plugin.cesium.CesiumRenderer.prototype.getPixelFromCoordinate = function(coordin
 
     if (cartesian) {
       var pixelCartesian = scene.cartesianToCanvasCoordinates(cartesian);
-      result = [pixelCartesian.x, pixelCartesian.y];
+      if (pixelCartesian) {
+        result = [pixelCartesian.x, pixelCartesian.y];
+      }
     }
   }
 


### PR DESCRIPTION
Scale line updates were throwing errors when the globe was tilted to extreme angles.