### PR TITLE
Show feature name/title and tweak overall layout.

### DIFF
--- a/src/os/ui/feature/featureinfo.js
+++ b/src/os/ui/feature/featureinfo.js
@@ -4,6 +4,8 @@ goog.provide('os.ui.feature.featureInfoDirective');
 goog.require('goog.Disposable');
 goog.require('ol.events');
 goog.require('ol.geom.Point');
+goog.require('os.feature');
+goog.require('os.fn');
 goog.require('os.layer');
 goog.require('os.map');
 goog.require('os.plugin.PluginManager');
@@ -68,6 +70,12 @@ os.ui.feature.FeatureInfoCtrl = function($scope, $element) {
    * @type {function(os.ui.tab.FeatureTab):string}
    */
   this['getUi'] = goog.bind(this.getUi_, this);
+
+  /**
+   * The displayed title for the active feature.
+   * @type {string}
+   */
+  this['title'] = '';
 
   /**
    * @type {?angular.JQLite}
@@ -176,6 +184,7 @@ os.ui.feature.FeatureInfoCtrl.prototype.onFeatureChange = function(newVal) {
 
   this.updateGeometry();
   this.updateTabs_();
+  this.updateTitle_();
 
   if (newVal) {
     var feature = newVal[0];
@@ -218,6 +227,27 @@ os.ui.feature.FeatureInfoCtrl.prototype.updateGeometry = function() {
       }
     }
   }
+};
+
+
+/**
+ * Update the title for the active feature.
+ * @private
+ */
+os.ui.feature.FeatureInfoCtrl.prototype.updateTitle_ = function() {
+  var parts = [];
+
+  var feature = /** @type {ol.Feature} */ (this.scope['items'][0]);
+  if (feature) {
+    var sourceId = /** @type {string|undefined} */ (feature.get('sourceId'));
+    if (sourceId) {
+      parts.push(os.layer.getTitle(sourceId, false) || undefined);
+    }
+
+    parts.push(os.feature.getTitle(feature) || undefined);
+  }
+
+  this['title'] = parts.filter(os.fn.filterFalsey).join(': ');
 };
 
 
@@ -290,17 +320,4 @@ os.ui.feature.FeatureInfoCtrl.prototype.showDescription = function(event) {
   if (descTabIndex > -1) {
     this.setActiveTab(this['tabs'][descTabIndex]);
   }
-};
-
-/**
- * Parses feature info for title.
- * @return {string}
- * @export
- */
-os.ui.feature.FeatureInfoCtrl.prototype.showFeatureTitle = function() {
-  var feature = this.scope['items'][0];
-  var sourceId = feature.get('sourceId');
-  var layerTitle = os.layer.getTitle(sourceId, true);
-  var title = '<h5>' + layerTitle + '</h5>';
-  return title;
 };

--- a/src/os/ui/feature/tab/abstractfeaturetabctrl.js
+++ b/src/os/ui/feature/tab/abstractfeaturetabctrl.js
@@ -24,6 +24,7 @@ os.ui.feature.tab.AbstractFeatureTabCtrl = function($scope, $element) {
     var data = this.scope['items'][0]['data'];
     setTimeout(function() {
       this.updateTab(null, data);
+      os.ui.apply(this.scope);
     }.bind(this), 0);
   }
 

--- a/views/feature/featureinfo.html
+++ b/views/feature/featureinfo.html
@@ -1,5 +1,5 @@
 <div class="d-flex flex-column flex-fill">
-  <h5 class="my-1">{{info.title}}</h5>
+  <div class="font-weight-bold my-1 text-truncate" ng-attr-title="{{info.title}}">{{info.title}}</div>
   <div class="flex-shrink-0 mb-1 w-100">
     <simple-location latdeg="lat" londeg="lon" ng-if="lat !== undefined && lon !== undefined"></simple-location>
     <span ng-if="alt">Altitude: {{alt}}</span>

--- a/views/feature/featureinfo.html
+++ b/views/feature/featureinfo.html
@@ -1,16 +1,15 @@
 <div class="d-flex flex-column flex-fill">
-    <div ng-bind-html="info.showFeatureTitle()">
-    </div>
-  <div class="flex-shrink-0 w-100">
+  <h5 class="my-1">{{info.title}}</h5>
+  <div class="flex-shrink-0 mb-1 w-100">
     <simple-location latdeg="lat" londeg="lon" ng-if="lat !== undefined && lon !== undefined"></simple-location>
     <span ng-if="alt">Altitude: {{alt}}</span>
   </div>
   <div class="flex-shrink-0" ng-if="info.numTabsShown > 1">
-    <ul class="nav nav-tabs">
+    <ul class="nav nav-tabs border-0">
       <li class="nav-item" ng-repeat="tab in info.tabs" ng-click="info.setActiveTab(tab)" ng-show="tab.isShown">
         <a href="" class="nav-link" ng-class="{active:activeTab.id == tab.id}"><i class="fa" ng-class="tab.icon"></i> {{tab.label}}</a>
       </li>
     </ul>
   </div>
-  <uiswitch items="activeTab" directive-function="info.getUi" generic="propertiestab" class="d-flex flex-fill"></uiswitch>
+  <uiswitch items="activeTab" directive-function="info.getUi" generic="propertiestab" class="d-flex flex-fill border"></uiswitch>
 </div>

--- a/views/feature/multifeatureinfo.html
+++ b/views/feature/multifeatureinfo.html
@@ -12,7 +12,7 @@
       <div>
         {{features.length == filteredFeatures.length ? features.length + ' features' : ' (' + filteredFeatures.length + '/' + features.length + ') features'}}
       </div>
-      <slickgrid x-data="filteredFeatures" columns="multiCtrl.columns" selected="selected" options="multiCtrl.options"></slickgrid>
+      <slickgrid class="border" x-data="filteredFeatures" columns="multiCtrl.columns" selected="selected" options="multiCtrl.options"></slickgrid>
     </div>
     <div class="d-flex col pl-0 pr-0">
       <uiswitch class="d-flex flex-column flex-fill" items="selected" directive-function="multiCtrl.getUi" generic="featureinfo"></uiswitch>

--- a/views/feature/tab/descriptiontab.html
+++ b/views/feature/tab/descriptiontab.html
@@ -1,3 +1,3 @@
-  <div class="flex-fill u-overflow-y-auto card d-flex">
-    <iframe class="card flex-fill bg-light" id="descriptionFrame"></iframe>
+  <div class="flex-fill u-overflow-y-auto d-flex">
+    <iframe class="flex-fill bg-light border-0" id="descriptionFrame"></iframe>
   </div>

--- a/views/feature/tab/propertiestab.html
+++ b/views/feature/tab/propertiestab.html
@@ -1,7 +1,7 @@
 <div class="d-flex flex-fill u-overflow-y-auto">
-  <table class="table table-striped table-hover">
+  <table class="table table-striped table-hover m-0">
     <thead>
-      <tr class="table-bordered">
+      <tr>
         <th ng-click="propctrl.order('field')">
           Field <i ng-show="propctrl.columnToOrder == 'field'" class="slick-sort-indicator" ng-class="{'slick-sort-indicator-desc': !propctrl.reverse, 'slick-sort-indicator-asc': propctrl.reverse}"></i>
         </th>


### PR DESCRIPTION
- Include the name/title field from a feature when present to help identify which feature is active in the window.
- Compute the title on feature change instead of every scope apply.
- Add borders around the feature list and tab pane to isolate scrollable areas, and remove other borders that were inconsistent from tab to tab.