### PR TITLE
test(cypress): Fixes empty file input dialog with newer versions of C…

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -48,6 +48,7 @@ Cypress.Commands.add('upload', function(fileName) {
           var dataTransfer = new DataTransfer();
           dataTransfer.items.add(testFile);
           el.files = dataTransfer.files;
+          return cy.wrap(subject).trigger('change', {force: true});
         });
   });
 });


### PR DESCRIPTION
…hrome (73+)

With Chrome 73+, the file input dialog was not ppulated with the file name after running cy.upload()
resulting in test failures.  This was only affecting tests run via GUI; tests via CLI were not
affected.  See https://github.com/cypress-io/cypress/issues/3730

#447