### PR TITLE
Set path to Papa Parse library.

### DIFF
--- a/externs/papaparse-3.1.2.js
+++ b/externs/papaparse-3.1.2.js
@@ -12,6 +12,12 @@ var Papa = {};
 
 
 /**
+ * @type {string}
+ */
+Papa.SCRIPT_PATH;
+
+
+/**
  * @type {number}
  */
 Papa.LocalChunkSize;

--- a/src/os/ui/file/csv/abstractcsvparser.js
+++ b/src/os/ui/file/csv/abstractcsvparser.js
@@ -5,6 +5,7 @@ goog.require('os.data.ColumnDefinition');
 goog.require('os.file.mime.text');
 goog.require('os.parse.AsyncParser');
 goog.require('os.parse.BaseParserConfig');
+goog.require('os.ui.file.csv');
 
 
 
@@ -36,11 +37,7 @@ os.ui.file.csv.AbstractCsvParser = function(config) {
    */
   this.results = [];
 
-  if (!Modernizr.webworkers) {
-    // if workers aren't available, reduce Papa's default chunk size to prevent the browser from hanging
-    Papa.LocalChunkSize = 1024 * 1024 * 1;  // 1 MB (default 10MB)
-    Papa.RemoteChunkSize = 1024 * 1024 * 1;  // 1 MB (default 5MB)
-  }
+  os.ui.file.csv.configurePapaParse();
 };
 goog.inherits(os.ui.file.csv.AbstractCsvParser, os.parse.AsyncParser);
 

--- a/src/os/ui/file/csv/csv.js
+++ b/src/os/ui/file/csv/csv.js
@@ -1,0 +1,23 @@
+goog.provide('os.ui.file.csv');
+
+
+/**
+ * Configure Papa Parse for use with OpenSphere.
+ */
+os.ui.file.csv.configurePapaParse = function() {
+  // Papa Parse locates the script path by looking up the last script element on the page. this is generally a fine
+  // assumption, unless a browser extension injects scripts at the end of the page. this locates the script by a more
+  // specific selector that should be less prone to false positives.
+  if (!Papa.SCRIPT_PATH) {
+    var papaScriptEl = /** @type {HTMLScriptElement} */ (document.querySelector('script[src*="papaparse"]'));
+    if (papaScriptEl) {
+      Papa.SCRIPT_PATH = papaScriptEl.src;
+    }
+  }
+
+  // if workers aren't available, reduce Papa's default chunk size to prevent the browser from hanging
+  if (!Modernizr.webworkers) {
+    Papa.LocalChunkSize = 1024 * 1024 * 1;  // 1 MB (default 10MB)
+    Papa.RemoteChunkSize = 1024 * 1024 * 1;  // 1 MB (default 5MB)
+  }
+};


### PR DESCRIPTION
To test, load a CSV in both the debug and compiled app. It should load normally. After loading at least one CSV, `Papa.SCRIPT_PATH` should be set (check in the console).

Fixes #455.