### PR TITLE
WIP: fix antimeridian queries via second r-tree

### DIFF
--- a/src/os/geo/geo2.js
+++ b/src/os/geo/geo2.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview This is intended to eventually replace os.geo with equivalent functions
+ * which are entirely projection-agnostic rather than requiring conversion to lonlat and
+ * back when using them.
+ */
+goog.provide('os.geo2');
+goog.require('os.map');
+
+
+/**
+ * @param {number} lon
+ * @param {number=} opt_min
+ * @param {number=} opt_max
+ * @param {ol.proj.Projection=} opt_proj
+ * @return {number}
+ */
+os.geo2.normalizeLongitude = function(lon, opt_min, opt_max, opt_proj) {
+  opt_proj = opt_proj || os.map.PROJECTION;
+  var projExtent = opt_proj.getExtent();
+  opt_min = opt_min != null ? opt_min : projExtent[0];
+  opt_max = opt_max != null ? opt_max : projExtent[2];
+  var width = opt_max - opt_min;
+
+  // Note: OpenLayers uses this same method in ol/renderer/map.js
+  var worldsAway = Math.ceil((opt_min - lon) / width);
+  lon += width * worldsAway;
+
+  return lon;
+};

--- a/test/os/extent.test.js
+++ b/test/os/extent.test.js
@@ -1,0 +1,229 @@
+goog.require('ol.proj');
+goog.require('os.extent');
+goog.require('os.proj');
+
+describe('os.extent', function() {
+  var expandExtent = function(extent) {
+    return [extent[0], 0, extent[1], 0];
+  };
+
+  var projections = [{
+    code: os.proj.EPSG4326,
+    precision: 12,
+    epsilon: 1E-12
+  }, {
+    code: os.proj.EPSG3857,
+    precision: 6,
+    epsilon: 1E-6
+  }];
+
+
+  it('should normalize extents', function() {
+    projections.forEach(function(config) {
+      var proj = ol.proj.get(config.code);
+      var projExtent = proj.getExtent();
+      var left = projExtent[0];
+      var right = projExtent[2];
+      var width = right - left;
+      var center = left + width / 2;
+      var min = left;
+      var max = min + width;
+      var w4 = width / 4;
+
+      var tests = [{
+        expected: [left, right],
+        extent: [center, width],
+        example: '[-180, 180] <- [0, 360]'
+      }, {
+        expected: [left, center],
+        extent: [right, width],
+        example: '[-180, 0] <- [180, 360]'
+      }, {
+        expected: [center, right],
+        extent: [center, right],
+        example: '[0, 180] <- [0, 180]'
+      }, {
+        expected: [-w4, w4],
+        extent: [center + 3 * w4, center + 5 * w4],
+        example: '[-90, 90] <- [270, 540]'
+      }];
+
+      for (var i = -3; i < 4; i++) {
+        tests.forEach(function(test, testIndex) {
+          var e = expandExtent(test.extent);
+          e[0] += width * i;
+          e[2] += width * i;
+
+          var ex = expandExtent(test.expected);
+
+          var result = os.extent.normalize(e, min, max, proj);
+
+          for (var j = 0; j < 4; j++) {
+            expect(result[j]).toBeCloseTo(ex[j], config.precision);
+
+            // if (Math.abs(ex[j] - result[j]) > config.epsilon) {
+            //   console.log('test', testIndex, 'at world', i, 'differs at index', j);
+            //   console.log(e);
+            //   console.log(result);
+            //   console.log(ex);
+            //   console.log(test.example);
+            //   console.log();
+
+            //   debugger;
+            //   os.extent.normalize(e, min, max, proj);
+            //   break;
+            // }
+          }
+        });
+      }
+    });
+  });
+
+  it('should normalize extents with alternate min/max values', function() {
+    projections.forEach(function(config) {
+      var proj = ol.proj.get(config.code);
+      var projExtent = proj.getExtent();
+      var left = projExtent[0];
+      var right = projExtent[2];
+      var width = right - left;
+      var center = left + width / 2;
+      var min = center;
+      var max = min + width;
+      var w4 = width / 4;
+
+      var tests = [{
+        extent: [left, right],
+        expected: [center, width],
+        example: '[-180, 180] -> [0, 360]'
+      }, {
+        extent: [left, center],
+        expected: [right, width],
+        example: '[-180, 0] -> [180, 360]'
+      }, {
+        extent: [center, right],
+        expected: [center, right],
+        example: '[0, 180] -> [0, 180]'
+      }, {
+        extent: [center, width],
+        expected: [center, width],
+        example: '[0, 360] -> [0, 360]'
+      }, {
+        extent: [-w4, w4],
+        expected: [center + 3 * w4, center + 5 * w4],
+        example: '[-90, 90] -> [270, 540]'
+      }];
+
+      for (var i = -3; i < 4; i++) {
+        tests.forEach(function(test, testIndex) {
+          var e = expandExtent(test.extent);
+          e[0] += width * i;
+          e[2] += width * i;
+
+          var ex = expandExtent(test.expected);
+
+          var result = os.extent.normalize(e, min, max, proj);
+
+          for (var j = 0; j < 4; j++) {
+            expect(result[j]).toBeCloseTo(ex[j], config.precision);
+
+            // if (Math.abs(ex[j] - result[j]) > config.epsilon) {
+            //   console.log('test', testIndex, 'at world', i, 'differs at index', j);
+            //   console.log(e);
+            //   console.log(result);
+            //   console.log(ex);
+            //   console.log(test.example);
+            //   console.log();
+
+            //   debugger;
+            //   os.extent.normalize(e, min, max, proj);
+            //   break;
+            // }
+          }
+        });
+      }
+    });
+  });
+
+
+  it('should copy latitude to the result extent', function() {
+    var extent = [-180, -90, 180, 90];
+    var result = [];
+    os.extent.normalize(extent, undefined, undefined, ol.proj.get(os.proj.EPSG4326), result);
+    expect(result[1]).toBe(extent[1]);
+    expect(result[3]).toBe(extent[3]);
+  });
+
+
+  it('should determine whether or not extents cross the antimeridian', function() {
+    projections.forEach(function(config) {
+      var proj = ol.proj.get(config.code);
+      var projExtent = proj.getExtent();
+      var left = projExtent[0];
+      var right = projExtent[2];
+      var width = right - left;
+      var center = left + width / 2;
+      var smallChunk = width / 360;
+      var largeChunk = width / 36;
+
+      var tests = [{
+        extent: [left, right],
+        expected: false,
+        desc: 'full-world'
+      }, {
+        extent: [left, center],
+        expected: false,
+        desc: 'left half'
+      }, {
+        extent: [center, right],
+        expected: false,
+        desc: 'right half'
+      }, {
+        extent: [left + smallChunk, center],
+        expected: false,
+        desc: 'most of left half'
+      }, {
+        extent: [0, right - smallChunk],
+        expected: false,
+        desc: 'most of right half'
+      }, {
+        extent: [left + smallChunk, right - smallChunk],
+        expected: false,
+        desc: 'most of full-world'
+      }, {
+        extent: [left - largeChunk, left + largeChunk],
+        expected: true,
+        desc: 'crosses left'
+      }, {
+        extent: [right - largeChunk, right + largeChunk],
+        expected: true,
+        desc: 'crosses right'
+      }, {
+        extent: [right - largeChunk, left + largeChunk],
+        expected: false,
+        desc: 'inverted extents are considered empty'
+      }];
+
+      for (var i = -3; i < 4; i++) {
+        tests.forEach(function(test, testIndex) {
+          var e = expandExtent(test.extent);
+          e[0] += width * i;
+          e[2] += width * i;
+          0;
+          var normalized = os.extent.normalize(e, undefined, undefined, proj);
+          // var result = os.extent.crossesAntimeridian(normalized, proj);
+          // if (result !== test.expected) {
+          //   console.log('test', testIndex, 'at world', i, 'was', result, 'expected', test.expected);
+          //   console.log(e);
+          //   console.log(normalized);
+          //   console.log(test.desc);
+          //   console.log();
+
+          //   debugger;
+          //   os.extent.crossesAntimeridian(normalized, proj);
+          // }
+          expect(os.extent.crossesAntimeridian(normalized, proj)).toBe(test.expected);
+        });
+      }
+    });
+  });
+});

--- a/test/os/geo/geo2.test.js
+++ b/test/os/geo/geo2.test.js
@@ -1,0 +1,78 @@
+
+goog.require('ol.proj');
+goog.require('os.geo2');
+goog.require('os.proj');
+
+describe('os.geo2', function() {
+  var projections = [{
+    code: os.proj.EPSG4326,
+    precision: 12,
+    epsilon: 1E-12
+  }, {
+    code: os.proj.EPSG3857,
+    precision: 6,
+    epsilon: 1E-6
+  }];
+
+
+  it('should normalize longitudes properly', function() {
+    projections.forEach(function(config) {
+      var proj = ol.proj.get(config.code);
+      var projExtent = proj.getExtent();
+      var projWidth = projExtent[2] - projExtent[0];
+      var min = projExtent[0];
+      var max = projExtent[2];
+      var chunk = projWidth / 4;
+
+      for (var i = -3; i < 4; i++) { // worlds away
+        for (var j = 0; j < 4; j++) { // distance from world left
+          var lon = projExtent[0] + i * projWidth + j * chunk;
+          var expected = min + j * chunk;
+
+          var result = os.geo2.normalizeLongitude(lon, min, max, proj);
+
+          if (Math.abs(min - result) < config.epsilon) {
+            expected = min;
+          }
+
+          if (Math.abs(max - result) < config.epsilon) {
+            expected = max;
+          }
+
+          expect(result).toBeCloseTo(expected, config.precision);
+        }
+      }
+    });
+  });
+
+
+  it('should normalize longitudes to alternate min/max values', function() {
+    projections.forEach(function(config) {
+      var proj = ol.proj.get(config.code);
+      var projExtent = proj.getExtent();
+      var projWidth = projExtent[2] - projExtent[0];
+      var min = projExtent[0] + projWidth / 2;
+      var max = min + projWidth;
+      var chunk = projWidth / 4;
+
+      for (var i = -3; i < 4; i++) { // worlds away
+        for (var j = 0; j < 4; j++) { // distance from world left
+          var lon = projExtent[0] + i * projWidth + j * chunk;
+          var expected = min + ((j + 2) % 4) * chunk;
+
+          var result = os.geo2.normalizeLongitude(lon, min, max, proj);
+
+          if (Math.abs(min - result) < config.epsilon) {
+            expected = min;
+          }
+
+          if (Math.abs(max - result) < config.epsilon) {
+            expected = max;
+          }
+
+          expect(result).toBeCloseTo(expected, config.precision);
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
Add a second r-tree indexed with extents in the range [0, 360] and use that r-tree when the extent query crosses the antimeridian.

resolves #468