### PR TITLE
Fix antimeridian queries via multiple world queries

### DIFF
--- a/src/os/command/transformvectorscmd.js
+++ b/src/os/command/transformvectorscmd.js
@@ -2,6 +2,7 @@ goog.provide('os.command.TransformVectors');
 
 goog.require('os.command.ICommand');
 goog.require('os.command.State');
+goog.require('os.geo2');
 
 
 
@@ -172,9 +173,8 @@ os.command.TransformVectors.prototype.transform = function(sourceProjection, tar
  */
 os.command.TransformVectors.transform_ = function(sourceProjection, targetProjection, geom) {
   if (geom && geom instanceof ol.geom.Geometry) {
-    geom.transform(sourceProjection, os.proj.EPSG4326);
-    os.geo.normalizeGeometryCoordinates(geom);
-    geom.transform(os.proj.EPSG4326, targetProjection);
+    geom.transform(sourceProjection, targetProjection);
+    os.geo2.normalizeGeometryCoordinates(geom, undefined, targetProjection);
   }
 };
 

--- a/src/os/extent.js
+++ b/src/os/extent.js
@@ -21,7 +21,7 @@ os.extent.clamp = function(extent, clampTo, opt_extent) {
 
 /**
  * @param {ol.Extent} extent
- * @param {ol.proj.Projection=} opt_proj
+ * @param {ol.ProjectionLike=} opt_proj
  * @return {boolean} Whether or not the extent crosses the antimeridian
  */
 os.extent.crossesAntimeridian = function(extent, opt_proj) {
@@ -29,7 +29,7 @@ os.extent.crossesAntimeridian = function(extent, opt_proj) {
     return false;
   }
 
-  opt_proj = opt_proj || os.map.PROJECTION;
+  opt_proj = ol.proj.get(opt_proj || os.map.PROJECTION);
   if (opt_proj.canWrapX()) {
     var projExtent = opt_proj.getExtent();
     var xmin = extent[0];
@@ -58,12 +58,12 @@ os.extent.crossesAntimeridian = function(extent, opt_proj) {
  * Normalizes an extent for a projection where the right antimeridian becomes
  * the meridian.
  * @param {ol.Extent} extent
- * @param {ol.proj.Projection=} opt_proj
+ * @param {ol.ProjectionLike=} opt_proj
  * @param {ol.Extent=} opt_result
  * @return {ol.Extent}
  */
 os.extent.normalizeAntiRight = function(extent, opt_proj, opt_result) {
-  opt_proj = opt_proj || os.map.PROJECTION;
+  opt_proj = ol.proj.get(opt_proj || os.map.PROJECTION);
   var projExtent = opt_proj.getExtent();
   var left = projExtent[0];
   var right = projExtent[2];
@@ -78,12 +78,12 @@ os.extent.normalizeAntiRight = function(extent, opt_proj, opt_result) {
  * Normalizes an extent for a projection where the left antimeridian becomes
  * the meridian.
  * @param {ol.Extent} extent
- * @param {ol.proj.Projection=} opt_proj
+ * @param {ol.ProjectionLike=} opt_proj
  * @param {ol.Extent=} opt_result
  * @return {ol.Extent}
  */
 os.extent.normalizeAntiLeft = function(extent, opt_proj, opt_result) {
-  opt_proj = opt_proj || os.map.PROJECTION;
+  opt_proj = ol.proj.get(opt_proj || os.map.PROJECTION);
   var projExtent = opt_proj.getExtent();
   var left = projExtent[0];
   var right = projExtent[2];
@@ -96,9 +96,26 @@ os.extent.normalizeAntiLeft = function(extent, opt_proj, opt_result) {
 
 /**
  * @param {ol.Extent} extent
+ * @param {number} center
+ * @param {ol.ProjectionLike=} opt_proj
+ * @param {ol.Extent=} opt_result
+ * @return {ol.Extent}
+ */
+os.extent.normalizeToCenter = function(extent, center, opt_proj, opt_result) {
+  opt_proj = ol.proj.get(opt_proj || os.map.PROJECTION);
+
+  var projExtent = opt_proj.getExtent();
+  var halfWidth = (projExtent[2] - projExtent[0]) / 2;
+
+  return os.extent.normalize(extent, center - halfWidth, center + halfWidth, opt_proj, opt_result);
+};
+
+
+/**
+ * @param {ol.Extent} extent
  * @param {number=} opt_min
  * @param {number=} opt_max
- * @param {ol.proj.Projection=} opt_proj
+ * @param {ol.ProjectionLike=} opt_proj
  * @param {ol.Extent=} opt_result
  * @return {ol.Extent}
  */
@@ -109,7 +126,7 @@ os.extent.normalize = function(extent, opt_min, opt_max, opt_proj, opt_result) {
 
   var extentWidth = extent[2] - extent[0];
 
-  opt_proj = opt_proj || os.map.PROJECTION;
+  opt_proj = ol.proj.get(opt_proj || os.map.PROJECTION);
   var projExtent = opt_proj.getExtent();
   opt_min = opt_min != null ? opt_min : projExtent[0];
   opt_max = opt_max != null ? opt_max : projExtent[2];

--- a/src/os/extent.js
+++ b/src/os/extent.js
@@ -1,4 +1,5 @@
 goog.provide('os.extent');
+goog.require('os.geo2');
 
 
 /**
@@ -19,58 +20,153 @@ os.extent.clamp = function(extent, clampTo, opt_extent) {
 
 
 /**
+ * @param {ol.Extent} extent
+ * @param {ol.proj.Projection=} opt_proj
+ * @return {boolean} Whether or not the extent crosses the antimeridian
+ */
+os.extent.crossesAntimeridian = function(extent, opt_proj) {
+  if (!extent || ol.extent.isEmpty(extent)) {
+    return false;
+  }
+
+  opt_proj = opt_proj || os.map.PROJECTION;
+  if (opt_proj.canWrapX()) {
+    var projExtent = opt_proj.getExtent();
+    var xmin = extent[0];
+    var xmax = extent[2];
+    var epsilon = opt_proj.getUnits() === 'm' ? 1E-6 : 1E-12;
+
+    var projMin = projExtent[0];
+    var projMax = projExtent[2];
+    var width = projMax - projMin;
+
+    if (Math.abs(projMin - xmin) < epsilon || Math.abs(projMax - xmax) < epsilon) {
+      // touches, but does not cross
+      return false;
+    }
+
+    var worldsAwayMin = Math.ceil((projMin - xmin) / width);
+    var worldsAwayMax = Math.ceil((projMin - xmax) / width);
+    return worldsAwayMin !== worldsAwayMax;
+  }
+
+  return false;
+};
+
+
+/**
+ * Normalizes an extent for a projection where the right antimeridian becomes
+ * the meridian.
+ * @param {ol.Extent} extent
+ * @param {ol.proj.Projection=} opt_proj
+ * @param {ol.Extent=} opt_result
+ * @return {ol.Extent}
+ */
+os.extent.normalizeAntiRight = function(extent, opt_proj, opt_result) {
+  opt_proj = opt_proj || os.map.PROJECTION;
+  var projExtent = opt_proj.getExtent();
+  var left = projExtent[0];
+  var right = projExtent[2];
+  var width = right - left;
+  var min = left + width / 2;
+  var max = min + width;
+  return os.extent.normalize(extent, min, max, opt_proj, opt_result);
+};
+
+
+/**
+ * Normalizes an extent for a projection where the left antimeridian becomes
+ * the meridian.
+ * @param {ol.Extent} extent
+ * @param {ol.proj.Projection=} opt_proj
+ * @param {ol.Extent=} opt_result
+ * @return {ol.Extent}
+ */
+os.extent.normalizeAntiLeft = function(extent, opt_proj, opt_result) {
+  opt_proj = opt_proj || os.map.PROJECTION;
+  var projExtent = opt_proj.getExtent();
+  var left = projExtent[0];
+  var right = projExtent[2];
+  var width = right - left;
+  var min = left - width / 2;
+  var max = min + width;
+  return os.extent.normalize(extent, min, max, opt_proj, opt_result);
+};
+
+
+/**
+ * @param {ol.Extent} extent
+ * @param {number=} opt_min
+ * @param {number=} opt_max
+ * @param {ol.proj.Projection=} opt_proj
+ * @param {ol.Extent=} opt_result
+ * @return {ol.Extent}
+ */
+os.extent.normalize = function(extent, opt_min, opt_max, opt_proj, opt_result) {
+  opt_result = opt_result || extent.slice();
+  opt_result[1] = extent[1];
+  opt_result[3] = extent[3];
+
+  var extentWidth = extent[2] - extent[0];
+
+  opt_proj = opt_proj || os.map.PROJECTION;
+  var projExtent = opt_proj.getExtent();
+  opt_min = opt_min != null ? opt_min : projExtent[0];
+  opt_max = opt_max != null ? opt_max : projExtent[2];
+  var projWidth = opt_max - opt_min;
+  var epsilon = opt_proj.getUnits() === 'm' ? 1E-6 : 1E-12;
+
+  if (Math.abs(extentWidth - projWidth) < epsilon) {
+    // the width is full-world
+    opt_result[0] = opt_min;
+    opt_result[2] = opt_max;
+  } else {
+    var lon1 = os.geo2.normalizeLongitude(extent[0], opt_min, opt_max, opt_proj);
+    var lon2 = lon1 + extentWidth;
+
+    if (lon2 > opt_max - epsilon) {
+      lon1 -= projWidth;
+      lon2 -= projWidth;
+    }
+
+    if (lon1 < opt_min - epsilon) {
+      lon1 += projWidth;
+      lon2 += projWidth;
+    }
+
+    opt_result[0] = lon1;
+    opt_result[2] = lon2;
+  }
+
+  return opt_result;
+};
+
+
+/**
  * Gets the "functional" extent of the geometry. Geometries that cross the
  * antimeridian have points that give a default extent like [-179.999, 179.999].
  * This is unhelpful for zooming and other extent aggregations. This function
  * produces an extent from longitudes normalized to [0, 360] instead.
  *
  * @param {?ol.geom.Geometry} geom The geom
- * @param {boolean=} opt_allowLargeWidths Leave false (default) for zooming. Use true if the extent
- *   is to be used in an RBush.
  * @return {?ol.Extent} the extent
  */
-os.extent.getFunctionalExtent = function(geom, opt_allowLargeWidths) {
+os.extent.getFunctionalExtent = function(geom) {
   if (!geom) {
     return null;
   }
 
   var proj = os.map.PROJECTION;
-
-  if (proj.getCode() !== os.proj.EPSG4326) {
-    geom = geom.clone().toLonLat();
-  }
-
   var extent = geom.getExtent();
-  if (geom instanceof ol.geom.SimpleGeometry && os.geo.crossesDateLine(geom)) {
-    var min = 360;
-    var max = 0;
-    var coords = geom.getFlatCoordinates();
-    var stride = geom.getStride();
+  var result = extent;
 
-    for (var i = 0, n = coords.length; i < n; i += stride) {
-      var lon = os.geo.normalizeLongitude(coords[i], 0, 360);
-      min = Math.min(min, lon);
-      max = Math.max(max, lon);
-    }
+  if (proj.canWrapX()) {
+    var extentWidth = ol.extent.getWidth(extent);
+    var antiExtent = geom.getAntiExtent();
+    var antiExtentWidth = ol.extent.getWidth(antiExtent);
 
-    extent[0] = min;
-    extent[2] = max;
+    result = antiExtentWidth < extentWidth ? antiExtent : extent;
   }
 
-  // This case is for zooming to multi-items which occupy a small area around the antimeridian
-  // but don't cross it. Such as a MultiPoint of [[-179, 0], [179, 0]].
-  //
-  // However, this will BREAK the index case if you attempt to put these extents in an R-Tree.
-  if (!opt_allowLargeWidths && extent[2] - extent[0] > 180) {
-    // assume the inverse
-    var tmp = extent[0] + 360;
-    extent[0] = extent[2];
-    extent[2] = tmp;
-  }
-
-  if (proj.getCode() !== os.proj.EPSG4326) {
-    extent = ol.proj.transformExtent(extent, os.proj.EPSG4326, proj);
-  }
-
-  return extent;
+  return result;
 };

--- a/src/os/geo/geo.js
+++ b/src/os/geo/geo.js
@@ -1851,6 +1851,7 @@ os.geo.toDegreesDecimalMinutes = function(coordinate, opt_isLon, opt_symbols) {
  * Normalizes a latitude value to the given range
  * @param {number} lat
  * @return {number}
+ * @deprecated Please use os.geo2.normalizeLatitude instead as it does not require conversion to/from lonlat before/after
  */
 os.geo.normalizeLatitude = function(lat) {
   return lat > 90 ? 90 : lat < -90 ? -90 : lat;
@@ -1877,6 +1878,7 @@ os.geo.extentToCoordinates = function(extent) {
  * @param {number=} opt_min
  * @param {number=} opt_max
  * @return {number}
+ * @deprecated Please use os.geo2.normalizeLongitude instead as it does not require conversion to/from lonlat before/after
  */
 os.geo.normalizeLongitude = function(lon, opt_min, opt_max) {
   if (opt_min !== undefined && opt_max !== undefined) {
@@ -1904,6 +1906,7 @@ os.geo.normalizeLongitude = function(lon, opt_min, opt_max) {
  * anti-meridian. Array format [xmin, ymin, xmax, ymax]
  * @param {Array<number>|ol.geom.Geometry|ol.Feature} target
  * @return {boolean}
+ * @suppress {deprecated}
  */
 os.geo.crossesDateLine = function(target) {
   if (target) {
@@ -1967,6 +1970,8 @@ os.geo.crossesDateLine = function(target) {
  * Normalize a set of coordinates.
  * @param {?Array<Array<number>>} coordinates The coordinates to normalize.
  * @param {number=} opt_to The longitude to normalize to.
+ * @deprecated Please use os.geo2.noralizeCoordinates instead as it does not require conversion to/from lonlat before/after
+ * @suppress {deprecated}
  */
 os.geo.normalizeCoordinates = function(coordinates, opt_to) {
   if (coordinates && coordinates.length > 0) {
@@ -1985,6 +1990,7 @@ os.geo.normalizeCoordinates = function(coordinates, opt_to) {
  * Normalize polygon rings.
  * @param {?Array<?Array<Array<number>>>} rings The rings to normalize.
  * @param {number=} opt_to The longitude to normalize to.
+ * @deprecated Please use os.geo2.normalizeRings instead as it does not require conversion to/from lonlat before/after
  */
 os.geo.normalizeRings = function(rings, opt_to) {
   if (rings) {
@@ -1998,6 +2004,7 @@ os.geo.normalizeRings = function(rings, opt_to) {
 /**
  * @param {?Array<?Array<?Array<Array<number>>>>} polys The polygons to normalize.
  * @param {number=} opt_to The longitude to normalize to.
+ * @deprecated Please use os.geo2.normalizePolygons instead as it does not require conversion to/from lonlat before/after
  */
 os.geo.normalizePolygons = function(polys, opt_to) {
   if (polys) {
@@ -2013,6 +2020,8 @@ os.geo.normalizePolygons = function(polys, opt_to) {
  * @param {ol.geom.Geometry|undefined} geometry The geometry to normalize.
  * @param {number=} opt_to The longitude to normalize to.
  * @return {boolean} If the geometry was normalized.
+ * @deprecated Please use os.geo2.normalizeGeometryCoordinates instead as it does not require conversion to/from lonlat before/after
+ * @suppress {deprecated}
  */
 os.geo.normalizeGeometryCoordinates = function(geometry, opt_to) {
   if (geometry) {
@@ -2181,6 +2190,7 @@ os.geo.isCoordInArea = function(x, y, vertX, vertY, nVert) {
  * @return {Array<Array<number>>} A polygon that circumscribes the pole closest to the input coordinates.
  *
  * @todo currently this only works for polygons which have no holes.
+ * @suppress {deprecated}
  */
 os.geo.createPolarPolygon = function(coordinates) {
   var newCoords = [coordinates.length + 4];
@@ -2243,6 +2253,7 @@ os.geo.isPolarPolygon = function(coordinates) {
  * Does this extent have valid lat lon min/max values?
  * @param {ol.Extent} extent
  * @return {boolean}
+ * @suppress {deprecated}
  */
 os.geo.isValidExtent = function(extent) {
   var invalid = false;
@@ -2452,6 +2463,7 @@ os.geo.createLineFromSegments_ = function(segments, layout) {
  * @param {!ol.geom.LineString} geometry The line geometry.
  * @return {!Array<!Array<!ol.Coordinate>>} The split line coordinates.
  * @private
+ * @suppress {deprecated}
  */
 os.geo.splitLineOnDateLine_ = function(geometry) {
   // normalize longitude to +/- 180

--- a/src/os/geo/geo2.js
+++ b/src/os/geo/geo2.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview This is intended to eventually replace os.geo with equivalent functions
+ * which are entirely projection-agnostic rather than requiring conversion to lonlat and
+ * back when using them.
+ */
+goog.provide('os.geo2');
+goog.require('os.map');
+
+
+/**
+ * @param {number} lon
+ * @param {number=} opt_min
+ * @param {number=} opt_max
+ * @param {ol.proj.Projection=} opt_proj
+ * @return {number}
+ */
+os.geo2.normalizeLongitude = function(lon, opt_min, opt_max, opt_proj) {
+  opt_proj = opt_proj || os.map.PROJECTION;
+  var projExtent = opt_proj.getExtent();
+  opt_min = opt_min != null ? opt_min : projExtent[0];
+  opt_max = opt_max != null ? opt_max : projExtent[2];
+  var width = opt_max - opt_min;
+
+  // Note: OpenLayers uses this same method in ol/renderer/map.js
+  var worldsAway = Math.ceil((opt_min - lon) / width);
+  lon += width * worldsAway;
+
+  return lon;
+};

--- a/src/os/geo/geo2.js
+++ b/src/os/geo/geo2.js
@@ -11,11 +11,11 @@ goog.require('os.map');
  * @param {number} lon
  * @param {number=} opt_min
  * @param {number=} opt_max
- * @param {ol.proj.Projection=} opt_proj
+ * @param {ol.ProjectionLike=} opt_proj
  * @return {number}
  */
 os.geo2.normalizeLongitude = function(lon, opt_min, opt_max, opt_proj) {
-  opt_proj = opt_proj || os.map.PROJECTION;
+  opt_proj = ol.proj.get(opt_proj || os.map.PROJECTION);
   var projExtent = opt_proj.getExtent();
   opt_min = opt_min != null ? opt_min : projExtent[0];
   opt_max = opt_max != null ? opt_max : projExtent[2];
@@ -27,3 +27,149 @@ os.geo2.normalizeLongitude = function(lon, opt_min, opt_max, opt_proj) {
 
   return lon;
 };
+
+
+/**
+ * Clamps latitude to the projection bounds
+ * @param {number} lat
+ * @param {number=} opt_min
+ * @param {number=} opt_max
+ * @param {ol.ProjectionLike=} opt_proj
+ * @return {number}
+ */
+os.geo2.normalizeLatitude = function(lat, opt_min, opt_max, opt_proj) {
+  opt_proj = ol.proj.get(opt_proj || os.map.PROJECTION);
+  var projExtent = opt_proj.getExtent();
+  opt_min = opt_min != null ? opt_min : projExtent[1];
+  opt_max = opt_max != null ? opt_max : projExtent[3];
+  return Math.min(Math.max(lat, opt_min), opt_max);
+};
+
+
+/**
+ * @param {?Array<number>} coordinate
+ * @param {number=} opt_to
+ * @param {ol.ProjectionLike=} opt_proj
+ */
+os.geo2.normalizeCoordinate = function(coordinate, opt_to, opt_proj) {
+  opt_proj = ol.proj.get(opt_proj || os.map.PROJECTION);
+
+  var projExtent = opt_proj.getExtent();
+  var halfWidth = (projExtent[2] - projExtent[0]) / 2;
+  opt_to = opt_to != null ? opt_to : projExtent[0] + halfWidth;
+  coordinate[0] = os.geo2.normalizeLongitude(coordinate[0], opt_to - halfWidth, opt_to + halfWidth, opt_proj);
+  coordinate[1] = os.geo2.normalizeLatitude(coordinate[1], undefined, undefined, opt_proj);
+};
+
+
+/**
+ * Normalize a set of coordinates
+ * @param {?Array<Array<number>>} coordinates The coordinates to normalize
+ * @param {number=} opt_to The longitude to normalize to
+ * @param {ol.ProjectionLike=} opt_proj
+ */
+os.geo2.normalizeCoordinates = function(coordinates, opt_to, opt_proj) {
+  if (coordinates && coordinates.length > 0) {
+    opt_proj = ol.proj.get(opt_proj || os.map.PROJECTION);
+
+    for (var i = 0, n = coordinates.length; i < n; i++) {
+      os.geo2.normalizeCoordinate(coordinates[i], opt_to, opt_proj);
+      opt_to = opt_to != null ? opt_to : coordinates[0][0];
+    }
+  }
+};
+
+
+/**
+ * @param {?Array<?Array<Array<number>>>} rings The rings to normalize
+ * @param {number=} opt_to The longitude to normalize to
+ * @param {ol.ProjectionLike=} opt_proj
+ */
+os.geo2.normalizeRings = function(rings, opt_to, opt_proj) {
+  if (rings) {
+    opt_proj = ol.proj.get(opt_proj || os.map.PROJECTION);
+
+    for (var i = 0, n = rings.length; i < n; i++) {
+      os.geo2.normalizeCoordinates(rings[i], opt_to, opt_proj);
+      opt_to = opt_to != null ? opt_to : rings[0][0][0];
+    }
+  }
+};
+
+
+/**
+ * @param {?Array<?Array<?Array<Array<number>>>>} polys The polygons to normalize.
+ * @param {number=} opt_to The longitude to normalize to.
+ * @param {ol.ProjectionLike=} opt_proj
+ */
+os.geo2.normalizePolygons = function(polys, opt_to, opt_proj) {
+  if (polys) {
+    opt_proj = ol.proj.get(opt_proj || os.map.PROJECTION);
+
+    for (var i = 0, n = polys.length; i < n; i++) {
+      os.geo2.normalizeRings(polys[i], opt_to, opt_proj);
+      opt_to = opt_to != null ? opt_to : polys[0][0][0][0];
+    }
+  }
+};
+
+
+/**
+ * Returns true if geometry coordinates are normlized.
+ * @param {ol.geom.Geometry|undefined} geometry The geometry to normalize.
+ * @param {number=} opt_to The longitude to normalize to.
+ * @param {ol.ProjectionLike=} opt_proj
+ * @return {boolean} If the geometry was normalized.
+ */
+os.geo2.normalizeGeometryCoordinates = function(geometry, opt_to, opt_proj) {
+  if (geometry) {
+    if (geometry.get(os.geom.GeometryField.NORMALIZED) || os.query.utils.isWorldQuery(geometry)) {
+      return false;
+    }
+
+    opt_proj = ol.proj.get(opt_proj || os.map.PROJECTION);
+
+    switch (geometry.getType()) {
+      case ol.geom.GeometryType.POINT:
+        var point = /** @type {ol.geom.Point} */ (geometry);
+        var coord = /** @type {Array<number>} */ (point.getCoordinates());
+        os.geo2.normalizeCoordinate(coord, opt_to, opt_proj);
+        point.setCoordinates(coord);
+        return true;
+      case ol.geom.GeometryType.LINE_STRING:
+      case ol.geom.GeometryType.MULTI_POINT:
+        var lineString = /** @type {ol.geom.LineString|ol.geom.MultiPoint} */ (geometry);
+        var coordinates = lineString.getCoordinates();
+        os.geo2.normalizeCoordinates(coordinates, opt_to, opt_proj);
+        lineString.setCoordinates(coordinates);
+        return true;
+      case ol.geom.GeometryType.POLYGON:
+      case ol.geom.GeometryType.MULTI_LINE_STRING:
+        var polygon = /** @type {ol.geom.Polygon|ol.geom.MultiLineString} */ (geometry);
+        var /** @type {?Array<?Array<Array<number>>>} */ rings = polygon.getCoordinates();
+        os.geo2.normalizeRings(rings, opt_to, opt_proj);
+        polygon.setCoordinates(rings);
+        return true;
+      case ol.geom.GeometryType.MULTI_POLYGON:
+        var multiPolygon = /** @type {ol.geom.MultiPolygon } */ (geometry);
+        var polygons = /** @type {?Array<?Array<?Array<Array<number>>>>} */ (
+            multiPolygon.getCoordinates());
+        os.geo2.normalizePolygons(polygons, opt_to, opt_proj);
+        multiPolygon.setCoordinates(polygons);
+        return true;
+      case ol.geom.GeometryType.GEOMETRY_COLLECTION:
+        var geometryCollection = /** @type {ol.geom.GeometryCollection} */ (geometry);
+        var /** @type {Array<ol.geom.Geometry>} */ geometries = geometryCollection.getGeometriesArray();
+        for (var i = 0, n = geometries.length; i < n; i++) {
+          os.geo2.normalizeGeometryCoordinates(geometries[i], opt_to);
+        }
+        return true;
+      case 'Circle':
+      default:
+        break;
+    }
+  }
+
+  return false;
+};
+

--- a/src/os/geo/jsts.js
+++ b/src/os/geo/jsts.js
@@ -211,7 +211,10 @@ os.geo.jsts.OLParser.prototype.convertFromLineString = function(lineString) {
  * @return {jsts.geom.LinearRing}
  */
 os.geo.jsts.OLParser.prototype.convertFromLinearRing = function(linearRing) {
-  return this.geometryFactory.createLinearRing(linearRing.getCoordinates().map(os.geo.jsts.convertFromCoordinate));
+  // ensure closed
+  var coords = linearRing.getCoordinates();
+  coords[coords.length - 1] = coords[0];
+  return this.geometryFactory.createLinearRing(coords.map(os.geo.jsts.convertFromCoordinate));
 };
 
 

--- a/src/os/geo/jsts.js
+++ b/src/os/geo/jsts.js
@@ -23,6 +23,7 @@ goog.require('ol.geom.Polygon');
 goog.require('ol.proj.Projection');
 goog.require('os.fn');
 goog.require('os.geo');
+goog.require('os.geo2');
 goog.require('os.geom.GeometryField');
 goog.require('os.map');
 goog.require('os.mixin.jsts');
@@ -723,7 +724,7 @@ os.geo.jsts.flattenPolygons = function(polygons) {
       var normalizeTo = (normalizeExtent[0] + normalizeExtent[2]) / 2;
       for (var i = 0; i < polygons.length; i++) {
         polygons[i].unset(os.geom.GeometryField.NORMALIZED, true);
-        os.geo.normalizeGeometryCoordinates(polygons[i], normalizeTo);
+        os.geo2.normalizeGeometryCoordinates(polygons[i], normalizeTo, os.proj.EPSG4326);
       }
 
       var merged = os.geo.jsts.merge(polygons);
@@ -773,7 +774,7 @@ os.geo.jsts.buffer = function(geometry, distance, opt_skipTransform) {
       break;
     case ol.geom.GeometryType.LINE_STRING:
     case ol.geom.GeometryType.MULTI_LINE_STRING:
-      os.geo.normalizeGeometryCoordinates(clone);
+      os.geo2.normalizeGeometryCoordinates(clone, undefined, os.proj.EPSG4326);
       buffer = os.geo.jsts.splitAndBuffer_(clone, Math.abs(distance));
       break;
     case ol.geom.GeometryType.POLYGON:
@@ -1107,7 +1108,7 @@ os.geo.jsts.createTMercProjection_ = function(geometry) {
 os.geo.jsts.fromBufferProjection_ = function(geometry, projection, opt_normalizeLon) {
   if (geometry) {
     geometry.transform(projection, os.proj.EPSG4326);
-    os.geo.normalizeGeometryCoordinates(geometry, opt_normalizeLon);
+    os.geo2.normalizeGeometryCoordinates(geometry, opt_normalizeLon, os.proj.EPSG4326);
   }
 };
 

--- a/src/os/interaction/contextmenuinteraction.js
+++ b/src/os/interaction/contextmenuinteraction.js
@@ -1,6 +1,7 @@
 goog.provide('os.interaction.ContextMenu');
 
 goog.require('os.I3DSupport');
+goog.require('os.geo');
 goog.require('os.implements');
 goog.require('os.ui.ol.interaction.ContextMenu');
 
@@ -55,9 +56,7 @@ os.interaction.ContextMenu.prototype.handleEventInternal = function(event) {
       var coord = event.map.getCoordinateFromPixel(pixel);
 
       if (coord) {
-        coord = ol.proj.toLonLat(coord, os.map.PROJECTION);
-        coord[0] = os.geo.normalizeLongitude(coord[0]);
-        coord = ol.proj.fromLonLat(coord, os.map.PROJECTION);
+        coord[0] = os.geo2.normalizeLongitude(coord[0]);
       }
 
       this.openMapContextMenu(coord, pixel);

--- a/src/os/interaction/drawlineinteraction.js
+++ b/src/os/interaction/drawlineinteraction.js
@@ -4,7 +4,7 @@ goog.require('ol');
 goog.require('ol.MapBrowserEventType');
 goog.require('ol.coordinate');
 goog.require('ol.geom.LineString');
-goog.require('os.geo');
+goog.require('os.geo2');
 goog.require('os.interaction.DrawPolygon');
 
 
@@ -78,10 +78,7 @@ os.interaction.DrawLine.prototype.getGeometry = function() {
 
   if (this.coords.length > 1) {
     geom = new ol.geom.LineString(this.coords);
-
-    geom.toLonLat();
-    os.geo.normalizeGeometryCoordinates(geom);
-    geom.osTransform();
+    os.geo2.normalizeGeometryCoordinates(geom);
   }
 
   return geom;

--- a/src/os/interaction/measureinteraction.js
+++ b/src/os/interaction/measureinteraction.js
@@ -15,7 +15,7 @@ goog.require('ol.style.Text');
 goog.require('os.bearing');
 goog.require('os.config.Settings');
 goog.require('os.feature.measure');
-goog.require('os.geo');
+goog.require('os.geo2');
 goog.require('os.interaction.DrawPolygon');
 goog.require('os.math');
 
@@ -106,11 +106,7 @@ os.interaction.Measure.prototype.disposeInternal = function() {
 os.interaction.Measure.prototype.getGeometry = function() {
   this.coords.length = this.coords.length - 1;
   var geom = new ol.geom.LineString(this.coords);
-
-  geom.toLonLat();
-  os.geo.normalizeGeometryCoordinates(geom);
-  geom.osTransform();
-
+  os.geo2.normalizeGeometryCoordinates(geom);
   return geom;
 };
 

--- a/src/os/interpolate.js
+++ b/src/os/interpolate.js
@@ -439,7 +439,7 @@ os.interpolate.interpolateLine = function(line) {
       var offset = 1;
       for (var j = 2, m = flatCoords.length - 2; j < m; j += 2) {
         var coord = [flatCoords[j], flatCoords[j + 1]];
-        coord[0] = os.geo.normalizeLongitude(coord[0], minLon, maxLon);
+        coord[0] = os.geo2.normalizeLongitude(coord[0], minLon, maxLon, os.proj.EPSG4326);
         coord = transforms.lonLatToCoord(coord);
 
         // use linear interpolation for other values in the coordinates
@@ -455,7 +455,7 @@ os.interpolate.interpolateLine = function(line) {
 
       osasm._free(ptr);
 
-      lonlat2[0] = os.geo.normalizeLongitude(lonlat2[0], minLon, maxLon);
+      lonlat2[0] = os.geo2.normalizeLongitude(lonlat2[0], minLon, maxLon, os.proj.EPSG4326);
       coord = transforms.lonLatToCoord(lonlat2, undefined, lonlat2.length);
 
       if (otherDiffs) {

--- a/src/os/map.js
+++ b/src/os/map.js
@@ -5,6 +5,7 @@ goog.require('goog.userAgent');
 goog.require('ol.Feature');
 goog.require('ol.Map');
 goog.require('os.map');
+goog.require('os.mixin.canvasreplaygroup');
 
 
 

--- a/src/os/mixin/canvasreplaygroupmixin.js
+++ b/src/os/mixin/canvasreplaygroupmixin.js
@@ -1,0 +1,51 @@
+goog.provide('os.mixin.canvasreplaygroup');
+
+goog.require('ol.extent');
+goog.require('ol.render.canvas.ReplayGroup');
+
+(function() {
+  var oldForEachFeatureAtCoordinate = ol.render.canvas.ReplayGroup.prototype.forEachFeatureAtCoordinate;
+
+  /**
+   * @param {ol.Coordinate} coordinate Coordinate.
+   * @param {number} resolution Resolution.
+   * @param {number} rotation Rotation.
+   * @param {number} hitTolerance Hit tolerance in pixels.
+   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features
+   *     to skip.
+   * @param {function((ol.Feature|ol.render.Feature)): T} callback Feature
+   *     callback.
+   * @param {Object.<string, ol.DeclutterGroup>} declutterReplays Declutter
+   *     replays.
+   * @return {T|undefined} Callback result.
+   * @template T
+   */
+  ol.render.canvas.ReplayGroup.prototype.forEachFeatureAtCoordinate = function(coordinate, resolution, rotation,
+      hitTolerance, skippedFeaturesHash, callback, declutterReplays) {
+    var val = oldForEachFeatureAtCoordinate.call(this, coordinate, resolution, rotation, hitTolerance,
+        skippedFeaturesHash, callback, declutterReplays);
+
+    var proj = os.map.PROJECTION;
+    if (!val && proj.canWrapX()) {
+      var width = ol.extent.getWidth(proj.getExtent());
+
+      // check one world left
+      coordinate[0] -= width;
+      val = oldForEachFeatureAtCoordinate.call(this, coordinate, resolution, rotation, hitTolerance,
+          skippedFeaturesHash, callback, declutterReplays);
+      // Put. Ze candle. BACK!
+      coordinate[0] += width;
+
+      if (!val) {
+        // check one world right
+        coordinate[0] += width;
+        val = oldForEachFeatureAtCoordinate.call(this, coordinate, resolution, rotation, hitTolerance,
+            skippedFeaturesHash, callback, declutterReplays);
+        // Put. Ze candle. BACK!
+        coordinate[0] -= width;
+      }
+    }
+
+    return val;
+  };
+})();

--- a/src/os/mixin/geometrymixin.js
+++ b/src/os/mixin/geometrymixin.js
@@ -2,6 +2,7 @@ goog.provide('os.mixin.geometry');
 
 goog.require('goog.log');
 goog.require('goog.log.Logger');
+goog.require('ol.extent');
 goog.require('ol.geom.Circle');
 goog.require('ol.geom.Geometry');
 goog.require('ol.geom.GeometryCollection');
@@ -67,17 +68,13 @@ ol.geom.Geometry.prototype.antiExtentRevision_ = NaN;
  * @inheritDoc
  */
 ol.geom.SimpleGeometry.prototype.computeAntiExtent = function(extent) {
+  ol.extent.createOrUpdateEmpty(extent);
   var coords = this.getFlatCoordinates();
   var stride = this.getStride();
   var proj = os.map.PROJECTION;
   var projExtent = proj.getExtent();
   var projWidth = ol.extent.getWidth(projExtent);
   var projCenter = projExtent[0] + projWidth / 2;
-
-  extent[0] = Infinity;
-  extent[1] = Infinity;
-  extent[2] = -Infinity;
-  extent[3] = -Infinity;
 
   for (var i = 0, n = coords.length; i < n; i += stride) {
     var x = coords[i];
@@ -88,6 +85,21 @@ ol.geom.SimpleGeometry.prototype.computeAntiExtent = function(extent) {
     extent[1] = Math.min(extent[1], y);
     extent[2] = Math.max(extent[2], x);
     extent[3] = Math.max(extent[3], y);
+  }
+
+  return extent;
+};
+
+
+/**
+ * @inheritDoc
+ * @suppress {accessControls}
+ */
+ol.geom.GeometryCollection.prototype.computeAntiExtent = function(extent) {
+  ol.extent.createOrUpdateEmpty(extent);
+  var geometries = this.geometries_;
+  for (var i = 0, n = geometries.length; i < n; i++) {
+    ol.extent.extend(extent, geometries[i].getAntiExtent());
   }
 
   return extent;

--- a/src/os/mixin/rbushmixin.js
+++ b/src/os/mixin/rbushmixin.js
@@ -41,14 +41,10 @@ goog.require('os.extent');
     }
 
     // query for features
+    var setsContainingFeatures = 0;
     featureSets.length = 0;
     for (var i = 0, n = extents.length; i < n; i++) {
       featureSets[i] = oldGetInExtent.call(this, extents[i]);
-    }
-
-    // see how many sets (extents) returned results
-    var setsContainingFeatures = 0;
-    for (i = 0, n = featureSets.length; i < n; i++) {
       if (featureSets[i].length) {
         setsContainingFeatures++;
       }

--- a/src/os/mixin/rbushmixin.js
+++ b/src/os/mixin/rbushmixin.js
@@ -1,0 +1,78 @@
+goog.provide('os.mixin.rbush');
+
+goog.require('ol.structs.RBush');
+goog.require('os.extent');
+
+(function() {
+  var oldGetInExtent = ol.structs.RBush.prototype.getInExtent;
+
+  var left = [];
+  var right = [];
+  var center = [];
+  var extents = [left, center, right];
+  var featureSets = [];
+
+  /**
+   * @param {Array} a
+   * @param {Array} b
+   * @return {number}
+   */
+  var sortLength = function(a, b) {
+    return b.length - a.length;
+  };
+
+  /**
+   * @param {ol.Extent} extent
+   * @return {Array<T>} All the items in the extent
+   */
+  ol.structs.RBush.prototype.getInExtent = function(extent) {
+    extents[0] = os.extent.normalizeAntiLeft(extent, undefined, left);
+    extents[1] = ol.extent.returnOrUpdate(extent, center);
+    extents[2] = os.extent.normalizeAntiRight(extent, undefined, right);
+
+    // merge any extents which intersect
+    for (var i = extents.length - 1; i > 0; i--) {
+      var prev = extents[i - 1];
+      var curr = extents[i];
+      if (ol.extent.intersects(prev, curr)) {
+        ol.extent.extend(prev, curr);
+        extents.splice(i, 1);
+      }
+    }
+
+    // query for features
+    featureSets.length = 0;
+    for (var i = 0, n = extents.length; i < n; i++) {
+      featureSets[i] = oldGetInExtent.call(this, extents[i]);
+    }
+
+    // see how many sets (extents) returned results
+    var setsContainingFeatures = 0;
+    for (i = 0, n = featureSets.length; i < n; i++) {
+      if (featureSets[i].length) {
+        setsContainingFeatures++;
+      }
+    }
+
+    featureSets.sort(sortLength);
+
+    // if more than one returned results, dedupe them
+    if (setsContainingFeatures > 1) {
+      var seen = {};
+      for (i = 0, n = featureSets.length; i < n; i++) {
+        for (var j = 0, m = featureSets[i].length; j < m; j++) {
+          var feature = featureSets[i][j];
+          var id = ol.getUid(feature);
+
+          if (i !== 0 && !seen[id]) {
+            featureSets[0].push(feature);
+          }
+
+          seen[id] = true;
+        }
+      }
+    }
+
+    return featureSets[0];
+  };
+})();

--- a/src/os/mixin/rbushmixin.js
+++ b/src/os/mixin/rbushmixin.js
@@ -55,18 +55,26 @@ goog.require('os.extent');
     // if more than one returned results, dedupe them
     if (setsContainingFeatures > 1) {
       var seen = {};
+      var currLength = featureSets[0].length;
+
       for (i = 0, n = featureSets.length; i < n; i++) {
+        if (i > 0) {
+          featureSets[0].length += featureSets[i].length;
+        }
+
         for (var j = 0, m = featureSets[i].length; j < m; j++) {
           var feature = featureSets[i][j];
           var id = ol.getUid(feature);
 
-          if (i !== 0 && !seen[id]) {
-            featureSets[0].push(feature);
+          if (i > 0 && !seen[id]) {
+            featureSets[0][currLength++] = feature;
           }
 
           seen[id] = true;
         }
       }
+
+      featureSets[0].length = currLength;
     }
 
     return featureSets[0];

--- a/src/os/mixin/rbushmixin.js
+++ b/src/os/mixin/rbushmixin.js
@@ -1,6 +1,7 @@
 goog.provide('os.mixin.rbush');
 
 goog.require('ol.structs.RBush');
+goog.require('os.array');
 goog.require('os.extent');
 
 (function() {
@@ -54,27 +55,9 @@ goog.require('os.extent');
 
     // if more than one returned results, dedupe them
     if (setsContainingFeatures > 1) {
-      var seen = {};
-      var currLength = featureSets[0].length;
-
-      for (i = 0, n = featureSets.length; i < n; i++) {
-        if (i > 0) {
-          featureSets[0].length += featureSets[i].length;
-        }
-
-        for (var j = 0, m = featureSets[i].length; j < m; j++) {
-          var feature = featureSets[i][j];
-          var id = ol.getUid(feature);
-
-          if (i > 0 && !seen[id]) {
-            featureSets[0][currLength++] = feature;
-          }
-
-          seen[id] = true;
-        }
-      }
-
-      featureSets[0].length = currLength;
+      var merged = Array.prototype.concat.apply([], featureSets);
+      os.array.removeDuplicates(merged, undefined, /** @type {function(?):string|undefined} */ (ol.getUid));
+      return merged;
     }
 
     return featureSets[0];

--- a/src/os/ol/control/mousepositioncontrol.js
+++ b/src/os/ol/control/mousepositioncontrol.js
@@ -77,7 +77,8 @@ os.ol.control.MousePosition.LON_LAT_FORMAT = function(coordinate) {
   }
 
   // fix the number of decimal places
-  var lon = os.geo.padCoordinate(os.geo.normalizeLongitude(coordinate[0]), true, 5);
+  var lon = os.geo.padCoordinate(os.geo2.normalizeLongitude(
+      coordinate[0], undefined, undefined, os.proj.EPSG4326), true, 5);
   var lat = os.geo.padCoordinate(coordinate[1], false, 5);
 
   if (lon.length < 10) {
@@ -109,7 +110,9 @@ os.ol.control.MousePosition.MGRS_FORMAT = function(coordinate) {
  */
 os.ol.control.MousePosition.SEXAGESIMAL_FORMAT = function(coordinate) {
   return (os.geo.toSexagesimal(coordinate[1], false, false) + ' ' +
-      os.geo.toSexagesimal(os.geo.normalizeLongitude(coordinate[0]), true, false) + ' (DMS)').replace(/°/g, '&deg;');
+    os.geo.toSexagesimal(
+        os.geo2.normalizeLongitude(coordinate[0], undefined, undefined, os.proj.EPSG4326),
+        true, false) + ' (DMS)').replace(/°/g, '&deg;');
 };
 
 
@@ -120,7 +123,9 @@ os.ol.control.MousePosition.SEXAGESIMAL_FORMAT = function(coordinate) {
  */
 os.ol.control.MousePosition.DDM = function(coordinate) {
   return (os.geo.toDegreesDecimalMinutes(coordinate[1], false, false) + ' ' +
-      os.geo.toDegreesDecimalMinutes(os.geo.normalizeLongitude(coordinate[0]), true, false) + ' (DDM)')
+    os.geo.toDegreesDecimalMinutes(
+        os.geo2.normalizeLongitude(coordinate[0], undefined, undefined, os.proj.EPSG4326),
+        true, false) + ' (DDM)')
       .replace(/°/g, '&deg;');
 };
 

--- a/src/os/query/areamanager.js
+++ b/src/os/query/areamanager.js
@@ -13,6 +13,8 @@ goog.require('os.command.TransformAreas');
 goog.require('os.config.Settings');
 goog.require('os.data.CollectionManager');
 goog.require('os.events.PropertyChangeEvent');
+goog.require('os.geo');
+goog.require('os.geo2');
 goog.require('os.map');
 goog.require('os.mixin.object');
 goog.require('os.query');
@@ -364,9 +366,7 @@ os.query.AreaManager.prototype.normalizeGeometry = function(feature) {
   var geom = feature.getGeometry();
 
   if (!geom.get(os.geom.GeometryField.NORMALIZED)) {
-    geom.toLonLat();
-    os.geo.normalizeGeometryCoordinates(geom);
-    geom.osTransform();
+    os.geo2.normalizeGeometryCoordinates(geom);
     feature.setGeometry(geom);
   }
 };

--- a/src/os/query/baseareamanager.js
+++ b/src/os/query/baseareamanager.js
@@ -14,6 +14,7 @@ goog.require('os.data.CollectionManager');
 goog.require('os.data.RecordField');
 goog.require('os.events.PropertyChangeEvent');
 goog.require('os.geo.jsts');
+goog.require('os.geo2');
 goog.require('os.map');
 goog.require('os.map.IMapContainer');
 goog.require('os.mixin.geometry');
@@ -285,7 +286,7 @@ os.query.BaseAreaManager.prototype.isValidFeature = function(feature) {
  * @protected
  */
 os.query.BaseAreaManager.prototype.normalizeGeometry = function(feature) {
-  os.geo.normalizeGeometryCoordinates(feature.getGeometry());
+  os.geo2.normalizeGeometryCoordinates(feature.getGeometry());
 };
 
 

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -2907,6 +2907,7 @@ os.source.Vector.prototype.isGeometryInArea_ = function(area, geometry, opt_rect
     case ol.geom.GeometryType.CIRCLE:
     case ol.geom.GeometryType.MULTI_LINE_STRING:
       geometry = geometry.clone();
+      geometry.set(os.geom.GeometryField.NORMALIZED, false);
       os.geo2.normalizeGeometryCoordinates(geometry, area.getCoordinates()[0].x);
       var jstsGeometry = os.geo.jsts.OLParser.getInstance().read(geometry);
       match = jstsGeometry != null &&

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -1941,12 +1941,7 @@ os.source.Vector.prototype.processImmediate = function(feature) {
       feature.setGeometry(geom);
     } else if (!geom.get(os.geom.GeometryField.NORMALIZED)) {
       // normalize non-point geometries unless they were normalized elsewhere
-      // convert to EPSG:4326 for calls to geo
-      geom.toLonLat();
-      // normalize
-      os.geo.normalizeGeometryCoordinates(geom);
-      // convert back
-      geom.osTransform();
+      os.geo2.normalizeGeometryCoordinates(geom);
     }
   }
 

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -36,6 +36,7 @@ goog.require('os.implements');
 goog.require('os.interpolate');
 goog.require('os.layer.AnimationOverlay');
 goog.require('os.load.LoadingManager');
+goog.require('os.mixin.rbush');
 goog.require('os.ogc');
 goog.require('os.registerClass');
 goog.require('os.source');
@@ -1041,7 +1042,7 @@ os.source.Vector.prototype.updateIndex = function(feature) {
       var geomFunc = styles[s].getGeometryFunction();
       var g = geomFunc(feature);
       if (g) {
-        var e = os.extent.getFunctionalExtent(g, true);
+        var e = os.extent.getFunctionalExtent(g);
         if (e) {
           ol.extent.extend(extent, e);
         }

--- a/src/os/ui/ol/interaction/dragboxinteraction.js
+++ b/src/os/ui/ol/interaction/dragboxinteraction.js
@@ -1,6 +1,6 @@
 goog.provide('os.ui.ol.interaction.DragBox');
 goog.require('ol.MapBrowserEvent');
-goog.require('os.geo');
+goog.require('os.geo2');
 goog.require('os.olm.render.Box');
 goog.require('os.ui.ol.interaction.AbstractDrag');
 
@@ -54,9 +54,7 @@ os.ui.ol.interaction.DragBox.prototype.getGeometry = function() {
   var geom = this.box2D.getOriginalGeometry();
 
   if (geom) {
-    geom.toLonLat();
-    os.geo.normalizeGeometryCoordinates(geom);
-    geom.osTransform();
+    os.geo2.normalizeGeometryCoordinates(geom);
   }
 
   return geom;
@@ -93,14 +91,13 @@ os.ui.ol.interaction.DragBox.prototype.update = function(mapBrowserEvent) {
       this.extent = [];
     }
 
-    var start = ol.proj.toLonLat(this.startCoord, this.getMap().getView().getProjection());
-    var end = ol.proj.toLonLat(this.endCoord, this.getMap().getView().getProjection());
+    if (this.startCoord && this.endCoord) {
+      this.extent[0] = Math.min(this.startCoord[0], this.endCoord[0]);
+      this.extent[1] = Math.min(this.startCoord[1], this.endCoord[1]);
+      this.extent[2] = Math.max(this.startCoord[0], this.endCoord[0]);
+      this.extent[3] = Math.max(this.startCoord[1], this.endCoord[1]);
 
-    if (start && end) {
-      this.extent[0] = os.geo.normalizeLongitude(Math.min(start[0], end[0]), start[0] - 180, start[0] + 180);
-      this.extent[1] = Math.min(start[1], end[1]);
-      this.extent[2] = os.geo.normalizeLongitude(Math.max(start[0], end[0]), start[0] - 180, start[0] + 180);
-      this.extent[3] = Math.max(start[1], end[1]);
+      this.extent = os.extent.normalize(this.extent, undefined, undefined, undefined, this.extent);
 
       this.update2D(this.startCoord, this.endCoord);
     }

--- a/src/os/ui/ol/interaction/dragboxinteraction.js
+++ b/src/os/ui/ol/interaction/dragboxinteraction.js
@@ -2,6 +2,7 @@ goog.provide('os.ui.ol.interaction.DragBox');
 goog.require('ol.MapBrowserEvent');
 goog.require('os.geo2');
 goog.require('os.olm.render.Box');
+goog.require('os.proj');
 goog.require('os.ui.ol.interaction.AbstractDrag');
 
 
@@ -92,10 +93,16 @@ os.ui.ol.interaction.DragBox.prototype.update = function(mapBrowserEvent) {
     }
 
     if (this.startCoord && this.endCoord) {
-      this.extent[0] = Math.min(this.startCoord[0], this.endCoord[0]);
-      this.extent[1] = Math.min(this.startCoord[1], this.endCoord[1]);
-      this.extent[2] = Math.max(this.startCoord[0], this.endCoord[0]);
-      this.extent[3] = Math.max(this.startCoord[1], this.endCoord[1]);
+      var proj = this.getMap().getView().getProjection();
+      var start = ol.proj.toLonLat(this.startCoord, proj);
+      var end = ol.proj.toLonLat(this.endCoord, proj);
+
+      this.extent[0] = os.geo2.normalizeLongitude(Math.min(start[0], end[0]),
+          start[0] - 180, start[0] + 180, os.proj.EPSG4326);
+      this.extent[1] = Math.min(start[1], end[1]);
+      this.extent[2] = os.geo2.normalizeLongitude(Math.max(start[0], end[0]),
+          start[0] - 180, start[0] + 180, os.proj.EPSG4326);
+      this.extent[3] = Math.max(start[1], end[1]);
 
       this.extent = os.extent.normalize(this.extent, undefined, undefined, undefined, this.extent);
 

--- a/src/os/ui/ol/interaction/dragcircleinteraction.js
+++ b/src/os/ui/ol/interaction/dragcircleinteraction.js
@@ -2,7 +2,7 @@ goog.provide('os.ui.ol.interaction.DragCircle');
 
 goog.require('goog.string');
 goog.require('ol');
-goog.require('os.geo');
+goog.require('os.geo2');
 goog.require('os.math.Units');
 goog.require('os.olm.render.Circle');
 goog.require('os.ui.ol.interaction.AbstractDrag');
@@ -55,9 +55,7 @@ os.ui.ol.interaction.DragCircle.prototype.getGeometry = function() {
   var geom = this.circle2D.getOriginalGeometry();
 
   if (geom) {
-    geom.toLonLat();
-    os.geo.normalizeGeometryCoordinates(geom);
-    geom.osTransform();
+    os.geo2.normalizeGeometryCoordinates(geom);
   }
 
   return geom;

--- a/src/os/ui/ol/interaction/drawpolygoninteraction.js
+++ b/src/os/ui/ol/interaction/drawpolygoninteraction.js
@@ -9,8 +9,8 @@ goog.require('ol.geom.LineString');
 goog.require('ol.geom.Polygon');
 goog.require('ol.layer.Vector');
 goog.require('ol.source.Vector');
-goog.require('os.geo');
 goog.require('os.geo.jsts');
+goog.require('os.geo2');
 goog.require('os.ui.ol.draw.DrawEvent');
 goog.require('os.ui.ol.interaction.AbstractDraw');
 
@@ -79,7 +79,7 @@ os.ui.ol.interaction.DrawPolygon.prototype.getGeometry = function() {
   geom.toLonLat();
 
   // normalize coordinates prior to validation, or polygons crossing the date line may be broken
-  os.geo.normalizeGeometryCoordinates(geom);
+  os.geo2.normalizeGeometryCoordinates(geom, undefined, os.proj.EPSG4326);
 
   // then interpolate so the coordinates reflect what was drawn
   os.interpolate.beginTempInterpolation(os.proj.EPSG4326, method);
@@ -286,9 +286,7 @@ os.ui.ol.interaction.DrawPolygon.prototype.update2D = function() {
   }
 
   var geom = this.createGeometry();
-  geom.toLonLat();
-  os.geo.normalizeGeometryCoordinates(geom);
-  geom.osTransform();
+  os.geo2.normalizeGeometryCoordinates(geom);
 
   this.line2D.setGeometry(geom);
   this.line2D.set(os.interpolate.ORIGINAL_GEOM_FIELD, undefined);

--- a/src/os/ui/search/place/coordinatesearch.js
+++ b/src/os/ui/search/place/coordinatesearch.js
@@ -7,7 +7,7 @@ goog.require('goog.log.Logger');
 goog.require('goog.net.EventType');
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');
-goog.require('os.geo');
+goog.require('os.geo2');
 goog.require('os.search.AbstractSearch');
 goog.require('os.search.SearchEvent');
 goog.require('os.search.SearchEventType');
@@ -75,7 +75,7 @@ os.ui.search.place.CoordinateSearch.prototype.searchTerm = function(term, opt_st
     var location = os.geo.parseLatLon(term);
     if (location) {
       if (location.lat < 90.0 && location.lat > -90.0) {
-        location.lon = os.geo.normalizeLongitude(location.lon);
+        location.lon = os.geo2.normalizeLongitude(location.lon, undefined, undefined, os.proj.EPSG4326);
         var feature = os.ui.search.place.createFeature({
           'geometry': new ol.geom.Point([location.lon, location.lat]).osTransform(),
           'label': term

--- a/src/plugin/ogc/query/ogcspatialformatter.js
+++ b/src/plugin/ogc/query/ogcspatialformatter.js
@@ -22,7 +22,7 @@ plugin.ogc.query.OGCSpatialFormatter.prototype.getGeometry = function(feature) {
 
   if (geom) {
     geom = geom.clone().toLonLat();
-    os.geo.normalizeGeometryCoordinates(geom);
+    os.geo2.normalizeGeometryCoordinates(geom, undefined, os.proj.EPSG4326);
   }
 
   return geom;

--- a/src/plugin/pelias/geocoder/search.js
+++ b/src/plugin/pelias/geocoder/search.js
@@ -8,6 +8,7 @@ goog.require('ol.geom.Point');
 goog.require('os.alert.AlertEventSeverity');
 goog.require('os.alert.AlertManager');
 goog.require('os.config.Settings');
+goog.require('os.extent');
 goog.require('os.geo');
 goog.require('os.search.AbstractUrlSearch');
 goog.require('plugin.pelias.geocoder.AttrResult');
@@ -67,7 +68,7 @@ plugin.pelias.geocoder.Search.prototype.getSearchUrl = function(term, opt_start,
 
     // translate to lon/lat
     extent = ol.proj.transformExtent(extent, os.map.PROJECTION, os.proj.EPSG4326);
-    extent = plugin.pelias.geocoder.Search.normaliseLongitudeExtent_(extent);
+    extent = os.extent.normalize(extent, undefined, undefined, os.proj.EPSG4326, extent);
     var distance = osasm.geodesicInverse(extent.slice(0, 2), extent.slice(2, 4)).distance;
 
     if (distance <= threshold) {
@@ -94,20 +95,6 @@ plugin.pelias.geocoder.Search.prototype.getSearchUrl = function(term, opt_start,
     }
   }
   return url;
-};
-
-/**
- * Normalise the longitudes in an extent.
- *
- * @param {ol.Extent} extent The extent to be normalised
- * @return {ol.Extent} The extent with longitudes normalised to [-180,180)
- * @private
- */
-plugin.pelias.geocoder.Search.normaliseLongitudeExtent_ = function(extent) {
-  var normalisedExtent = extent;
-  normalisedExtent[0] = os.geo.normalizeLongitude(extent[0]);
-  normalisedExtent[2] = os.geo.normalizeLongitude(extent[2]);
-  return normalisedExtent;
 };
 
 

--- a/test/os/extent.test.js
+++ b/test/os/extent.test.js
@@ -1,0 +1,231 @@
+goog.require('ol.proj');
+goog.require('os.extent');
+goog.require('os.proj');
+
+describe('os.extent', function() {
+  var expandExtent = function(extent) {
+    return [extent[0], 0, extent[1], 0];
+  };
+
+  var projections = [{
+    code: os.proj.EPSG4326,
+    precision: 12,
+    epsilon: 1E-12
+  }, {
+    code: os.proj.EPSG3857,
+    precision: 6,
+    epsilon: 1E-6
+  }];
+
+
+  it('should normalize extents', function() {
+    projections.forEach(function(config) {
+      var proj = ol.proj.get(config.code);
+      var projExtent = proj.getExtent();
+      var left = projExtent[0];
+      var right = projExtent[2];
+      var width = right - left;
+      var center = left + width / 2;
+      var min = left;
+      var max = min + width;
+      var w4 = width / 4;
+
+      var tests = [{
+        expected: [left, right],
+        extent: [center, width],
+        example: '[-180, 180] <- [0, 360]'
+      }, {
+        expected: [left, center],
+        extent: [right, width],
+        example: '[-180, 0] <- [180, 360]'
+      }, {
+        expected: [center, right],
+        extent: [center, right],
+        example: '[0, 180] <- [0, 180]'
+      }, {
+        expected: [-w4, w4],
+        extent: [center + 3 * w4, center + 5 * w4],
+        example: '[-90, 90] <- [270, 540]'
+      }];
+
+      for (var i = -3; i < 4; i++) {
+        tests.forEach(function(test, testIndex) {
+          var e = expandExtent(test.extent);
+          e[0] += width * i;
+          e[2] += width * i;
+
+          var ex = expandExtent(test.expected);
+
+          var result = os.extent.normalize(e, min, max, proj);
+
+          for (var j = 0; j < 4; j++) {
+            expect(result[j]).toBeCloseTo(ex[j], config.precision);
+
+            // if (Math.abs(ex[j] - result[j]) > config.epsilon) {
+            //   console.log('test', testIndex, 'at world', i, 'differs at index', j);
+            //   console.log(e);
+            //   console.log(result);
+            //   console.log(ex);
+            //   console.log(test.example);
+            //   console.log();
+
+            //   debugger;
+            //   os.extent.normalize(e, min, max, proj);
+            //   break;
+            // }
+          }
+        });
+      }
+    });
+  });
+
+  it('should normalize extents with alternate min/max values', function() {
+    projections.forEach(function(config) {
+      var proj = ol.proj.get(config.code);
+      var projExtent = proj.getExtent();
+      var left = projExtent[0];
+      var right = projExtent[2];
+      var width = right - left;
+      var center = left + width / 2;
+      var min = center;
+      var max = min + width;
+      var w4 = width / 4;
+
+      var tests = [{
+        extent: [left, right],
+        expected: [center, width],
+        example: '[-180, 180] -> [0, 360]'
+      }, {
+        extent: [left, center],
+        expected: [right, width],
+        example: '[-180, 0] -> [180, 360]'
+      }, {
+        extent: [center, right],
+        expected: [center, right],
+        example: '[0, 180] -> [0, 180]'
+      }, {
+        extent: [center, width],
+        expected: [center, width],
+        example: '[0, 360] -> [0, 360]'
+      }, {
+        extent: [-w4, w4],
+        expected: [center + 3 * w4, center + 5 * w4],
+        example: '[-90, 90] -> [270, 540]'
+      }];
+
+      for (var i = -3; i < 4; i++) {
+        tests.forEach(function(test, testIndex) {
+          var e = expandExtent(test.extent);
+          e[0] += width * i;
+          e[2] += width * i;
+
+          var ex = expandExtent(test.expected);
+
+          var result = os.extent.normalize(e, min, max, proj);
+
+          for (var j = 0; j < 4; j++) {
+            expect(result[j]).toBeCloseTo(ex[j], config.precision);
+
+            // if (Math.abs(ex[j] - result[j]) > config.epsilon) {
+            //   console.log('test', testIndex, 'at world', i, 'differs at index', j);
+            //   console.log(e);
+            //   console.log(result);
+            //   console.log(ex);
+            //   console.log(test.example);
+            //   console.log();
+
+            //   debugger;
+            //   os.extent.normalize(e, min, max, proj);
+            //   break;
+            // }
+          }
+        });
+      }
+    });
+  });
+
+
+  it('should copy latitude into the result extent', function() {
+    var result = [];
+    var extent = [-180, -90, 180, 90];
+
+    os.extent.normalize(extent, undefined, undefined, ol.proj.get(os.proj.EPSG4326), result);
+
+    expect(result[1]).toBe(extent[1]);
+    expect(result[3]).toBe(extent[3]);
+  });
+
+
+  it('should determine whether or not extents cross the antimeridian', function() {
+    projections.forEach(function(config) {
+      var proj = ol.proj.get(config.code);
+      var projExtent = proj.getExtent();
+      var left = projExtent[0];
+      var right = projExtent[2];
+      var width = right - left;
+      var center = left + width / 2;
+      var smallChunk = width / 360;
+      var largeChunk = width / 36;
+
+      var tests = [{
+        extent: [left, right],
+        expected: false,
+        desc: 'full-world'
+      }, {
+        extent: [left, center],
+        expected: false,
+        desc: 'left half'
+      }, {
+        extent: [center, right],
+        expected: false,
+        desc: 'right half'
+      }, {
+        extent: [left + smallChunk, center],
+        expected: false,
+        desc: 'most of left half'
+      }, {
+        extent: [0, right - smallChunk],
+        expected: false,
+        desc: 'most of right half'
+      }, {
+        extent: [left + smallChunk, right - smallChunk],
+        expected: false,
+        desc: 'most of full-world'
+      }, {
+        extent: [left - largeChunk, left + largeChunk],
+        expected: true,
+        desc: 'crosses left'
+      }, {
+        extent: [right - largeChunk, right + largeChunk],
+        expected: true,
+        desc: 'crosses right'
+      }, {
+        extent: [right - largeChunk, left + largeChunk],
+        expected: false,
+        desc: 'inverted extents are considered empty'
+      }];
+
+      for (var i = -3; i < 4; i++) {
+        tests.forEach(function(test, testIndex) {
+          var e = expandExtent(test.extent);
+          e[0] += width * i;
+          e[2] += width * i;
+          0;
+          var normalized = os.extent.normalize(e, undefined, undefined, proj);
+          // var result = os.extent.crossesAntimeridian(normalized, proj);
+          // if (result !== test.expected) {
+          //   console.log('test', testIndex, 'at world', i, 'was', result, 'expected', test.expected);
+          //   console.log(e);
+          //   console.log(normalized);
+          //   console.log(test.desc);
+          //   console.log();
+
+          //   debugger;
+          //   os.extent.crossesAntimeridian(normalized, proj);
+          // }
+          expect(os.extent.crossesAntimeridian(normalized, proj)).toBe(test.expected);
+        });
+      }
+    });
+  });
+});

--- a/test/os/feature/feature.mock.js
+++ b/test/os/feature/feature.mock.js
@@ -1,0 +1,127 @@
+goog.provide('os.feature.mock');
+
+goog.require('plugin.file.geojson.GeoJSONParser');
+
+(function() {
+  var geoms = [{
+    'coordinates': [0.0, 0.0],
+    'type': 'Point'
+  }, {
+    'coordinates': [[0.0, 5.0], [5.0, 5.0], [10.0, 5.0]],
+    'type': 'MultiPoint'
+  }, {
+    'coordinates': [[0.0, 10.0], [10.0, 10.0]],
+    'type': 'LineString'
+  }, {
+    'coordinates': [[
+          [0.0, 15.0], [5.0, 15.0]], [[10.0, 15.0], [15.0, 15.0]],
+          [[20.0, 15.0], [25.0, 15.0]]],
+    'type': 'MultiLineString'
+  }, {
+    'coordinates': [[[0.0, 20.0], [5.0, 20.0], [5.0, 22.0], [0.0, 22.0], [0.0, 20.0]]],
+    'type': 'Polygon'
+  }, {
+    'coordinates': [[[10.0, 20.0], [15.0, 20.0], [15.0, 22.0], [10.0, 22.0], [10.0, 20.0]],
+      [[11.0, 20.5], [14.0, 20.5], [14.0, 21.5],
+          [11.0, 21.5], [11.0, 20.5]]],
+    'type': 'Polygon'
+  }, {
+    'coordinates': [[[[0.0, 25.0], [5.0, 25.0], [5.0, 30.0], [0.0, 25.0]]],
+          [[[10.0, 25.0], [15.0, 25.0], [15.0, 30.0], [10.0, 25.0]]]],
+    'type': 'MultiPolygon'
+  }, {
+    'coordinates': [[[[20.0, 25.0], [25.0, 25.0], [25.0, 30.0], [20.0, 25.0]],
+          [[21.5, 25.5], [24.5, 25.5], [24.5, 28.5], [21.5, 25.5]]],
+    [[[30.0, 25.0], [35.0, 25.0], [35.0, 30.0], [30.0, 25.0]],
+          [[31.5, 25.5], [34.5, 25.5], [34.5, 28.5], [31.5, 25.5]]]],
+    'type': 'MultiPolygon'
+  }, {
+    'geometries': [{
+      'coordinates': [50.0, 0.0],
+      'type': 'Point'
+    }, {
+      'coordinates': [[50.0, 5.0], [55.0, 5.0], [60.0, 5.0]],
+      'type': 'MultiPoint'
+    }, {
+      'coordinates': [[50.0, 10.0], [60.0, 10.0]],
+      'type': 'LineString'
+    }, {
+      'coordinates': [[[50.0, 20.0], [55.0, 20.0], [55.0, 22.0], [50.0, 22.0], [50.0, 20.0]]],
+      'type': 'Polygon'
+    }, {
+      'coordinates': [[[60.0, 20.0], [65.0, 20.0], [65.0, 22.0], [60.0, 22.0], [60.0, 20.0]],
+              [[61.0, 20.5], [64.0, 20.5], [64.0, 21.5], [61.0, 21.5], [61.0, 20.5]]],
+      'type': 'Polygon'
+    }],
+    'type': 'GeometryCollection'
+  }];
+
+  var cloneOrReturn = function(val) {
+    return /^(number|string|boolean)$/.test(typeof val) ? val : clone(val);
+  };
+
+  var clone = function(obj) {
+    var c;
+    if (Array.isArray(obj)) {
+      c = obj.map(cloneOrReturn);
+    } else {
+      c = {};
+      for (var key in obj) {
+        c[key] = cloneOrReturn(obj[key]);
+      }
+    }
+
+    return c;
+  };
+
+  var antimeridian = function(obj, offset, lastOffset) {
+    lastOffset = lastOffset === undefined ? 175 : lastOffset;
+
+    if (offset === undefined && 'type' in obj) {
+      offset = lastOffset < 0 ? 175 : -185;
+    }
+
+    if (Array.isArray(obj)) {
+      if (obj.length && typeof obj[0] === 'number') {
+        obj[0] += offset;
+      } else {
+        for (var i = 0, n = obj.length; i < n; i++) {
+          antimeridian(obj[i], offset, lastOffset);
+        }
+      }
+    } else if (!/^(number|string|boolean)$/.test(typeof obj)) {
+      for (var key in obj) {
+        antimeridian(obj[key], offset, lastOffset);
+      }
+    }
+
+    return obj;
+  };
+
+
+  /**
+   * Gets some sample features with various geometries
+   * @param {boolean=} opt_moveToAntimeridian
+   * @return {Array<ol.Feature>}
+   */
+  os.feature.mock.getFeatures = function(opt_moveToAntimeridian) {
+    var geometries = clone(geoms);
+
+    if (opt_moveToAntimeridian) {
+      geometries = antimeridian(geometries);
+    }
+
+    var features = [];
+    var p = new plugin.file.geojson.GeoJSONParser();
+    p.setSource(geometries);
+    while (p.hasNext()) {
+      Array.prototype.push.apply(features, p.parseNext());
+    }
+
+    features.forEach(function(f, i) {
+      f.id = i;
+    });
+
+    return features;
+  };
+})();

--- a/test/os/geo/geo2.test.js
+++ b/test/os/geo/geo2.test.js
@@ -1,0 +1,78 @@
+
+goog.require('ol.proj');
+goog.require('os.geo2');
+goog.require('os.proj');
+
+describe('os.geo2', function() {
+  var projections = [{
+    code: os.proj.EPSG4326,
+    precision: 12,
+    epsilon: 1E-12
+  }, {
+    code: os.proj.EPSG3857,
+    precision: 6,
+    epsilon: 1E-6
+  }];
+
+
+  it('should normalize longitudes properly', function() {
+    projections.forEach(function(config) {
+      var proj = ol.proj.get(config.code);
+      var projExtent = proj.getExtent();
+      var projWidth = projExtent[2] - projExtent[0];
+      var min = projExtent[0];
+      var max = projExtent[2];
+      var chunk = projWidth / 4;
+
+      for (var i = -3; i < 4; i++) { // worlds away
+        for (var j = 0; j < 4; j++) { // distance from world left
+          var lon = projExtent[0] + i * projWidth + j * chunk;
+          var expected = min + j * chunk;
+
+          var result = os.geo2.normalizeLongitude(lon, min, max, proj);
+
+          if (Math.abs(min - result) < config.epsilon) {
+            expected = min;
+          }
+
+          if (Math.abs(max - result) < config.epsilon) {
+            expected = max;
+          }
+
+          expect(result).toBeCloseTo(expected, config.precision);
+        }
+      }
+    });
+  });
+
+
+  it('should normalize longitudes to alternate min/max values', function() {
+    projections.forEach(function(config) {
+      var proj = ol.proj.get(config.code);
+      var projExtent = proj.getExtent();
+      var projWidth = projExtent[2] - projExtent[0];
+      var min = projExtent[0] + projWidth / 2;
+      var max = min + projWidth;
+      var chunk = projWidth / 4;
+
+      for (var i = -3; i < 4; i++) { // worlds away
+        for (var j = 0; j < 4; j++) { // distance from world left
+          var lon = projExtent[0] + i * projWidth + j * chunk;
+          var expected = min + ((j + 2) % 4) * chunk;
+
+          var result = os.geo2.normalizeLongitude(lon, min, max, proj);
+
+          if (Math.abs(min - result) < config.epsilon) {
+            expected = min;
+          }
+
+          if (Math.abs(max - result) < config.epsilon) {
+            expected = max;
+          }
+
+          expect(result).toBeCloseTo(expected, config.precision);
+        }
+      }
+    });
+  });
+});

--- a/test/os/mixin/rbushmixin.test.js
+++ b/test/os/mixin/rbushmixin.test.js
@@ -77,8 +77,8 @@ describe('os.mixin.rbush', function() {
     var right = os.extent.normalizeAntiRight(extent);
 
     return features.filter(function(f) {
-      var geom = f.getGeometry();
-      return geom && (geom.intersectsExtent(left) || geom.intersectsExtent(right));
+      var gExtent = f.getGeometry().getExtent();
+      return ol.extent.intersects(left, gExtent) || ol.extent.intersects(right, gExtent);
     });
   };
 

--- a/test/os/mixin/rbushmixin.test.js
+++ b/test/os/mixin/rbushmixin.test.js
@@ -1,0 +1,183 @@
+goog.require('ol.proj');
+goog.require('os.extent');
+goog.require('os.mixin.rbush');
+goog.require('os.proj');
+goog.require('plugin.file.geojson.GeoJSONParser');
+
+
+describe('os.mixin.rbush', function() {
+  var geoms = [{
+    'coordinates': [0.0, 0.0],
+    'type': 'Point'
+  }, {
+    'coordinates': [[0.0, 5.0], [5.0, 5.0], [10.0, 5.0]],
+    'type': 'MultiPoint'
+  }, {
+    'coordinates': [[0.0, 10.0], [10.0, 10.0]],
+    'type': 'LineString'
+  }, {
+    'coordinates': [[
+          [0.0, 15.0], [5.0, 15.0]], [[10.0, 15.0], [15.0, 15.0]],
+          [[20.0, 15.0], [25.0, 15.0]]],
+    'type': 'MultiLineString'
+  }, {
+    'coordinates': [[[0.0, 20.0], [5.0, 20.0], [5.0, 22.0], [0.0, 22.0], [0.0, 20.0]]],
+    'type': 'Polygon'
+  }, {
+    'coordinates': [[[10.0, 20.0], [15.0, 20.0], [15.0, 22.0], [10.0, 22.0], [10.0, 20.0]],
+      [[11.0, 20.5], [14.0, 20.5], [14.0, 21.5],
+          [11.0, 21.5], [11.0, 20.5]]],
+    'type': 'Polygon'
+  }, {
+    'coordinates': [[[[0.0, 25.0], [5.0, 25.0], [5.0, 30.0], [0.0, 25.0]]],
+          [[[10.0, 25.0], [15.0, 25.0], [15.0, 30.0], [10.0, 25.0]]]],
+    'type': 'MultiPolygon'
+  }, {
+    'coordinates': [[[[20.0, 25.0], [25.0, 25.0], [25.0, 30.0], [20.0, 25.0]],
+          [[21.5, 25.5], [24.5, 25.5], [24.5, 28.5], [21.5, 25.5]]],
+    [[[30.0, 25.0], [35.0, 25.0], [35.0, 30.0], [30.0, 25.0]],
+          [[31.5, 25.5], [34.5, 25.5], [34.5, 28.5], [31.5, 25.5]]]],
+    'type': 'MultiPolygon'
+  }, {
+    'geometries': [{
+      'coordinates': [50.0, 0.0],
+      'type': 'Point'
+    }, {
+      'coordinates': [[50.0, 5.0], [55.0, 5.0], [60.0, 5.0]],
+      'type': 'MultiPoint'
+    }, {
+      'coordinates': [[50.0, 10.0], [60.0, 10.0]],
+      'type': 'LineString'
+    }, {
+      'coordinates': [[[50.0, 20.0], [55.0, 20.0], [55.0, 22.0], [50.0, 22.0], [50.0, 20.0]]],
+      'type': 'Polygon'
+    }, {
+      'coordinates': [[[60.0, 20.0], [65.0, 20.0], [65.0, 22.0], [60.0, 22.0], [60.0, 20.0]],
+              [[61.0, 20.5], [64.0, 20.5], [64.0, 21.5], [61.0, 21.5], [61.0, 20.5]]],
+      'type': 'Polygon'
+    }],
+    'type': 'GeometryCollection'
+  }];
+
+  var features = [];
+
+  var originalProjection = os.map.PROJECTION;
+
+  beforeEach(function() {
+    os.map.PROJECTION = ol.proj.get(os.proj.EPSG4326);
+  });
+
+  afterEach(function() {
+    os.map.PROJECTION = originalProjection;
+  });
+
+
+  var bruteQuery = function(extent) {
+    var left = os.extent.normalizeAntiLeft(extent);
+    var right = os.extent.normalizeAntiRight(extent);
+
+    return features.filter(function(f) {
+      var geom = f.getGeometry();
+      return geom && (geom.intersectsExtent(left) || geom.intersectsExtent(right));
+    });
+  };
+
+  var mapToId = function(f) {
+    return f.id;
+  };
+
+  var testExtent = function(rbush, extent) {
+    var result = rbush.getInExtent(extent).map(mapToId);
+    var expected = bruteQuery(extent).map(mapToId);
+
+    result.sort();
+    expected.sort();
+
+    expect(result).toEqual(expected);
+    return result;
+  };
+
+  var standardImport = function(rbush, opt_source) {
+    features.length = 0;
+    opt_source = opt_source || geoms;
+    var p = new plugin.file.geojson.GeoJSONParser();
+    p.setSource(opt_source);
+    while (p.hasNext()) {
+      Array.prototype.push.apply(features, p.parseNext());
+    }
+
+    features.forEach(function(f, i) {
+      f.id = i;
+      rbush.insert(f.getGeometry().getExtent(), f);
+    });
+  };
+
+  var cloneOrReturn = function(val) {
+    return /^(number|string|boolean)$/.test(typeof val) ? val : clone(val);
+  };
+
+  var clone = function(obj) {
+    var c;
+    if (Array.isArray(obj)) {
+      c = obj.map(cloneOrReturn);
+    } else {
+      c = {};
+      for (var key in obj) {
+        c[key] = cloneOrReturn(obj[key]);
+      }
+    }
+
+    return c;
+  };
+
+  var antimeridian = function(obj, offset, lastOffset) {
+    lastOffset = lastOffset === undefined ? 175 : lastOffset;
+
+    if (offset === undefined && 'type' in obj) {
+      offset = lastOffset < 0 ? 175 : -185;
+    }
+
+    if (Array.isArray(obj)) {
+      if (obj.length && typeof obj[0] === 'number') {
+        obj[0] += offset;
+      } else {
+        for (var i = 0, n = obj.length; i < n; i++) {
+          antimeridian(obj[i], offset, lastOffset);
+        }
+      }
+    } else if (!/^(number|string|boolean)$/.test(typeof obj)) {
+      for (var key in obj) {
+        antimeridian(obj[key], offset, lastOffset);
+      }
+    }
+
+    return obj;
+  };
+
+
+  it('should query normal items within the extent', function() {
+    var rbush = new ol.structs.RBush();
+    standardImport(rbush);
+    var result = testExtent(rbush, [-5, -20, 5, 20]);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+
+  it('should query items around the antimeridian', function() {
+    var rbush = new ol.structs.RBush();
+    standardImport(rbush, antimeridian(clone(geoms)));
+
+    var left = testExtent(rbush, [-185, -20, -175, 20]);
+    var right = testExtent(rbush, [175, -20, 185, 20]);
+
+    expect(left).toEqual(right);
+    expect(left.length).toBeGreaterThan(0);
+  });
+
+
+  it('should query full-world extents', function() {
+    var rbush = new ol.structs.RBush();
+    standardImport(rbush, antimeridian(clone(geoms)));
+    testExtent(rbush, [-180, -90, 180, 90]);
+  });
+});

--- a/test/os/mixin/rbushmixin.test.js
+++ b/test/os/mixin/rbushmixin.test.js
@@ -1,66 +1,12 @@
 goog.require('ol.proj');
 goog.require('os.extent');
+goog.require('os.feature.mock');
+goog.require('os.geo2');
 goog.require('os.mixin.rbush');
 goog.require('os.proj');
-goog.require('plugin.file.geojson.GeoJSONParser');
 
 
 describe('os.mixin.rbush', function() {
-  var geoms = [{
-    'coordinates': [0.0, 0.0],
-    'type': 'Point'
-  }, {
-    'coordinates': [[0.0, 5.0], [5.0, 5.0], [10.0, 5.0]],
-    'type': 'MultiPoint'
-  }, {
-    'coordinates': [[0.0, 10.0], [10.0, 10.0]],
-    'type': 'LineString'
-  }, {
-    'coordinates': [[
-          [0.0, 15.0], [5.0, 15.0]], [[10.0, 15.0], [15.0, 15.0]],
-          [[20.0, 15.0], [25.0, 15.0]]],
-    'type': 'MultiLineString'
-  }, {
-    'coordinates': [[[0.0, 20.0], [5.0, 20.0], [5.0, 22.0], [0.0, 22.0], [0.0, 20.0]]],
-    'type': 'Polygon'
-  }, {
-    'coordinates': [[[10.0, 20.0], [15.0, 20.0], [15.0, 22.0], [10.0, 22.0], [10.0, 20.0]],
-      [[11.0, 20.5], [14.0, 20.5], [14.0, 21.5],
-          [11.0, 21.5], [11.0, 20.5]]],
-    'type': 'Polygon'
-  }, {
-    'coordinates': [[[[0.0, 25.0], [5.0, 25.0], [5.0, 30.0], [0.0, 25.0]]],
-          [[[10.0, 25.0], [15.0, 25.0], [15.0, 30.0], [10.0, 25.0]]]],
-    'type': 'MultiPolygon'
-  }, {
-    'coordinates': [[[[20.0, 25.0], [25.0, 25.0], [25.0, 30.0], [20.0, 25.0]],
-          [[21.5, 25.5], [24.5, 25.5], [24.5, 28.5], [21.5, 25.5]]],
-    [[[30.0, 25.0], [35.0, 25.0], [35.0, 30.0], [30.0, 25.0]],
-          [[31.5, 25.5], [34.5, 25.5], [34.5, 28.5], [31.5, 25.5]]]],
-    'type': 'MultiPolygon'
-  }, {
-    'geometries': [{
-      'coordinates': [50.0, 0.0],
-      'type': 'Point'
-    }, {
-      'coordinates': [[50.0, 5.0], [55.0, 5.0], [60.0, 5.0]],
-      'type': 'MultiPoint'
-    }, {
-      'coordinates': [[50.0, 10.0], [60.0, 10.0]],
-      'type': 'LineString'
-    }, {
-      'coordinates': [[[50.0, 20.0], [55.0, 20.0], [55.0, 22.0], [50.0, 22.0], [50.0, 20.0]]],
-      'type': 'Polygon'
-    }, {
-      'coordinates': [[[60.0, 20.0], [65.0, 20.0], [65.0, 22.0], [60.0, 22.0], [60.0, 20.0]],
-              [[61.0, 20.5], [64.0, 20.5], [64.0, 21.5], [61.0, 21.5], [61.0, 20.5]]],
-      'type': 'Polygon'
-    }],
-    'type': 'GeometryCollection'
-  }];
-
-  var features = [];
-
   var originalProjection = os.map.PROJECTION;
 
   beforeEach(function() {
@@ -71,8 +17,7 @@ describe('os.mixin.rbush', function() {
     os.map.PROJECTION = originalProjection;
   });
 
-
-  var bruteQuery = function(extent) {
+  var bruteQuery = function(features, extent) {
     var left = os.extent.normalizeAntiLeft(extent);
     var right = os.extent.normalizeAntiRight(extent);
 
@@ -86,9 +31,9 @@ describe('os.mixin.rbush', function() {
     return f.id;
   };
 
-  var testExtent = function(rbush, extent) {
+  var testExtent = function(rbush, features, extent) {
     var result = rbush.getInExtent(extent).map(mapToId);
-    var expected = bruteQuery(extent).map(mapToId);
+    var expected = bruteQuery(features, extent).map(mapToId);
 
     result.sort();
     expected.sort();
@@ -97,78 +42,32 @@ describe('os.mixin.rbush', function() {
     return result;
   };
 
-  var standardImport = function(rbush, opt_source) {
-    features.length = 0;
-    opt_source = opt_source || geoms;
-    var p = new plugin.file.geojson.GeoJSONParser();
-    p.setSource(opt_source);
-    while (p.hasNext()) {
-      Array.prototype.push.apply(features, p.parseNext());
-    }
+  var standardImport = function(rbush, opt_moveToAntimeridian) {
+    var features = os.feature.mock.getFeatures(opt_moveToAntimeridian);
 
     features.forEach(function(f, i) {
-      f.id = i;
+      os.geo2.normalizeGeometryCoordinates(f.getGeometry());
       rbush.insert(f.getGeometry().getExtent(), f);
     });
-  };
 
-  var cloneOrReturn = function(val) {
-    return /^(number|string|boolean)$/.test(typeof val) ? val : clone(val);
-  };
-
-  var clone = function(obj) {
-    var c;
-    if (Array.isArray(obj)) {
-      c = obj.map(cloneOrReturn);
-    } else {
-      c = {};
-      for (var key in obj) {
-        c[key] = cloneOrReturn(obj[key]);
-      }
-    }
-
-    return c;
-  };
-
-  var antimeridian = function(obj, offset, lastOffset) {
-    lastOffset = lastOffset === undefined ? 175 : lastOffset;
-
-    if (offset === undefined && 'type' in obj) {
-      offset = lastOffset < 0 ? 175 : -185;
-    }
-
-    if (Array.isArray(obj)) {
-      if (obj.length && typeof obj[0] === 'number') {
-        obj[0] += offset;
-      } else {
-        for (var i = 0, n = obj.length; i < n; i++) {
-          antimeridian(obj[i], offset, lastOffset);
-        }
-      }
-    } else if (!/^(number|string|boolean)$/.test(typeof obj)) {
-      for (var key in obj) {
-        antimeridian(obj[key], offset, lastOffset);
-      }
-    }
-
-    return obj;
+    return features;
   };
 
 
   it('should query normal items within the extent', function() {
     var rbush = new ol.structs.RBush();
-    standardImport(rbush);
-    var result = testExtent(rbush, [-5, -20, 5, 20]);
+    var features = standardImport(rbush);
+    var result = testExtent(rbush, features, [-5, -20, 5, 20]);
     expect(result.length).toBeGreaterThan(0);
   });
 
 
   it('should query items around the antimeridian', function() {
     var rbush = new ol.structs.RBush();
-    standardImport(rbush, antimeridian(clone(geoms)));
+    var features = standardImport(rbush, true);
 
-    var left = testExtent(rbush, [-185, -20, -175, 20]);
-    var right = testExtent(rbush, [175, -20, 185, 20]);
+    var left = testExtent(rbush, features, [-185, -20, -175, 20]);
+    var right = testExtent(rbush, features, [175, -20, 185, 20]);
 
     expect(left).toEqual(right);
     expect(left.length).toBeGreaterThan(0);
@@ -177,7 +76,8 @@ describe('os.mixin.rbush', function() {
 
   it('should query full-world extents', function() {
     var rbush = new ol.structs.RBush();
-    standardImport(rbush, antimeridian(clone(geoms)));
-    testExtent(rbush, [-180, -90, 180, 90]);
+    var features = standardImport(rbush, true);
+    var result = testExtent(rbush, features, [-180, -90, 180, 90]);
+    expect(result.length).toBe(features.length);
   });
 });

--- a/test/os/mixin/rbushmixin.test.js
+++ b/test/os/mixin/rbushmixin.test.js
@@ -1,9 +1,13 @@
+goog.require('ol.Feature');
+goog.require('ol.geom.LineString');
+goog.require('ol.geom.Polygon');
 goog.require('ol.proj');
 goog.require('os.extent');
 goog.require('os.feature.mock');
 goog.require('os.geo2');
 goog.require('os.mixin.rbush');
 goog.require('os.proj');
+goog.require('os.source.Vector');
 
 
 describe('os.mixin.rbush', function() {
@@ -79,5 +83,59 @@ describe('os.mixin.rbush', function() {
     var features = standardImport(rbush, true);
     var result = testExtent(rbush, features, [-180, -90, 180, 90]);
     expect(result.length).toBe(features.length);
+  });
+
+
+  it('should query items indexed from right to left', function() {
+    var featureLeft = new ol.Feature(new ol.geom.LineString([[-175, 0], [-185, 0]]));
+    featureLeft.id = 0;
+    var featureRight = new ol.Feature(new ol.geom.LineString([[175, 0], [185, 0]]));
+    featureRight.id = 1;
+    var features = [featureLeft, featureRight];
+
+    var rbush = new ol.structs.RBush();
+    rbush.insert(featureLeft.getGeometry().getExtent(), featureLeft);
+    rbush.insert(featureRight.getGeometry().getExtent(), featureRight);
+
+    // try a box covering each end
+    var leftLeft = testExtent(rbush, features, [-187, -2, -183, 2]);
+    var leftRight = testExtent(rbush, features, [-177, -2, -173, 2]);
+    var rightLeft = testExtent(rbush, features, [173, -2, 177, 2]);
+    var rightRight = testExtent(rbush, features, [183, -2, 187, 2]);
+
+    expect(leftLeft.length).toBe(2);
+    expect(leftRight.length).toBe(2);
+    expect(rightLeft.length).toBe(2);
+    expect(rightRight.length).toBe(2);
+
+    expect(leftLeft).toEqual(leftRight);
+    expect(leftRight).toEqual(rightLeft);
+    expect(rightLeft).toEqual(rightRight);
+  });
+
+  it('should work with sources', function() {
+    var featureLeft = new ol.Feature(new ol.geom.LineString([[-175, 0], [-185, 0]]));
+    featureLeft.id = 0;
+    var featureRight = new ol.Feature(new ol.geom.LineString([[175, 0], [185, 0]]));
+    featureRight.id = 1;
+    var features = [featureLeft, featureRight];
+
+    var source = new os.source.Vector();
+    source.addFeatures(features);
+
+    var results = [[-187, -2, -183, 2],
+      [-177, -2, -173, 2],
+      [173, -2, 177, 2],
+      [183, -2, 187, 2]].map(function(extent) {
+        return source.getFeaturesInGeometry(ol.geom.Polygon.fromExtent(extent)).map(mapToId);
+      });
+
+    for (var i = 0, n = results.length; i < n; i++) {
+      expect(results[i].length).toBe(2);
+
+      if (i > 0) {
+        expect(results[i]).toEqual(results[i - 1]);
+      }
+    }
   });
 });

--- a/test/plugin/pelias/geocoder/peliasgeocoder.test.js
+++ b/test/plugin/pelias/geocoder/peliasgeocoder.test.js
@@ -152,20 +152,4 @@ describe('plugin.pelias.geocoder.Search', function() {
           expect(search.results[0].getResult().get('address')).toBe('4004 West 38th Avenue, Denver, CO, 80212');
         });
   });
-
-  it('should normalise longitudes greater than 180.0', function() {
-    expect(plugin.pelias.geocoder.Search.normaliseLongitudeExtent_([190.2, 20.3, 230.4, 40.1])[0]).toBeCloseTo([-169.8, 20.3, -129.6, 40.1][0]);
-    expect(plugin.pelias.geocoder.Search.normaliseLongitudeExtent_([190.2, 20.3, 230.4, 40.1])[1]).toBeCloseTo([-169.8, 20.3, -129.6, 40.1][1]);
-    expect(plugin.pelias.geocoder.Search.normaliseLongitudeExtent_([190.2, 20.3, 230.4, 40.1])[2]).toBeCloseTo([-169.8, 20.3, -129.6, 40.1][2]);
-    expect(plugin.pelias.geocoder.Search.normaliseLongitudeExtent_([190.2, 20.3, 230.4, 40.1])[3]).toBeCloseTo([-169.8, 20.3, -129.6, 40.1][3]);
-  });
-
-  it('should normalise longitudes less than -180.0', function() {
-    expect(plugin.pelias.geocoder.Search.normaliseLongitudeExtent_([-230.4, 20.3, -190.2, 40.1])[0]).toBeCloseTo([129.6, 20.3, 169.8, 40.1][0]);
-    expect(plugin.pelias.geocoder.Search.normaliseLongitudeExtent_([-230.4, 20.3, -190.2, 40.1])[1]).toBeCloseTo([129.6, 20.3, 169.8, 40.1][1]);
-    expect(plugin.pelias.geocoder.Search.normaliseLongitudeExtent_([-230.4, 20.3, -190.2, 40.1])[2]).toBeCloseTo([129.6, 20.3, 169.8, 40.1][2]);
-    expect(plugin.pelias.geocoder.Search.normaliseLongitudeExtent_([-230.4, 20.3, -190.2, 40.1])[3]).toBeCloseTo([129.6, 20.3, 169.8, 40.1][3]);
-  });
-
 });
-


### PR DESCRIPTION
Mixes in functionality to the OL RBush wrapper that queries for multiple 'worlds' of an extent and
dedupes those results.

Edit:
This now also addresses hit detection over the antimeridian from OpenLayers. A good test file for both of these items is
[KML Test.txt](https://github.com/ngageoint/opensphere/files/3074784/KML.Test.txt)

resolves #468