### PR TITLE
style(sass-lint): Remove/fix unnecessary sass-lint:disable lines.

### DIFF
--- a/scss/fontloader.scss
+++ b/scss/fontloader.scss
@@ -1,5 +1,4 @@
 // The purpose of this file is to convert any google fonts into local fonts if it exists in this theme
-// sass-lint:disable quotes
 @function str-replace($string, $search, $replace: '') {
   $index: str-index($string, $search);
 
@@ -14,36 +13,36 @@
 // Convert any google.api.fonts to local fonts that might have come from themes
 @if variable-exists(web-font-path) {
   // Example Start
-  // $web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" !default;
+  // $web-font-path: 'https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700' !default;
 
   // Replace the url to be local
   $web-font-path: str-replace($web-font-path,
-    "https://fonts.googleapis.com/css?family=", "../../vendor/fonts/typeface-");
+    'https://fonts.googleapis.com/css?family=', '../../vendor/fonts/typeface-');
 
   // Replace + with -
-  $web-font-path: str-replace($web-font-path, "+", "-");
+  $web-font-path: str-replace($web-font-path, '+', '-');
 
   // Strip off specifics (Open+Sans:400italic,700italic,400,700)
-  $web-font-path--colon-index: str-index($web-font-path, ":");
+  $web-font-path--colon-index: str-index($web-font-path, ':');
 
   @if $web-font-path--colon-index {
     $web-font-path: str-slice($web-font-path, 0, ($web-font-path--colon-index - 1));
   }
 
   // Strip off multiple fonts (Neucha|Cabin+Sketch)
-  $web-font-path--colon-index: str-index($web-font-path, "|");
+  $web-font-path--colon-index: str-index($web-font-path, '|');
 
   @if $web-font-path--colon-index {
     $web-font-path: str-slice($web-font-path, 0, ($web-font-path--colon-index - 1));
   }
 
-  $web-font-path: $web-font-path + "/index.css";
+  $web-font-path: $web-font-path + '/index.css';
 
   // Lowercase everything
   $web-font-path: to-lower-case($web-font-path);
 
   // Example End
-  // $web-font-path: "../../vendor/fonts/typeface-source-sans-pro/index.css"
+  // $web-font-path: '../../vendor/fonts/typeface-source-sans-pro/index.css'
 
   // Final import paths
   @import url($web-font-path);

--- a/scss/os/_nganimate.scss
+++ b/scss/os/_nganimate.scss
@@ -74,18 +74,18 @@
   &.ng-hide,
   &.cloak {
     opacity: 0;
-    transform: scaleY(.3);  // sass-lint:disable-line mixin-name-format
+    transform: scaleY(.3);
     visibility: hidden;
   }
 
   &.ng-leave {
     opacity: 1;
-    transform: scaleY(1);  // sass-lint:disable-line mixin-name-format
+    transform: scaleY(1);
     visibility: visible;
 
     &.ng-leave-active {
       opacity: 0;
-      transform: scaleY(.3);  // sass-lint:disable-line mixin-name-format
+      transform: scaleY(.3);
       visibility: hidden;
     }
   }
@@ -93,7 +93,7 @@
   &.ng-show,
   &.ng-enter.ng-enter-active {
     opacity: 1;
-    transform: scaleY(1);  // sass-lint:disable-line mixin-name-format
+    transform: scaleY(1);
     visibility: visible;
   }
 }
@@ -107,18 +107,18 @@
   &.ng-hide,
   &.cloak {
     opacity: 0;
-    transform: scaleY(.3);  // sass-lint:disable-line mixin-name-format
+    transform: scaleY(.3);
     visibility: hidden;
   }
 
   &.ng-leave {
     opacity: 1;
-    transform: scaleY(1);  // sass-lint:disable-line mixin-name-format
+    transform: scaleY(1);
     visibility: visible;
 
     &.ng-leave-active {
       opacity: 0;
-      transform: scaleY(.3);  // sass-lint:disable-line mixin-name-format
+      transform: scaleY(.3);
       visibility: hidden;
     }
   }
@@ -126,7 +126,7 @@
   &.ng-show,
   &.ng-enter.ng-enter-active {
     opacity: 1;
-    transform: scaleY(1);  // sass-lint:disable-line mixin-name-format
+    transform: scaleY(1);
     visibility: visible;
   }
 }
@@ -141,18 +141,18 @@
   &.ng-hide,
   &.cloak {
     opacity: 0;
-    transform: scaleX(.3);  // sass-lint:disable-line mixin-name-format
+    transform: scaleX(.3);
     visibility: hidden;
   }
 
   &.ng-leave {
     opacity: 1;
-    transform: scaleX(1);  // sass-lint:disable-line mixin-name-format
+    transform: scaleX(1);
     visibility: visible;
 
     &.ng-leave-active {
       opacity: 0;
-      transform: scaleX(.3);  // sass-lint:disable-line mixin-name-format
+      transform: scaleX(.3);
       visibility: hidden;
     }
   }
@@ -160,7 +160,7 @@
   &.ng-show,
   &.ng-enter.ng-enter-active {
     opacity: 1;
-    transform: scaleX(1);  // sass-lint:disable-line mixin-name-format
+    transform: scaleX(1);
     visibility: visible;
   }
 }
@@ -174,18 +174,18 @@
   &.ng-hide,
   &.cloak {
     opacity: 0;
-    transform: scaleX(.3);  // sass-lint:disable-line mixin-name-format
+    transform: scaleX(.3);
     visibility: hidden;
   }
 
   &.ng-leave {
     opacity: 1;
-    transform: scaleX(1);  // sass-lint:disable-line mixin-name-format
+    transform: scaleX(1);
     visibility: visible;
 
     &.ng-leave-active {
       opacity: 0;
-      transform: scaleX(.3);  // sass-lint:disable-line mixin-name-format
+      transform: scaleX(.3);
       visibility: hidden;
     }
   }
@@ -193,7 +193,7 @@
   &.ng-show,
   &.ng-enter.ng-enter-active {
     opacity: 1;
-    transform: scaleX(1); // sass-lint:disable-line mixin-name-format
+    transform: scaleX(1);
     visibility: visible;
   }
 }
@@ -269,14 +269,14 @@
   &.ng-hide,
   &.ng-leave.ng-leave-active {
     opacity: 0;
-    transform: translateY(5%); // sass-lint:disable-line mixin-name-format
+    transform: translateY(5%);
   }
 
   &.animate-present-large {
     &.ng-enter,
     &.ng-hide,
     &.ng-leave.ng-leave-active {
-      transform: translateY(2%); // sass-lint:disable-line mixin-name-format
+      transform: translateY(2%);
     }
   }
 
@@ -284,7 +284,7 @@
   &.ng-show,
   &.ng-enter.ng-enter-active {
     opacity: 1;
-    transform: translateY(0); // sass-lint:disable-line mixin-name-format
+    transform: translateY(0);
   }
 }
 
@@ -299,11 +299,11 @@
 
   &.ng-hide {
     opacity: 0;
-    transform: translateY(5%); // sass-lint:disable-line mixin-name-format
+    transform: translateY(5%);
   }
 
   &.animate-present-large.ng-hide {
-    transform: translateY(2%); // sass-lint:disable-line mixin-name-format
+    transform: translateY(2%);
   }
 }
 
@@ -319,11 +319,11 @@
 
   &.ng-hide {
     opacity: 0;
-    transform: translateY(5%); // sass-lint:disable-line mixin-name-format
+    transform: translateY(5%);
   }
 
   &.animate-present-large.ng-hide {
-    transform: translateY(2%); // sass-lint:disable-line mixin-name-format
+    transform: translateY(2%);
   }
 }
 
@@ -344,23 +344,23 @@
   &.ng-enter,
   &.ng-hide {
     opacity: 0;
-    transform: rotateX(70deg); // sass-lint:disable-line mixin-name-format
+    transform: rotateX(70deg);
   }
 
   &.ng-leave {
     opacity: 1;
-    transform: rotateX(0deg); // sass-lint:disable-line mixin-name-format
+    transform: rotateX(0deg);
 
     &.ng-leave-active {
       opacity: 0;
-      transform: rotateX(70deg); // sass-lint:disable-line mixin-name-format
+      transform: rotateX(70deg);
     }
   }
 
   &.ng-show,
   &.ng-enter.ng-enter-active {
     opacity: 1;
-    transform: rotateX(0deg); // sass-lint:disable-line mixin-name-format
+    transform: rotateX(0deg);
   }
 }
 
@@ -368,23 +368,23 @@
   &.ng-enter,
   &.ng-hide {
     opacity: 0;
-    transform: rotateY(-70deg); // sass-lint:disable-line mixin-name-format
+    transform: rotateY(-70deg);
   }
 
   &.ng-leave {
     opacity: 1;
-    transform: rotateY(0deg); // sass-lint:disable-line mixin-name-format
+    transform: rotateY(0deg);
 
     &.ng-leave-active {
       opacity: 0;
-      transform: rotateY(-70deg); // sass-lint:disable-line mixin-name-format
+      transform: rotateY(-70deg);
     }
   }
 
   &.ng-show,
   &.ng-enter.ng-enter-active {
     opacity: 1;
-    transform: rotateY(0deg); // sass-lint:disable-line mixin-name-format
+    transform: rotateY(0deg);
   }
 }
 

--- a/scss/overrides_default/_bootswatch.scss
+++ b/scss/overrides_default/_bootswatch.scss
@@ -1,5 +1,4 @@
-// sass-lint:disable quotes
-$web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400,700" !default;
+$web-font-path: 'https://fonts.googleapis.com/css?family=Open+Sans:400,700' !default;
 
 .nav-tabs {
   .nav-link {

--- a/scss/overrides_slate/_bootswatch.scss
+++ b/scss/overrides_slate/_bootswatch.scss
@@ -1,7 +1,6 @@
 @import 'slate/bootswatch';
 
-// sass-lint:disable quotes
-$web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400,700" !default;
+$web-font-path: 'https://fonts.googleapis.com/css?family=Open+Sans:400,700' !default;
 
 .navbar-dark .navbar-nav .show > .nav-link,
 .navbar-dark .navbar-nav .active > .nav-link,


### PR DESCRIPTION
Contributes to #141.

- Font loader double quotes are no longer needed, and must have been from another rendition of that during the Bootstrap 4 upgrade. The output CSS is the same with single/double quotes.
- `mixin-name-format` rules are OBE with the Bootstrap 4 upgrade.

Remaining `sass-lint:disable` lines are more involved and will require deeper investigation if we want to remove them. Several are for browser support and cannot be removed unless we change minimum versions.