### PR TITLE
Fix stuck interacting flag.

### DIFF
--- a/src/os/interaction/doubleclickzoominteraction.js
+++ b/src/os/interaction/doubleclickzoominteraction.js
@@ -1,6 +1,7 @@
 goog.provide('os.interaction.DoubleClickZoom');
 
 goog.require('ol.MapBrowserEventType');
+goog.require('ol.events.condition');
 goog.require('ol.interaction.DoubleClickZoom');
 goog.require('os.I3DSupport');
 goog.require('os.implements');
@@ -34,13 +35,14 @@ ol.interaction.DoubleClickZoom.handleEvent = function(mapBrowserEvent) {
 
   if (mapBrowserEvent.type == ol.MapBrowserEventType.DBLCLICK) {
     var anchor = mapBrowserEvent.coordinate;
+    var zoomOut = ol.events.condition.platformModifierKeyOnly(mapBrowserEvent);
 
     var mapContainer = os.MapContainer.getInstance();
     if (mapContainer.is3DEnabled()) {
       var camera = mapContainer.getWebGLCamera();
       if (camera) {
         var currentAltitude = camera.getAltitude();
-        var altitude = mapBrowserEvent.originalEvent.ctrlKey ? (currentAltitude * 2) : (currentAltitude / 2);
+        var altitude = zoomOut ? (currentAltitude * 2) : (currentAltitude / 2);
 
         camera.flyTo(/** @type {!osx.map.FlyToOptions} */ ({
           center: anchor,
@@ -49,7 +51,7 @@ ol.interaction.DoubleClickZoom.handleEvent = function(mapBrowserEvent) {
         }));
       }
     } else {
-      var delta = mapBrowserEvent.originalEvent.ctrlKey ? -this.delta_ : this.delta_;
+      var delta = zoomOut ? -this.delta_ : this.delta_;
       var view = mapBrowserEvent.map.getView();
       if (view) {
         ol.interaction.Interaction.zoomByDelta(view, delta, anchor, this.duration_);

--- a/src/os/interaction/mousezoominteraction.js
+++ b/src/os/interaction/mousezoominteraction.js
@@ -102,7 +102,7 @@ os.interaction.MouseZoom.handleEvent = function(mapBrowserEvent) {
   if (mapBrowserEvent.pointerEvent &&
       mapBrowserEvent.pointerEvent.buttons == 2 &&
       mapBrowserEvent.dragging &&
-      mapBrowserEvent.originalEvent.ctrlKey) {
+      ol.events.condition.platformModifierKeyOnly(mapBrowserEvent)) {
     this.zoom(mapBrowserEvent);
     stopEvent = true;
   } else {

--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -797,6 +797,7 @@ os.MapContainer.prototype.addHelpControls_ = function() {
   var moveGrp = 'Map Movement Controls';
   var zoomGrp = 'Map Zoom Controls';
   var controls = os.ui.help.Controls.getInstance();
+  var platformModifier = ol.has.MAC ? goog.events.KeyCodes.META : goog.events.KeyCodes.CTRL;
 
   // Map
   controls.addControl(genMapGrp, 1, 'Draw Geometry',
@@ -816,13 +817,13 @@ os.MapContainer.prototype.addHelpControls_ = function() {
 
   // Zoom
   controls.addControl(zoomGrp, 3, 'Zoom to Box',
-      [goog.events.KeyCodes.CTRL, '+'], [os.ui.help.Controls.MOUSE.LEFT_MOUSE, '+', os.ui.help.Controls.FONT.ALL]);
+      [platformModifier, '+'], [os.ui.help.Controls.MOUSE.LEFT_MOUSE, '+', os.ui.help.Controls.FONT.ALL]);
   controls.addControl(zoomGrp, 3, 'Smooth Zoom In/Out',
-      [goog.events.KeyCodes.CTRL, '+'], [os.ui.help.Controls.MOUSE.RIGHT_MOUSE, '+',
+      [platformModifier, '+'], [os.ui.help.Controls.MOUSE.RIGHT_MOUSE, '+',
         os.ui.help.Controls.FONT.VERTICAL]);
   controls.addControl(zoomGrp, 3, 'Zoom About Mouse', null, ['Mouse Wheel']);
   controls.addControl(zoomGrp, 3, 'Zoom In', null, ['Double Left Click']);
-  controls.addControl(zoomGrp, 3, 'Zoom Out', [goog.events.KeyCodes.CTRL, '+'], ['Double Left Click']);
+  controls.addControl(zoomGrp, 3, 'Zoom Out', [platformModifier, '+'], ['Double Left Click']);
 
   controls.addControl(zoomGrp, 3, 'Large Zoom In/Out',
       [goog.events.KeyCodes.PAGE_UP, 'or', goog.events.KeyCodes.PAGE_DOWN]);


### PR DESCRIPTION
This ensures `ol.ViewHint.INTERACTING` is unset correctly in drawing interactions, and also changes zoom interactions to use Command instead of Control as the modifier on Macs.

The interacting issue was caused by unsetting the flag on a delay to prevent the select interaction from also handling the event. The flag was set on each mouse down event, but only unset after a delay which was restarted on each mouse up event. On double click, it was set twice but only unset once.

The delay was intended to prevent selecting features when drawing completed on top of them. This is now done by calling `preventDefault` on the event when drawing ends (preventing further interactions from handling the event).

Fixes #184.