### PR TITLE
feat(map): Scale down icons/labels as the map/globe is zoomed out.

### DIFF
--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -445,6 +445,7 @@ Cesium.BillboardCollection = function(opt_options) {};
  *   pixelOffsetScaleByDistance : (Cesium.NearFarScalar|undefined),
  *   scale: (number|undefined),
  *   scaleByDistance: (Cesium.NearFarScalar|undefined),
+ *   translucencyByDistance: (Cesium.NearFarScalar|undefined),
  *   position: !Cesium.Cartesian3,
  *   geomRevision: (number|undefined)
  * }}
@@ -1997,6 +1998,24 @@ Cesium.optionsLabelCollection.prototype.verticalOrigin;
  * @type {Cesium.HeightReference|undefined}
  */
 Cesium.optionsLabelCollection.prototype.heightReference;
+
+
+/**
+ * @type {Cesium.NearFarScalar|undefined}
+ */
+Cesium.optionsLabelCollection.prototype.pixelOffsetScaleByDistance;
+
+
+/**
+ * @type {Cesium.NearFarScalar|undefined}
+ */
+Cesium.optionsLabelCollection.prototype.scaleByDistance;
+
+
+/**
+ * @type {Cesium.NearFarScalar|undefined}
+ */
+Cesium.optionsLabelCollection.prototype.translucencyByDistance;
 
 
 /**

--- a/src/os/map/map.js
+++ b/src/os/map/map.js
@@ -164,6 +164,19 @@ os.map.ZERO_EXTENT = [0, 0, 0, 0];
 
 
 /**
+ * Properties to scale icons/labels by camera distance. Near/far values represent camera altitude in meters.
+ * @type {!Object<string, number>}
+ * @const
+ */
+os.map.ZoomScale = {
+  NEAR: 3e6,
+  NEAR_SCALE: 1,
+  FAR: 3e7,
+  FAR_SCALE: .25
+};
+
+
+/**
  * Gets the zoom level from the given resolution.
  * @param {number} resolution The view resolution.
  * @param {ol.proj.Projection} projection The map projection.

--- a/src/os/mixin/mixin.js
+++ b/src/os/mixin/mixin.js
@@ -19,6 +19,7 @@ goog.require('os.mixin.geometry');
 goog.require('os.mixin.layerbase');
 goog.require('os.mixin.map');
 goog.require('os.mixin.object');
+goog.require('os.mixin.zoomscale');
 goog.require('os.net');
 goog.require('os.ol');
 goog.require('os.registerClass');

--- a/src/os/mixin/zoomscalemixin.js
+++ b/src/os/mixin/zoomscalemixin.js
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview This recreates behavior from Google Earth in the 2D map, where icons and labels are scaled/hidden
+ *               based on the zoom level/camera distance.
+ *
+ * @suppress {accessControls} To allow access to private properties in OpenLayers classes.
+ */
+goog.provide('os.mixin.zoomscale');
+
+goog.require('goog.math');
+goog.require('ol.render.canvas.ImageReplay');
+goog.require('ol.render.canvas.TextReplay');
+goog.require('os.MapEvent');
+goog.require('os.map');
+
+
+(function() {
+  // cache the zoom scale to reduce how often it's computed, resetting on map view change.
+  var zoomScale;
+  os.MapContainer.getInstance().listen(os.MapEvent.VIEW_CHANGE, function() {
+    zoomScale = undefined;
+  });
+
+  /**
+   * Get the scale value for the current map zoom.
+   * @return {number|undefined} The scale value, or undefined when the current zoom is not rescaled.
+   */
+  var getZoomScale = function() {
+    var altitude = os.MapContainer.getInstance().getAltitude();
+    if (altitude > os.map.ZoomScale.NEAR) {
+      // don't scale beyond the far altitude value
+      altitude = Math.min(altitude, os.map.ZoomScale.FAR);
+
+      zoomScale = goog.math.lerp(os.map.ZoomScale.NEAR_SCALE, os.map.ZoomScale.FAR_SCALE,
+          (altitude - os.map.ZoomScale.NEAR) / (os.map.ZoomScale.FAR - os.map.ZoomScale.NEAR));
+    }
+
+    return zoomScale;
+  };
+
+  var oldSetImageStyle = ol.render.canvas.ImageReplay.prototype.setImageStyle;
+
+  /**
+   * @override
+   */
+  ol.render.canvas.ImageReplay.prototype.setImageStyle = function(imageStyle, declutterGroup) {
+    oldSetImageStyle.call(this, imageStyle, declutterGroup);
+
+    var zoomScale = getZoomScale();
+    if (zoomScale != null) {
+      this.scale_ *= zoomScale;
+    }
+  };
+
+  var oldSetTextStyle = ol.render.canvas.TextReplay.prototype.setTextStyle;
+
+  /**
+   * @override
+   */
+  ol.render.canvas.TextReplay.prototype.setTextStyle = function(textStyle, declutterGroup) {
+    oldSetTextStyle.call(this, textStyle, declutterGroup);
+
+    var zoomScale = getZoomScale();
+    if (zoomScale != null) {
+      var textState = this.textState_;
+
+      // hide text once it's scaled below 50% original size. it would be preferable to scale opacity, but in OpenLayers
+      // that requires manipulating the color string which would not be performant here.
+      zoomScale = zoomScale >= .5 ? zoomScale : 0;
+
+      // this.textKey_ is a map index, so limit the scale adjustment to 1/10 increments
+      textState.scale = Math.round(textState.scale * zoomScale * 10) / 10;
+      this.textKey_ = textState.font + textState.scale + (textState.textAlign || '?');
+
+      // adjust the offset to account for the scale change
+      this.textOffsetX_ *= zoomScale;
+      this.textOffsetY_ *= zoomScale;
+    }
+  };
+})();

--- a/src/plugin/cesium/sync/featureconverter.js
+++ b/src/plugin/cesium/sync/featureconverter.js
@@ -80,6 +80,24 @@ plugin.cesium.sync.FeatureConverter = function(scene) {
    * @private
    */
   this.listenerMap_ = {};
+
+  /**
+   * Scales billboards/labels based on globe zoom.
+   * @type {Cesium.NearFarScalar}
+   * @private
+   */
+  this.distanceScalar_ = new Cesium.NearFarScalar(
+      os.map.ZoomScale.NEAR, os.map.ZoomScale.NEAR_SCALE,
+      os.map.ZoomScale.FAR, os.map.ZoomScale.FAR_SCALE);
+
+  /**
+   * Adjusts translucency based on globe zoom.
+   * @type {Cesium.NearFarScalar}
+   * @private
+   */
+  this.translucencyScalar_ = new Cesium.NearFarScalar(
+      os.map.ZoomScale.NEAR * 2, 1,
+      os.map.ZoomScale.FAR / 3, 0);
 };
 
 
@@ -274,7 +292,10 @@ plugin.cesium.sync.FeatureConverter.prototype.wrapFillAndOutlineGeometries = fun
 plugin.cesium.sync.FeatureConverter.prototype.createLabel = function(feature, geometry, label, context) {
   if (!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(label.getText()))) {
     var options = /** @type {!Cesium.optionsLabelCollection} */ ({
-      heightReference: this.getHeightReference(context.layer, feature, geometry)
+      heightReference: this.getHeightReference(context.layer, feature, geometry),
+      pixelOffsetScaleByDistance: this.distanceScalar_,
+      scaleByDistance: this.distanceScalar_,
+      translucencyByDistance: this.translucencyScalar_
     });
 
     this.updateLabel(options, geometry, label, context);
@@ -1260,6 +1281,8 @@ plugin.cesium.sync.FeatureConverter.prototype.createBillboard = function(feature
 
   var options = /** @type {!Cesium.optionsBillboardCollectionAdd} */ ({
     heightReference: heightReference,
+    pixelOffsetScaleByDistance: this.distanceScalar_,
+    scaleByDistance: this.distanceScalar_,
     show: show
   });
 


### PR DESCRIPTION
[Demo Here](https://schmidtk.github.io/opensphere-zoom-scale/)

This attempts to mimic the behavior of Google Earth, where icons and labels are scaled/hidden when zooming far out. The general goal with this approach was to get the behavior as close as possible, without impacting performance.

* OpenLayers: Mixin the image/label canvas renderers to apply the scale value without modifying OpenLayers style objects. This avoids changing individual styles on features, which we know to be costly. I did not scale label opacity (like Cesium/GE) either, because that would require manipulating color strings on each render. Instead they're hidden (scale = 0) at roughly the same level.
* Cesium: Use Cesium's `NearFarScalar` to scale billboards/labels, and to fade out labels.

There is one potentially odd side effect to our Cesium highlight behavior - highlighted items will appear at normal size. This happens because we adjust `eyeOffset` to put highlighted items immediately in front of the camera, so they're always visible. Because they're moved closer to the camera, Cesium will not scale them. I'm not sure if that should be considered a bug or a feature, but it is inconsistent with 2D behavior and would probably require a hack to make them consistent.

Resolves #374.