### PR TITLE
Refresh

### DIFF
--- a/src/os/layer/vector.js
+++ b/src/os/layer/vector.js
@@ -847,20 +847,22 @@ os.layer.Vector.prototype.isFilterable = function() {
  */
 os.layer.Vector.prototype.getFilterKey = function() {
   var options = this.getLayerOptions();
-  var id = /** @type {string} */ (options['id']);
+  if (options) {
+    var id = /** @type {string} */ (options['id']);
 
-  // try to get it from the descriptor
-  var d = os.dataManager.getDescriptor(id);
-  if (os.implements(d, os.filter.IFilterable.ID)) {
-    return /** @type {!os.filter.IFilterable} */ (d).getFilterKey();
-  }
+    // try to get it from the descriptor
+    var d = os.dataManager.getDescriptor(id);
+    if (os.implements(d, os.filter.IFilterable.ID)) {
+      return /** @type {!os.filter.IFilterable} */ (d).getFilterKey();
+    }
 
-  // try to derive it from the layer options
-  var url = /** @type {string} */ (options['url']);
-  var params = /** @type {string} */ (options['params']);
-  var typeName = params ? /** @type {string} */ (params.get('typename')) : null;
-  if (url && typeName) {
-    return url + '!!' + typeName;
+    // try to derive it from the layer options
+    var url = /** @type {string} */ (options['url']);
+    var params = /** @type {string} */ (options['params']);
+    var typeName = params ? /** @type {string} */ (params.get('typename')) : null;
+    if (url && typeName) {
+      return url + '!!' + typeName;
+    }
   }
 
   // dang

--- a/src/os/ui/filter/ui/editfilters.js
+++ b/src/os/ui/filter/ui/editfilters.js
@@ -335,6 +335,13 @@ os.ui.filter.ui.EditFiltersCtrl.prototype.finish = function() {
   var filter = this['root'].writeFilter(this['title'], this['description']);
   this.entry.setFilter(filter);
 
+  var dm = os.data.OSDataManager.getInstance();
+  if (dm) {
+    if (dm.getDescriptor(this.entry.getType()) == null) {
+      this.entry.setTemporary(true);
+    }
+  }
+
   // tell the thing that launched us that we're done
   if (this.scope['callback']) {
     this.scope['callback'](this.entry);

--- a/src/plugin/featureaction/featureactionmenu.js
+++ b/src/plugin/featureaction/featureactionmenu.js
@@ -54,7 +54,7 @@ plugin.im.action.feature.visibleIfSupported = function(context) {
     var layers = os.ui.menu.layer.getLayersFromContext(context).filter(os.MapContainer.isVectorLayer);
     if (layers && layers.length == 1 && layers[0].getOSType() != os.layer.LayerType.REF) {
       var source = /** @type {ol.layer.Layer} */ (layers[0]).getSource();
-      this.visible = os.implements(source, os.source.IImportSource.ID);
+      this.visible = source != null;
     }
   }
 };


### PR DESCRIPTION
#613 
For this PR I was working on the following problem: 
"We were asked to enable feature actions for merged/joined layers, which we can do now that they no longer require their data sources to implement refresh functionality. Change featureactionmenu.js to not bother checking whether the layer implements IImportSource and make sure that feature actions on static data layers don't persist on refresh (because the layers themselves don't persist on refresh)."