### PR TITLE
fix(cesium): fix null pointer in camera extent computation

### DIFF
--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -1260,7 +1260,7 @@ Cesium.Cartesian3.subtract = function(left, right, opt_result) {};
 
 
 /**
- * @param {Cesium.Cartesian3} cartesian
+ * @param {Cesium.Cartesian3|Cesium.Cartesian4} cartesian
  * @param {Cesium.Cartesian3} result
  * @return {!Cesium.Cartesian3}
  */
@@ -1420,6 +1420,16 @@ Cesium.Cartesian4.prototype.w;
  */
 Cesium.Cartesian4.clone = function(result) {};
 
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {number} z
+ * @param {number} w
+ * @param {Cesium.Cartesian4=} opt_result
+ * @return {Cesium.Cartesian4}
+ */
+Cesium.Cartesian4.fromElements = function(x, y, z, w, opt_result) {};
 
 
 /**
@@ -3680,19 +3690,19 @@ Cesium.Matrix4.prototype.clone = function(opt_result) {};
 /**
  * @param {Cesium.Matrix4} matrix .
  * @param {Cesium.Cartesian3} point .
- * @param {Cesium.Cartesian3} result .
+ * @param {Cesium.Cartesian3=} opt_result .
  * @return {Cesium.Cartesian3} .
  */
-Cesium.Matrix4.multiplyByPoint = function(matrix, point, result) {};
+Cesium.Matrix4.multiplyByPoint = function(matrix, point, opt_result) {};
 
 
 /**
  * @param {Cesium.Matrix4} matrix .
  * @param {Cesium.Cartesian4} point .
- * @param {Cesium.Cartesian4} result .
+ * @param {Cesium.Cartesian4=} opt_result .
  * @return {Cesium.Cartesian4} .
  */
-Cesium.Matrix4.multiplyByVector = function(matrix, point, result) {};
+Cesium.Matrix4.multiplyByVector = function(matrix, point, opt_result) {};
 
 
 /**
@@ -4231,6 +4241,14 @@ Cesium.SceneTransforms = function() {};
  */
 Cesium.SceneTransforms.wgs84ToWindowCoordinates = function(scene, position, opt_result) {};
 
+
+/**
+ * @param {Cesium.BoundingRectangle} viewPort
+ * @param {Cesium.Cartesian4} position
+ * @param {Cesium.Cartesian2=} opt_result
+ * @return {Cesium.Cartesian2}
+ */
+Cesium.SceneTransforms.clipToGLWindowCoordinates = function(viewPort, position, opt_result) {};
 
 
 /**

--- a/src/plugin/cesium/cesiumcamera.js
+++ b/src/plugin/cesium/cesiumcamera.js
@@ -217,6 +217,35 @@ plugin.cesium.Camera.prototype.initExtentComputation_ = function() {
   };
 
 
+  // This is a duplication of the method in Cesium.SceneTransforms because it is not exposed
+  var scratchCartesian4 = new Cesium.Cartesian4();
+  var scratchEyeOffset = new Cesium.Cartesian3();
+
+  /**
+   * This is a duplication of the method in Cesium.SceneTransforms because it is not exposed
+   * @param {Cesium.Cartesian3} position
+   * @param {Cesium.Cartesian3} eyeOffset
+   * @param {Cesium.Camera} camera
+   * @param {Cesium.Cartesian4=} opt_result
+   * @return {Cesium.Cartesian4}
+   */
+  var worldToClip = function(position, eyeOffset, camera, opt_result) {
+    var viewMatrix = camera.viewMatrix;
+
+    var positionEC = Cesium.Matrix4.multiplyByVector(viewMatrix,
+        Cesium.Cartesian4.fromElements(position.x, position.y, position.z, 1, scratchCartesian4), scratchCartesian4);
+
+    var zEyeOffset = Cesium.Cartesian3.multiplyComponents(eyeOffset,
+        Cesium.Cartesian3.normalize(positionEC, scratchEyeOffset), scratchEyeOffset);
+    positionEC.x += eyeOffset.x + zEyeOffset.x;
+    positionEC.y += eyeOffset.y + zEyeOffset.y;
+    positionEC.z += zEyeOffset.z;
+
+    return Cesium.Matrix4.multiplyByVector(camera.frustum.projectionMatrix, positionEC, opt_result);
+  };
+
+  var scratchViewport = new Cesium.BoundingRectangle();
+
   /**
    * @return {Cesium.Rectangle}
    */
@@ -233,9 +262,17 @@ plugin.cesium.Camera.prototype.initExtentComputation_ = function() {
         Cesium.Cartesian3.multiplyByScalar(this.scene_.globe.ellipsoid.radii, 1 / cameraMagnitude, scratchCartesian1),
         scratchCartesian2);
 
-    // convert that position vector to screen coords
-    var cameraGroundScreen = Cesium.SceneTransforms.wgs84ToWindowCoordinates(
-        this.scene_, cameraGroundCartesian, scratchPixel1);
+    // we are specifically avoiding Cesium.SceneTransforms.wgs84ToWindowCoordinates() because it does not return
+    // pixels for coordinates outside of the view window.
+    var clipPosition = worldToClip(cameraGroundCartesian, Cesium.Cartesian3.ZERO, this.cam_, scratchCartesian4);
+    scratchViewport.x = 0;
+    scratchViewport.y = 0;
+    scratchViewport.width = this.scene_.canvas.clientWidth;
+    scratchViewport.height = this.scene_.canvas.clientHeight;
+    var cameraGroundScreen = Cesium.SceneTransforms.clipToGLWindowCoordinates(scratchViewport, clipPosition,
+        scratchPixel1);
+    cameraGroundScreen.y = scratchViewport.height - cameraGroundScreen.y;
+
 
     //    r
     //    |   r2


### PR DESCRIPTION
Cesium's `SceneTransforms.wgs84ToWindowCoordinates()` returns `undefined` for coordinates outside the window. We need it to return the pixel as if it existed. This condition occurs when the camera's position vector is outside the camera frustum.