### PR TITLE
chore(surge): Update surge to 0.20.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "rimraf": "^2.5.4",
     "sass-lint": "^1.12.1",
     "semantic-release": "^11.0.2",
-    "surge": "^0.19.0",
+    "surge": "^0.20.4",
     "validate-commit-msg": "^2.8.2",
     "xmllint": "^0.1.1"
   },


### PR DESCRIPTION
This avoids a few obsolete dependency warnings on initial yarn install.