### PR TITLE
fix(vectortools): add case-insensitive match and contain indexers

### DIFF
--- a/src/os/data/sourcemanager.js
+++ b/src/os/data/sourcemanager.js
@@ -93,6 +93,7 @@ os.data.SourceManager.prototype.disposeInternal = function() {
     ol.events.unlistenByKey(this.sourceListeners_[key]);
   }
 
+  goog.dispose(this.updateDelay);
   this.sourceListeners_ = {};
   this.sources.length = 0;
 };

--- a/src/plugin/vectortools/joinlayercmd.js
+++ b/src/plugin/vectortools/joinlayercmd.js
@@ -187,6 +187,8 @@ plugin.vectortools.JoinLayer.prototype.getUniqueIndexer = function(accessorFunct
  * @protected
  */
 plugin.vectortools.JoinLayer.prototype.getContainsIndexer = function(accessorFunction) {
+  var memoryIndex = [];
+
   return (
     /**
      * @param {string} field
@@ -194,8 +196,6 @@ plugin.vectortools.JoinLayer.prototype.getContainsIndexer = function(accessorFun
      * @private
      */
     function(field) {
-      var memoryIndex = [];
-
       /**
        * @param {Object} obj
        * @param {boolean} crossProduct

--- a/src/plugin/vectortools/joinwindow.js
+++ b/src/plugin/vectortools/joinwindow.js
@@ -83,7 +83,8 @@ plugin.vectortools.JoinCtrl = function($scope, $element) {
   this['joinMethodHelp'] = 'The Join Method determines how we compare values between columns.' +
       '<ul><li> Exact Match: Joins two features when the value is exactly the same on both.</li>' +
       '<li> Contains: Joins two features when one value contains the other.</li>' +
-      '<li> Case Insensitive: Joins two features when one value is not the same case.</li>';
+      '<li> Match (Case-Insensitive): Same as "Exact Match" but case-insensitive</li>' +
+      '<li> Contains (Case-Insensitive): Same as "Contains" but case-insensitive</li>';
 
   /**
    * @type {Array<Object>}

--- a/src/plugin/vectortools/joinwindow.js
+++ b/src/plugin/vectortools/joinwindow.js
@@ -156,6 +156,10 @@ plugin.vectortools.JoinCtrl.prototype.onSourcePropertyChange = function(event) {
  * @inheritDoc
  */
 plugin.vectortools.JoinCtrl.prototype.onUpdateDelay = function() {
+  if (!this.scope_) {
+    return;
+  }
+
   this.scope_['joinForm'].$setValidity('featureCount', true);
   this['count'] = 0;
 

--- a/views/plugin/vectortools/join.html
+++ b/views/plugin/vectortools/join.html
@@ -31,19 +31,24 @@
         <div class="col pl-0">Join Method</div>
         <popover x-title="'Join Method'" x-content="ctrl.joinMethodHelp" x-pos="'right'"></popover>
       </div>
-      <div class="form-group row">
-        <div class="form-check form-check-inline">
-          <input type="radio" id="exactMatch_{{$id}}" class="form-check-input" name="dateTypeRadios" value="unique" ng-model="ctrl.joinMethod" ng-disabled="disabled" />
-          <label class="form-check-label" for="exactMatch_{{$id}}" ng-disabled="disabled">Exact Match</label>
+      <div class="form-group">
+        <div class="form-check">
+          <input type="radio" id="unique_{{$id}}" class="form-check-input" name="dateTypeRadios" value="unique" ng-model="ctrl.joinMethod" ng-disabled="disabled" />
+          <label class="form-check-label" for="unique_{{$id}}" ng-disabled="disabled">Exact Match</label>
         </div>
-        <div class="form-check form-check-inline">
+        <div class="form-check">
           <input type="radio" id="contains_{{$id}}" class="form-check-input" name="dateTypeRadios" value="contains" ng-model="ctrl.joinMethod" ng-disabled="disabled" />
           <label class="form-check-label" for="contains_{{$id}}" ng-disabled="disabled">Contains</label>
         </div>
-        <div class="form-check form-check-inline">
-          <input type="radio" id="case_{{$id}}" class="form-check-input" name="dateTypeRadios" value="uniqueCaseInsensitive" ng-model="ctrl.joinMethod"
+        <div class="form-check">
+          <input type="radio" id="uniqueCase_{{$id}}" class="form-check-input" name="dateTypeRadios" value="uniqueCaseInsensitive" ng-model="ctrl.joinMethod"
             ng-disabled="disabled" />
-          <label class="form-check-label" for="case_{{$id}}" ng-disabled="disabled">Case Insensitive</label>
+          <label class="form-check-label" for="uniqueCase_{{$id}}" ng-disabled="disabled">Match (Case-Insensitive)</label>
+        </div>
+        <div class="form-check">
+          <input type="radio" id="containsCase_{{$id}}" class="form-check-input" name="dateTypeRadios" value="containsCaseInsensitive" ng-model="ctrl.joinMethod"
+            ng-disabled="disabled" />
+          <label class="form-check-label" for="containsCase_{{$id}}" ng-disabled="disabled">Contains (Case-Insensitive)</label>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The previous version indicated to the user that it was more of a "match" while using the logic from "contains". This adds support for both while avoiding repeating logic.