### PR TITLE
fix(fn): use duck typing rather than instanceOf

### DIFF
--- a/src/os/fn/fn.js
+++ b/src/os/fn/fn.js
@@ -58,7 +58,8 @@ os.fn.reduceExtentFromLayers = function(extent, layer) {
  */
 os.fn.reduceExtentFromGeometries = function(extent, geometry) {
   if (geometry) {
-    var geom = geometry instanceof ol.geom.Geometry ? geometry : geometry.geometry;
+    var geom = /** @type {ol.geom.Geometry} */ (
+      /** @type {ol.geom.Geometry} */ (geometry).getType ? geometry : geometry.geometry);
 
     if (geom) {
       ol.extent.extend(extent, os.extent.getFunctionalExtent(geom));


### PR DESCRIPTION
This allows the function to be run in multiple window contexts.