### PR TITLE
fix(vector): Fix detection of vector source refresh support.

### DIFF
--- a/src/os/layer/vector.js
+++ b/src/os/layer/vector.js
@@ -781,8 +781,8 @@ os.layer.Vector.prototype.callAction = function(type) {
         os.ui.timeline.TimelineCtrl.setView();
         break;
       case os.action.EventType.REFRESH:
-        if (source instanceof os.source.Request) {
-          /** @type {os.source.Request} */ (source).refresh();
+        if (source instanceof os.source.Vector && source.isRefreshEnabled()) {
+          source.refresh();
         }
         break;
       case os.action.EventType.LOCK:


### PR DESCRIPTION
This was fixed in `supportsAction`, but not `callAction`. Result was the option being displayed, but not working unless the source was a request source.