### PR TITLE
fix(columnmapping): Allow all numeric column types in column mappings.

### DIFF
--- a/src/os/ui/column/mapping/mappingexpression.js
+++ b/src/os/ui/column/mapping/mappingexpression.js
@@ -171,8 +171,9 @@ os.ui.column.mapping.MappingExpressionCtrl.prototype.setColumns_ = function(colu
   var columnName = this.model_['column'];
   this['column'] = null;
   columns = columns.filter(function(column) {
-    if (column['type'] !== 'string' && column['type'] !== 'decimal') {
-      // only include string and decimal type columns
+    if (column['type'] !== 'string' && column['type'] !== 'decimal' && column['type'] !== 'integer') {
+      // only include string and numeric type columns. this is based on the limited set of types we convert to in
+      // os.ogc.wfs.DescribeFeatureTypeParser, and intended to avoid displaying geometry/time columns.
       return false;
     }
 


### PR DESCRIPTION
Columns of type `integer` should be supported, but were hidden from the column mapping UI.