### PR TITLE
refactor: replace goog.abstractMethod with @abstract

### DIFF
--- a/conformance_config.textproto
+++ b/conformance_config.textproto
@@ -133,6 +133,12 @@ requirement: {
                  'ol.obj.assign instead.'
 }
 
+requirement: {
+  type: BANNED_NAME
+  value: 'goog.abstractMethod'
+  error_message: 'goog.abstractMethod is not permitted. Use @abstract on the class and method instead.'
+}
+
 #requirement: {
 #  type: BANNED_NAME
 #  value: 'goog.bind'

--- a/src/os/capture/abstractrecorder.js
+++ b/src/os/capture/abstractrecorder.js
@@ -10,7 +10,7 @@ goog.require('os.capture.IRecorder');
 
 /**
  * Abstract class for creating a recording.
- *
+ * @abstract
  * @implements {os.capture.IRecorder}
  * @extends {goog.events.EventTarget}
  * @constructor
@@ -133,9 +133,10 @@ os.capture.AbstractRecorder.prototype.abort = function(opt_msg) {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.capture.AbstractRecorder.prototype.record = goog.abstractMethod;
+os.capture.AbstractRecorder.prototype.record = function() {};
 
 
 /**

--- a/src/os/capture/abstractvideoencoder.js
+++ b/src/os/capture/abstractvideoencoder.js
@@ -11,6 +11,7 @@ goog.require('os.capture.IVideoEncoder');
 
 /**
  * Abstract class for exporting a video.
+ * @abstract
  * @extends {goog.events.EventTarget}
  * @implements {os.capture.IVideoEncoder}
  * @constructor
@@ -122,9 +123,10 @@ os.capture.AbstractVideoEncoder.prototype.process = function() {
 
 /**
  * Process the video frames once the encoder has been loaded.
+ * @abstract
  * @protected
  */
-os.capture.AbstractVideoEncoder.prototype.processInternal = goog.abstractMethod;
+os.capture.AbstractVideoEncoder.prototype.processInternal = function() {};
 
 
 /**

--- a/src/os/command/abstractasynccommand.js
+++ b/src/os/command/abstractasynccommand.js
@@ -9,6 +9,7 @@ goog.require('os.command.State');
 
 /**
  * Abstract asynchronous command implementation.
+ * @abstract
  * @implements {os.command.ICommand}
  * @extends {goog.events.EventTarget}
  * @constructor
@@ -24,9 +25,10 @@ goog.inherits(os.command.AbstractAsyncCommand, goog.events.EventTarget);
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.command.AbstractAsyncCommand.prototype.execute = goog.abstractMethod;
+os.command.AbstractAsyncCommand.prototype.execute = function() {};
 
 
 /**

--- a/src/os/command/abstractlayercmd.js
+++ b/src/os/command/abstractlayercmd.js
@@ -14,7 +14,7 @@ goog.require('os.metrics.Metrics');
  *
  * This should only be used for layers that do not have a descriptor. Layers will a synchronized descriptor should use
  * {@link os.data.AbstractDescriptor} instead.
- *
+ * @abstract
  * @param {(Object<string, *>)=} opt_options The configuration for the map layer.
  * @implements {os.command.ICommand}
  * @extends {goog.Disposable}
@@ -46,15 +46,17 @@ os.command.AbstractLayer.prototype.disposeInternal = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.command.AbstractLayer.prototype.execute = goog.abstractMethod;
+os.command.AbstractLayer.prototype.execute = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.command.AbstractLayer.prototype.revert = goog.abstractMethod;
+os.command.AbstractLayer.prototype.revert = function() {};
 
 
 /**

--- a/src/os/command/abstractselectcmd.js
+++ b/src/os/command/abstractselectcmd.js
@@ -7,6 +7,7 @@ goog.require('os.command.State');
 
 /**
  * Abstract command for performing selections on a source
+ * @abstract
  * @implements {os.command.ICommand}
  * @extends {os.command.AbstractSource}
  * @param {!string} sourceId
@@ -53,8 +54,9 @@ os.command.AbstractSelect.prototype.execute = function() {
 
 /**
  * Does the selection
+ * @abstract
  */
-os.command.AbstractSelect.prototype.select = goog.abstractMethod;
+os.command.AbstractSelect.prototype.select = function() {};
 
 
 /**

--- a/src/os/command/abstractsourcecmd.js
+++ b/src/os/command/abstractsourcecmd.js
@@ -8,6 +8,7 @@ goog.require('os.source.ISource');
 
 /**
  * Abstract command for interaction with sources
+ * @abstract
  * @constructor
  * @implements {os.command.ICommand}
  * @param {!string} sourceId
@@ -41,15 +42,17 @@ os.command.AbstractSource.prototype.isAsync = false;
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.command.AbstractSource.prototype.execute = goog.abstractMethod;
+os.command.AbstractSource.prototype.execute = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.command.AbstractSource.prototype.revert = goog.abstractMethod;
+os.command.AbstractSource.prototype.revert = function() {};
 
 
 /**

--- a/src/os/command/abstractstylecmd.js
+++ b/src/os/command/abstractstylecmd.js
@@ -8,6 +8,7 @@ goog.require('os.layer.PropertyChange');
 
 /**
  * Commands for style changes should extend this class
+ * @abstract
  * @implements {os.command.ICommand}
  * @param {string} layerId
  * @param {T} value
@@ -106,18 +107,20 @@ os.command.AbstractStyle.prototype.canExecute = function() {
 
 /**
  * Gets the old value
+ * @abstract
  * @return {T} the old value
  * @protected
  */
-os.command.AbstractStyle.prototype.getOldValue = goog.abstractMethod;
+os.command.AbstractStyle.prototype.getOldValue = function() {};
 
 
 /**
  * Applies a value to the style config
+ * @abstract
  * @param {Object} config The style config
  * @param {T} value The value to apply
  */
-os.command.AbstractStyle.prototype.applyValue = goog.abstractMethod;
+os.command.AbstractStyle.prototype.applyValue = function(config, value) {};
 
 
 /**

--- a/src/os/command/abstractsynccommand.js
+++ b/src/os/command/abstractsynccommand.js
@@ -8,6 +8,7 @@ goog.require('os.command.State');
 
 /**
  * Abstract synchronous command implementation.
+ * @abstract
  * @implements {os.command.ICommand}
  * @extends {goog.Disposable}
  * @constructor
@@ -23,9 +24,10 @@ goog.inherits(os.command.AbstractSyncCommand, goog.Disposable);
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.command.AbstractSyncCommand.prototype.execute = goog.abstractMethod;
+os.command.AbstractSyncCommand.prototype.execute = function() {};
 
 
 /**

--- a/src/os/config/abstractsettingsinitializer.js
+++ b/src/os/config/abstractsettingsinitializer.js
@@ -7,6 +7,7 @@ goog.require('os.config.Settings');
 /**
  * Abstract class for running logic to initialize settings.  Each application should have an
  * extension of this to implement its specific needs.
+ * @abstract
  * @constructor
  */
 os.config.AbstractSettingsInitializer = function() {
@@ -42,8 +43,9 @@ os.config.AbstractSettingsInitializer.prototype.init = function() {
 
 /**
  * Register settings storages
+ * @abstract
  */
-os.config.AbstractSettingsInitializer.prototype.registerStorages = goog.abstractMethod;
+os.config.AbstractSettingsInitializer.prototype.registerStorages = function() {};
 
 
 /**
@@ -58,6 +60,7 @@ os.config.AbstractSettingsInitializer.prototype.onInitialized = function() {
 
 /**
  * Handle settings finished loading
+ * @abstract
  * @protected
  */
-os.config.AbstractSettingsInitializer.prototype.onSettingsLoaded = goog.abstractMethod;
+os.config.AbstractSettingsInitializer.prototype.onSettingsLoaded = function() {};

--- a/src/os/data/abstractdescriptorcmd.js
+++ b/src/os/data/abstractdescriptorcmd.js
@@ -20,6 +20,7 @@ goog.require('os.metrics.keys');
 
 /**
  * Abstract command for activating/deactivating descriptors.
+ * @abstract
  * @param {!os.data.IDataDescriptor} descriptor The descriptor
  * @implements {os.command.ICommand}
  * @extends {goog.events.EventTarget}
@@ -58,15 +59,17 @@ os.data.AbstractDescriptor.LOGGER_ = goog.log.getLogger('os.data.AbstractDescrip
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.data.AbstractDescriptor.prototype.execute = goog.abstractMethod;
+os.data.AbstractDescriptor.prototype.execute = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.data.AbstractDescriptor.prototype.revert = goog.abstractMethod;
+os.data.AbstractDescriptor.prototype.revert = function() {};
 
 
 /**
@@ -156,18 +159,20 @@ os.data.AbstractDescriptor.prototype.deactivateDescriptor = function() {
 
 /**
  * Callback for the descriptor's activation event.
+ * @abstract
  * @param {goog.events.Event=} opt_event
  * @protected
  */
-os.data.AbstractDescriptor.prototype.onActivated = goog.abstractMethod;
+os.data.AbstractDescriptor.prototype.onActivated = function(opt_event) {};
 
 
 /**
  * Callback for the descriptor's deactivation event.
+ * @abstract
  * @param {goog.events.Event=} opt_event
  * @protected
  */
-os.data.AbstractDescriptor.prototype.onDeactivated = goog.abstractMethod;
+os.data.AbstractDescriptor.prototype.onDeactivated = function(opt_event) {};
 
 
 /**

--- a/src/os/data/fileprovider.js
+++ b/src/os/data/fileprovider.js
@@ -6,6 +6,7 @@ goog.require('os.ui.data.DescriptorProvider');
 
 /**
  * Generic file-based provider
+ * @abstract
  * @extends {os.ui.data.DescriptorProvider<!T>}
  * @template T
  * @constructor
@@ -35,4 +36,12 @@ os.data.FileProvider.prototype.configure = function(config) {
  */
 os.data.FileProvider.prototype.getToolTip = function() {
   return 'Contains all ' + this.getId().toUpperCase() + ' files that have been imported into the application.';
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.data.FileProvider.prototype.getErrorMessage = function() {
+  return null;
 };

--- a/src/os/data/iextent.js
+++ b/src/os/data/iextent.js
@@ -17,4 +17,4 @@ os.data.IExtent.ID = 'os.data.IExtent';
 /**
  * @return {?ol.Extent} The extent or null
  */
-os.data.IExtent.prototype.getExtent = goog.abstractMethod;
+os.data.IExtent.prototype.getExtent;

--- a/src/os/data/ireimport.js
+++ b/src/os/data/ireimport.js
@@ -11,10 +11,10 @@ os.data.IReimport = function() {};
 /**
  * @return {boolean}
  */
-os.data.IReimport.prototype.canReimport = goog.abstractMethod;
+os.data.IReimport.prototype.canReimport;
 
 
 /**
  * Reimports this item
  */
-os.data.IReimport.prototype.reimport = goog.abstractMethod;
+os.data.IReimport.prototype.reimport;

--- a/src/os/data/layersyncdescriptor.js
+++ b/src/os/data/layersyncdescriptor.js
@@ -23,7 +23,7 @@ goog.require('os.ui.node.defaultLayerNodeUIDirective');
  * A descriptor that synchronizes one or more layers on the map. This descriptor should be extended to implement the
  * getLayerOptions function, which should produce the options object(s) to be used in creating the layers synchronized
  * to this descriptor.
- *
+ * @abstract
  * @extends {os.data.BaseDescriptor}
  * @constructor
  */
@@ -128,12 +128,13 @@ os.data.LayerSyncDescriptor.prototype.populateLayerIds = function(opt_options) {
  * layer config applied to it, then will be passed to {@link os.layer.createFromOptions} to create the layer prior to
  * adding it to the map.
  *
+ * @abstract
  * @return {(Array<!Object<string, *>>|Object<string, *>)} An options object that can be used to create a layer, or an
  *                                                         array of options objects.
  *
  * @protected
  */
-os.data.LayerSyncDescriptor.prototype.getLayerOptions = goog.abstractMethod;
+os.data.LayerSyncDescriptor.prototype.getLayerOptions = function() {};
 
 
 /**

--- a/src/os/ex/abstractexporter.js
+++ b/src/os/ex/abstractexporter.js
@@ -9,6 +9,7 @@ goog.require('os.thread.Thread');
 
 /**
  * Base class for exporting content
+ * @abstract
  * @extends {goog.events.EventTarget}
  * @implements {os.ex.IExportMethod}
  * @constructor
@@ -106,9 +107,10 @@ os.ex.AbstractExporter.prototype.reset = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ex.AbstractExporter.prototype.getExtension = goog.abstractMethod;
+os.ex.AbstractExporter.prototype.getExtension = function() {};
 
 
 /**
@@ -128,9 +130,10 @@ os.ex.AbstractExporter.prototype.setItems = function(items) {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ex.AbstractExporter.prototype.getLabel = goog.abstractMethod;
+os.ex.AbstractExporter.prototype.getLabel = function() {};
 
 
 /**

--- a/src/os/filter/ifilterable.js
+++ b/src/os/filter/ifilterable.js
@@ -30,36 +30,36 @@ os.filter.IFilterable.ID = 'os.filter.IFilterable';
 /**
  * @return {?string} The title of the filterable.
  */
-os.filter.IFilterable.prototype.getTitle = goog.abstractMethod;
+os.filter.IFilterable.prototype.getTitle;
 
 
 /**
  * @return {boolean} Whether or not this class is filterable
  */
-os.filter.IFilterable.prototype.isFilterable = goog.abstractMethod;
+os.filter.IFilterable.prototype.isFilterable;
 
 
 /**
  * @return {?string} The filter key to uniquely identify this filterable
  */
-os.filter.IFilterable.prototype.getFilterKey = goog.abstractMethod;
+os.filter.IFilterable.prototype.getFilterKey;
 
 
 /**
  * Launches the filter manager for this class
  */
-os.filter.IFilterable.prototype.launchFilterManager = goog.abstractMethod;
+os.filter.IFilterable.prototype.launchFilterManager;
 
 
 /**
  * Get filter columns
  * @return {?Array<os.ogc.FeatureTypeColumn>} the columns
  */
-os.filter.IFilterable.prototype.getFilterColumns = goog.abstractMethod;
+os.filter.IFilterable.prototype.getFilterColumns;
 
 
 /**
  * Get filterable types
  * @return {!Array<!string>} the list of filterable types
  */
-os.filter.IFilterable.prototype.getFilterableTypes = goog.abstractMethod;
+os.filter.IFilterable.prototype.getFilterableTypes;

--- a/src/os/filter/ifilterentry.js
+++ b/src/os/filter/ifilterentry.js
@@ -11,7 +11,7 @@ os.filter.IFilterEntry = function() {};
 /**
  * @return {string}
  */
-os.filter.IFilterEntry.prototype.getTitle = goog.abstractMethod;
+os.filter.IFilterEntry.prototype.getTitle;
 
 
 /**
@@ -23,7 +23,7 @@ os.filter.IFilterEntry.prototype.setTitle;
 /**
  * @return {?string}
  */
-os.filter.IFilterEntry.prototype.getDescription = goog.abstractMethod;
+os.filter.IFilterEntry.prototype.getDescription;
 
 
 /**
@@ -35,7 +35,7 @@ os.filter.IFilterEntry.prototype.setDescription;
 /**
  * @return {?string} The filter
  */
-os.filter.IFilterEntry.prototype.getFilter = goog.abstractMethod;
+os.filter.IFilterEntry.prototype.getFilter;
 
 
 /**

--- a/src/os/hist/abstracthistogramdata.js
+++ b/src/os/hist/abstracthistogramdata.js
@@ -6,6 +6,7 @@ goog.require('os.hist.IHistogramData');
 /**
  * Abstract class that should be extended by all histogram data classes. It deliberately
  * does not implement the count data structure in order to allow subclasses to do so.
+ * @abstract
  * @implements {os.hist.IHistogramData}
  * @constructor
  */
@@ -49,15 +50,17 @@ os.hist.AbstractHistogramData = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.hist.AbstractHistogramData.prototype.getCounts = goog.abstractMethod;
+os.hist.AbstractHistogramData.prototype.getCounts = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.hist.AbstractHistogramData.prototype.setCounts = goog.abstractMethod;
+os.hist.AbstractHistogramData.prototype.setCounts = function(value) {};
 
 
 /**

--- a/src/os/histo/ibinmethod.js
+++ b/src/os/histo/ibinmethod.js
@@ -22,7 +22,7 @@ os.histo.IBinMethod.prototype.getValue;
 /**
  * @return {string}
  */
-os.histo.IBinMethod.prototype.getField = goog.abstractMethod;
+os.histo.IBinMethod.prototype.getField;
 
 
 /**

--- a/src/os/i3dsupport.js
+++ b/src/os/i3dsupport.js
@@ -19,4 +19,4 @@ os.I3DSupport.ID = 'os.I3DSupport';
  * Whether or not 3D is supported
  * @return {boolean}
  */
-os.I3DSupport.prototype.is3DSupported = goog.abstractMethod;
+os.I3DSupport.prototype.is3DSupported;

--- a/src/os/im/action/abstractimportaction.js
+++ b/src/os/im/action/abstractimportaction.js
@@ -9,6 +9,7 @@ goog.require('os.xml');
 
 /**
  * Abstract import action.
+ * @abstract
  * @implements {os.im.action.IImportAction<T>}
  * @constructor
  * @template T
@@ -66,9 +67,10 @@ os.im.action.AbstractImportAction.XML_TYPE = 'AbstractImportAction';
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.im.action.AbstractImportAction.prototype.execute = goog.abstractMethod;
+os.im.action.AbstractImportAction.prototype.execute = function() {};
 
 
 /**
@@ -131,9 +133,10 @@ os.im.action.AbstractImportAction.prototype.persist = function(opt_to) {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.im.action.AbstractImportAction.prototype.restore = goog.abstractMethod;
+os.im.action.AbstractImportAction.prototype.restore = function(config) {};
 
 
 /**
@@ -145,12 +148,14 @@ os.im.action.AbstractImportAction.prototype.toXml = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.im.action.AbstractImportAction.prototype.fromXml = goog.abstractMethod;
+os.im.action.AbstractImportAction.prototype.fromXml = function(xml) {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.im.action.AbstractImportAction.prototype.reset = goog.abstractMethod;
+os.im.action.AbstractImportAction.prototype.reset = function(items) {};

--- a/src/os/im/action/cmd/abstractfilteractioncmd.js
+++ b/src/os/im/action/cmd/abstractfilteractioncmd.js
@@ -8,6 +8,7 @@ goog.require('os.ui.query.cmd.QueryEntries');
 
 /**
  * Abstract command for adding/removing filter actions.
+ * @abstract
  * @param {!os.im.action.FilterActionEntry} entry The filter action.
  * @param {number=} opt_index The index in the entry list.
  * @param {string=} opt_parentId The parent node ID.
@@ -57,15 +58,17 @@ os.im.action.cmd.AbstractFilterAction = function(entry, opt_index, opt_parentId)
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.im.action.cmd.AbstractFilterAction.prototype.execute = goog.abstractMethod;
+os.im.action.cmd.AbstractFilterAction.prototype.execute = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.im.action.cmd.AbstractFilterAction.prototype.revert = goog.abstractMethod;
+os.im.action.cmd.AbstractFilterAction.prototype.revert = function() {};
 
 
 /**

--- a/src/os/im/mapping/abstractmapping.js
+++ b/src/os/im/mapping/abstractmapping.js
@@ -9,6 +9,7 @@ goog.require('os.xml');
 
 
 /**
+ * @abstract
  * @implements {os.im.mapping.IMapping.<T, S>}
  * @implements {os.IXmlPersistable}
  * @template T,S
@@ -96,9 +97,10 @@ os.im.mapping.AbstractMapping.prototype.getFieldsChanged = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.im.mapping.AbstractMapping.prototype.execute = goog.abstractMethod;
+os.im.mapping.AbstractMapping.prototype.execute = function(item, opt_targetItem) {};
 
 
 /**

--- a/src/os/im/mapping/abstractpositionmapping.js
+++ b/src/os/im/mapping/abstractpositionmapping.js
@@ -6,6 +6,7 @@ goog.require('os.xml');
 
 
 /**
+ * @abstract
  * @extends {os.im.mapping.AbstractMapping}
  * @constructor
  */

--- a/src/os/im/mapping/mapping.js
+++ b/src/os/im/mapping/mapping.js
@@ -55,17 +55,19 @@ os.im.mapping.getTimeTypeForString = function(input) {
 
 /**
  * Convenience function to get a mapping field from an item, or null if the field doesn't exist.
- * @param {Object} item
+ * @param {?Object|undefined} item
  * @param {string} field
  * @return {*}
  *
  * @suppress {accessControls} To allow direct access to feature metadata.
  */
 os.im.mapping.getItemField = function(item, field) {
-  if (os.instanceOf(item, ol.Feature.NAME)) {
-    return /** @type {!ol.Feature} */ (item).values_[field];
-  } else {
-    return item[field];
+  if (item) {
+    if (os.instanceOf(item, ol.Feature.NAME)) {
+      return /** @type {!ol.Feature} */ (item).values_[field];
+    } else {
+      return item[field];
+    }
   }
 };
 

--- a/src/os/layer/config/abstractdatasourcelayerconfig.js
+++ b/src/os/layer/config/abstractdatasourcelayerconfig.js
@@ -21,6 +21,7 @@ goog.require('os.ui.slick.column');
 
 
 /**
+ * @abstract
  * @extends {os.layer.config.AbstractLayerConfig}
  * @constructor
  * @template T
@@ -184,11 +185,12 @@ os.layer.config.AbstractDataSourceLayerConfig.prototype.getImporter = function(o
 
 
 /**
+ * @abstract
  * @param {Object<string, *>} options Layer configuration options.
  * @return {os.parse.IParser<T>}
  * @protected
  */
-os.layer.config.AbstractDataSourceLayerConfig.prototype.getParser = goog.abstractMethod;
+os.layer.config.AbstractDataSourceLayerConfig.prototype.getParser = function(options) {};
 
 
 /**

--- a/src/os/layer/config/abstractlayerconfig.js
+++ b/src/os/layer/config/abstractlayerconfig.js
@@ -8,6 +8,7 @@ goog.require('os.style');
 
 
 /**
+ * @abstract
  * @implements {os.layer.config.ILayerConfig}
  * @constructor
  */
@@ -90,9 +91,10 @@ os.layer.config.AbstractLayerConfig.LOGGER_ = goog.log.getLogger('os.layer.confi
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.layer.config.AbstractLayerConfig.prototype.createLayer = goog.abstractMethod;
+os.layer.config.AbstractLayerConfig.prototype.createLayer = function(options) {};
 
 
 /**

--- a/src/os/layer/config/abstracttilelayerconfig.js
+++ b/src/os/layer/config/abstracttilelayerconfig.js
@@ -15,6 +15,7 @@ goog.require('os.tile.ColorableTile');
 
 
 /**
+ * @abstract
  * @extends {os.layer.config.AbstractLayerConfig}
  * @constructor
  */
@@ -210,11 +211,12 @@ os.layer.config.AbstractTileLayerConfig.prototype.configureLayer = function(laye
 
 
 /**
+ * @abstract
  * @param {Object<string, *>} options
  * @return {ol.source.TileImage}
  * @protected
  */
-os.layer.config.AbstractTileLayerConfig.prototype.getSource = goog.abstractMethod;
+os.layer.config.AbstractTileLayerConfig.prototype.getSource = function(options) {};
 
 
 /**

--- a/src/os/layer/ilayer.js
+++ b/src/os/layer/ilayer.js
@@ -251,7 +251,7 @@ os.layer.ILayer.prototype.setLayerOptions;
  * Gets the layer tree node UI displayed on hover/selection.
  * @return {!string}
  */
-os.layer.ILayer.prototype.getNodeUI = goog.abstractMethod;
+os.layer.ILayer.prototype.getNodeUI;
 
 
 /**
@@ -265,14 +265,14 @@ os.layer.ILayer.prototype.setNodeUI;
  * Gets the group node UI for this layer
  * @return {?string}
  */
-os.layer.ILayer.prototype.getGroupUI = goog.abstractMethod;
+os.layer.ILayer.prototype.getGroupUI;
 
 
 /**
  * Gets the layer controls UI.
  * @return {!string}
  */
-os.layer.ILayer.prototype.getLayerUI = goog.abstractMethod;
+os.layer.ILayer.prototype.getLayerUI;
 
 
 /**

--- a/src/os/mixin/geometrymixin.js
+++ b/src/os/mixin/geometrymixin.js
@@ -43,11 +43,12 @@ ol.geom.Geometry.prototype.getAntiExtent = function(opt_extent) {
 
 
 /**
+ * @abstract
  * @param {ol.Extent} extent
  * @return {ol.Extent}
  * @protected
  */
-ol.geom.Geometry.prototype.computeAntiExtent = goog.abstractMethod;
+ol.geom.Geometry.prototype.computeAntiExtent = function(extent) {};
 
 
 /**

--- a/src/os/net/abstractmodifier.js
+++ b/src/os/net/abstractmodifier.js
@@ -4,6 +4,7 @@ goog.require('os.net.IModifier');
 
 
 /**
+ * @abstract
  * @param {string} id Identifier for the modifier
  * @param {number=} opt_priority Priority of the modifier
  * @implements {os.net.IModifier}
@@ -57,6 +58,7 @@ os.net.AbstractModifier.prototype.setPriority = function(priority) {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.net.AbstractModifier.prototype.modify = goog.abstractMethod;
+os.net.AbstractModifier.prototype.modify = function(uri) {};

--- a/src/os/net/abstractrequesthandler.js
+++ b/src/os/net/abstractrequesthandler.js
@@ -9,6 +9,7 @@ goog.require('os.net.IRequestHandler');
 
 /**
  * The base class for all handlers which make an actual URL request
+ * @abstract
  * @constructor
  * @extends {goog.events.EventTarget}
  * @implements {os.net.IRequestHandler}
@@ -93,33 +94,39 @@ os.net.AbstractRequestHandler.prototype.getStatusCode = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.net.AbstractRequestHandler.prototype.buildRequest = goog.abstractMethod;
+os.net.AbstractRequestHandler.prototype.buildRequest = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.net.AbstractRequestHandler.prototype.getResponse = goog.abstractMethod;
+os.net.AbstractRequestHandler.prototype.getResponse = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.net.AbstractRequestHandler.prototype.getResponseHeaders = goog.abstractMethod;
+os.net.AbstractRequestHandler.prototype.getResponseHeaders = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.net.AbstractRequestHandler.prototype.abort = goog.abstractMethod;
+os.net.AbstractRequestHandler.prototype.abort = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.net.AbstractRequestHandler.prototype.execute = goog.abstractMethod;
+os.net.AbstractRequestHandler.prototype.execute = function(method, uri, opt_headers, opt_formatter, opt_nocache,
+    opt_responseType) {};
 
 
 /**

--- a/src/os/olm/render/baseshape.js
+++ b/src/os/olm/render/baseshape.js
@@ -11,10 +11,10 @@ goog.require('ol.source.Vector');
 
 
 /**
+ * @abstract
  * @constructor
  * @extends {goog.Disposable}
  * @param {ol.style.Style|Array<ol.style.Style>} style Style.
- * @abstract
  */
 os.olm.render.BaseShape = function(style) {
   /**
@@ -100,9 +100,10 @@ os.olm.render.BaseShape.prototype.setMap = function(map) {
 
 
 /**
+ * @abstract
  * @return {ol.geom.Geometry} The geometry to draw
  */
-os.olm.render.BaseShape.prototype.getGeometry = goog.abstractMethod;
+os.olm.render.BaseShape.prototype.getGeometry = function() {};
 
 
 /**

--- a/src/os/parse/asyncparser.js
+++ b/src/os/parse/asyncparser.js
@@ -8,6 +8,7 @@ goog.require('os.parse.IParser');
 /**
  * A generic asynchronous parser. This should be used when setSource involves asynchronous calls. When the parser
  * is ready, call onReady to fire the ready event.
+ * @abstract
  * @extends {goog.events.EventTarget}
  * @implements {os.parse.IParser<T>}
  * @constructor
@@ -38,24 +39,28 @@ os.parse.AsyncParser.prototype.onReady = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.parse.AsyncParser.prototype.hasNext = goog.abstractMethod;
+os.parse.AsyncParser.prototype.hasNext = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.parse.AsyncParser.prototype.parseNext = goog.abstractMethod;
+os.parse.AsyncParser.prototype.parseNext = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.parse.AsyncParser.prototype.setSource = goog.abstractMethod;
+os.parse.AsyncParser.prototype.setSource = function(source) {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.parse.AsyncParser.prototype.cleanup = goog.abstractMethod;
+os.parse.AsyncParser.prototype.cleanup = function() {};

--- a/src/os/parse/asynczipparser.js
+++ b/src/os/parse/asynczipparser.js
@@ -4,6 +4,7 @@ goog.require('os.parse.AsyncParser');
 
 
 /**
+ * @abstract
  * @extends {os.parse.AsyncParser<T>}
  * @template T
  * @constructor
@@ -104,8 +105,9 @@ os.parse.AsyncZipParser.prototype.onError = function() {
 
 
 /**
+ * @abstract
  * @param {Array<!zip.Entry>} entries
  * @protected
  */
-os.parse.AsyncParser.prototype.handleZipEntries = goog.abstractMethod;
+os.parse.AsyncZipParser.prototype.handleZipEntries = function(entries) {};
 

--- a/src/os/parse/baseparserconfig.js
+++ b/src/os/parse/baseparserconfig.js
@@ -55,4 +55,4 @@ os.parse.BaseParserConfig = function() {
  * Updates the preview data and columns from the source.
  * @param {Array.<os.im.mapping.IMapping>=} opt_mappings Mappings to apply to preview items.
  */
-os.parse.BaseParserConfig.prototype.updatePreview = goog.abstractMethod;
+os.parse.BaseParserConfig.prototype.updatePreview = function(opt_mappings) {};

--- a/src/os/plugin/abstractplugin.js
+++ b/src/os/plugin/abstractplugin.js
@@ -46,6 +46,7 @@ os.plugin.AbstractPlugin.prototype.getError = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.plugin.AbstractPlugin.prototype.init = goog.abstractMethod;
+os.plugin.AbstractPlugin.prototype.init = function() {};

--- a/src/os/search/abstractsearch.js
+++ b/src/os/search/abstractsearch.js
@@ -10,6 +10,7 @@ goog.require('os.search.ISearch');
 
 /**
  * Abstract implementation of a search provider.
+ * @abstract
  * @param {string} id The unique identifier for the search provider.
  * @param {string} name The user-facing name of the search provider.
  * @param {string=} opt_type The search type
@@ -170,19 +171,22 @@ os.search.AbstractSearch.prototype.shouldNormalize = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.search.AbstractSearch.prototype.cancel = goog.abstractMethod;
+os.search.AbstractSearch.prototype.cancel = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.search.AbstractSearch.prototype.autocomplete = goog.abstractMethod;
+os.search.AbstractSearch.prototype.autocomplete = function(term, opt_maxResults) {};
 
 
 /**
  * Search for a term.
+ * @abstract
  * @param {string} term The keyword to use in the search
  * @param {number=} opt_start The start index of the page of results to return.
  *   Defaults to the first page.
@@ -190,7 +194,7 @@ os.search.AbstractSearch.prototype.autocomplete = goog.abstractMethod;
  *   Defaults to an appropriate value.
  * @return {boolean} Return true to continue, othereise false.
  */
-os.search.AbstractSearch.prototype.searchTerm = goog.abstractMethod;
+os.search.AbstractSearch.prototype.searchTerm = function(term, opt_start, opt_pageSize) {};
 
 
 /**

--- a/src/os/search/abstractsearchmanager.js
+++ b/src/os/search/abstractsearchmanager.js
@@ -8,6 +8,7 @@ goog.require('os.user.settings.FavoriteManager');
 
 /**
  * Responsible for executing search terms against the registered search managers
+ * @abstract
  * @param {string=} opt_id
  * @param {string=} opt_name
  * @extends {goog.events.EventTarget}
@@ -208,6 +209,7 @@ os.search.AbstractSearchManager.prototype.isContainer = function() {
 
 /**
  * Execute search using registered searches.
+ * @abstract
  * @param {string} term The keyword search term
  * @param {number=} opt_start The index of the search results page
  * @param {number=} opt_pageSize The number of results to include per page
@@ -216,73 +218,80 @@ os.search.AbstractSearchManager.prototype.isContainer = function() {
  * @param {boolean=} opt_noFacets flag for indicating facet search is not needed
  * @param {string=} opt_sortOrder The sort order
  */
-os.search.AbstractSearchManager.prototype.search = goog.abstractMethod;
+os.search.AbstractSearchManager.prototype.search = function(term, opt_start, opt_pageSize, opt_sortBy, opt_force,
+    opt_noFacets, opt_sortOrder) {};
 
 
 /**
  * Requests autocomplete results from a search term.
+ * @abstract
  * @param {string} term The keyword to use in the search
  * @param {number=} opt_maxResults The maximum number of autocomplete results.
  */
-os.search.AbstractSearchManager.prototype.autocomplete = goog.abstractMethod;
+os.search.AbstractSearchManager.prototype.autocomplete = function(term, opt_maxResults) {};
 
 
 /**
  * Clear the search results.
+ * @abstract
  * @param {string=} opt_term A default search term. If not provided, the term will be cleared.
  */
-os.search.AbstractSearchManager.prototype.clear = goog.abstractMethod;
+os.search.AbstractSearchManager.prototype.clear = function(opt_term) {};
 
 
 /**
  * Retrieve the total number of search results
+ * @abstract
  * @return {number}
  */
-os.search.AbstractSearchManager.prototype.getTotal = goog.abstractMethod;
+os.search.AbstractSearchManager.prototype.getTotal = function() {};
 
 
 /**
  * Retrieve the identifying names of all the registered searches.
+ * @abstract
  * @param {boolean=} opt_excludeExternal
  * @return {!Array<!os.search.ISearch>}
  */
-os.search.AbstractSearchManager.prototype.getRegisteredSearches = goog.abstractMethod;
+os.search.AbstractSearchManager.prototype.getRegisteredSearches = function(opt_excludeExternal) {};
 
 
 /**
  * Get the search providers that are currently enabled, and
  * optionally support the search term.
+ * @abstract
  * @param {string=} opt_term
  * @return {!Array<!os.search.ISearch>}
  */
-os.search.AbstractSearchManager.prototype.getEnabledSearches = goog.abstractMethod;
+os.search.AbstractSearchManager.prototype.getEnabledSearches = function(opt_term) {};
 
 
 /**
  * Retrieve search results as they have been captured be all searches or for a specitic search
+ * @abstract
  * @param {number=} opt_limit
  * @return {Array} A shallow copy of the search results
  */
-os.search.AbstractSearchManager.prototype.getResults = goog.abstractMethod;
+os.search.AbstractSearchManager.prototype.getResults = function(opt_limit) {};
 
 
 /**
  * Force events to fire indicating whether there is a search in progress.
+ * @abstract
  */
-os.search.AbstractSearchManager.prototype.checkProgress = goog.abstractMethod;
+os.search.AbstractSearchManager.prototype.checkProgress = function() {};
 
 
 /**
  * Gets the providers still loading.
+ * @abstract
  * @return {!Object<string, boolean>} object of loading providers
  */
-os.search.AbstractSearchManager.prototype.getLoading = goog.abstractMethod;
+os.search.AbstractSearchManager.prototype.getLoading = function() {};
 
 
 /**
+ * @abstract
  * @return {boolean} whether providers are still loading
  */
-os.search.AbstractSearchManager.prototype.isLoading = goog.abstractMethod;
-
-
-
+os.search.AbstractSearchManager.prototype.isLoading = function() {};

--- a/src/os/search/abstractsearchresult.js
+++ b/src/os/search/abstractsearchresult.js
@@ -5,6 +5,7 @@ goog.require('os.search.ISearchResult');
 
 /**
  * Base class for a search result.
+ * @abstract
  * @param {T} result The result.
  * @param {number=} opt_score The result's score.
  * @param {number|string=} opt_id The result's id.
@@ -85,15 +86,10 @@ os.search.AbstractSearchResult.prototype.setScore = function(value) {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.search.AbstractSearchResult.prototype.getSearchUI = goog.abstractMethod;
-
-
-/**
- * @inheritDoc
- */
-os.search.AbstractSearchResult.prototype.setSearchUI = goog.abstractMethod;
+os.search.AbstractSearchResult.prototype.getSearchUI = function() {};
 
 
 /**

--- a/src/os/search/abstracturlsearch.js
+++ b/src/os/search/abstracturlsearch.js
@@ -10,6 +10,7 @@ goog.require('os.search.SearchEventType');
 
 
 /**
+ * @abstract
  * @param {string} id The unique identifier for the search provider.
  * @param {string} name The user-facing name of the search provider.
  * @extends {os.search.AbstractSearch}
@@ -46,14 +47,13 @@ goog.inherits(os.search.AbstractUrlSearch, os.search.AbstractSearch);
 
 
 /**
+ * @abstract
  * @param {string} term
  * @param {number=} opt_start
  * @param {number=} opt_pageSize
  * @return {?string} The search URL
  */
-os.search.AbstractUrlSearch.prototype.getSearchUrl = function(term, opt_start, opt_pageSize) {
-  return null;
-};
+os.search.AbstractUrlSearch.prototype.getSearchUrl = function(term, opt_start, opt_pageSize) {};
 
 
 /**

--- a/src/os/search/ifacetedsearch.js
+++ b/src/os/search/ifacetedsearch.js
@@ -24,13 +24,13 @@ os.search.IFacetedSearch.ID = 'os.search.IFacetedSearch';
  *
  * When facets are loaded, SearchEventType.FACETLOAD should be dispatched
  */
-os.search.IFacetedSearch.prototype.loadFacets = goog.abstractMethod;
+os.search.IFacetedSearch.prototype.loadFacets;
 
 
 /**
  * @return {?os.search.FacetSet}
  */
-os.search.IFacetedSearch.prototype.getFacets = goog.abstractMethod;
+os.search.IFacetedSearch.prototype.getFacets;
 
 
 /**

--- a/src/os/search/isearch.js
+++ b/src/os/search/isearch.js
@@ -30,7 +30,7 @@ os.search.ISearch.prototype.search;
 /**
  * Cancels any pending requests
  */
-os.search.ISearch.prototype.cancel = goog.abstractMethod;
+os.search.ISearch.prototype.cancel;
 
 
 /**

--- a/src/os/search/isearchresult.js
+++ b/src/os/search/isearchresult.js
@@ -53,13 +53,6 @@ os.search.ISearchResult.prototype.getSearchUI;
 
 
 /**
- * Set the interface used to render the search result.
- * @param {string} value
- */
-os.search.ISearchResult.prototype.setSearchUI;
-
-
-/**
  * Perform an application action for the result. Should return if action was taken, otherwise the result will be
  * displayed in the search results.
  * @return {boolean} If the action was performed.

--- a/src/os/state/abstractstate.js
+++ b/src/os/state/abstractstate.js
@@ -7,6 +7,7 @@ goog.require('os.state.Tag');
 
 
 /**
+ * @abstract
  * @implements {os.state.IState.<T, S>}
  * @constructor
  * @template T,S
@@ -143,11 +144,12 @@ os.state.AbstractState.prototype.save = function(options) {
 
 /**
  * Create the root object for the saved state.
+ * @abstract
  * @param {S} options The save options
  * @return {T}
  * @protected
  */
-os.state.AbstractState.prototype.createRoot = goog.abstractMethod;
+os.state.AbstractState.prototype.createRoot = function(options) {};
 
 
 /**
@@ -180,20 +182,22 @@ os.state.AbstractState.prototype.saveFailed = function(errorMsg) {
 
 /**
  * Subclasses should implement this method to perform the save operation.
+ * @abstract
  * @param {S} options The save options
  * @param {!T} rootObj The root XML node for this state.
  * @protected
  */
-os.state.AbstractState.prototype.saveInternal = goog.abstractMethod;
+os.state.AbstractState.prototype.saveInternal = function(options, rootObj) {};
 
 
 /**
  * Get the source for the provided node
+ * @abstract
  * @param {T} node The node
  * @return {?string} The source
  * @protected
  */
-os.state.AbstractState.prototype.getSource = goog.abstractMethod;
+os.state.AbstractState.prototype.getSource = function(node) {};
 
 
 /**
@@ -208,15 +212,17 @@ os.state.AbstractState.prototype.toString = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.state.AbstractState.prototype.load = goog.abstractMethod;
+os.state.AbstractState.prototype.load = function(obj, id, opt_title) {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.state.AbstractState.prototype.remove = goog.abstractMethod;
+os.state.AbstractState.prototype.remove = function(id) {};
 
 
 /**

--- a/src/os/state/basestatemanager.js
+++ b/src/os/state/basestatemanager.js
@@ -27,6 +27,7 @@ os.stateManager = null;
 
 /**
  * Base state manager. Applications should extend this to fill in the abstract methods.
+ * @abstract
  * @extends {goog.events.EventTarget}
  * @constructor
  * @template T,S
@@ -420,14 +421,16 @@ os.state.BaseStateManager.prototype.onFileError_ = function(error) {
 
 /**
  * Determine which parts of a state are supported by the application.
+ * @abstract
  * @param {T|string} obj The state
  * @return {!Array.<!os.state.IState>} Supported states
  */
-os.state.BaseStateManager.prototype.analyze = goog.abstractMethod;
+os.state.BaseStateManager.prototype.analyze = function(obj) {};
 
 
 /**
  * Creates the root state object.
+ * @abstract
  * @param {os.ex.IPersistenceMethod} method The persistence method
  * @param {string} title The title
  * @param {string=} opt_desc The description
@@ -435,11 +438,12 @@ os.state.BaseStateManager.prototype.analyze = goog.abstractMethod;
  * @return {T} The save options
  * @protected
  */
-os.state.BaseStateManager.prototype.createStateObject = goog.abstractMethod;
+os.state.BaseStateManager.prototype.createStateObject = function(method, title, opt_desc, opt_tags) {};
 
 
 /**
  * Creates state save options.
+ * @abstract
  * @param {os.ex.IPersistenceMethod} method The persistence method
  * @param {string} title The title
  * @param {T} obj The root state object
@@ -448,30 +452,33 @@ os.state.BaseStateManager.prototype.createStateObject = goog.abstractMethod;
  * @return {S} The save options
  * @protected
  */
-os.state.BaseStateManager.prototype.createStateOptions = goog.abstractMethod;
+os.state.BaseStateManager.prototype.createStateOptions = function(method, title, obj, opt_desc, opt_tags) {};
 
 
 /**
  * Gets the state file name.
+ * @abstract
  * @param {S} options The state options
  * @return {?string} The file name
  */
-os.state.BaseStateManager.prototype.getStateFileName = goog.abstractMethod;
+os.state.BaseStateManager.prototype.getStateFileName = function(options) {};
 
 
 /**
  * Load a state from a document.
+ * @abstract
  * @param {T|string} obj The state
  * @param {Array.<!os.state.IState>} states The states to load
  * @param {string} stateId The state's identifier
  * @param {?string=} opt_title The state's title
  */
-os.state.BaseStateManager.prototype.loadState = goog.abstractMethod;
+os.state.BaseStateManager.prototype.loadState = function(obj, states, stateId, opt_title) {};
 
 
 /**
  * Serializes the state file content to a string.
+ * @abstract
  * @param {S} options The state options
  * @return {?string} The serialized content
  */
-os.state.BaseStateManager.prototype.serializeContent = goog.abstractMethod;
+os.state.BaseStateManager.prototype.serializeContent = function(options) {};

--- a/src/os/state/v2/basefilterstate.js
+++ b/src/os/state/v2/basefilterstate.js
@@ -201,3 +201,9 @@ os.state.v2.BaseFilter.prototype.processFilters = function(rootObj, opt_sourceId
     }
   }
 };
+
+
+/**
+ * @inheritDoc
+ */
+os.state.v2.BaseFilter.prototype.remove = function(id) {};

--- a/src/os/state/v4/baselayerstate.js
+++ b/src/os/state/v4/baselayerstate.js
@@ -1172,3 +1172,9 @@ os.state.v4.BaseLayerState.prototype.colorModeOptionsToXml_ = function(colorMode
   }
   return element;
 };
+
+
+/**
+ * @inheritDoc
+ */
+os.state.v4.BaseLayerState.prototype.remove = function(id) {};

--- a/src/os/state/xmlstate.js
+++ b/src/os/state/xmlstate.js
@@ -10,6 +10,7 @@ goog.require('os.xml');
 
 /**
  * Base class for XML states.
+ * @abstract
  * @extends {os.state.AbstractState.<!Element, os.state.XMLStateOptions>}
  * @constructor
  */

--- a/src/os/storage/asyncstorage.js
+++ b/src/os/storage/asyncstorage.js
@@ -10,6 +10,7 @@ goog.require('os.storage.IAsyncStorage');
 
 /**
  * Basic interface for all asynchronous storage mechanisms.
+ * @abstract
  * @implements {os.storage.IAsyncStorage}
  * @extends {goog.Disposable}
  * @constructor
@@ -22,44 +23,48 @@ goog.inherits(os.storage.AsyncStorage, goog.Disposable);
 
 
 /**
+ * @abstract
  * @inheritDoc
  * @see {os.storage.IAsyncStorage}
  */
-os.storage.AsyncStorage.prototype.init = goog.abstractMethod;
+os.storage.AsyncStorage.prototype.init = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  * @see {os.storage.IAsyncStorage}
  */
-os.storage.AsyncStorage.prototype.get = goog.abstractMethod;
+os.storage.AsyncStorage.prototype.get = function(key) {};
 
 
 /**
  * Get all values from storage.
- *
+ * @abstract
  * @return {!goog.async.Deferred<!Array<T>>} A deferred that resolves with all values in storage.
- *
  * @template T
  */
-os.storage.AsyncStorage.prototype.getAll = goog.abstractMethod;
+os.storage.AsyncStorage.prototype.getAll = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.storage.AsyncStorage.prototype.set = goog.abstractMethod;
+os.storage.AsyncStorage.prototype.set = function(key, value, opt_replace) {};
 
 
 /**
- * @inheritDoc
- * @see {os.storage.IAsyncStorage}
- */
-os.storage.AsyncStorage.prototype.remove = goog.abstractMethod;
-
-
-/**
+ * @abstract
  * @inheritDoc
  * @see {os.storage.IAsyncStorage}
  */
-os.storage.AsyncStorage.prototype.clear = goog.abstractMethod;
+os.storage.AsyncStorage.prototype.remove = function(key) {};
+
+
+/**
+ * @abstract
+ * @inheritDoc
+ * @see {os.storage.IAsyncStorage}
+ */
+os.storage.AsyncStorage.prototype.clear = function() {};

--- a/src/os/storage/imechanism.js
+++ b/src/os/storage/imechanism.js
@@ -23,7 +23,7 @@ os.storage.IMechanism.ID = 'os.storage.IMechanism';
  * @param {string} key The key to get.
  * @return {?string} The corresponding value, null if not found.
  */
-os.storage.IMechanism.prototype.get = goog.abstractMethod;
+os.storage.IMechanism.prototype.get;
 
 
 /**
@@ -59,7 +59,7 @@ os.storage.IMechanism.prototype.clear;
  * @param {string} key The key to set.
  * @param {string} value The string to save.
  */
-os.storage.IMechanism.prototype.set = goog.abstractMethod;
+os.storage.IMechanism.prototype.set;
 
 
 /**
@@ -67,4 +67,4 @@ os.storage.IMechanism.prototype.set = goog.abstractMethod;
  *
  * @param {string} key The key to remove.
  */
-os.storage.IMechanism.prototype.remove = goog.abstractMethod;
+os.storage.IMechanism.prototype.remove;

--- a/src/os/style/abstractreader.js
+++ b/src/os/style/abstractreader.js
@@ -6,6 +6,7 @@ goog.require('os.style.IStyleReader');
 
 /**
  * Base implementation of a style configuration reader.
+ * @abstract
  * @implements {os.style.IStyleReader<T>}
  * @constructor
  * @template T
@@ -35,9 +36,10 @@ os.style.AbstractReader = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.style.AbstractReader.prototype.getOrCreateStyle = goog.abstractMethod;
+os.style.AbstractReader.prototype.getOrCreateStyle = function(config) {};
 
 
 /**

--- a/src/os/style/iconreader.js
+++ b/src/os/style/iconreader.js
@@ -154,7 +154,7 @@ os.style.IconReader.prototype.toConfig = function(style, obj) {
  *   1. Those URLs will be inaccessible on other networks
  *   2. To avoid cross-origin security restrictions that result in a tainted canvas
  *
- * @param {Object<string, *>} config
+ * @param {!Object<string, *>} config
  */
 os.style.IconReader.translateIcons = function(config) {
   // fall back to the default icon if none provided

--- a/src/os/style/istylereader.js
+++ b/src/os/style/istylereader.js
@@ -11,7 +11,7 @@ os.style.IStyleReader = function() {};
 
 /**
  * Get a style from the cache, or create a new one and add it to the cache.
- * @param {Object<string, *>} config
+ * @param {!Object<string, *>} config
  * @return {T}
  */
 os.style.IStyleReader.prototype.getOrCreateStyle;

--- a/src/os/style/stylemanager.js
+++ b/src/os/style/stylemanager.js
@@ -99,7 +99,7 @@ goog.addSingletonGetter(os.style.StyleManager);
 
 
 /**
- * @param {Object} config
+ * @param {!Object<string, *>} config
  * @return {?ol.style.Style}
  */
 os.style.StyleManager.prototype.getOrCreateStyle = function(config) {

--- a/src/os/ui/capture/elementrenderer.js
+++ b/src/os/ui/capture/elementrenderer.js
@@ -7,6 +7,7 @@ goog.require('os.capture');
 
 /**
  * Renders an element to the canvas.
+ * @abstract
  * @param {Object=} opt_options Options to configure the renderer
  * @constructor
  * @template T
@@ -56,9 +57,10 @@ os.ui.capture.ElementRenderer.prototype.drawToCanvas = function(canvas) {
 
 /**
  * Get the canvas for this renderer.
+ * @abstract
  * @return {!goog.Promise<HTMLCanvasElement>}
  */
-os.ui.capture.ElementRenderer.prototype.getCanvas = goog.abstractMethod;
+os.ui.capture.ElementRenderer.prototype.getCanvas = function() {};
 
 
 /**

--- a/src/os/ui/columnactions/abstractcolumnaction.js
+++ b/src/os/ui/columnactions/abstractcolumnaction.js
@@ -4,7 +4,7 @@ goog.require('goog.structs.Map');
 
 
 /**
- *
+ * @abstract
  * @constructor
  */
 os.ui.columnactions.AbstractColumnAction = function() {
@@ -44,10 +44,11 @@ os.ui.columnactions.AbstractColumnAction.prototype.getDescription = function() {
 
 /**
  * Get a represntation of the action for display.
+ * @abstract
  * @param {*} value the value to be manipulated for display.
  * @return {*}
  */
-os.ui.columnactions.AbstractColumnAction.prototype.toDisplay = goog.abstractMethod;
+os.ui.columnactions.AbstractColumnAction.prototype.toDisplay = function(value) {};
 
 
 /**
@@ -68,16 +69,18 @@ os.ui.columnactions.AbstractColumnAction.prototype.setRegExps = function(regexps
 /**
  * Set the action to be performed
  * Can come from a config, or be passed in.
+ * @abstract
  * @param {*} action
  */
-os.ui.columnactions.AbstractColumnAction.prototype.setAction = goog.abstractMethod;
+os.ui.columnactions.AbstractColumnAction.prototype.setAction = function(action) {};
 
 
 /**
  * Run the action
+ * @abstract
  * @param {*} value
  */
-os.ui.columnactions.AbstractColumnAction.prototype.execute = goog.abstractMethod;
+os.ui.columnactions.AbstractColumnAction.prototype.execute = function(value) {};
 
 
 /**
@@ -86,6 +89,7 @@ os.ui.columnactions.AbstractColumnAction.prototype.execute = goog.abstractMethod
  * exist and the <code>sourceId</code> or <code>sourceUrl</code> parameter is supplied, then
  * they are given higher priority than the column match and will fail first.
  *
+ * @abstract
  * @param {Object.<string, *>} context  The items to be matched.  They are meaningful to the concrete column
  *                                          action class.
  * @param {os.ui.columnactions.IColumnActionModel} a technology agnostic model that describes the table column.
@@ -93,4 +97,4 @@ os.ui.columnactions.AbstractColumnAction.prototype.execute = goog.abstractMethod
  * @return {boolean} True if the column action applies, false otherwise.
  *
  */
-os.ui.columnactions.AbstractColumnAction.prototype.matches = goog.abstractMethod;
+os.ui.columnactions.AbstractColumnAction.prototype.matches = function(context, a, value) {};

--- a/src/os/ui/config/angularappsettingsinitializer.js
+++ b/src/os/ui/config/angularappsettingsinitializer.js
@@ -5,6 +5,7 @@ goog.require('os.config.ThemeSettings');
 
 
 /**
+ * @abstract
  * @extends {os.config.AbstractSettingsInitializer}
  * @constructor
  */

--- a/src/os/ui/data/baseprovider.js
+++ b/src/os/ui/data/baseprovider.js
@@ -8,6 +8,7 @@ goog.require('os.ui.slick.SlickTreeNode');
 
 /**
  * The base implementation of a provider
+ * @abstract
  * @extends {os.ui.slick.SlickTreeNode}
  * @implements {os.data.IDataProvider}
  * @constructor
@@ -175,9 +176,10 @@ os.ui.data.BaseProvider.prototype.getCheckboxDisabled = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.data.BaseProvider.prototype.getErrorMessage = goog.abstractMethod;
+os.ui.data.BaseProvider.prototype.getErrorMessage = function() {};
 
 
 /**

--- a/src/os/ui/data/descriptorprovider.js
+++ b/src/os/ui/data/descriptorprovider.js
@@ -10,6 +10,7 @@ goog.require('os.ui.data.DescriptorNode');
 
 /**
  * Generic descriptor-based provider
+ * @abstract
  * @extends {os.ui.data.BaseProvider}
  * @constructor
  * @template T

--- a/src/os/ui/draw/abstractdrawcontrol.js
+++ b/src/os/ui/draw/abstractdrawcontrol.js
@@ -10,6 +10,7 @@ goog.require('os.ui.draw.IDrawControl');
 
 /**
  * Box drawing control.
+ * @abstract
  * @param {!SVGSVGElement} owner Owner DOM element.
  * @extends {goog.events.EventTarget}
  * @implements {os.ui.draw.IDrawControl}
@@ -112,12 +113,14 @@ os.ui.draw.AbstractDrawControl.prototype.setMarker = function(marker) {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.draw.AbstractDrawControl.prototype.getElementType = goog.abstractMethod;
+os.ui.draw.AbstractDrawControl.prototype.getElementType = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.draw.AbstractDrawControl.prototype.contains = goog.abstractMethod;
+os.ui.draw.AbstractDrawControl.prototype.contains = function(coord) {};

--- a/src/os/ui/feature/tab/abstractfeaturetabctrl.js
+++ b/src/os/ui/feature/tab/abstractfeaturetabctrl.js
@@ -4,6 +4,7 @@ goog.provide('os.ui.feature.tab.AbstractFeatureTabCtrl');
 
 /**
  * Abstract controller for feature tabs.
+ * @abstract
  * @param {!angular.Scope} $scope
  * @param {!angular.JQLite} $element
  * @constructor
@@ -45,8 +46,9 @@ os.ui.feature.tab.AbstractFeatureTabCtrl.prototype.destroy = function() {
 
 /**
  * Update the tab content
+ * @abstract
  * @param {?angular.Scope.Event} event The broadcast event
  * @param {*} data The event data
  * @protected
  */
-os.ui.feature.tab.AbstractFeatureTabCtrl.prototype.updateTab = goog.abstractMethod;
+os.ui.feature.tab.AbstractFeatureTabCtrl.prototype.updateTab = function(event, data) {};

--- a/src/os/ui/file/anytypeimport.js
+++ b/src/os/ui/file/anytypeimport.js
@@ -71,7 +71,7 @@ os.ui.file.AnyTypeImportCtrl = function($scope, $element) {
  */
 os.ui.file.AnyTypeImportCtrl.prototype.accept = function() {
   try {
-    this['import'].launchUI(this.scope_['file'], this.scope_['config']);
+    this['import'].launchUI(/** @type {os.file.File} */ (this.scope_['file']), this.scope_['config']);
   } catch (e) {
     os.alert.AlertManager.getInstance().sendAlert(
         'Error loading file: <b>' + this.scope_['file'].getFileName() + '</b>', os.alert.AlertEventSeverity.ERROR);

--- a/src/os/ui/file/csv/abstractcsvexporter.js
+++ b/src/os/ui/file/csv/abstractcsvexporter.js
@@ -6,6 +6,7 @@ goog.require('os.ex.AbstractExporter');
 
 /**
  * A CSV exporter driven by PapaParse.
+ * @abstract
  * @extends {os.ex.AbstractExporter.<T>}
  * @constructor
  * @template T
@@ -89,12 +90,13 @@ os.ui.file.csv.AbstractCSVExporter.prototype.process = function() {
 
 /**
  * Process a single item, returning a JSON object for PapaParse.
+ * @abstract
  * @param {T} item The item
  * @return {Object.<string, string>} The Papa item
  * @protected
  * @template T
  */
-os.ui.file.csv.AbstractCSVExporter.prototype.processItem = goog.abstractMethod;
+os.ui.file.csv.AbstractCSVExporter.prototype.processItem = function(item) {};
 
 
 /**

--- a/src/os/ui/file/csv/abstractcsvparser.js
+++ b/src/os/ui/file/csv/abstractcsvparser.js
@@ -11,6 +11,7 @@ goog.require('os.ui.file.csv');
 
 /**
  * A CSV parser driven by PapaParse.
+ * @abstract
  * @param {os.parse.BaseParserConfig} config
  * @extends {os.parse.AsyncParser}
  * @template T
@@ -113,12 +114,13 @@ os.ui.file.csv.AbstractCsvParser.prototype.handleComplete_ = function(results) {
 
 /**
  * Processes a single PapaParse result.
+ * @abstract
  * @protected
  * @param {Object.<string, *>} result The result to process
  * @param {Array.<os.im.mapping.IMapping>=} opt_mappings The set of mappings to apply to parsed features.
  * @return {!T}
  */
-os.ui.file.csv.AbstractCsvParser.prototype.processResult = goog.abstractMethod;
+os.ui.file.csv.AbstractCsvParser.prototype.processResult = function(result, opt_mappings) {};
 
 
 /**
@@ -187,11 +189,12 @@ os.ui.file.csv.AbstractCsvParser.prototype.prepareSource = function(source) {
 
 /**
  * Synchronously parse a limited set of results from a source.
+ * @abstract
  * @param {string} source The CSV source.
  * @param {Array.<os.im.mapping.IMapping>=} opt_mappings The set of mappings to apply to parsed features.
  * @return {Array.<!T>}
  */
-os.ui.file.csv.AbstractCsvParser.prototype.parsePreview = goog.abstractMethod;
+os.ui.file.csv.AbstractCsvParser.prototype.parsePreview = function(source, opt_mappings) {};
 
 
 /**

--- a/src/os/ui/file/kml/abstractkmlexporter.js
+++ b/src/os/ui/file/kml/abstractkmlexporter.js
@@ -22,6 +22,7 @@ goog.require('os.xml');
 
 /**
  * Abstract KML exporter
+ * @abstract
  * @extends {os.ex.ZipExporter<T>}
  * @constructor
  * @template T
@@ -742,11 +743,12 @@ os.ui.file.kml.AbstractKMLExporter.prototype.getChildren = function(item) {
 
 /**
  * Get the color of an item. This should return an ABGR string that can be dropped directly into the KML.
+ * @abstract
  * @param {T} item The item
  * @return {string} The item's color as an ABGR string
  * @protected
  */
-os.ui.file.kml.AbstractKMLExporter.prototype.getColor = goog.abstractMethod;
+os.ui.file.kml.AbstractKMLExporter.prototype.getColor = function(item) {};
 
 
 /**
@@ -780,20 +782,22 @@ os.ui.file.kml.AbstractKMLExporter.prototype.setFields = function(value) {
 
 /**
  * Get the geometry for an item.
+ * @abstract
  * @param {T} item The item
  * @return {(ol.geom.Geometry|undefined)}
  * @protected
  */
-os.ui.file.kml.AbstractKMLExporter.prototype.getGeometry = goog.abstractMethod;
+os.ui.file.kml.AbstractKMLExporter.prototype.getGeometry = function(item) {};
 
 
 /**
  * Get the icon rotation column.
+ * @abstract
  * @param {T} item The item
  * @return {string|null|undefined}
  * @protected
  */
-os.ui.file.kml.AbstractKMLExporter.prototype.getRotationColumn = goog.abstractMethod;
+os.ui.file.kml.AbstractKMLExporter.prototype.getRotationColumn = function(item) {};
 
 
 /**
@@ -818,21 +822,23 @@ os.ui.file.kml.AbstractKMLExporter.prototype.setIcon = function(icon) {
 
 /**
  * Get the id of an item.
+ * @abstract
  * @param {T} item The item
  * @return {string} The item's id
  * @protected
  */
-os.ui.file.kml.AbstractKMLExporter.prototype.getId = goog.abstractMethod;
+os.ui.file.kml.AbstractKMLExporter.prototype.getId = function(item) {};
 
 
 /**
  * Get the field value from an item.
+ * @abstract
  * @param {T} item The item
  * @param {string} field The field
  * @return {*} The value
  * @protected
  */
-os.ui.file.kml.AbstractKMLExporter.prototype.getField = goog.abstractMethod;
+os.ui.file.kml.AbstractKMLExporter.prototype.getField = function(item, field) {};
 
 
 /**
@@ -884,11 +890,12 @@ os.ui.file.kml.AbstractKMLExporter.prototype.getParent = function(item) {
 
 /**
  * Get all properties from an item.
+ * @abstract
  * @param {T} item The item
  * @return {Object<string, *>} The item's properties
  * @protected
  */
-os.ui.file.kml.AbstractKMLExporter.prototype.getProperties = goog.abstractMethod;
+os.ui.file.kml.AbstractKMLExporter.prototype.getProperties = function(item) {};
 
 
 /**
@@ -934,20 +941,22 @@ os.ui.file.kml.AbstractKMLExporter.prototype.getStyleId = function(item) {
 
 /**
  * Gets the style type for an item.
+ * @abstract
  * @param {T} item The item
  * @return {string} The style type for the item
  * @protected
  */
-os.ui.file.kml.AbstractKMLExporter.prototype.getStyleType = goog.abstractMethod;
+os.ui.file.kml.AbstractKMLExporter.prototype.getStyleType = function(item) {};
 
 
 /**
  * Gets the time associated with the provided item.
+ * @abstract
  * @param {T} item The item
  * @return {os.time.ITime} The item's time
  * @protected
  */
-os.ui.file.kml.AbstractKMLExporter.prototype.getTime = goog.abstractMethod;
+os.ui.file.kml.AbstractKMLExporter.prototype.getTime = function(item) {};
 
 
 /**

--- a/src/os/ui/file/ui/abstractfileimport.js
+++ b/src/os/ui/file/ui/abstractfileimport.js
@@ -10,6 +10,7 @@ goog.require('os.ui.window');
 
 /**
  * Abstract controller for a file import UI.
+ * @abstract
  * @param {!angular.Scope} $scope
  * @param {!angular.JQLite} $element
  * @constructor
@@ -110,10 +111,11 @@ os.ui.file.ui.AbstractFileImportCtrl.prototype.onTitleChange = function(newVal) 
 
 /**
  * Create a descriptor for the import.
+ * @abstract
  * @return {DESCRIPTOR}
  * @protected
  */
-os.ui.file.ui.AbstractFileImportCtrl.prototype.createDescriptor = goog.abstractMethod;
+os.ui.file.ui.AbstractFileImportCtrl.prototype.createDescriptor = function() {};
 
 
 /**

--- a/src/os/ui/im/abstractimportui.js
+++ b/src/os/ui/im/abstractimportui.js
@@ -4,6 +4,7 @@ goog.require('os.ui.im.IImportUI');
 
 
 /**
+ * @abstract
  * @implements {os.ui.im.IImportUI<T>}
  * @constructor
  * @template T
@@ -26,9 +27,10 @@ os.ui.im.AbstractImportUI.prototype.getTitle = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.im.AbstractImportUI.prototype.launchUI = goog.abstractMethod;
+os.ui.im.AbstractImportUI.prototype.launchUI = function(file, config) {};
 
 
 /**

--- a/src/os/ui/im/abstractmapperctrl.js
+++ b/src/os/ui/im/abstractmapperctrl.js
@@ -266,16 +266,10 @@ os.ui.im.AbstractMapperCtrl.prototype.update = function() {
 /**
  * Gets the rules appropriate to the implementation. Should be overridden to get the right ones.
  * @abstract
+ * @param {Array} uniqueKeys
+ * @return {?Array<!os.im.mapping.Rule>}
  */
-os.ui.im.AbstractMapperCtrl.prototype.createRules = function() {};
-
-
-/**
- * @abstract
- * Validates the state of the form. Should be implemented to check the validity of the mapping in
- * extensions of this class.
- */
-os.ui.im.AbstractMapperCtrl.prototype.validate = function() {};
+os.ui.im.AbstractMapperCtrl.prototype.createRules = function(uniqueKeys) {};
 
 
 /**

--- a/src/os/ui/im/abstractmapperctrl.js
+++ b/src/os/ui/im/abstractmapperctrl.js
@@ -25,6 +25,7 @@ goog.require('os.ui.slick.slickGridDirective');
  * back to the import process to be called on accept. The mapping is modified by reference
  * by user interaction with the mapper UI.
  *
+ * @abstract
  * @param {!angular.Scope} $scope
  * @param {!angular.JQLite} $element
  * @param {!angular.$timeout} $timeout
@@ -264,18 +265,21 @@ os.ui.im.AbstractMapperCtrl.prototype.update = function() {
 
 /**
  * Gets the rules appropriate to the implementation. Should be overridden to get the right ones.
+ * @abstract
  */
-os.ui.im.AbstractMapperCtrl.prototype.createRules = goog.abstractMethod;
+os.ui.im.AbstractMapperCtrl.prototype.createRules = function() {};
 
 
 /**
+ * @abstract
  * Validates the state of the form. Should be implemented to check the validity of the mapping in
  * extensions of this class.
  */
-os.ui.im.AbstractMapperCtrl.prototype.validate = goog.abstractMethod;
+os.ui.im.AbstractMapperCtrl.prototype.validate = function() {};
 
 
 /**
  * Validates the rules on the form. Should be implemented for each subclass.
+ * @abstract
  */
-os.ui.im.AbstractMapperCtrl.prototype.validateRules = goog.abstractMethod;
+os.ui.im.AbstractMapperCtrl.prototype.validateRules = function() {};

--- a/src/os/ui/im/fileimportwizard.js
+++ b/src/os/ui/im/fileimportwizard.js
@@ -9,6 +9,7 @@ goog.require('os.ui.wiz.wizardDirective');
 
 /**
  * Generic controller for a file import wizard window
+ * @abstract
  * @param {!angular.Scope} $scope
  * @param {!angular.JQLite} $element
  * @param {!angular.$timeout} $timeout
@@ -119,23 +120,26 @@ os.ui.im.FileImportWizard.prototype.onPersistError = function(error) {
 
 
 /**
+ * @abstract
  * @param {!S} descriptor
  * @protected
  */
-os.ui.im.FileImportWizard.prototype.addDescriptorToProvider = goog.abstractMethod;
+os.ui.im.FileImportWizard.prototype.addDescriptorToProvider = function(descriptor) {};
 
 
 /**
+ * @abstract
  * @param {!T} config
  * @return {!S}
  * @protected
  */
-os.ui.im.FileImportWizard.prototype.createFromConfig = goog.abstractMethod;
+os.ui.im.FileImportWizard.prototype.createFromConfig = function(config) {};
 
 
 /**
+ * @abstract
  * @param {!S} descriptor
  * @param {!T} config
  * @protected
  */
-os.ui.im.FileImportWizard.prototype.updateFromConfig = goog.abstractMethod;
+os.ui.im.FileImportWizard.prototype.updateFromConfig = function(descriptor, config) {};

--- a/src/os/ui/menu/imenusupplier.js
+++ b/src/os/ui/menu/imenusupplier.js
@@ -21,4 +21,4 @@ os.ui.menu.IMenuSupplier.ID = 'os.ui.menu.IMenuSupplier';
  * Get the context menu.
  * @return {os.ui.menu.Menu|undefined} The menu.
  */
-os.ui.menu.IMenuSupplier.prototype.getMenu = goog.abstractMethod;
+os.ui.menu.IMenuSupplier.prototype.getMenu;

--- a/src/os/ui/multiurlproviderimport.js
+++ b/src/os/ui/multiurlproviderimport.js
@@ -7,6 +7,7 @@ goog.require('os.ui.uniqueServerUrl');
 
 /**
  * Base controller for server import UIs that use a single URL configuration
+ * @abstract
  * @param {!angular.Scope} $scope
  * @param {!angular.JQLite} $element
  * @extends {os.ui.SingleUrlProviderImportCtrl}

--- a/src/os/ui/ogc/wms/abstractwmslayerparser.js
+++ b/src/os/ui/ogc/wms/abstractwmslayerparser.js
@@ -7,6 +7,7 @@ goog.require('os.ui.ogc.wms.IWMSLayerParser');
 
 
 /**
+ * @abstract
  * @implements {os.ui.ogc.wms.IWMSLayerParser}
  * @constructor
  */
@@ -30,9 +31,10 @@ os.ui.ogc.wms.AbstractWMSLayerParser.prototype.parseLayerTitle = function(node) 
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.ogc.wms.AbstractWMSLayerParser.prototype.parseLayer = goog.abstractMethod;
+os.ui.ogc.wms.AbstractWMSLayerParser.prototype.parseLayer = function(node, layer) {};
 
 
 /**

--- a/src/os/ui/ogc/wms/iwmslayer.js
+++ b/src/os/ui/ogc/wms/iwmslayer.js
@@ -185,7 +185,7 @@ os.ui.ogc.wms.IWMSLayer.prototype.parseBBox;
 /**
  * @return {?Array<!string>}
  */
-os.ui.ogc.wms.IWMSLayer.prototype.getSupportedCRS = goog.abstractMethod;
+os.ui.ogc.wms.IWMSLayer.prototype.getSupportedCRS;
 
 
 /**

--- a/src/os/ui/ol/interaction/abstractdraginteraction.js
+++ b/src/os/ui/ol/interaction/abstractdraginteraction.js
@@ -8,6 +8,7 @@ goog.require('os.ui.ol.interaction.AbstractDraw');
 
 
 /**
+ * @abstract
  * @constructor
  * @extends {os.ui.ol.interaction.AbstractDraw}
  * @param {olx.interaction.PointerOptions=} opt_options

--- a/src/os/ui/ol/interaction/abstractdrawinteraction.js
+++ b/src/os/ui/ol/interaction/abstractdrawinteraction.js
@@ -22,6 +22,7 @@ goog.require('os.ui.ol.draw.DrawEventType');
  * An abstract class that serves as the base class for pointer drawing
  * interactions.
  *
+ * @abstract
  * @constructor
  * @extends {ol.interaction.Pointer}
  * @param {olx.interaction.PointerOptions=} opt_options
@@ -152,9 +153,10 @@ os.ui.ol.interaction.AbstractDraw.prototype.setStyle = function(style) {
 
 
 /**
+ * @abstract
  * @return {ol.geom.Geometry} the drawn geometry
  */
-os.ui.ol.interaction.AbstractDraw.prototype.getGeometry = goog.abstractMethod;
+os.ui.ol.interaction.AbstractDraw.prototype.getGeometry = function() {};
 
 
 /**
@@ -320,9 +322,10 @@ os.ui.ol.interaction.AbstractDraw.prototype.onKey = function(event) {
 
 
 /**
+ * @abstract
  * @return {string}
  */
-os.ui.ol.interaction.AbstractDraw.prototype.getResultString = goog.abstractMethod;
+os.ui.ol.interaction.AbstractDraw.prototype.getResultString = function() {};
 
 
 /**

--- a/src/os/ui/providerimport.js
+++ b/src/os/ui/providerimport.js
@@ -9,6 +9,7 @@ goog.require('os.ui.window');
 
 /**
  * Controller for the provider import UI
+ * @abstract
  * @param {!angular.Scope} $scope
  * @param {!angular.JQLite} $element
  * @constructor
@@ -149,9 +150,10 @@ os.ui.ProviderImportCtrl.prototype.saveAndClose = function() {
 
 /**
  * Creates a data provider from the form
+ * @abstract
  * @return {os.data.IDataProvider} The data provider
  */
-os.ui.ProviderImportCtrl.prototype.getDataProvider = goog.abstractMethod;
+os.ui.ProviderImportCtrl.prototype.getDataProvider = function() {};
 
 
 /**
@@ -176,14 +178,16 @@ os.ui.ProviderImportCtrl.prototype.afterTest = function() {
 
 
 /**
+ * @abstract
  * @return {boolean} True if the form differs from this.dp, false otherwise
  */
-os.ui.ProviderImportCtrl.prototype.formDiff = goog.abstractMethod;
+os.ui.ProviderImportCtrl.prototype.formDiff = function() {};
 
 
 /**
  * Gets the config to be persisted
+ * @abstract
  * @return {Object.<string, *>} the config
  * @protected
  */
-os.ui.ProviderImportCtrl.prototype.getConfig = goog.abstractMethod;
+os.ui.ProviderImportCtrl.prototype.getConfig = function() {};

--- a/src/os/ui/query/abstractqueryreader.js
+++ b/src/os/ui/query/abstractqueryreader.js
@@ -10,6 +10,7 @@ goog.require('os.ui.query.IQueryReader');
 
 /**
  * Abstract implementation of IQueryReader.
+ * @abstract
  * @implements {os.ui.query.IQueryReader}
  * @constructor
  */
@@ -68,9 +69,10 @@ os.ui.query.AbstractQueryReader.prototype.setLayerId = function(layerId) {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.query.AbstractQueryReader.prototype.parseEntries = goog.abstractMethod;
+os.ui.query.AbstractQueryReader.prototype.parseEntries = function() {};
 
 
 /**

--- a/src/os/ui/query/cmd/abstractareacmd.js
+++ b/src/os/ui/query/cmd/abstractareacmd.js
@@ -11,6 +11,7 @@ goog.require('os.query.BaseAreaManager');
 
 /**
  * Abstract command for adding/removing area
+ * @abstract
  * @param {!ol.Feature} area
  * @implements {os.command.ICommand}
  * @extends {goog.Disposable}
@@ -79,15 +80,17 @@ os.ui.query.cmd.AbstractArea.prototype.state = os.command.State.READY;
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.query.cmd.AbstractArea.prototype.execute = goog.abstractMethod;
+os.ui.query.cmd.AbstractArea.prototype.execute = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.query.cmd.AbstractArea.prototype.revert = goog.abstractMethod;
+os.ui.query.cmd.AbstractArea.prototype.revert = function() {};
 
 
 /**

--- a/src/os/ui/query/cmd/abstractfiltercmd.js
+++ b/src/os/ui/query/cmd/abstractfiltercmd.js
@@ -9,6 +9,7 @@ goog.require('os.ui.query.cmd.QueryEntries');
 
 /**
  * Abstract command for adding/removing filters
+ * @abstract
  * @implements {os.command.ICommand}
  * @constructor
  * @param {os.filter.FilterEntry} filter
@@ -48,15 +49,17 @@ os.ui.query.cmd.AbstractFilter = function(filter) {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.query.cmd.AbstractFilter.prototype.execute = goog.abstractMethod;
+os.ui.query.cmd.AbstractFilter.prototype.execute = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.query.cmd.AbstractFilter.prototype.revert = goog.abstractMethod;
+os.ui.query.cmd.AbstractFilter.prototype.revert = function() {};
 
 
 /**

--- a/src/os/ui/search/noresult.js
+++ b/src/os/ui/search/noresult.js
@@ -20,11 +20,3 @@ goog.inherits(os.ui.search.NoResult, os.search.AbstractSearchResult);
 os.ui.search.NoResult.prototype.getSearchUI = function() {
   return '<div class="coord-result-card"><div class="result-card-header">No results found</div></div>';
 };
-
-
-/**
- * @inheritDoc
- */
-os.ui.search.NoResult.prototype.setSearchUI = function(value) {
-  // does nothing until the search UI is implemented as a directive
-};

--- a/src/os/ui/search/place/coordinateresult.js
+++ b/src/os/ui/search/place/coordinateresult.js
@@ -114,14 +114,6 @@ os.ui.search.place.CoordinateResult.prototype.getSearchUI = function() {
 
 
 /**
- * @inheritDoc
- */
-os.ui.search.place.CoordinateResult.prototype.setSearchUI = function(value) {
-  // does nothing until the search UI is implemented as a directive
-};
-
-
-/**
  * Creates a feature representing a coordinate result.
  * @param {Object.<string, *>=} opt_options Feature options.
  * @return {!ol.Feature}

--- a/src/os/ui/singleurlproviderimport.js
+++ b/src/os/ui/singleurlproviderimport.js
@@ -9,6 +9,7 @@ goog.require('os.ui.uniqueServerUrl');
 
 /**
  * Base controller for server import UIs that use a single URL configuration
+ * @abstract
  * @param {!angular.Scope} $scope
  * @param {!angular.JQLite} $element
  * @extends {os.ui.ProviderImportCtrl}
@@ -64,12 +65,6 @@ os.ui.SingleUrlProviderImportCtrl.prototype.getUrl = function() {
 
   return '';
 };
-
-
-/**
- * @return {!string} url
- */
-os.ui.SingleUrlProviderImportCtrl.prototype.getLabel = goog.abstractMethod;
 
 
 /**

--- a/src/os/ui/sourceaware.js
+++ b/src/os/ui/sourceaware.js
@@ -12,7 +12,7 @@ goog.require('os.data.event.DataEventType');
 /**
  * Abstract class for UI's that need to be aware of what sources are available and visible in the application.
  * Extending classes must call init to load/monitor sources.
- *
+ * @abstract
  * @deprecated Please use `os.data.SourceManager` instead.
  * @extends {goog.Disposable}
  * @constructor
@@ -245,6 +245,7 @@ os.ui.SourceAware.prototype.validate_ = function(source) {
 
 /**
  * Update the UI after a source was added/removed/changed.
+ * @abstract
  * @protected
  */
-os.ui.SourceAware.prototype.updateUI = goog.abstractMethod;
+os.ui.SourceAware.prototype.updateUI = function() {};

--- a/src/os/ui/state/abstractstatedescriptor.js
+++ b/src/os/ui/state/abstractstatedescriptor.js
@@ -16,6 +16,7 @@ goog.require('os.ui.state.IStateDescriptor');
 
 /**
  * Base descriptor for state files.
+ * @abstract
  * @extends {os.data.BaseDescriptor}
  * @implements {os.ui.state.IStateDescriptor}
  * @constructor
@@ -229,9 +230,10 @@ os.ui.state.AbstractStateDescriptor.prototype.deactivateState = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.state.AbstractStateDescriptor.prototype.getIcons = goog.abstractMethod;
+os.ui.state.AbstractStateDescriptor.prototype.getIcons = function() {};
 
 
 /**

--- a/src/os/ui/state/stateprovider.js
+++ b/src/os/ui/state/stateprovider.js
@@ -57,3 +57,11 @@ os.ui.state.StateProvider.prototype.getToolTip = function() {
   var appName = os.config.getAppName('the application');
   return 'Contains all state files that have been imported into ' + appName;
 };
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.state.StateProvider.prototype.getErrorMessage = function() {
+  return null;
+};

--- a/src/os/ui/timeline/baseitem.js
+++ b/src/os/ui/timeline/baseitem.js
@@ -6,6 +6,7 @@ goog.require('os.ui.timeline.ITimelineItem');
 
 /**
  * Base timeline item
+ * @abstract
  * @constructor
  * @extends {goog.events.EventTarget}
  * @implements {os.ui.timeline.ITimelineItem}
@@ -140,21 +141,24 @@ os.ui.timeline.BaseItem.prototype.setActions = function(value) {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.timeline.BaseItem.prototype.getExtent = goog.abstractMethod;
+os.ui.timeline.BaseItem.prototype.getExtent = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.timeline.BaseItem.prototype.getAvg = goog.abstractMethod;
+os.ui.timeline.BaseItem.prototype.getAvg = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.ui.timeline.BaseItem.prototype.render = goog.abstractMethod;
+os.ui.timeline.BaseItem.prototype.render = function() {};
 
 
 /**

--- a/src/os/ui/timeline/itimelineitem.js
+++ b/src/os/ui/timeline/itimelineitem.js
@@ -15,7 +15,7 @@ os.ui.timeline.ITimelineItem = function() {};
 /**
  * @return {string}
  */
-os.ui.timeline.ITimelineItem.prototype.getId = goog.abstractMethod;
+os.ui.timeline.ITimelineItem.prototype.getId;
 
 
 /**
@@ -27,7 +27,7 @@ os.ui.timeline.ITimelineItem.prototype.setId;
 /**
  * @return {boolean}
  */
-os.ui.timeline.ITimelineItem.prototype.isInteractive = goog.abstractMethod;
+os.ui.timeline.ITimelineItem.prototype.isInteractive;
 
 
 /**
@@ -39,7 +39,7 @@ os.ui.timeline.ITimelineItem.prototype.setInteractive;
 /**
  * @return {?d3.Scale}
  */
-os.ui.timeline.ITimelineItem.prototype.getXScale = goog.abstractMethod;
+os.ui.timeline.ITimelineItem.prototype.getXScale;
 
 
 /**
@@ -51,7 +51,7 @@ os.ui.timeline.ITimelineItem.prototype.setXScale;
 /**
  * @return {Array<os.ui.action.Action>}
  */
-os.ui.timeline.ITimelineItem.prototype.getActions = goog.abstractMethod;
+os.ui.timeline.ITimelineItem.prototype.getActions;
 
 
 /**
@@ -70,14 +70,14 @@ os.ui.timeline.ITimelineItem.prototype.setSnap;
  * Gets the time extent of the item
  * @return {Array.<number>}
  */
-os.ui.timeline.ITimelineItem.prototype.getExtent = goog.abstractMethod;
+os.ui.timeline.ITimelineItem.prototype.getExtent;
 
 
 /**
  * Gets the average time for this item
  * @return {number}
  */
-os.ui.timeline.ITimelineItem.prototype.getAvg = goog.abstractMethod;
+os.ui.timeline.ITimelineItem.prototype.getAvg;
 
 
 /**

--- a/src/os/ui/timeline/offarrows.js
+++ b/src/os/ui/timeline/offarrows.js
@@ -159,6 +159,25 @@ os.ui.timeline.OffArrows.prototype.onClick_ = function() {
 
 
 /**
+ * @inheritDoc
+ */
+os.ui.timeline.OffArrows.prototype.getExtent = function() {
+  return this.items_.reduce(function(extent, item) {
+    return ol.extent.extend(extent, item.getExtent());
+  }, ol.extent.createEmpty());
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.timeline.OffArrows.prototype.getAvg = function() {
+  var extent = this.getExtent();
+  return (extent[1] - extent[0]) / 2;
+};
+
+
+/**
  * Filters items down to what is off the left edge
  * @param {os.ui.timeline.ITimelineItem} item
  * @return {boolean} Whether or not the item belongs in the left list

--- a/src/os/url/abstracturlhandler.js
+++ b/src/os/url/abstracturlhandler.js
@@ -11,6 +11,7 @@ goog.require('goog.Uri');
  *
  * Everything after the # in the fragment is grabbed and initially checked, then any change is listened for. When
  * a change occurs, the parameters are checked for anything added or removed.
+ * @abstract
  * @extends {goog.Disposable}
  * @constructor
  */
@@ -106,10 +107,11 @@ os.url.AbstractUrlHandler.prototype.handles = function(key) {
 
 /**
  * Handles a key value pair. Should be implemented by extending classes.
+ * @abstract
  * @param {string} key
  * @param {string} value
  */
-os.url.AbstractUrlHandler.prototype.handleInternal = goog.abstractMethod;
+os.url.AbstractUrlHandler.prototype.handleInternal = function(key, value) {};
 
 
 /**

--- a/src/os/webgl/abstractrootsynchronizer.js
+++ b/src/os/webgl/abstractrootsynchronizer.js
@@ -186,7 +186,8 @@ os.webgl.AbstractRootSynchronizer.prototype.synchronizeLayer_ = function(layer) 
 os.webgl.AbstractRootSynchronizer.prototype.createSynchronizer = function(constructor, layer) {
   goog.asserts.assert(!!this.map);
 
-  return new constructor(layer, this.map);
+  return /** @type {!os.webgl.AbstractWebGLSynchronizer} */ (new
+      /** @type {function(new: Object, ol.layer.Layer, ol.PluggableMap)} */ (constructor)(layer, this.map));
 };
 
 

--- a/src/os/webgl/abstractsynchronizer.js
+++ b/src/os/webgl/abstractsynchronizer.js
@@ -5,6 +5,7 @@ goog.require('goog.Disposable');
 
 /**
  * Abstract class to synchronize an OpenLayers layer to a WebGL renderer.
+ * @abstract
  * @param {!T} layer The OpenLayers layer.
  * @param {!ol.PluggableMap} map The OpenLayers map.
  * @extends {goog.Disposable}
@@ -54,14 +55,16 @@ goog.inherits(os.webgl.AbstractWebGLSynchronizer, goog.Disposable);
 
 /**
  * Performs complete synchronization of the layer.
+ * @abstract
  */
-os.webgl.AbstractWebGLSynchronizer.prototype.synchronize = goog.abstractMethod;
+os.webgl.AbstractWebGLSynchronizer.prototype.synchronize = function() {};
 
 
 /**
  * Resets the synchronizer to a clean state.
+ * @abstract
  */
-os.webgl.AbstractWebGLSynchronizer.prototype.reset = goog.abstractMethod;
+os.webgl.AbstractWebGLSynchronizer.prototype.reset = function() {};
 
 
 /**

--- a/src/os/webgl/abstractwebglrenderer.js
+++ b/src/os/webgl/abstractwebglrenderer.js
@@ -183,7 +183,7 @@ os.webgl.AbstractWebGLRenderer.prototype.forEachFeatureAtPixel = function(pixel,
  * @abstract
  * @inheritDoc
  */
-os.webgl.AbstractWebGLRenderer.prototype.toggleMovement = function() {};
+os.webgl.AbstractWebGLRenderer.prototype.toggleMovement = function(value) {};
 
 
 /**

--- a/src/os/webgl/abstractwebglrenderer.js
+++ b/src/os/webgl/abstractwebglrenderer.js
@@ -9,6 +9,7 @@ goog.require('os.webgl.IWebGLRenderer');
 
 /**
  * Abstract WebGL renderer implementation.
+ * @abstract
  * @implements {os.webgl.IWebGLRenderer}
  * @extends {goog.Disposable}
  * @constructor
@@ -158,27 +159,31 @@ os.webgl.AbstractWebGLRenderer.prototype.resetSync = function() {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.webgl.AbstractWebGLRenderer.prototype.getCoordinateFromPixel = goog.abstractMethod;
+os.webgl.AbstractWebGLRenderer.prototype.getCoordinateFromPixel = function(pixel) {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.webgl.AbstractWebGLRenderer.prototype.getPixelFromCoordinate = goog.abstractMethod;
+os.webgl.AbstractWebGLRenderer.prototype.getPixelFromCoordinate = function(coord) {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.webgl.AbstractWebGLRenderer.prototype.forEachFeatureAtPixel = goog.abstractMethod;
+os.webgl.AbstractWebGLRenderer.prototype.forEachFeatureAtPixel = function(pixel, callback) {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.webgl.AbstractWebGLRenderer.prototype.toggleMovement = goog.abstractMethod;
+os.webgl.AbstractWebGLRenderer.prototype.toggleMovement = function() {};
 
 
 /**
@@ -202,9 +207,10 @@ os.webgl.AbstractWebGLRenderer.prototype.setEnabled = function(value) {
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-os.webgl.AbstractWebGLRenderer.prototype.getCamera = goog.abstractMethod;
+os.webgl.AbstractWebGLRenderer.prototype.getCamera = function() {};
 
 
 /**

--- a/src/plugin/arc/arcserverimport.js
+++ b/src/plugin/arc/arcserverimport.js
@@ -73,7 +73,7 @@ plugin.arc.ArcImportCtrl.prototype.getUrl = function() {
 
 
 /**
- * @inheritDoc
+ * @return {string}
  */
 plugin.arc.ArcImportCtrl.prototype.getLabel = function() {
   if (this.dp) {

--- a/src/plugin/basemap/basemapprovider.js
+++ b/src/plugin/basemap/basemapprovider.js
@@ -290,3 +290,11 @@ plugin.basemap.BaseMapProvider.prototype.onTerrainDisabled = function(event) {
     goog.dispose(descriptor);
   }
 };
+
+
+/**
+ * @inheritDoc
+ */
+plugin.basemap.BaseMapProvider.prototype.getErrorMessage = function() {
+  return null;
+};

--- a/src/plugin/cesium/cesiumrenderer.js
+++ b/src/plugin/cesium/cesiumrenderer.js
@@ -377,7 +377,7 @@ plugin.cesium.CesiumRenderer.prototype.toggleMovement = function(value) {
   if (this.olCesium_) {
     var scene = this.olCesium_.getCesiumScene();
     if (scene && scene.screenSpaceCameraController) {
-      scene.screenSpaceCameraController.enableInputs = !!value;
+      scene.screenSpaceCameraController.enableInputs = value;
     }
   }
 };

--- a/src/plugin/cesium/cesiumrenderer.js
+++ b/src/plugin/cesium/cesiumrenderer.js
@@ -377,7 +377,7 @@ plugin.cesium.CesiumRenderer.prototype.toggleMovement = function(value) {
   if (this.olCesium_) {
     var scene = this.olCesium_.getCesiumScene();
     if (scene && scene.screenSpaceCameraController) {
-      scene.screenSpaceCameraController.enableInputs = value;
+      scene.screenSpaceCameraController.enableInputs = !!value;
     }
   }
 };

--- a/src/plugin/cesium/sync/cesiumsynchronizer.js
+++ b/src/plugin/cesium/sync/cesiumsynchronizer.js
@@ -6,6 +6,7 @@ goog.require('os.webgl.AbstractWebGLSynchronizer');
 
 /**
  * Abstract class to synchronize an OpenLayers layer to Cesium.
+ * @abstract
  * @param {!T} layer The OpenLayers layer.
  * @param {!ol.PluggableMap} map The OpenLayers map.
  * @param {!Cesium.Scene} scene The Cesium scene.

--- a/src/plugin/cesium/sync/rootsynchronizer.js
+++ b/src/plugin/cesium/sync/rootsynchronizer.js
@@ -44,7 +44,9 @@ plugin.cesium.sync.RootSynchronizer.prototype.createSynchronizer = function(cons
   goog.asserts.assert(!!this.scene_);
   goog.asserts.assert(!!layer);
 
-  return new constructor(layer, this.map, this.scene_);
+  return /** @type {!os.webgl.AbstractWebGLSynchronizer} */ (new
+    /** @type {function(new: Object, ol.layer.Layer, ol.PluggableMap, (Cesium.Scene|undefined))} */ (
+      constructor)(layer, this.map, this.scene_));
 };
 
 

--- a/src/plugin/config/configprovider.js
+++ b/src/plugin/config/configprovider.js
@@ -137,3 +137,11 @@ plugin.config.Provider.prototype.addIcons = function(conf) {
     conf['icons'] = icons;
   }
 };
+
+
+/**
+ * @inheritDoc
+ */
+plugin.config.Provider.prototype.getErrorMessage = function() {
+  return null;
+};

--- a/src/plugin/descriptor/facet/basefacet.js
+++ b/src/plugin/descriptor/facet/basefacet.js
@@ -5,6 +5,7 @@ goog.require('os.search.FacetSet');
 
 
 /**
+ * @abstract
  * @constructor
  */
 plugin.descriptor.facet.BaseFacet = function() {};
@@ -12,21 +13,23 @@ plugin.descriptor.facet.BaseFacet = function() {};
 
 /**
  * Loads available facets from the descriptor
+ * @abstract
  * @param {!os.data.IDataDescriptor} descriptor
  * @param {!os.search.FacetSet} facets
  * @return {goog.Promise|undefined} undefined for synchronous or promise that resolves when the facet counts load
  */
-plugin.descriptor.facet.BaseFacet.prototype.load = goog.abstractMethod;
+plugin.descriptor.facet.BaseFacet.prototype.load = function(descriptor, facets) {};
 
 
 /**
  * Tests applied facets against the descriptor
+ * @abstract
  * @param {!os.data.IDataDescriptor} descriptor
  * @param {os.search.AppliedFacets} facets
  * @param {Object<string, number>} results
  * @return {goog.Promise|undefined} undefined for synchronous or promise that resolves when the test finishes
  */
-plugin.descriptor.facet.BaseFacet.prototype.test = goog.abstractMethod;
+plugin.descriptor.facet.BaseFacet.prototype.test = function(descriptor, facets, results) {};
 
 
 /**

--- a/src/plugin/file/kml/cmd/abstractkmlnodecmd.js
+++ b/src/plugin/file/kml/cmd/abstractkmlnodecmd.js
@@ -8,7 +8,7 @@ goog.require('os.command.State');
 
 /**
  * Abstract command for adding/removing KML nodes.
- *
+ * @abstract
  * @param {!plugin.file.kml.ui.KMLNode} node The KML node
  * @param {plugin.file.kml.ui.KMLNode} parent The parent node
  *
@@ -44,15 +44,17 @@ goog.inherits(plugin.file.kml.cmd.AbstractKMLNode, goog.Disposable);
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-plugin.file.kml.cmd.AbstractKMLNode.prototype.execute = goog.abstractMethod;
+plugin.file.kml.cmd.AbstractKMLNode.prototype.execute = function() {};
 
 
 /**
+ * @abstract
  * @inheritDoc
  */
-plugin.file.kml.cmd.AbstractKMLNode.prototype.revert = goog.abstractMethod;
+plugin.file.kml.cmd.AbstractKMLNode.prototype.revert = function() {};
 
 
 /**

--- a/src/plugin/file/kml/tour/abstracttourprimitive.js
+++ b/src/plugin/file/kml/tour/abstracttourprimitive.js
@@ -3,6 +3,7 @@ goog.provide('plugin.file.kml.tour.AbstractTourPrimitive');
 
 /**
  * Abstract KML tour primitive.
+ * @abstract
  * @constructor
  */
 plugin.file.kml.tour.AbstractTourPrimitive = function() {
@@ -16,9 +17,10 @@ plugin.file.kml.tour.AbstractTourPrimitive = function() {
 
 /**
  * Execute the tour instruction.
+ * @abstract
  * @return {!goog.Promise} A promise that resolves when execution completes.
  */
-plugin.file.kml.tour.AbstractTourPrimitive.prototype.execute = goog.abstractMethod;
+plugin.file.kml.tour.AbstractTourPrimitive.prototype.execute = function() {};
 
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: This allows the compiler to do proper checks on
missing implementation of abstract classes.

Resolves #507