### PR TITLE
Create separate functions to get original columns or a copy.

### DIFF
--- a/src/os/source/isource.js
+++ b/src/os/source/isource.js
@@ -88,7 +88,7 @@ os.source.ISource.prototype.getColumns;
 
 
 /**
- * Get the origial array of columns for the data source.
+ * Get the original array of columns for the data source.
  * @return {!Array<!os.data.ColumnDefinition>}
  */
 os.source.ISource.prototype.getColumnsArray;

--- a/src/os/source/isource.js
+++ b/src/os/source/isource.js
@@ -81,10 +81,17 @@ os.source.ISource.prototype.getColor;
 
 
 /**
- * Get the array of data grid columns for the data source.
+ * Get a copy of the columns for the data source.
  * @return {!Array<!os.data.ColumnDefinition>}
  */
 os.source.ISource.prototype.getColumns;
+
+
+/**
+ * Get the origial array of columns for the data source.
+ * @return {!Array<!os.data.ColumnDefinition>}
+ */
+os.source.ISource.prototype.getColumnsArray;
 
 
 /**

--- a/src/os/source/source.js
+++ b/src/os/source/source.js
@@ -76,7 +76,7 @@ os.source.getFilterColumns = function(source, opt_local, opt_includeTime) {
 
   if (source) {
     if (opt_local) {
-      columns = source.getColumns();
+      columns = source.getColumnsArray();
 
       if (columns && columns.length > 0) {
         // do not include the TIME column or any column with a datetime type by default for filtering
@@ -234,7 +234,7 @@ os.source.getExportFields = function(source, opt_internal, opt_includeTime) {
   var fields = null;
 
   if (source) {
-    var columns = source.getColumns();
+    var columns = source.getColumnsArray();
     if (columns && columns.length > 0) {
       fields = [];
 

--- a/src/os/source/sourcecolumn.js
+++ b/src/os/source/sourcecolumn.js
@@ -82,7 +82,7 @@ os.source.column.addDefaults = function(source) {
   var hasSemiMinor = false;
 
   // test for each column type
-  source.getColumns().forEach(function(column) {
+  source.getColumnsArray().forEach(function(column) {
     var name = column['name'];
     if (name) {
       hasID |= goog.string.caseInsensitiveEquals(name, os.Fields.ID);

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -699,6 +699,14 @@ os.source.Vector.prototype.onRefreshTimer = function() {
  * @inheritDoc
  */
 os.source.Vector.prototype.getColumns = function() {
+  return this.columns.slice();
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.source.Vector.prototype.getColumnsArray = function() {
   return this.columns;
 };
 
@@ -710,14 +718,16 @@ os.source.Vector.prototype.getColumns = function() {
  * @suppress {accessControls}
  */
 os.source.Vector.prototype.getEmptyColumns = function() {
-  var empty = this.columns ? this.columns.slice() : [];
+  if (!this.getFeatureCount()) {
+    return [];
+  }
+
+  // make sure columns are all non-null and have a field
+  var empty = this.getColumnsArray().filter(function(col) {
+    return !!col && !!col['field'];
+  });
 
   if (empty.length > 0) {
-    // make sure columns are all non-null and have a field
-    empty = empty.filter(function(col) {
-      return !!col && !!col['field'];
-    });
-
     var features = this.getFeatures();
     for (var i = 0; i < features.length && empty.length > 0; i++) {
       var j = empty.length;
@@ -740,19 +750,21 @@ os.source.Vector.prototype.getEmptyColumns = function() {
  * @export Prevent the compiler from moving the function off the prototype.
  */
 os.source.Vector.prototype.setColumns = function(columns) {
-  this.externalColumns = true;
+  if (columns) {
+    this.externalColumns = true;
 
-  // ensure all columns are column definition objects
-  this.columns = columns.map(os.source.column.mapStringOrDef);
+    // ensure all columns are column definition objects
+    this.columns = columns.map(os.source.column.mapStringOrDef);
 
-  // add defaults columns
-  os.source.column.addDefaults(this);
+    // add defaults columns
+    os.source.column.addDefaults(this);
 
-  // test for shape support
-  this.testShapeFields_(this.geometryShape_);
+    // test for shape support
+    this.testShapeFields_(this.geometryShape_);
 
-  // clean up the columns
-  this.processColumns();
+    // clean up the columns
+    this.processColumns();
+  }
 };
 
 

--- a/src/os/ui/buffer/bufferform.js
+++ b/src/os/ui/buffer/bufferform.js
@@ -170,7 +170,7 @@ os.ui.buffer.BufferFormCtrl.prototype.onOptionsChange_ = function(event, items, 
       }
     }
 
-    this['columns'] = sources && sources.length > 0 ? sources[0].getColumns().slice() : [];
+    this['columns'] = sources && sources.length > 0 ? sources[0].getColumns() : [];
     this['columns'].sort(os.ui.slick.column.nameCompare);
 
     this.updateLivePreview();

--- a/src/os/ui/data/addcolumnform.js
+++ b/src/os/ui/data/addcolumnform.js
@@ -90,7 +90,7 @@ os.ui.data.AddColumnFormCtrl.prototype.addValidators_ = function() {
  * @return {boolean}
  */
 os.ui.data.AddColumnFormCtrl.isDuplicate = function(source, modelVal, viewVal) {
-  var columns = source.getColumns();
+  var columns = source.getColumnsArray();
   var value = modelVal || viewVal;
   if (value) {
     for (var i = 0, ii = columns.length; i < ii; i++) {

--- a/src/os/ui/featureedit.js
+++ b/src/os/ui/featureedit.js
@@ -413,7 +413,7 @@ os.ui.FeatureEditCtrl = function($scope, $element, $timeout) {
     // grab available columns off the feature source if available, and don't show internal columns
     var source = os.feature.getSource(feature);
     if (source) {
-      this['labelColumns'] = source.getColumns().filter(function(column) {
+      this['labelColumns'] = source.getColumnsArray().filter(function(column) {
         return !os.feature.isInternalField(column['field']);
       });
 

--- a/src/os/ui/layer/layers.js
+++ b/src/os/ui/layer/layers.js
@@ -90,9 +90,7 @@ os.ui.layer.getColumns = function(layer) {
  * @return {Array<os.data.ColumnDefinition>}
  */
 os.ui.layer.getColumnsFromSource = function(source) {
-  var columns = source.getColumns().slice();
-  columns.sort(os.ui.slick.column.nameCompare);
-  return columns;
+  return source ? source.getColumns().sort(os.ui.slick.column.nameCompare) : [];
 };
 
 

--- a/src/plugin/file/kml/kmlnodelayerui.js
+++ b/src/plugin/file/kml/kmlnodelayerui.js
@@ -343,7 +343,7 @@ plugin.file.kml.KMLNodeLayerUICtrl.prototype.getColumns = function() {
   if (items) {
     for (var i = 0, n = items.length; i < n; i++) {
       var source = items[i].getSource();
-      labelColumns = labelColumns.concat(source.getColumns().filter(function(column) {
+      labelColumns = labelColumns.concat(source.getColumnsArray().filter(function(column) {
         return !os.feature.isInternalField(column['field']);
       }));
     }

--- a/src/plugin/file/shp/shpexporter.js
+++ b/src/plugin/file/shp/shpexporter.js
@@ -291,7 +291,7 @@ plugin.file.shp.SHPExporter.prototype.parseColumns = function() {
   if (this.items && this.items.length > 0) {
     var item = this.items[0];
     var source = this.getSource_(item);
-    var columns = source && source.getColumns() || goog.object.getKeys(item.getProperties());
+    var columns = source && source.getColumnsArray() || goog.object.getKeys(item.getProperties());
 
     for (var i = 0; i < this.items.length; i++) {
       item = this.items[i];

--- a/src/plugin/places/ui/saveplaces.js
+++ b/src/plugin/places/ui/saveplaces.js
@@ -198,7 +198,7 @@ plugin.places.ui.SavePlacesCtrl.prototype.onOptionsChange_ = function(event, ite
     }
 
     // update the displayed columns
-    this['columns'] = sources && sources.length > 0 ? sources[0].getColumns().slice() : [];
+    this['columns'] = sources && sources.length > 0 ? sources[0].getColumns() : [];
     this['columns'].sort(os.ui.slick.column.nameCompare);
   }
 };

--- a/src/plugin/track/track.js
+++ b/src/plugin/track/track.js
@@ -1092,7 +1092,7 @@ plugin.track.getSortField = function(feature, opt_sortField) {
     if (value == null || value == '') {
       var source = os.feature.getSource(feature);
       if (source) {
-        var columns = source.getColumns().slice();
+        var columns = source.getColumns();
         columns.sort(os.ui.slick.column.sortByField.bind(null, 'name'));
 
         var prompt;

--- a/src/plugin/vectortools/vectortools.js
+++ b/src/plugin/vectortools/vectortools.js
@@ -275,7 +275,7 @@ plugin.vectortools.getCombinedColumns = function(sources, mappings) {
       return true;
     };
 
-    return columns.concat(source.getColumns().filter(filter));
+    return columns.concat(source.getColumnsArray().filter(filter));
   }, []).filter(function(column) {
     var field = typeof column === 'string' ? column : column['field'];
 

--- a/test/os/source/source.mock.js
+++ b/test/os/source/source.mock.js
@@ -102,6 +102,14 @@ os.source.MockSource.prototype.getColor = function() {
  * @inheritDoc
  */
 os.source.MockSource.prototype.getColumns = function() {
+  return this.columns.slice();
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.source.MockSource.prototype.getColumnsArray = function() {
   return this.columns;
 };
 

--- a/test/os/source/source.test.js
+++ b/test/os/source/source.test.js
@@ -1,15 +1,16 @@
-goog.require('os.time.TimeInstant');
-goog.require('os.time.TimeRange');
+goog.require('ol.Feature');
+goog.require('ol.layer.Vector');
 goog.require('os.data.BaseDescriptor');
-goog.require('os.ui.ogc.OGCDescriptor');
 goog.require('os.data.RecordField');
 goog.require('os.layer.Vector');
 goog.require('os.mock');
 goog.require('os.source');
+goog.require('os.source.MockSource');
 goog.require('os.source.Vector');
 goog.require('os.style.StyleType');
-goog.require('ol.Feature');
-goog.require('ol.layer.Vector');
+goog.require('os.time.TimeInstant');
+goog.require('os.time.TimeRange');
+goog.require('os.ui.ogc.OGCDescriptor');
 
 describe('os.source', function() {
   it('checks if a source is filterable', function() {
@@ -154,11 +155,8 @@ describe('os.source', function() {
     expect(os.source.getExportFields(null)).toBeNull();
 
     var columns = [];
-    var source = {
-      getColumns: function() {
-        return columns;
-      }
-    };
+    var source = new os.source.MockSource();
+    source.setColumns(columns);
 
     var fields = os.source.getExportFields(source);
     expect(fields).toBeNull();
@@ -184,32 +182,26 @@ describe('os.source', function() {
     expect(fields.length).toBe(0);
 
     // internal fields are not exported
-    columns.push(
-      {
-        field: os.data.RecordField.TIME,
-        visible: true
-      },
-      {
-        field: os.style.StyleType.FEATURE,
-        visible: true
-      }
-    );
+    columns.push({
+      field: os.data.RecordField.TIME,
+      visible: true
+    }, {
+      field: os.style.StyleType.FEATURE,
+      visible: true
+    });
 
     fields = os.source.getExportFields(source);
     expect(fields).toBeDefined();
     expect(fields.length).toBe(0);
 
     // other fields are exported
-    columns.push(
-      {
-        field: 'TEST 1',
-        visible: true
-      },
-      {
-        field: 'TEST 2',
-        visible: true
-      }
-    );
+    columns.push({
+      field: 'TEST 1',
+      visible: true
+    }, {
+      field: 'TEST 2',
+      visible: true
+    });
 
     fields = os.source.getExportFields(source);
     expect(fields).toBeDefined();
@@ -218,16 +210,13 @@ describe('os.source', function() {
     expect(fields).toContain('TEST 2');
 
     // but are not duplicated
-    columns.push(
-      {
-        field: 'TEST 1',
-        visible: true
-      },
-      {
-        field: 'TEST 2',
-        visible: true
-      }
-    );
+    columns.push({
+      field: 'TEST 1',
+      visible: true
+    }, {
+      field: 'TEST 2',
+      visible: true
+    });
 
     fields = os.source.getExportFields(source);
     expect(fields).toBeDefined();

--- a/test/os/source/vectorsource.test.js
+++ b/test/os/source/vectorsource.test.js
@@ -456,6 +456,37 @@ describe('os.source.Vector', function() {
   describe('columns', function() {
     var columns;
 
+    var createColumn = function(name, field) {
+      var columnDefinition = new os.data.ColumnDefinition();
+      columnDefinition['id'] = name;
+      columnDefinition['name'] = name;
+      columnDefinition['field'] = field || name;
+      columnDefinition['sortable'] = true;
+
+      return columnDefinition;
+    };
+
+    var createColumns = function() {
+      return [
+        createColumn('ID'),
+        createColumn('LAT'),
+        createColumn('LON'),
+        createColumn('TEST1'),
+        createColumn('TEST2'),
+        createColumn('TEST3')
+      ];
+    };
+
+    it('should support getting the original columns or a copy', function() {
+      var columns = createColumns();
+      source.setColumns(columns);
+      expect(source.getColumnsArray()).toBe(source.columns);
+
+      var copy = source.getColumns();
+      expect(copy).not.toBe(source.columns);
+      expect(goog.array.equals(copy, source.columns)).toBe(true);
+    });
+
     it('should always add an ID column to the source', function() {
       source.setColumns([]);
       expect(source.columns.length).toBe(1);
@@ -480,23 +511,7 @@ describe('os.source.Vector', function() {
     });
 
     it('should set columns on the source from an array of columns', function() {
-      var createColumn = function(name, field) {
-        var columnDefinition = new os.data.ColumnDefinition();
-        columnDefinition['id'] = name;
-        columnDefinition['name'] = name;
-        columnDefinition['field'] = field || name;
-        columnDefinition['sortable'] = true;
-
-        return columnDefinition;
-      };
-
-      columns = [];
-      columns.push(createColumn('ID'));
-      columns.push(createColumn('LAT'));
-      columns.push(createColumn('LON'));
-      columns.push(createColumn('TEST1'));
-      columns.push(createColumn('TEST2'));
-      columns.push(createColumn('TEST3'));
+      columns = createColumns();
 
       source.setColumns(columns);
       expect(source.columns.length).toBe(columns.length + 5); // +5 for mgrs, latdms, londms, latddm, londdm
@@ -637,7 +652,7 @@ describe('os.source.Vector', function() {
       expect(source.hasColumn('DESCRIPTION')).toBe(true);
 
       // expect the formatter on that column to be the DescriptionFormatter
-      expect(source.getColumns()[1]['formatter']).toBe(os.ui.formatter.DescriptionFormatter);
+      expect(source.columns[1]['formatter']).toBe(os.ui.formatter.DescriptionFormatter);
     });
 
     it('should add a formatter to a "PROPERTIES" column', function() {
@@ -648,7 +663,7 @@ describe('os.source.Vector', function() {
       expect(source.hasColumn('PROPERTIES')).toBe(true);
 
       // expect the formatter on that column to be the PropertiesFormatter
-      expect(source.getColumns()[1]['formatter']).toBe(os.ui.formatter.PropertiesFormatter);
+      expect(source.columns[1]['formatter']).toBe(os.ui.formatter.PropertiesFormatter);
     });
 
     it('should detect an icon rotation column', function() {


### PR DESCRIPTION
This prefers `getColumnsArray` for performance when the source columns are not being modified. Otherwise use `getColumnsArray` when intentionally modifying columns, and `getColumns` when modifying for local use.

Fixes #548.