### PR TITLE
chore(api): Deprecate IOGCDescriptor::getUrlKey(), use getFilterKey()

### DIFF
--- a/src/os/ui/column/mapping/columnmappingform.js
+++ b/src/os/ui/column/mapping/columnmappingform.js
@@ -130,7 +130,7 @@ os.ui.column.mapping.ColumnMappingFormCtrl.prototype.init_ = function() {
     try {
       desc = /** @type {os.ui.ogc.IOGCDescriptor} */ (desc);
       if (desc.isWfsEnabled() === true) {
-        descMap[desc.getUrlKey()] = desc;
+        descMap[desc.getFilterKey()] = desc;
         this.cachedDescriptorList_.push(desc);
       }
     } catch (e) {
@@ -208,7 +208,7 @@ os.ui.column.mapping.ColumnMappingFormCtrl.prototype.validateLayers_ = function(
 
   if (duplicates) {
     var node = ol.array.find(this['tree'], function(item) {
-      return item.getInitialLayer().getUrlKey() === found[0]['layer'];
+      return item.getInitialLayer().getFilterKey() === found[0]['layer'];
     });
     this['duplicateLayerText'] =
         'Duplicate layers are not supported (<b>' + node.getInitialLayer().getTitle() + '</b>)';

--- a/src/os/ui/column/mapping/mappingexpression.js
+++ b/src/os/ui/column/mapping/mappingexpression.js
@@ -135,7 +135,7 @@ os.ui.column.mapping.MappingExpressionCtrl.prototype.onColumnChange_ = function(
  */
 os.ui.column.mapping.MappingExpressionCtrl.prototype.setLayer_ = function(layer) {
   var featureType = layer.getFeatureType();
-  this.model_['layer'] = layer.getUrlKey();
+  this.model_['layer'] = layer.getFilterKey();
   this.scope_['node'].setInitialLayer(layer);
 
   if (!featureType) {

--- a/src/os/ui/ogc/iogcdescriptor.js
+++ b/src/os/ui/ogc/iogcdescriptor.js
@@ -234,6 +234,7 @@ os.ui.ogc.IOGCDescriptor.prototype.getLayerName;
 
 /**
  * @return {?string}
+ * @deprecated Use IFilterable.getFilterKey()
  */
 os.ui.ogc.IOGCDescriptor.prototype.getUrlKey;
 

--- a/src/os/ui/ogc/ogcdescriptor.js
+++ b/src/os/ui/ogc/ogcdescriptor.js
@@ -574,7 +574,7 @@ os.ui.ogc.OGCDescriptor.prototype.setUsePost = function(value) {
  * @inheritDoc
  */
 os.ui.ogc.OGCDescriptor.prototype.getUrlKey = function() {
-  return this.wfsUrl_ + '!!' + this.wfsName_;
+  return this.getFilterKey();
 };
 
 
@@ -759,7 +759,7 @@ os.ui.ogc.OGCDescriptor.prototype.isFilterable = function() {
  * @inheritDoc
  */
 os.ui.ogc.OGCDescriptor.prototype.getFilterKey = function() {
-  return this.getUrlKey();
+  return this.wfsUrl_ + '!!' + this.wfsName_;
 };
 
 

--- a/src/plugin/ogc/ogclayerdescriptor.js
+++ b/src/plugin/ogc/ogclayerdescriptor.js
@@ -702,7 +702,7 @@ plugin.ogc.OGCLayerDescriptor.prototype.setUsePost = function(value) {
  * @inheritDoc
  */
 plugin.ogc.OGCLayerDescriptor.prototype.getUrlKey = function() {
-  return this.wfsUrl_ + '!!' + this.wfsName_;
+  return this.getFilterKey();
 };
 
 
@@ -1111,7 +1111,7 @@ plugin.ogc.OGCLayerDescriptor.prototype.launchFilterManager = function() {
  * @inheritDoc
  */
 plugin.ogc.OGCLayerDescriptor.prototype.getFilterKey = function() {
-  return this.getUrlKey();
+  return this.wfsUrl_ + '!!' + this.wfsName_;
 };
 
 


### PR DESCRIPTION
IOGCDescriptor extends IFilterable, so its better to just implement in terms
of the parent API.

Resolves #545.