### PR TITLE
Support for quickly adding places and reusing lists

### DIFF
--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -1598,7 +1598,7 @@ os.MapContainer.prototype.addFeature = function(feature, opt_style) {
     os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Map.ADD_FEATURE, 1);
     if (!(feature instanceof ol.Feature)) {
       // created in another context
-      feature = os.ol.feature.clone(feature);
+      feature = os.ol.feature.clone(feature, [os.data.RecordField.DRAWING_LAYER_NODE]);
     }
 
     if (typeof opt_style === 'object') {

--- a/src/os/mixin/geometrymixin.js
+++ b/src/os/mixin/geometrymixin.js
@@ -170,14 +170,14 @@ ol.geom.Geometry.prototype.toLonLat = function() {
 
   classes.forEach(function(cls) {
     if (cls && cls.prototype && cls.prototype.clone) {
-      cls.prototype.cloneSuper_ = cls.prototype.clone;
+      var origClone = cls.prototype.clone;
 
       /**
        * Overridden to clone values in addition to coordinates
        * @override
        */
       cls.prototype.clone = function() {
-        var geom = this.cloneSuper_();
+        var geom = origClone.call(this);
         os.object.merge(this.values_, geom.values_);
         return geom;
       };

--- a/src/os/ui/list.js
+++ b/src/os/ui/list.js
@@ -91,6 +91,49 @@ os.ui.list.remove = function(id, markup) {
 
 
 /**
+ * Remove a list by ID.
+ * @param {string} id The list ID to remove
+ */
+os.ui.list.removeList = function(id) {
+  var map = os.ui.list.map_[id];
+  if (map) {
+    map.forEach(function(item) {
+      if (item) {
+        if (item.scope) {
+          item.scope.$destroy();
+          item.scope = undefined;
+        }
+
+        if (item.element) {
+          item.element.remove();
+          item.element = undefined;
+        }
+      }
+    });
+
+    delete os.ui.list.map_[id];
+  }
+};
+
+
+/**
+ * Copy a list under a new ID.
+ * @param {string} id The new list ID.
+ * @param {string} listId The original list ID.
+ */
+os.ui.list.copy = function(id, listId) {
+  if (id !== listId) {
+    var items = os.ui.list.get(listId);
+    if (items) {
+      items.forEach(function(item) {
+        os.ui.list.add(id, item.markup, item.priority);
+      });
+    }
+  }
+};
+
+
+/**
  * @param {os.ui.list.ListEntry} a list entry 1
  * @param {os.ui.list.ListEntry} b list entry 2
  * @return {number} per typical compare function


### PR DESCRIPTION
This PR adds a few new function calls:
* Add Saved Places folders/places without going through the Create/Edit UI.
* Copy/remove UI lists. Lists are meant to be singletons, and this allows them to be reused.

It also resolves a couple bugs dealing with different window contexts:
* Geometry clone mixin now uses the OL clone function from the original context, instead of the passed geometry. This was causing `os.ol.feature.cloneGeometry` to create another geometry in the same context as the last.
* When correcting feature object context, `os.MapContainer#addFeature` preserves the flag to prevent temporary features from showing up in the map container.