### PR TITLE
fix(style): avoid changing values on cached styles

### DIFF
--- a/src/os/style/iconstyle.js
+++ b/src/os/style/iconstyle.js
@@ -68,12 +68,6 @@ os.style.Icon.prototype.onImageChange = function(event) {
   if (state >= ol.ImageState.LOADED) {
     this.unlistenImageChange(this.onImageChange, this);
   }
-
-  if (state === ol.ImageState.LOADED && this.iconImage_.getSrc() == os.style.IconReader.DEFAULT_ICON) {
-    // reset these values for the default icon
-    this.setScale(1);
-    this.setRotation(0);
-  }
 };
 
 


### PR DESCRIPTION
Changing values such as scale or rotation after load pollutes the style cache. A style could be already in the cache under a different scale, and changing it on the instance to 1 will make all requests for the original scale pull 1 instead.

Load [scale_bug.txt](https://github.com/ngageoint/opensphere/files/3237829/scale_bug.txt) under both this and master to see the difference.
