### PR TITLE
Automatically determine height by default for confirm windows.

### DIFF
--- a/src/os/ui/window/confirm.js
+++ b/src/os/ui/window/confirm.js
@@ -54,10 +54,7 @@ os.ui.window.launchConfirm = function(opt_options, opt_scopeOptions) {
 
   var windowOverrides = /** @type {!osx.window.WindowOptions} */ (options.windowOptions || {});
 
-  var height = windowOverrides.height || 140;
-  var minHeight = windowOverrides.minHeight || height;
-  var maxHeight = windowOverrides.maxHeight || height;
-
+  var height = windowOverrides.height || 'auto';
   var width = windowOverrides.width || 325;
   var minWidth = windowOverrides.minWidth || width;
   var maxWidth = windowOverrides.maxWidth || width;
@@ -72,8 +69,8 @@ os.ui.window.launchConfirm = function(opt_options, opt_scopeOptions) {
     'min-width': minWidth,
     'max-width': maxWidth,
     'height': height,
-    'min-height': minHeight,
-    'max-height': maxHeight,
+    'min-height': windowOverrides.minHeight,
+    'max-height': windowOverrides.maxHeight,
     'modal': windowOverrides.modal != null ? windowOverrides.modal : true,
     'show-close': windowOverrides.showClose != null ? windowOverrides.showClose : false,
     'no-scroll': windowOverrides.noScroll != null ? windowOverrides.noScroll : true


### PR DESCRIPTION
`os.ui.window.launchConfirm` was picking an arbitrary default height of 140px. Now that we can auto size windows based on their content, this is a much better default. This fixes display for windows like Saved Places folder removal, and is consistent with the similar `os.ui.window.launchConfirmText` call.