### PR TITLE
fix: Clear button window closure

### DIFF
--- a/src/os/debug/fancierwindow.js
+++ b/src/os/debug/fancierwindow.js
@@ -43,10 +43,6 @@ os.debug.FancierWindow.STYLE_RULES_ = goog.string.Const.from(
 os.debug.FancierWindow.prototype.writeInitialDocument = function() {
   os.debug.FancierWindow.superClass_.writeInitialDocument.call(this);
 
-  // close button should set the debug window to disabled
-  if (this.win) {
-    goog.events.listenOnce(this.win, goog.events.EventType.BEFOREUNLOAD, this.onBeforeUnload_, false, this);
-  }
 };
 
 


### PR DESCRIPTION
Clear button on log no longer closes window, only clears log in FF60.7.0esr and Chrome