### PR TITLE
Reduce updates to the current time marker and fix disposal.

### DIFF
--- a/src/os/ui/timeline/currenttimemarker.js
+++ b/src/os/ui/timeline/currenttimemarker.js
@@ -1,4 +1,6 @@
 goog.provide('os.ui.timeline.CurrentTimeMarker');
+
+goog.require('goog.async.Delay');
 goog.require('os.time.TimeInstant');
 goog.require('os.ui.timeline.BaseItem');
 goog.require('os.ui.timeline.ITimelineItem');
@@ -14,29 +16,18 @@ os.ui.timeline.CurrentTimeMarker = function() {
   os.ui.timeline.CurrentTimeMarker.base(this, 'constructor');
 
   /**
-   * @type {number?}
-   * @private
-   */
-  this.animationFrameRef_ = null;
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  this.stopped_ = false;
-
-  /**
-   * @type {number}
-   * @private
-   */
-  this.lastUpdateTime_ = 0;
-
-  /**
    * The main background of the timeline
    * @type {?d3.Selection}
    * @private
    */
   this.backgroundElement_ = null;
+
+  /**
+   * Delay to handle periodic updates to the marker.
+   * @type {goog.async.Delay}
+   * @private
+   */
+  this.updateDelay_ = new goog.async.Delay(this.updateCurrentTime_, 1000, this);
 };
 goog.inherits(os.ui.timeline.CurrentTimeMarker, os.ui.timeline.BaseItem);
 
@@ -44,9 +35,11 @@ goog.inherits(os.ui.timeline.CurrentTimeMarker, os.ui.timeline.BaseItem);
 /**
  * @inheritDoc
  */
-os.ui.timeline.CurrentTimeMarker.prototype.dispose = function() {
-  this.stopAnimation_();
-  os.ui.timeline.CurrentTimeMarker.base(this, 'dispose');
+os.ui.timeline.CurrentTimeMarker.prototype.disposeInternal = function() {
+  os.ui.timeline.CurrentTimeMarker.base(this, 'disposeInternal');
+
+  goog.dispose(this.updateDelay_);
+  this.updateDelay_ = null;
 };
 
 
@@ -64,72 +57,66 @@ os.ui.timeline.CurrentTimeMarker.prototype.initSVG = function(container, height)
   currentTime.attr('id', 'js-svg-timeline__time-background').append('title').text('Click to hide/show current time');
   currentTime.append('rect').attr('class', 'js-svg-timeline__bg-time').attr('height', '16');
   currentTime.append('text').attr('class', 'label c-svg-timeline__current-time js-svg-timeline__current-time');
-  this.animationFrameRef_ = window.requestAnimationFrame(this.updateCurrentTimeRAF.bind(this));
+
+  this.updateCurrentTime_();
 };
 
 
 /**
- * Compatible RAF call to update the time
- * @param {number} timestamp a DOMHighResTimeStamp indicating the point in time when RAF starts to excute
+ * Updates the current time clock and background.
+ * @private
  */
-os.ui.timeline.CurrentTimeMarker.prototype.updateCurrentTimeRAF = function(timestamp) {
-  this.updateCurrentTime();
-};
-
-
-/**
- * Updates the current time clock and background
- * @param {boolean=} opt_immediate apply changes immediately
- */
-os.ui.timeline.CurrentTimeMarker.prototype.updateCurrentTime = function(opt_immediate) {
-  var now = Date.now();
-  if (!this.stopped_ && (now - this.lastUpdateTime_ >= 1000 || opt_immediate)) { // run once per second
-    this.lastUpdateTime_ = now;
-    var times = this.getExtent();
-    var dates = [new Date(times[0]), new Date(times[1])];
-    var range = this.xScale.range();
-    var today = new Date();
-    var date = new os.time.TimeInstant(today).toISOString().split(' ');
-    var prettyDate = date.length === 2 ? date[1] : date.length === 3 ? date[1] + ' ' + date[2] : ''; // include offset
-    var timeBackground = d3.select('.js-svg-timeline__bg-time');
-    var currentDateText = d3.select('.js-svg-timeline__current-time');
-    var placeholder = d3.select('#js-svg-timeline__background-time-placeholder');
-
-    if (today > dates[0] && today < dates[1]) { // in view
-      var currentDiff = today - dates[0];
-      var ratio = currentDiff / (dates[1] - dates[0]);
-      var translate = range[1] * ratio;
-      this.backgroundElement_.style('display', 'block').attr('transform', 'translate(' + translate + ', 0)');
-      placeholder.style('display', 'block');
-
-      var transformString = 'translate(' + (translate + prettyDate.length - 5) + ', -4)';
-      currentDateText.style('display', 'block').text(prettyDate).attr('transform', transformString);
-
-      // fit background to text
-      var currentDateTextEl = currentDateText[0][0];
-      if (currentDateTextEl) {
-        var textRect = currentDateTextEl.getBBox();
-        timeBackground.style('display', 'block').attr('transform', transformString).
-            attr('x', textRect.x).attr('y', textRect.y).attr('width', textRect.width);
-      }
-    } else if (today > dates[0]) { // completely in past
-      this.backgroundElement_.style('display', 'none');
-      currentDateText.style('display', 'none');
-      timeBackground.style('display', 'none');
-      placeholder.style('display', 'none');
-      if (this.animationFrameRef_) {
-        window.cancelAnimationFrame(this.animationFrameRef_);
-      }
-      return;
-    } else { // completely in future
-      this.backgroundElement_.style('display', 'block').attr('transform', 'translate(0, 0)');
-      currentDateText.style('display', 'none');
-      timeBackground.style('display', 'none');
-      placeholder.style('display', 'none');
-    }
+os.ui.timeline.CurrentTimeMarker.prototype.updateCurrentTime_ = function() {
+  if (this.isDisposed()) {
+    return;
   }
 
-  this.animationFrameRef_ = window.requestAnimationFrame(this.updateCurrentTimeRAF.bind(this));
+  var visible = true;
+  var times = this.getExtent();
+  var dates = [new Date(times[0]), new Date(times[1])];
+  var range = this.xScale.range();
+  var today = new Date();
+  var date = new os.time.TimeInstant(today).toISOString().split(' ');
+  var prettyDate = date.length === 2 ? date[1] : date.length === 3 ? date[1] + ' ' + date[2] : ''; // include offset
+  var timeBackground = d3.select('.js-svg-timeline__bg-time');
+  var currentDateText = d3.select('.js-svg-timeline__current-time');
+  var placeholder = d3.select('#js-svg-timeline__background-time-placeholder');
+
+  if (today > dates[0] && today < dates[1]) { // in view
+    var currentDiff = today - dates[0];
+    var ratio = currentDiff / (dates[1] - dates[0]);
+    var translate = range[1] * ratio;
+    this.backgroundElement_.style('display', 'block').attr('transform', 'translate(' + translate + ', 0)');
+    placeholder.style('display', 'block');
+
+    var transformString = 'translate(' + (translate + prettyDate.length - 5) + ', -4)';
+    currentDateText.style('display', 'block').text(prettyDate).attr('transform', transformString);
+
+    // fit background to text
+    var currentDateTextEl = currentDateText[0][0];
+    if (currentDateTextEl) {
+      var textRect = currentDateTextEl.getBBox();
+      timeBackground.style('display', 'block').attr('transform', transformString).
+          attr('x', textRect.x).attr('y', textRect.y).attr('width', textRect.width);
+    }
+  } else if (today > dates[0]) { // completely in past
+    this.backgroundElement_.style('display', 'none');
+    currentDateText.style('display', 'none');
+    timeBackground.style('display', 'none');
+    placeholder.style('display', 'none');
+    visible = false;
+  } else { // completely in future
+    this.backgroundElement_.style('display', 'block').attr('transform', 'translate(0, 0)');
+    currentDateText.style('display', 'none');
+    timeBackground.style('display', 'none');
+    placeholder.style('display', 'none');
+    visible = false;
+  }
+
+  if (visible && this.updateDelay_) {
+    // update as close to the next second as possible
+    this.updateDelay_.start(1000 - Date.now() % 1000);
+  }
 };
 
 
@@ -154,23 +141,10 @@ os.ui.timeline.CurrentTimeMarker.prototype.styleDragEnd_ = function() {
 
 
 /**
- * Stop updating the clock time
- * @private
- */
-os.ui.timeline.CurrentTimeMarker.prototype.stopAnimation_ = function() {
-  if (this.animationFrameRef_) {
-    window.cancelAnimationFrame(this.animationFrameRef_);
-    this.animationFrameRef_ = null;
-  }
-  this.stopped_ = true;
-};
-
-
-/**
  * @inheritDoc
  */
 os.ui.timeline.CurrentTimeMarker.prototype.render = function(opt_height) {
-  this.updateCurrentTime(true);
+  this.updateCurrentTime_();
 };
 
 


### PR DESCRIPTION
The timeline's current time marker was using `requestAnimationFrame` with an internal limiter to prevent updates from happening more than once per second (usually). The callback was being fired repeatedly and consuming a measurable level of CPU resources in the performance trace. This optimizes callbacks to fire when the time marker would actually be changing.

This class was also calling `requestAnimationFrame` while another request was pending, and replacing the request ID. That was causing the updates to stack, and continue even when the timeline was closed/disposed.