### PR TITLE
Fix-594(Window Closure)

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "init": "npm run init:base && npm run init:debug && npm run init:version && npm run init:vfolder",
     "lint:css": "sass-lint -v -s scss -i 'scss/nolint/**/*.scss' 'scss/**/*.scss'",
     "lint:js": "eslint --cache 'src/**/*.js' 'cypress/**/*.js'",
-    "lint": "npm run lint:css",
+    "lint": "npm run lint:js && npm run lint:css",
     "compile:dossier": "npm run init:apidoc && os-docs-gen-config dossier.conf.json .build/dossier.conf.json && os-docs -c .build/dossier.conf.json",
     "precompile:resolve": "cp addlayer.js .build",
     "compile:resolve": "os-resolve --outputDir .build --defineRoots $(cat .build/version)",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "init": "npm run init:base && npm run init:debug && npm run init:version && npm run init:vfolder",
     "lint:css": "sass-lint -v -s scss -i 'scss/nolint/**/*.scss' 'scss/**/*.scss'",
     "lint:js": "eslint --cache 'src/**/*.js' 'cypress/**/*.js'",
-    "lint": "npm run lint:js && npm run lint:css",
+    "lint": "npm run lint:css",
     "compile:dossier": "npm run init:apidoc && os-docs-gen-config dossier.conf.json .build/dossier.conf.json && os-docs -c .build/dossier.conf.json",
     "precompile:resolve": "cp addlayer.js .build",
     "compile:resolve": "os-resolve --outputDir .build --defineRoots $(cat .build/version)",

--- a/src/os/debug/fancierwindow.js
+++ b/src/os/debug/fancierwindow.js
@@ -43,10 +43,6 @@ os.debug.FancierWindow.STYLE_RULES_ = goog.string.Const.from(
 os.debug.FancierWindow.prototype.writeInitialDocument = function() {
   os.debug.FancierWindow.superClass_.writeInitialDocument.call(this);
 
-  // close button should set the debug window to disabled
-  if (this.win) {
-    goog.events.listenOnce(this.win, goog.events.EventType.BEFOREUNLOAD, this.onBeforeUnload_, false, this);
-  }
 };
 
 

--- a/src/os/debug/fancierwindow.js
+++ b/src/os/debug/fancierwindow.js
@@ -43,8 +43,8 @@ os.debug.FancierWindow.STYLE_RULES_ = goog.string.Const.from(
 os.debug.FancierWindow.prototype.writeInitialDocument = function() {
   os.debug.FancierWindow.superClass_.writeInitialDocument.call(this);
   // close button should set the debug window to disabled
-  if (this.window) {
-    goog.events.listenOnce(this.win, goog.events.EventType.BEFOREUNLOAD, this.onBeforeUnload_, false, this);
+  if (window) {
+    goog.events.listenOnce(window, goog.events.EventType.BEFOREUNLOAD, this.onBeforeUnload_, false, this);
   }
 };
 
@@ -56,7 +56,6 @@ os.debug.FancierWindow.prototype.onBeforeUnload_ = function() {
   // this.exit_ is private (grr), so copy it here
   this.setEnabled(false);
   if (this.win) {
-    goog.events.unlisten(this.win, goog.events.EventType.BEFOREUNLOAD, this.onBeforeUnload_, false, this);
     this.win.close();
   }
 };

--- a/src/os/debug/fancierwindow.js
+++ b/src/os/debug/fancierwindow.js
@@ -42,7 +42,10 @@ os.debug.FancierWindow.STYLE_RULES_ = goog.string.Const.from(
  */
 os.debug.FancierWindow.prototype.writeInitialDocument = function() {
   os.debug.FancierWindow.superClass_.writeInitialDocument.call(this);
-
+  // close button should set the debug window to disabled
+  if (this.window) {
+    goog.events.listenOnce(this.win, goog.events.EventType.BEFOREUNLOAD, this.onBeforeUnload_, false, this);
+  }
 };
 
 


### PR DESCRIPTION
Clear button on log no longer closes window, only clears log in FF60.7.0esr and Chrome.
Test Steps:
Using Fire Fox version 60.7.0esr

1.Top right hand corner click the "support" button
2.Drop down appears
3.Click "View Log"
4.Top right corner select "clear"
5.After selecting "clear" the data should be cleared, and the window should remain open.