### PR TITLE
feat: webgl fly to should fly to bounding sphere rather than extent

### DIFF
--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -1097,9 +1097,9 @@ Cesium.Camera.prototype.flyTo = function(options) {};
 
 /**
  * @param {!Cesium.BoundingSphere} boundingSphere The bounding sphere
- * @param {!Cesium.optionsCameraFlyToBoundingSphere} options The flyTo options
+ * @param {Cesium.optionsCameraFlyToBoundingSphere=} opt_options The flyTo options
  */
-Cesium.Camera.prototype.flyToBoundingSphere = function(boundingSphere, options) {};
+Cesium.Camera.prototype.flyToBoundingSphere = function(boundingSphere, opt_options) {};
 
 
 /**
@@ -1330,9 +1330,11 @@ Cesium.Cartesian3.fromElements = function(x, y, z, result) {};
  * @param {number} lon Longitude in degrees
  * @param {number} lat latitude in degrees
  * @param {number=} opt_alt Altitude in meters
+ * @param {Cesium.Ellipsoid=} opt_ellipsoid Defaults to WGS84
+ * @param {Cesium.Cartesian3=} opt_result
  * @return {!Cesium.Cartesian3}
  */
-Cesium.Cartesian3.fromDegrees = function(lon, lat, opt_alt) {};
+Cesium.Cartesian3.fromDegrees = function(lon, lat, opt_alt, opt_ellipsoid, opt_result) {};
 
 
 /**
@@ -5226,6 +5228,24 @@ Cesium.EventHelper.prototype.removeAll = function() {};
  * @param {number=} opt_radius The radius
  */
 Cesium.BoundingSphere = function(opt_center, opt_radius) {};
+
+
+/**
+ * @param {Cesium.BoundingSphere} sphere
+ * @param {Cesium.Cartesian3} point
+ * @param {Cesium.BoundingSphere=} opt_result
+ * @return {Cesium.BoundingSphere}
+ */
+Cesium.BoundingSphere.expand = function(sphere, point, opt_result) {};
+
+
+/**
+ * @param {Cesium.BoundingSphere} left
+ * @param {Cesium.BoundingSphere} right
+ * @param {Cesium.BoundingSphere=} opt_result
+ * @return {Cesium.BoundingSphere}
+ */
+Cesium.BoundingSphere.union = function(left, right, opt_result) {};
 
 
 /**

--- a/src/os/feature/feature.js
+++ b/src/os/feature/feature.js
@@ -13,7 +13,9 @@ goog.require('ol.source.VectorEventType');
 goog.require('os');
 goog.require('os.Fields');
 goog.require('os.MapContainer');
+goog.require('os.command.FlyToExtent');
 goog.require('os.data.RecordField');
+goog.require('os.fn');
 goog.require('os.geo');
 goog.require('os.geom.Ellipse');
 goog.require('os.im.mapping.MappingManager');
@@ -61,6 +63,29 @@ os.feature.LOBOptions;
  * @const
  */
 os.feature.TITLE_REGEX = /^(name|title)$/i;
+
+
+/**
+ * @param {null|undefined|ol.Feature|Array<ol.Feature>} features
+ */
+os.feature.flyTo = function(features) {
+  if (!features) {
+    return;
+  }
+
+  if (!Array.isArray(features)) {
+    features = [features];
+  }
+
+  if (os.map.mapContainer.is3DEnabled()) {
+    os.map.mapContainer.getWebGLRenderer().flyToFeatures(features);
+  } else {
+    var extent = features.map(os.fn.mapFeatureToGeometry).
+        reduce(os.fn.reduceExtentFromGeometries, ol.extent.createEmpty());
+    var cmd = new os.command.FlyToExtent(extent);
+    os.commandStack.addCommand(cmd);
+  }
+};
 
 
 /**

--- a/src/os/fn/fn.js
+++ b/src/os/fn/fn.js
@@ -53,7 +53,7 @@ os.fn.reduceExtentFromLayers = function(extent, layer) {
 
 /**
  * @param {!ol.Extent} extent The extent
- * @param {?(ol.geom.Geometry|{geometry: ol.geom.Geometry})} geometry The geometry
+ * @param {?(ol.geom.Geometry|{geometry: ol.geom.Geometry})|undefined} geometry The geometry
  * @return {!ol.Extent} The combined extent
  */
 os.fn.reduceExtentFromGeometries = function(extent, geometry) {

--- a/src/os/fn/fn.js
+++ b/src/os/fn/fn.js
@@ -5,6 +5,7 @@
 goog.provide('os.fn');
 
 goog.require('ol.extent');
+goog.require('ol.geom.GeometryType');
 goog.require('ol.layer.Layer');
 goog.require('os.extent');
 
@@ -63,6 +64,35 @@ os.fn.reduceExtentFromGeometries = function(extent, geometry) {
 
     if (geom) {
       ol.extent.extend(extent, os.extent.getFunctionalExtent(geom));
+    }
+  }
+
+  return extent;
+};
+
+
+/**
+ * @param {!Array<number>} extent
+ * @param {?ol.geom.Geometry|undefined} geometry
+ * @return {!Array<number>}
+ */
+os.fn.reduceAltitudeExtentFromGeometries = function(extent, geometry) {
+  if (geometry) {
+    var type = geometry.getType();
+
+    if (type === ol.geom.GeometryType.GEOMETRY_COLLECTION) {
+      var geoms = /** @type {ol.geom.GeometryCollection} */ (geometry).getGeometriesArray();
+      extent = geoms.reduce(os.fn.reduceAltitudeExtentFromGeometries, extent);
+    } else {
+      geometry = /** @type {ol.geom.SimpleGeometry} */ (geometry);
+      var flats = geometry.getFlatCoordinates();
+      var stride = geometry.getStride();
+
+      for (var i = 0, n = flats.length; i < n; i += stride) {
+        var alt = flats[i + 2] || 0;
+        extent[0] = Math.min(extent[0], alt);
+        extent[1] = Math.max(extent[1], alt);
+      }
     }
   }
 

--- a/src/os/map/map.js
+++ b/src/os/map/map.js
@@ -110,7 +110,7 @@ os.map.MAX_ZOOM = 25;
  * @type {number}
  * @const
  */
-os.map.MAX_AUTO_ZOOM = 15;
+os.map.MAX_AUTO_ZOOM = 18;
 
 
 /**

--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -644,21 +644,24 @@ os.MapContainer.prototype.flyToExtent = function(extent, opt_buffer, opt_maxZoom
 os.MapContainer.prototype.onZoom_ = function(event) {
   try {
     var context = event.getContext();
-
-    // if zooming to a single feature, use the default fly to zoom limit to avoid zooming too far. otherwise this is
-    // from a temporary (drawn) geometry and zoom should be unconstrained.
-    var maxZoom = context['feature'] != null ? undefined : -1;
-
     if (!goog.isArray(context)) {
       context = [context];
     }
 
-    var extent = /** @type {!Array<?{geometry: ol.geom.Geometry}>} */ (context).reduce(
-        os.fn.reduceExtentFromGeometries,
-        ol.extent.createEmpty());
+    var features = context.map(function(c) {
+      return c['feature'];
+    }).filter(os.fn.filterFalsey);
 
-    if (!ol.extent.isEmpty(extent)) {
-      os.commandStack.addCommand(new os.command.FlyToExtent(extent, undefined, maxZoom));
+    if (features.length) {
+      os.feature.flyTo(/** @type {Array<ol.Feature>} */ (features));
+    } else {
+      var extent = /** @type {!Array<?{geometry: ol.geom.Geometry}>} */ (context).reduce(
+          os.fn.reduceExtentFromGeometries,
+          ol.extent.createEmpty());
+
+      if (!ol.extent.isEmpty(extent)) {
+        os.commandStack.addCommand(new os.command.FlyToExtent(extent, undefined, -1));
+      }
     }
   } catch (e) {
     goog.log.error(os.MapContainer.LOGGER_, 'Zoom action failed:', e);

--- a/src/os/ui/menu/listmenu.js
+++ b/src/os/ui/menu/listmenu.js
@@ -1,7 +1,6 @@
 goog.provide('os.ui.menu.list');
 
 goog.require('os.command.FeaturesVisibility');
-goog.require('os.command.FlyToExtent');
 goog.require('os.command.InvertSelect');
 goog.require('os.command.SelectAll');
 goog.require('os.command.SelectNone');
@@ -152,14 +151,7 @@ os.ui.menu.list.handleListEvent = function(event) {
       case os.action.EventType.GOTO:
         var selected = source.getSelectedItems();
         if (selected.length > 0) {
-          var geometries = selected.map(function(f) {
-            return f.getGeometry();
-          }).filter(os.fn.filterFalsey);
-
-          if (geometries.length > 0) {
-            var extent = geometries.reduce(os.fn.reduceExtentFromGeometries, ol.extent.createEmpty());
-            cmd = new os.command.FlyToExtent(extent);
-          }
+          os.feature.flyTo(selected);
         }
         break;
       default:

--- a/src/os/ui/menu/timelinemenu.js
+++ b/src/os/ui/menu/timelinemenu.js
@@ -1,7 +1,6 @@
 goog.provide('os.ui.menu.timeline');
 
 goog.require('os.action.EventType');
-goog.require('os.command.FlyToExtent');
 goog.require('os.metrics.keys');
 goog.require('os.time.TimeRange');
 goog.require('os.time.TimelineActionEventType');
@@ -224,15 +223,7 @@ os.ui.menu.timeline.onFeatureCollection = function(event) {
         os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Timeline.FEATURE_INFO, 1);
         break;
       case os.time.TimelineActionEventType.GO_TO:
-        var geometries = features.map(function(f) {
-          return f.getGeometry();
-        }).filter(os.fn.filterFalsey);
-
-        if (geometries.length > 0) {
-          var zoomExtent = geometries.reduce(os.fn.reduceExtentFromGeometries, ol.extent.createEmpty());
-          var cmd = new os.command.FlyToExtent(zoomExtent);
-          os.command.CommandProcessor.getInstance().addCommand(cmd);
-        }
+        os.feature.flyTo(features);
         os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Timeline.GO_TO, 1);
         break;
       default:

--- a/src/os/webgl/abstractwebglrenderer.js
+++ b/src/os/webgl/abstractwebglrenderer.js
@@ -350,3 +350,10 @@ os.webgl.AbstractWebGLRenderer.prototype.getAltitudeModes = function() {
 os.webgl.AbstractWebGLRenderer.prototype.onPostRender = function(callback) {
   return undefined;
 };
+
+
+/**
+ * @inheritDoc
+ * @abstract
+ */
+os.webgl.AbstractWebGLRenderer.prototype.flyToFeatures = function(features) {};

--- a/src/os/webgl/iwebglrenderer.js
+++ b/src/os/webgl/iwebglrenderer.js
@@ -132,3 +132,10 @@ os.webgl.IWebGLRenderer.prototype.getAltitudeModes;
  * @return {function()|undefined} A deregistration function, or undefined if unsupported by the renderer.
  */
 os.webgl.IWebGLRenderer.prototype.onPostRender;
+
+
+/**
+ * Adds a command to fly to the features
+ * @param {Array<ol.Feature>} features
+ */
+os.webgl.IWebGLRenderer.prototype.flyToFeatures;

--- a/src/plugin/cesium/cesium.js
+++ b/src/plugin/cesium/cesium.js
@@ -398,3 +398,72 @@ plugin.cesium.createWorldTerrain = function(options) {
 plugin.cesium.createWMSTerrain = function(options) {
   return new plugin.cesium.WMSTerrainProvider(options);
 };
+
+
+
+/**
+ * @type {?Cesium.Cartesian3}
+ * @private
+ */
+plugin.cesium.scratchCartesian_ = null;
+
+
+/**
+ * @type {?Cesium.BoundingSphere}
+ * @private
+ */
+plugin.cesium.scratchSphere_ = null;
+
+
+/**
+ * @type {ol.Coordinate}
+ * @private
+ */
+plugin.cesium.scratchCoord_ = [];
+
+
+/**
+ * @param {Cesium.BoundingSphere} sphere
+ * @param {?ol.geom.Geometry|undefined} geom
+ * @return {Cesium.BoundingSphere}
+ */
+plugin.cesium.reduceBoundingSphere = function(sphere, geom) {
+  if (geom) {
+    var type = geom.getType();
+
+    if (type === ol.geom.GeometryType.GEOMETRY_COLLECTION) {
+      var geoms = /** @type {ol.geom.GeometryCollection} */ (geom).getGeometriesArray();
+      sphere = geoms.reduce(plugin.cesium.reduceBoundingSphere, sphere);
+    } else {
+      geom = /** @type {ol.geom.SimpleGeometry} */ (geom);
+      var flats = geom.getFlatCoordinates();
+      var stride = geom.getStride();
+      var scratchCartesian = plugin.cesium.scratchCartesian_ || new Cesium.Cartesian3();
+      var scratchCoord = plugin.cesium.scratchCoord_;
+      var scratchSphere = plugin.cesium.scratchSphere_;
+
+      for (var i = 0, n = flats.length; i < n; i += stride) {
+        scratchCoord[0] = flats[i];
+        scratchCoord[1] = flats[i + 1];
+        scratchCoord[2] = flats[i + 2] || 0;
+
+        if (!ol.proj.equivalent(os.map.PROJECTION, ol.proj.get(os.proj.EPSG4326))) {
+          scratchCoord = ol.proj.toLonLat(scratchCoord, os.map.PROJECTION);
+        }
+
+        scratchCartesian = Cesium.Cartesian3.fromDegrees(
+            scratchCoord[0], scratchCoord[1], scratchCoord[2], undefined, scratchCartesian);
+
+        if (!scratchSphere) {
+          scratchSphere = new Cesium.BoundingSphere(scratchCartesian);
+        } else {
+          scratchSphere.center = scratchCartesian;
+        }
+
+        sphere = !sphere ? scratchSphere.clone() : Cesium.BoundingSphere.union(scratchSphere, sphere, sphere);
+      }
+    }
+  }
+
+  return sphere;
+};

--- a/src/plugin/cesium/cesium.js
+++ b/src/plugin/cesium/cesium.js
@@ -462,6 +462,9 @@ plugin.cesium.reduceBoundingSphere = function(sphere, geom) {
 
         sphere = !sphere ? scratchSphere.clone() : Cesium.BoundingSphere.union(scratchSphere, sphere, sphere);
       }
+
+      plugin.cesium.scratchCoord_ = scratchCoord;
+      plugin.cesium.scratchSphere = scratchSphere;
     }
   }
 

--- a/src/plugin/cesium/cesiumrenderer.js
+++ b/src/plugin/cesium/cesiumrenderer.js
@@ -10,6 +10,7 @@ goog.require('plugin.cesium');
 goog.require('plugin.cesium.Camera');
 goog.require('plugin.cesium.TerrainLayer');
 goog.require('plugin.cesium.TileGridTilingScheme');
+goog.require('plugin.cesium.command.FlyToSphere');
 goog.require('plugin.cesium.interaction');
 goog.require('plugin.cesium.mixin');
 goog.require('plugin.cesium.sync.RootSynchronizer');
@@ -616,3 +617,18 @@ plugin.cesium.CesiumRenderer.prototype.getAltitudeModes = function() {
     os.webgl.AltitudeMode.RELATIVE_TO_GROUND
   ];
 };
+
+
+/**
+ * @inheritDoc
+ */
+plugin.cesium.CesiumRenderer.prototype.flyToFeatures = function(features) {
+  var sphere = features.map(os.fn.mapFeatureToGeometry).reduce(plugin.cesium.reduceBoundingSphere, null);
+
+  if (sphere) {
+    var cmd = new plugin.cesium.command.FlyToSphere(sphere);
+    os.commandStack.addCommand(cmd);
+  }
+};
+
+

--- a/src/plugin/cesium/command/flytospherecmd.js
+++ b/src/plugin/cesium/command/flytospherecmd.js
@@ -31,12 +31,19 @@ plugin.cesium.command.FlyToSphere = function(sphere, opt_options) {
       os.map.zoomToResolution(os.map.MAX_AUTO_ZOOM, os.map.PROJECTION),
       Cesium.Cartographic.fromCartesian(sphere.center).latitude);
 
+  sphere.radius = sphere.radius || 10;
+
   // gets the default offset
   var camera = /** @type {plugin.cesium.Camera} */ (os.map.mapContainer.getWebGLCamera());
   var offset = new Cesium.HeadingPitchRange(camera.cam_.heading, camera.cam_.pitch,
     os.command.FlyToExtent.DEFAULT_BUFFER * 2 * sphere.radius);
 
   offset.range = Math.max(offset.range, minRange);
+
+  // the min range needs to include the furthest eye offset for the given sphere altitude
+  // @see plugin.cesium.sync.VectorSynchronizer.updateLabelOffsets
+  var distance = Cesium.Cartographic.fromCartesian(sphere.center).height + offset.range;
+  offset.range += os.command.FlyToExtent.DEFAULT_BUFFER * distance / 10;
 
   /**
    * @type {Cesium.optionsCameraFlyToBoundingSphere}

--- a/src/plugin/cesium/command/flytospherecmd.js
+++ b/src/plugin/cesium/command/flytospherecmd.js
@@ -28,8 +28,7 @@ plugin.cesium.command.FlyToSphere = function(sphere, opt_options) {
 
   var cam = /** @type {plugin.cesium.Camera} */ (os.map.mapContainer.getWebGLCamera());
   var minRange = cam.calcDistanceForResolution(
-      os.map.zoomToResolution(os.map.MAX_AUTO_ZOOM, os.map.PROJECTION),
-      Cesium.Cartographic.fromCartesian(sphere.center).latitude);
+      os.map.zoomToResolution(os.map.MAX_AUTO_ZOOM, os.map.PROJECTION), 0);
 
   sphere.radius = sphere.radius || 10;
 

--- a/src/plugin/cesium/command/flytospherecmd.js
+++ b/src/plugin/cesium/command/flytospherecmd.js
@@ -29,10 +29,7 @@ plugin.cesium.command.FlyToSphere = function(sphere, opt_options) {
   // gets the default offset
   var camera = /** @type {plugin.cesium.Camera} */ (os.map.mapContainer.getWebGLCamera());
   var offset = new Cesium.HeadingPitchRange(camera.cam_.heading, camera.cam_.pitch,
-    os.command.FlyToExtent.DEFAULT_BUFFER *
-      (Cesium.Cartesian3.magnitude(sphere.center) + sphere.radius - Cesium.Ellipsoid.WGS84.maximumRadius));
-
-  offset.range = Math.max(offset.range, 10000);
+    os.command.FlyToExtent.DEFAULT_BUFFER * 2 * sphere.radius || 10000);
 
   /**
    * @type {Cesium.optionsCameraFlyToBoundingSphere}

--- a/src/plugin/cesium/command/flytospherecmd.js
+++ b/src/plugin/cesium/command/flytospherecmd.js
@@ -1,0 +1,78 @@
+goog.provide('plugin.cesium.command.FlyToSphere');
+
+goog.require('os.command.AbstractSyncCommand');
+
+
+/**
+ * @constructor
+ * @param {!Cesium.BoundingSphere} sphere
+ * @param {Cesium.optionsCameraFlyToBoundingSphere=} opt_options
+ * @extends {os.command.AbstractSyncCommand}
+ * @suppress {accessControls}
+ */
+plugin.cesium.command.FlyToSphere = function(sphere, opt_options) {
+  plugin.cesium.command.FlyToSphere.base(this, 'constructor');
+  this.title = 'Zoom to Bounding Sphere';
+
+  /**
+   * @type {!Cesium.BoundingSphere}
+   * @private
+   */
+  this.sphere_ = sphere;
+
+  /**
+   * @type {osx.map.CameraState}
+   * @private
+   */
+  this.oldPosition_ = os.map.mapContainer.persistCameraState();
+
+  // gets the default offset
+  var camera = /** @type {plugin.cesium.Camera} */ (os.map.mapContainer.getWebGLCamera());
+  var offset = new Cesium.HeadingPitchRange(camera.cam_.heading, camera.cam_.pitch,
+    os.command.FlyToExtent.DEFAULT_BUFFER *
+      (Cesium.Cartesian3.magnitude(sphere.center) + sphere.radius - Cesium.Ellipsoid.WGS84.maximumRadius));
+
+  offset.range = Math.max(offset.range, 10000);
+
+  /**
+   * @type {Cesium.optionsCameraFlyToBoundingSphere}
+   * @private
+   */
+  this.options_ = opt_options || /** @type {Cesium.optionsCameraFlyToBoundingSphere} */ ({
+    offset: offset
+  });
+};
+goog.inherits(plugin.cesium.command.FlyToSphere, os.command.AbstractSyncCommand);
+
+
+/**
+ * @inheritDoc
+ * @suppress {accessControls}
+ */
+plugin.cesium.command.FlyToSphere.prototype.execute = function() {
+  this.state = os.command.State.EXECUTING;
+
+  this.sphere_.radius *= os.command.FlyToExtent.DEFAULT_BUFFER;
+
+  var cam = /** @type {plugin.cesium.Camera} */ (os.map.mapContainer.getWebGLCamera());
+  cam.cam_.flyToBoundingSphere(this.sphere_, this.options_);
+
+  this.sphere_.radius /= os.command.FlyToExtent.DEFAULT_BUFFER;
+
+  return this.finish();
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.cesium.command.FlyToSphere.prototype.revert = function() {
+  this.state = os.command.State.REVERTING;
+
+  if (this.oldPosition_) {
+    os.map.mapContainer.restoreCameraState(this.oldPosition_);
+  }
+
+  return plugin.cesium.command.FlyToSphere.base(this, 'revert');
+};
+

--- a/src/plugin/cesium/command/flytospherecmd.js
+++ b/src/plugin/cesium/command/flytospherecmd.js
@@ -26,10 +26,17 @@ plugin.cesium.command.FlyToSphere = function(sphere, opt_options) {
    */
   this.oldPosition_ = os.map.mapContainer.persistCameraState();
 
+  var cam = /** @type {plugin.cesium.Camera} */ (os.map.mapContainer.getWebGLCamera());
+  var minRange = cam.calcDistanceForResolution(
+      os.map.zoomToResolution(os.map.MAX_AUTO_ZOOM, os.map.PROJECTION),
+      Cesium.Cartographic.fromCartesian(sphere.center).latitude);
+
   // gets the default offset
   var camera = /** @type {plugin.cesium.Camera} */ (os.map.mapContainer.getWebGLCamera());
   var offset = new Cesium.HeadingPitchRange(camera.cam_.heading, camera.cam_.pitch,
-    os.command.FlyToExtent.DEFAULT_BUFFER * 2 * sphere.radius || 10000);
+    os.command.FlyToExtent.DEFAULT_BUFFER * 2 * sphere.radius);
+
+  offset.range = Math.max(offset.range, minRange);
 
   /**
    * @type {Cesium.optionsCameraFlyToBoundingSphere}

--- a/src/plugin/cesium/sync/vectorsynchronizer.js
+++ b/src/plugin/cesium/sync/vectorsynchronizer.js
@@ -726,6 +726,7 @@ plugin.cesium.sync.VectorSynchronizer.prototype.updateBillboardOffsets = functio
 plugin.cesium.sync.VectorSynchronizer.prototype.updateFromCamera = function() {
   this.updateLabelOffsets();
   this.updateBillboardOffsets();
+  os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
 };
 
 

--- a/src/plugin/file/kml/kmlmenu.js
+++ b/src/plugin/file/kml/kmlmenu.js
@@ -1,7 +1,6 @@
 goog.provide('plugin.file.kml.menu');
 
 goog.require('os.buffer');
-goog.require('os.command.FlyToExtent');
 goog.require('os.ui.feature.featureInfoDirective');
 goog.require('os.ui.menu.layer');
 goog.require('plugin.file.kml.ui.KMLNetworkLinkNode');
@@ -185,11 +184,7 @@ plugin.file.kml.menu.onLayerEvent_ = function(event) {
             }
             break;
           case plugin.file.kml.menu.EventType.GOTO:
-            var extent = node.getExtent();
-
-            if (extent && !ol.extent.isEmpty(extent)) {
-              os.commandStack.addCommand(new os.command.FlyToExtent(extent));
-            }
+            os.feature.flyTo(node.getFeatures());
             break;
           case plugin.file.kml.menu.EventType.SELECT:
             source.addToSelected(node.getFeatures());


### PR DESCRIPTION
FlyTo in 3D was still using the 2D `FlyToExtent`, which does not take altitude into account and could potentially fly the camera too far in to see the feature.

Test:
* Make some places with and without altitude
* Right click each one and select "Go To" in 2D and 3D
  * In 3D, tilt the camera before and verify that it keeps the general orientation after flying to the feature(s)
* Place the features in a folder and select "Go To" on the folder in both 2D and 3D