### PR TITLE
build(cypress): Disable Cypress in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ script:
 after_success:
 - chmod ugo+x ./deploy.sh
 - "./deploy.sh"
-after_failure:
-- "./cypress/support/s3-artifact-upload.sh"
+# after_failure:
+# - "./cypress/support/s3-artifact-upload.sh"
 branches:
   except:
   - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/ci-script.sh
+++ b/ci-script.sh
@@ -3,5 +3,19 @@
 set -e
 yarn run build
 yarn run test
-./cypress/support/execute-tests.sh ci cli all
-yarn run apidoc
+
+#
+# Cypress tests are disabled in CI until they can reliably run without false positives, or inconsistent behavior
+# caused by bugs in Cypress itself (ie, fixed element visibility).
+#
+
+# ./cypress/support/execute-tests.sh ci cli all
+
+#
+# js-dossier does not currently work with OpenSphere's version of the Closure Library, and will need a compiler
+# upgrade to resolve this problem.
+#
+# See: https://github.com/jleyba/js-dossier/issues/111
+#
+
+# yarn run apidoc


### PR DESCRIPTION
This also disables API doc generation due to problems with the current version of js-dossier.