### PR TITLE
fix(style): fix merge to allow fill and outline deletions

### DIFF
--- a/src/os/style/style.js
+++ b/src/os/style/style.js
@@ -980,7 +980,7 @@ os.style.createFeatureConfig = function(feature, baseConfig, opt_layerConfig) {
           opt_layerConfig[os.style.StyleField.IMAGE], os.style.DEFAULT_FEATURE_SIZE);
       imageConfig['radius'] = mergedSize;
       imageConfig['scale'] = Math.max(os.style.sizeToScale(mergedSize), 0.01);
-    } else if (opt_layerConfig[os.style.StyleField.IMAGE]) {
+    } else if (imageConfig != null && opt_layerConfig[os.style.StyleField.IMAGE]) {
       // ensure the feature has an image config
       featureConfig[os.style.StyleField.IMAGE] = {};
       os.style.mergeConfig(opt_layerConfig[os.style.StyleField.IMAGE],
@@ -1002,7 +1002,7 @@ os.style.createFeatureConfig = function(feature, baseConfig, opt_layerConfig) {
       var mergedWidth = os.style.getMergedSize(styleOverride[os.style.StyleField.STROKE],
           opt_layerConfig[os.style.StyleField.STROKE], os.style.DEFAULT_STROKE_WIDTH);
       strokeConfig['width'] = Math.max(mergedWidth, 1);
-    } else if (opt_layerConfig[os.style.StyleField.STROKE]) {
+    } else if (strokeConfig != null && opt_layerConfig[os.style.StyleField.STROKE]) {
       // ensure the feature has a stroke config
       featureConfig[os.style.StyleField.STROKE] = {};
       os.style.mergeConfig(opt_layerConfig[os.style.StyleField.STROKE],
@@ -1251,6 +1251,10 @@ os.style.createFeatureStyle = function(feature, baseConfig, opt_layerConfig) {
 os.style.mergeConfig = function(from, to) {
   for (var key in from) {
     var fval = from[key];
+    if (fval === os.object.IGNORE_VAL) {
+      continue;
+    }
+
     if (fval && typeof fval == 'object' && !(typeof fval.length == 'number')) {
       // clone objects into the target
       if (!(key in to)) {

--- a/src/os/style/style.js
+++ b/src/os/style/style.js
@@ -522,15 +522,17 @@ os.style.setConfigColor = function(config, color, opt_includeStyleFields) {
   if (config) {
     var styleFields = opt_includeStyleFields || os.style.DEFAULT_COLOR_STYLE_FIELDS;
     for (var key in config) {
-      // color can exist in the image, fill, or stroke styles. in the case of icons, there may not be a color property
-      // but we still need to ensure the color is set correctly. set the color if a key that may contain a color is
-      // encountered.
-      if (styleFields.indexOf(key) !== -1) {
-        config[key][os.style.StyleField.COLOR] = color;
-      }
+      if (config[key]) {
+        // color can exist in the image, fill, or stroke styles. in the case of icons, there may not be a color property
+        // but we still need to ensure the color is set correctly. set the color if a key that may contain a color is
+        // encountered.
+        if (styleFields.indexOf(key) !== -1) {
+          config[key][os.style.StyleField.COLOR] = color;
+        }
 
-      if (!os.object.isPrimitive(config[key])) {
-        os.style.setConfigColor(config[key], color, opt_includeStyleFields);
+        if (!os.object.isPrimitive(config[key])) {
+          os.style.setConfigColor(config[key], color, opt_includeStyleFields);
+        }
       }
     }
   }
@@ -637,24 +639,26 @@ os.style.setConfigOpacityColor = function(config, opacity, opt_multiply) {
     var styleFields = os.style.DEFAULT_COLOR_STYLE_FIELDS;
     var colorArr;
     for (var key in config) {
-      // color can exist in the image, fill, or stroke styles. in the case of icons, there may not be a color property
-      // but we still need to ensure the color is set correctly. set the color if a key that may contain a color is
-      // encountered.
-      if (styleFields.indexOf(key) !== -1) {
-        colorArr = os.color.toRgbArray(config[key][os.style.StyleField.COLOR]);
-        if (colorArr) {
-          if (opt_multiply) {
-            colorArr[3] *= opacity;
-          } else {
-            colorArr[3] = opacity;
+      if (config[key]) {
+        // color can exist in the image, fill, or stroke styles. in the case of icons, there may not be a color property
+        // but we still need to ensure the color is set correctly. set the color if a key that may contain a color is
+        // encountered.
+        if (styleFields.indexOf(key) !== -1) {
+          colorArr = os.color.toRgbArray(config[key][os.style.StyleField.COLOR]);
+          if (colorArr) {
+            if (opt_multiply) {
+              colorArr[3] *= opacity;
+            } else {
+              colorArr[3] = opacity;
+            }
+
+            config[key][os.style.StyleField.COLOR] = os.style.toRgbaString(colorArr);
           }
-
-          config[key][os.style.StyleField.COLOR] = os.style.toRgbaString(colorArr);
         }
-      }
 
-      if (!os.object.isPrimitive(config[key])) {
-        os.style.setConfigOpacityColor(config[key], opacity, opt_multiply);
+        if (!os.object.isPrimitive(config[key])) {
+          os.style.setConfigOpacityColor(config[key], opacity, opt_multiply);
+        }
       }
     }
   }
@@ -672,18 +676,20 @@ os.style.getConfigOpacityColor = function(config) {
     var styleFields = os.style.DEFAULT_COLOR_STYLE_FIELDS;
     var colorArr;
     for (var key in config) {
-      // color can exist in the image, fill, or stroke styles. in the case of icons, there may not be a color property
-      // but we still need to ensure the color is set correctly. set the color if a key that may contain a color is
-      // encountered.
-      if (styleFields.indexOf(key) !== -1) {
-        colorArr = os.color.toRgbArray(config[key][os.style.StyleField.COLOR]);
-        if (colorArr) {
-          return colorArr[3];
+      if (config[key]) {
+        // color can exist in the image, fill, or stroke styles. in the case of icons, there may not be a color property
+        // but we still need to ensure the color is set correctly. set the color if a key that may contain a color is
+        // encountered.
+        if (styleFields.indexOf(key) !== -1) {
+          colorArr = os.color.toRgbArray(config[key][os.style.StyleField.COLOR]);
+          if (colorArr) {
+            return colorArr[3];
+          }
         }
-      }
 
-      if (!os.object.isPrimitive(config[key])) {
-        return os.style.getConfigOpacityColor(config[key]);
+        if (!os.object.isPrimitive(config[key])) {
+          return os.style.getConfigOpacityColor(config[key]);
+        }
       }
     }
   }

--- a/src/os/style/style.js
+++ b/src/os/style/style.js
@@ -1257,7 +1257,7 @@ os.style.mergeConfig = function(from, to) {
 
     if (fval && typeof fval == 'object' && !(typeof fval.length == 'number')) {
       // clone objects into the target
-      if (!(key in to) || to[key] === null) {
+      if (!(key in to) || to[key] == null) {
         to[key] = {};
       }
 

--- a/src/os/style/style.js
+++ b/src/os/style/style.js
@@ -980,7 +980,7 @@ os.style.createFeatureConfig = function(feature, baseConfig, opt_layerConfig) {
           opt_layerConfig[os.style.StyleField.IMAGE], os.style.DEFAULT_FEATURE_SIZE);
       imageConfig['radius'] = mergedSize;
       imageConfig['scale'] = Math.max(os.style.sizeToScale(mergedSize), 0.01);
-    } else if (imageConfig != null && opt_layerConfig[os.style.StyleField.IMAGE]) {
+    } else if (imageConfig !== null && opt_layerConfig[os.style.StyleField.IMAGE]) {
       // ensure the feature has an image config
       featureConfig[os.style.StyleField.IMAGE] = {};
       os.style.mergeConfig(opt_layerConfig[os.style.StyleField.IMAGE],
@@ -1002,7 +1002,7 @@ os.style.createFeatureConfig = function(feature, baseConfig, opt_layerConfig) {
       var mergedWidth = os.style.getMergedSize(styleOverride[os.style.StyleField.STROKE],
           opt_layerConfig[os.style.StyleField.STROKE], os.style.DEFAULT_STROKE_WIDTH);
       strokeConfig['width'] = Math.max(mergedWidth, 1);
-    } else if (strokeConfig != null && opt_layerConfig[os.style.StyleField.STROKE]) {
+    } else if (strokeConfig !== null && opt_layerConfig[os.style.StyleField.STROKE]) {
       // ensure the feature has a stroke config
       featureConfig[os.style.StyleField.STROKE] = {};
       os.style.mergeConfig(opt_layerConfig[os.style.StyleField.STROKE],
@@ -1257,7 +1257,7 @@ os.style.mergeConfig = function(from, to) {
 
     if (fval && typeof fval == 'object' && !(typeof fval.length == 'number')) {
       // clone objects into the target
-      if (!(key in to)) {
+      if (!(key in to) || to[key] === null) {
         to[key] = {};
       }
 

--- a/src/plugin/file/kml/kml.js
+++ b/src/plugin/file/kml/kml.js
@@ -59,6 +59,9 @@ plugin.file.kml.DEFAULT_STYLE = {
     'rotation': 0,
     'src': os.ui.file.kml.DEFAULT_ICON_PATH
   },
+  'fill': {
+    'color': os.style.DEFAULT_LAYER_COLOR
+  },
   'stroke': {
     'color': os.style.DEFAULT_LAYER_COLOR,
     'width': os.style.DEFAULT_STROKE_WIDTH
@@ -148,6 +151,15 @@ plugin.file.kml.OL_NETWORK_LINK_PARSERS = function() {
  * Accessor for private Openlayers code.
  * @return {Object<string, Object<string, ol.XmlParser>>}
  */
+plugin.file.kml.OL_PAIR_PARSERS = function() {
+  return ol.format.KML.PAIR_PARSERS_;
+};
+
+
+/**
+ * Accessor for private Openlayers code.
+ * @return {Object<string, Object<string, ol.XmlParser>>}
+ */
 plugin.file.kml.OL_PLACEMARK_PARSERS = function() {
   return ol.format.KML.PLACEMARK_PARSERS_;
 };
@@ -210,11 +222,75 @@ plugin.file.kml.replaceParsers_(ol.format.KML.POLY_STYLE_PARSERS_, 'color',
  * Accessor for private Openlayers code.
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {Array<ol.style.Style>} Style.
+ * @return {Object} style config
  */
 plugin.file.kml.readStyle = function(node, objectStack) {
-  return ol.format.KML.readStyle_(node, objectStack);
+  var styleObject = ol.xml.pushParseAndPop(
+      {}, ol.format.KML.STYLE_PARSERS_, node, objectStack);
+  if (!styleObject) {
+    return null;
+  }
+  var fillStyle = /** @type {ol.style.Fill} */
+      ('fillStyle' in styleObject ?
+        styleObject['fillStyle'] : ol.format.KML.DEFAULT_FILL_STYLE_);
+  var fill = /** @type {boolean|undefined} */ (styleObject['fill']);
+  var imageStyle = /** @type {ol.style.Image} */
+      ('imageStyle' in styleObject ?
+        styleObject['imageStyle'] : ol.format.KML.DEFAULT_IMAGE_STYLE_);
+  if (imageStyle == ol.format.KML.DEFAULT_NO_IMAGE_STYLE_) {
+    imageStyle = undefined;
+  }
+  var textStyle = /** @type {ol.style.Text} */
+      ('textStyle' in styleObject ?
+        styleObject['textStyle'] : ol.format.KML.DEFAULT_TEXT_STYLE_);
+  var strokeStyle = /** @type {ol.style.Stroke} */
+      ('strokeStyle' in styleObject ?
+        styleObject['strokeStyle'] : ol.format.KML.DEFAULT_STROKE_STYLE_);
+  var outline = /** @type {boolean|undefined} */
+      (styleObject['outline']);
+
+  var config = os.style.StyleManager.getInstance().toConfig(new ol.style.Style({
+    fill: fillStyle,
+    image: imageStyle,
+    stroke: strokeStyle,
+    text: textStyle,
+    zIndex: undefined // FIXME
+  }));
+
+  if (fill !== undefined && !fill) {
+    config['fill'] = null;
+  }
+
+  if (outline !== undefined && !outline) {
+    config['stroke'] = null;
+  }
+
+  return config;
 };
+
+
+/**
+ * @type {Object<string, Object<string, ol.XmlParser>>}
+ * @const
+ */
+plugin.file.kml.PAIR_PARSERS = ol.xml.makeStructureNS(
+    plugin.file.kml.OL_NAMESPACE_URIS(), {
+      'Style': ol.xml.makeObjectPropertySetter(plugin.file.kml.readStyle)
+    });
+
+os.object.merge(plugin.file.kml.PAIR_PARSERS, plugin.file.kml.OL_PAIR_PARSERS(), true);
+
+
+/**
+ * @type {Object<string, Object<string, ol.XmlParser>>}
+ * @const
+ */
+plugin.file.kml.PLACEMARK_PARSERS = ol.xml.makeStructureNS(
+    plugin.file.kml.OL_NAMESPACE_URIS(), {
+      'Style': ol.xml.makeObjectPropertySetter(plugin.file.kml.readStyle)
+    });
+
+os.object.merge(plugin.file.kml.PLACEMARK_PARSERS, plugin.file.kml.OL_PLACEMARK_PARSERS(), true);
 
 
 /**

--- a/src/plugin/file/kml/kmlparser.js
+++ b/src/plugin/file/kml/kmlparser.js
@@ -140,7 +140,7 @@ plugin.file.kml.KMLParser = function(options) {
 
   /**
    * The KML style config map for highlight styles from StyleMap tags
-   * @type {!Object<string, !Array<Object>>}
+   * @type {!Object<string, !Object>}
    * @private
    */
   this.highlightStyleMap_ = {};

--- a/src/plugin/file/kml/kmlparser.js
+++ b/src/plugin/file/kml/kmlparser.js
@@ -126,21 +126,21 @@ plugin.file.kml.KMLParser = function(options) {
 
   /**
    * The KML style config map
-   * @type {!Object<string, Object>}
+   * @type {!Object<string, Object<string, *>>}
    * @private
    */
   this.styleMap_ = {};
 
   /**
    * The KML balloon style config map.
-   * @type {!Object<string, !Object>}
+   * @type {!Object<string, !Object<string, *>>}
    * @private
    */
   this.balloonStyleMap = {};
 
   /**
    * The KML style config map for highlight styles from StyleMap tags
-   * @type {!Object<string, !Object>}
+   * @type {!Object<string, !Object<string, *>>}
    * @private
    */
   this.highlightStyleMap_ = {};
@@ -1444,8 +1444,8 @@ plugin.file.kml.KMLParser.prototype.applyStyles_ = function(el, feature) {
       feature.set(os.style.StyleType.FEATURE, mergedStyle, true);
     }
 
-    if (highlightStyle && highlightStyle.length) {
-      feature.set(os.style.StyleType.CUSTOM_HIGHLIGHT, highlightStyle[0], true);
+    if (highlightStyle) {
+      feature.set(os.style.StyleType.CUSTOM_HIGHLIGHT, highlightStyle, true);
     }
 
     // set the feature shape if it wasn't defined in the file and an icon style is present

--- a/src/plugin/file/kml/kmlparser.js
+++ b/src/plugin/file/kml/kmlparser.js
@@ -59,9 +59,14 @@ plugin.file.kml.KMLParserStackObj;
  * @implements {os.parse.IParser.<plugin.file.kml.ui.KMLNode>}
  * @template T
  * @constructor
+ * @suppress {accessControls}
  */
 plugin.file.kml.KMLParser = function(options) {
   plugin.file.kml.KMLParser.base(this, 'constructor');
+
+  if (!ol.format.KML.DEFAULT_STYLE_ARRAY_) {
+    ol.format.KML.createStyleDefaults_();
+  }
 
   /**
    * The source document
@@ -121,7 +126,7 @@ plugin.file.kml.KMLParser = function(options) {
 
   /**
    * The KML style config map
-   * @type {!Object<string, !Array<Object>>}
+   * @type {!Object<string, Object>}
    * @private
    */
   this.styleMap_ = {};
@@ -1369,24 +1374,15 @@ plugin.file.kml.KMLParser.prototype.parseSizeXY_ = function(obj) {
 
 
 /**
- * @param {?Object} config The style config
- * @param {Array<Object>} set The style set
+ * @param {?Object} merged The merged style config
+ * @param {Array<Object>} config The current config
  * @return {Object}
  * @private
  */
-plugin.file.kml.KMLParser.reduceStyles_ = function(config, set) {
-  if (set && set.length) {
-    config = config || {};
-    var s = set[0];
-    os.object.merge(s, config, true, false);
-
-    if (set.length > 1) {
-      goog.log.warning(plugin.file.kml.KMLParser.LOGGER_,
-          'An array of style configs with more than one entry was found!');
-    }
-  }
-
-  return config;
+plugin.file.kml.KMLParser.reduceStyles_ = function(merged, config) {
+  merged = merged || {};
+  os.style.mergeConfig(config, merged);
+  return merged;
 };
 
 
@@ -1396,14 +1392,14 @@ plugin.file.kml.KMLParser.reduceStyles_ = function(config, set) {
  * @private
  */
 plugin.file.kml.KMLParser.prototype.applyStyles_ = function(el, feature) {
-  var styleSets = [];
+  var styles = [];
   var highlightStyle = null;
 
   // style from style url
   var styleUrl = /** @type {string} */ (feature.get('styleUrl'));
   if (styleUrl) {
     var styleId = this.getStyleId(decodeURIComponent(styleUrl));
-    styleSets.push(styleId in this.styleMap_ ? this.styleMap_[styleId] : null);
+    styles.push(styleId in this.styleMap_ ? this.styleMap_[styleId] : null);
     highlightStyle = styleId in this.highlightStyleMap_ ? this.highlightStyleMap_[styleId] : null;
   }
 
@@ -1411,26 +1407,27 @@ plugin.file.kml.KMLParser.prototype.applyStyles_ = function(el, feature) {
 
 
   // local style
-  var styles = /** @type {Array<ol.style.Style>} */ (feature.get(plugin.file.kml.STYLE_KEY));
-  if (styles && styles.length) {
-    styleSets.push(styles.map(this.mapStyleToConfig_, this));
+  var style = /** @type {Object} */ (feature.get(plugin.file.kml.STYLE_KEY));
+  if (style) {
+    this.updateStyleConfig_(style);
+    styles.push(style);
   }
 
   // inherited styles
   var p = el.parentNode;
   while (p) {
     if (p.kmlStyle) {
-      styleSets.unshift(p.kmlStyle);
+      styles.unshift(p.kmlStyle);
     }
 
     p = p.parentNode;
   }
 
   // default style
-  styleSets.unshift(plugin.file.kml.DEFAULT_STYLE_ARRAY);
+  styles.unshift(plugin.file.kml.DEFAULT_STYLE);
 
   // reduce style sets to single set
-  var mergedStyle = styleSets.reduce(plugin.file.kml.KMLParser.reduceStyles_, null);
+  var mergedStyle = styles.reduce(plugin.file.kml.KMLParser.reduceStyles_, null);
   if (mergedStyle) {
     var existingStyle = /** @type {Array<!Object>|Object|undefined} */ (feature.get(os.style.StyleType.FEATURE));
     if (existingStyle) {
@@ -1499,7 +1496,8 @@ plugin.file.kml.KMLParser.prototype.extractStyles_ = function(el) {
 
     this.examineStyles_(style);
 
-    var styles = plugin.file.kml.readStyle(style, []);
+    var styleConfig = plugin.file.kml.readStyle(style, this.stack_);
+    this.updateStyleConfig_(styleConfig);
     var id = style.id || style.getAttribute('id');
     if (!id) {
       // styles without an ID are merely the base styles for the container
@@ -1507,7 +1505,7 @@ plugin.file.kml.KMLParser.prototype.extractStyles_ = function(el) {
       // Clever hack alert!
       // The "stack" in this class is not really a stack. Therefore, we are
       // going to store the KML styles on the element itself
-      el.kmlStyle = styles.map(this.mapStyleToConfig_, this);
+      el.kmlStyle = styleConfig;
       continue;
     }
 
@@ -1523,7 +1521,7 @@ plugin.file.kml.KMLParser.prototype.extractStyles_ = function(el) {
       id = newId;
     }
 
-    this.styleMap_[id] = styles.map(this.mapStyleToConfig_, this);
+    this.styleMap_[id] = styleConfig;
   }
 
   // handle StyleMap elements
@@ -1634,15 +1632,11 @@ plugin.file.kml.KMLParser.prototype.getKmlThingRegex = function() {
 
 
 /**
- * @param {ol.style.Style} style
- * @return {Object}
+ * @param {Object} config
  * @private
  */
-plugin.file.kml.KMLParser.prototype.mapStyleToConfig_ = function(style) {
-  var config = null;
-  if (style) {
-    config = os.style.StyleManager.getInstance().toConfig(style);
-
+plugin.file.kml.KMLParser.prototype.updateStyleConfig_ = function(config) {
+  if (config) {
     // attempt to convert local KMZ asset URIs to the proper data URIs
     if (config['image'] && config['image']['src']) {
       try {
@@ -1656,8 +1650,6 @@ plugin.file.kml.KMLParser.prototype.mapStyleToConfig_ = function(style) {
       }
     }
   }
-
-  return config;
 };
 
 

--- a/test/os/style/style.test.js
+++ b/test/os/style/style.test.js
@@ -167,3 +167,98 @@ describe('os.style.createFeatureStyle', function() {
     expect(style.length).toBe(2);
   });
 });
+
+describe('os.style.mergeConfig', function() {
+  it('should merge basic style configs', function() {
+    var from = {
+      'string': 'This is a test',
+      'number': 1,
+      'boolean': true
+    };
+
+    var to = {};
+
+    os.style.mergeConfig(from, to);
+    expect(to).toEqual(from);
+    expect(to).not.toBe(from);
+  });
+
+  it('should merge nested style configs', function() {
+    var from = {
+      'nested': {
+        'string': 'test',
+        'number': 1,
+        'boolean': true
+      },
+      'string': 'This is a test',
+      'number': 2,
+      'boolean': false
+    };
+
+    var to = {};
+    os.style.mergeConfig(from, to);
+    expect(to).toEqual(from);
+  });
+
+  it('should overwrite when merging', function() {
+    var from = {
+      'nested': {
+        'egg': 2
+      },
+      'string': 'test',
+      'number': 1,
+      'boolean': true
+    };
+
+    var toMergeAll = {
+      'nested': {
+        'egg': 1
+      },
+      'string': 'mergeAll',
+      'number': 0,
+      'boolean': false,
+      'other': 'no change'
+    };
+
+    os.style.mergeConfig(from, toMergeAll);
+    expect(toMergeAll).toEqual(ol.obj.assign({}, toMergeAll, from));
+
+    var toMergeSome = {
+      'string': 'mergeSome',
+      'number': -1
+    };
+
+    os.style.mergeConfig(from, toMergeSome);
+    expect(toMergeSome).toEqual(from);
+
+    var toMergeSomeNested = {
+      'nested': {},
+      'string': 'mergeSomeNested'
+    };
+
+    os.style.mergeConfig(from, toMergeSomeNested);
+    expect(toMergeSomeNested).toEqual(from);
+  });
+
+  it('should use null for deletions', function() {
+    var from = {'value': null};
+
+    var to = {'value': {'color': 'red'}};
+
+    os.style.mergeConfig(from, to);
+    expect(to).toEqual(from);
+
+    var newAddition = {'value': {'color': 'blue'}};
+
+    os.style.mergeConfig(newAddition, to);
+    expect(to).toEqual(newAddition);
+  });
+
+  it('should use undefined for inheritence', function() {
+    // we've already tested implicit undefined above, so test explicit undefined
+    var to = {'value': undefined};
+    var from = {'value': 1};
+    os.style.mergeConfig(from, to);
+    expect(to).toEqual(from);
+  });
+});

--- a/test/os/style/style.test.js
+++ b/test/os/style/style.test.js
@@ -260,5 +260,10 @@ describe('os.style.mergeConfig', function() {
     var from = {'value': 1};
     os.style.mergeConfig(from, to);
     expect(to).toEqual(from);
+
+    var to = {'stroke': undefined};
+    var from = {'stroke': {'color': 'red'}};
+    os.style.mergeConfig(from, to);
+    expect(to).toEqual(from);
   });
 });


### PR DESCRIPTION
This changes the style config merging to allow for a definition of `null` to remove the parent style rather than inheriting it (`undefined`). Additionally, the `readStyle_` parser in `ol.format.KML` was replaced with a custom implementation which returns style configs rather than OpenLayers style objects.

Example: create a style config that removes a stroke rather than inheriting the default stroke:
```
var styleConfig = {
  'fill': {
    'color': 'rgba(255,0,0,1)',
  },
  'stroke': null
};
```

Testing:
Compare [PolygonStyles.txt](https://github.com/ngageoint/opensphere/files/3302618/PolygonStyles.txt) to the same file in Google Earth (making labels always on helps with identifying the correct style)

Google Earth result:
<img width="489" alt="Screen Shot 2019-06-13 at 12 15 52 PM" src="https://user-images.githubusercontent.com/7914731/59704453-66bab480-91b9-11e9-867e-c58442ba7c2d.png">

resolves #604