### PR TITLE
fix(Fix-616): Drag Cursor

### DIFF
--- a/index-template.html
+++ b/index-template.html
@@ -6,7 +6,7 @@
 <link rel="icon" href="@version@images/favicon.ico?v=1" sizes="16x16 24x24 32x32 48x48 64x64" type="image/x-icon"/>
 <!--VENDOR_CSS-->
 <!--APP_CSS-->
-<div id="ng-app" class="unselectable os-app d-flex flex-fill" ng-init="version='@packageVersion@';versionPath='@version@'">
+<div id="ng-app" class="ol-unselectable os-app d-flex flex-fill" ng-init="version='@packageVersion@';versionPath='@version@'">
   <div ng-view></div>
 </div>
 <noscript>Javascript is disabled in your browser. Turn it on and refresh the page.</noscript>

--- a/scss/os/_overrides_bootstrap.scss
+++ b/scss/os/_overrides_bootstrap.scss
@@ -120,6 +120,6 @@ body {
 }
 
 // Blocks cursor select outside of input field
-* label {
+div {
   user-select: none;
 }

--- a/scss/os/_overrides_bootstrap.scss
+++ b/scss/os/_overrides_bootstrap.scss
@@ -118,3 +118,8 @@ body {
     cursor: pointer;
   }
 }
+
+// Blocks cursor select outside of input field
+* label {
+  user-select: none;
+}

--- a/views/layers.html
+++ b/views/layers.html
@@ -1,4 +1,4 @@
-<div class="d-flex flex-column flex-fill u-user-select-none">
+<div class="d-flex flex-column flex-fill">
   <div class="form-row align-items-center flex-shrink-0 mt-1">
     <div class="col-auto col-form-label">
       Group By

--- a/views/menu/actionmenuitemlist.html
+++ b/views/menu/actionmenuitemlist.html
@@ -11,7 +11,7 @@
       <!-- action item -->
       <div class="d-flex">
         <div class="text-truncate flex-fill d-inline">
-          <a class="unselectable" ng-if="!(isSeparator || isSeparatorHeader)">
+          <a class="ol-unselectable" ng-if="!(isSeparator || isSeparatorHeader)">
             <span><i class="fa fa-fw" ng-class="menuItem.getAction().getIcon() || 'fa-indent'"></i></span>
             <span>{{menuItem.getName()}}</span>
           </a>
@@ -37,7 +37,7 @@
 
   <div class="dropdown-item" ng-if="isSubmenu && isMoreButton" title="See more results..." ng-click="actionMenu.handleMoreResults()">
     <div class="text-truncate d-inline">
-      <a class="unselectable">
+      <a class="ol-unselectable">
         <span><i class="fa fa-fw" ng-class="fa-indent"></i></span>
         <span class="text-truncate">MORE...</span>
       </a>

--- a/views/ol/draw/drawmenu.html
+++ b/views/ol/draw/drawmenu.html
@@ -1,4 +1,4 @@
-<ul class="draw-menu menu unselectable">
+<ul class="draw-menu menu ol-unselectable">
   <li class="menu-item menu-item-action dropdown-item"
       ng-click="drawControls.activateControl('box')"
       ng-class="{active: drawControls.selectedType == 'box', on: drawControls.selectedType == 'box' && drawControls.isActive()}"

--- a/views/windows/adddata.html
+++ b/views/windows/adddata.html
@@ -53,7 +53,7 @@
     <div class="d-flex flex-fill mt-1">
       <slicktree class="border col p-0 o-add-data__slicktree" x-data="providers" checkbox-class="c-toggle-switch" checkbox-tooltip="Activates or deactivates the layer"
         selected="selected" disable-folders="true"></slicktree>
-      <div class="border col ml-1 p-2 u-overflow-y-auto" bind-directive="addData.getInfo()"></div>
+      <div class="border col ml-1 p-2 u-overflow-y-auto u-user-select-text" bind-directive="addData.getInfo()"></div>
     </div>
   </div>
 


### PR DESCRIPTION
Drag of cursor has been removed to select labels. Only selects input fields.

1. Open any dialog box.
2. Attempt to highlight a label (or multiple labels).
3. Labels should not be highlighted globally.

windy-kite.surge.sh