### PR TITLE
ci: disable cypress tests

### DIFF
--- a/ci-script.sh
+++ b/ci-script.sh
@@ -3,7 +3,11 @@
 set -e
 yarn run build
 yarn run test
-./cypress/support/execute-tests.sh ci cli all
+#
+# Cypress tests are not currently running with enough consistency to be part of the CI Build.
+# When the consistency is improved, they will be enabled again.
+#
+# ./cypress/support/execute-tests.sh ci cli all
 
 #
 # js-dossier does not currently work with OpenSphere's version of the Closure Library, and will need a compiler


### PR DESCRIPTION
The Cypress tests are not currently running with enough consistency (not only in the Travis CI environment but also locally) to be run as part of the `master` build and the failures introduced by it are holding up other development.

The development of those tests should be continued on another branch until we can address the consistency issue.