### PR TITLE
Create/update tracks from coordinates.

### DIFF
--- a/src/plugin/track/track.js
+++ b/src/plugin/track/track.js
@@ -91,6 +91,14 @@ plugin.track.TrackLike;
 
 
 /**
+ * A type representing a track feature. Tracks will use `os.feature.DynamicFeature` if they have a time component and
+ * can be animated, `ol.Feature` otherwise.
+ * @typedef {os.feature.DynamicFeature|ol.Feature}
+ */
+plugin.track.TrackFeatureLike;
+
+
+/**
  * @typedef {{
  *   entry: !os.filter.FilterEntry,
  *   mappings: !Array<!Object>,
@@ -104,6 +112,17 @@ plugin.track.QueryOptions;
 
 /**
  * @typedef {{
+ *   coordinates: (Array<!ol.Coordinate>|undefined),
+ *   features: (Array<!ol.Feature>|undefined),
+ *   track: !ol.Feature
+ * }}
+ */
+plugin.track.AddOptions;
+
+
+/**
+ * @typedef {{
+ *   coordinates: (Array<!ol.Coordinate>|undefined),
  *   features: (Array<!ol.Feature>|undefined),
  *   geometry: (plugin.track.TrackLike|undefined),
  *   id: (string|undefined),
@@ -421,24 +440,36 @@ plugin.track.getTrackCoordinates = function(features, sortField) {
 /**
  * Creates a track from the provided options.
  * @param {!plugin.track.CreateOptions} options The track creation options.
- * @return {os.feature.DynamicFeature|ol.Feature|undefined} The track feature.
+ * @return {plugin.track.TrackFeatureLike|undefined} The track feature.
  */
 plugin.track.createTrack = function(options) {
   var sortField = options.sortField || os.data.RecordField.TIME;
-  var featureColor;
-  var sourceColor;
-
+  var trackColor = options.color;
+  var coordinates = options.coordinates;
+  var features = options.features;
   var geometry = options.geometry;
-  if (!geometry && options.features && options.features.length) {
-    var coordinates = plugin.track.getTrackCoordinates(options.features, sortField);
-    if (coordinates.length) {
-      geometry = new ol.geom.LineString(coordinates, ol.geom.GeometryLayout.XYZM);
-      featureColor = /** @type {string|undefined} */ (options.features[0].get(os.data.RecordField.COLOR));
 
-      var source = os.feature.getSource(options.features[0]);
-      if (source) {
-        sourceColor = source ? source.getColor() : undefined;
+  if (!geometry) {
+    if (coordinates) {
+      coordinates.sort(plugin.track.sortCoordinatesByValue);
+    } else if (features && features.length) {
+      coordinates = plugin.track.getTrackCoordinates(features, sortField);
+
+      // if the color wasn't provided via options, determine the color from the features/source
+      if (!trackColor && features.length) {
+        trackColor = /** @type {string|undefined} */ (features[0].get(os.data.RecordField.COLOR));
+
+        if (!trackColor) {
+          var source = os.feature.getSource(features[0]);
+          if (source) {
+            trackColor = source ? source.getColor() : undefined;
+          }
+        }
       }
+    }
+
+    if (coordinates && coordinates.length) {
+      geometry = new ol.geom.LineString(coordinates, ol.geom.GeometryLayout.XYZM);
     }
   }
 
@@ -477,7 +508,7 @@ plugin.track.createTrack = function(options) {
   // set the track name, defaulting to the id if one isn't provided
   track.set(plugin.file.kml.KMLField.NAME, options.name || trackId);
 
-  // keep a copy of the features used to assemble the track
+  // save the field used to sort coordinates in the track
   track.set(plugin.track.TrackField.SORT_FIELD, sortField);
 
   var distance = plugin.track.updateDistance(track, true);
@@ -485,21 +516,12 @@ plugin.track.createTrack = function(options) {
   plugin.track.updateAverageSpeed(track, distance, duration);
   plugin.track.updateTime(track);
 
-  // create the track and current position styles. color is the first defined value in:
-  //  - color override parameter
-  //  - feature color
-  //  - source color
-  //  - default feature color
-  //
+  // set the style config for the track
   var trackStyle = /** @type {!Object<string, *>} */ (os.object.unsafeClone(plugin.track.TRACK_CONFIG));
   var currentStyle = /** @type {!Object<string, *>} */ (os.object.unsafeClone(plugin.track.CURRENT_CONFIG));
-  var trackColor = options.color || featureColor || sourceColor || os.style.DEFAULT_LAYER_COLOR;
-  if (trackColor) {
-    os.style.setConfigColor(trackStyle, trackColor, [os.style.StyleField.STROKE]);
-    os.style.setConfigColor(currentStyle, trackColor, [os.style.StyleField.IMAGE]);
-  }
-
-  // set the style config for the track
+  trackColor = trackColor || os.style.DEFAULT_LAYER_COLOR;
+  os.style.setConfigColor(trackStyle, trackColor, [os.style.StyleField.STROKE]);
+  os.style.setConfigColor(currentStyle, trackColor, [os.style.StyleField.IMAGE]);
   track.set(os.style.StyleType.FEATURE, [trackStyle, currentStyle]);
 
   // configure default label for the track
@@ -521,11 +543,101 @@ plugin.track.createTrack = function(options) {
 
 
 /**
+ * Adds coordinates or features to an existing track.
+ * @param {!plugin.track.AddOptions} options The options.
+ * @return {!Array<!(ol.Coordinate|ol.Feature)>} The added coordinates or features, depending on the options.
+ * @suppress {accessControls} To allow direct access to line coordinates.
+ */
+plugin.track.addToTrack = function(options) {
+  var added = [];
+
+  var track = options.track;
+  if (!track) {
+    goog.log.error(plugin.track.LOGGER_, 'Unable to add to track: track not provided.');
+    return added;
+  }
+
+  var sortField = /** @type {string|undefined} */ (track.get(plugin.track.TrackField.SORT_FIELD));
+  if (!sortField) {
+    goog.log.error(plugin.track.LOGGER_, 'Unable to add coordinates to track: track is missing sorting data.');
+    return added;
+  }
+
+  var features = options.features;
+  var coordinates = options.coordinates;
+  if (!coordinates && !features) {
+    goog.log.error(plugin.track.LOGGER_, 'Unable to add to track: coordinates/features not provided.');
+    return added;
+  }
+
+  if (!coordinates && features) {
+    coordinates = plugin.track.getTrackCoordinates(features, sortField);
+
+    var skippedFeatures = features.length - coordinates.length;
+    if (skippedFeatures) {
+      goog.log.info(plugin.track.LOGGER_, 'Skipped ' + skippedFeatures + ' features due to unknown coordinate.');
+    }
+  } else if (coordinates) {
+    coordinates.sort(plugin.track.sortCoordinatesByValue);
+  }
+
+  var skippedCoords = 0;
+  if (coordinates.length) {
+    // add point(s) to the original geometry, in case the track was interpolated
+    var geometry = /** @type {!plugin.track.TrackLike} */ (track.get(os.interpolate.ORIGINAL_GEOM_FIELD) ||
+        track.getGeometry());
+
+    // merge the split line so coordinates can be added in the correct location
+    geometry.toLonLat();
+    geometry = os.geo.mergeLineGeometry(geometry);
+    geometry.osTransform();
+
+    var flatCoordinates = geometry.flatCoordinates;
+    var stride = geometry.stride;
+
+    for (var i = 0; i < coordinates.length; i++) {
+      var coordinate = coordinates[i];
+      if (coordinate.length != stride) {
+        // if the coordinate length doesn't match the track geometry stride, it can't be inserted
+        skippedCoords++;
+        continue;
+      }
+
+      // figure out where the value fits in the array. if the value value already exists, just skip the feature to
+      // avoid duplicate values.
+      var value = /** @type {number|undefined} */ (coordinate[coordinate.length - 1]);
+      var insertIndex = os.array.binaryStrideSearch(flatCoordinates, value, stride, stride - 1);
+      if (insertIndex < 0) {
+        // insert coordinates in the corresponding location
+        goog.array.insertArrayAt(flatCoordinates, coordinate, ~insertIndex);
+        added.push(features ? features[i] : coordinate);
+      } else {
+        skippedCoords++;
+      }
+    }
+  }
+
+  // update the geometry on the track if coordinates were added
+  if (skippedCoords < coordinates.length) {
+    plugin.track.setGeometry(track, /** @type {!plugin.track.TrackLike} */ (geometry));
+  }
+
+  if (skippedCoords) {
+    goog.log.info(plugin.track.LOGGER_, 'Skipped ' + skippedCoords +
+        ' coordinates due to missing/duplicate sort value.');
+  }
+
+  return added;
+};
+
+
+/**
  * Adds a set of features to a track.
  * @param {!ol.Feature} track The track
  * @param {!Array<!ol.Feature>} features The features to add to the track
  * @return {!Array<!ol.Feature>} return the non-duplicate features
  * @suppress {accessControls} To allow direct access to line coordinates.
+ * @deprecated Please use `plugin.track.addToTrack` instead.
  */
 plugin.track.addFeaturesToTrack = function(track, features) {
   var addedFeatures = /** @type {!Array<!ol.Feature>} */ ([]);
@@ -768,13 +880,13 @@ plugin.track.setGeometry = function(track, geometry) {
 /**
  * Creates a track and adds it to the tracks layer.
  * @param {!plugin.track.CreateOptions} options The options object for the track.
- * @return {os.feature.DynamicFeature|ol.Feature|undefined} The track feature.
+ * @return {plugin.track.TrackFeatureLike|undefined} The track feature.
  */
 plugin.track.createAndAdd = function(options) {
   var track = plugin.track.createTrack(options);
 
   if (!track) {
-    var msg = 'Track creation failed. There were no valid features to create a track from.';
+    var msg = 'Track creation failed. There were no valid features/coordinates to create a track.';
     os.alertManager.sendAlert(msg, os.alert.AlertEventSeverity.WARNING);
     return;
   }
@@ -786,7 +898,7 @@ plugin.track.createAndAdd = function(options) {
   var rootNode = plugin.track.getTrackNode(true);
   if (rootNode) {
     var cmd = new plugin.file.kml.cmd.KMLNodeAdd(trackNode, rootNode);
-    cmd.title = 'Create track from ' + options.features.length + ' features';
+    cmd.title = 'Create Track';
     os.command.CommandProcessor.getInstance().addCommand(cmd);
 
     return track;

--- a/src/plugin/track/trackmenu.js
+++ b/src/plugin/track/trackmenu.js
@@ -574,7 +574,10 @@ plugin.track.menu.handleAddCreateTrackEvent_ = function(event) {
       } else if (event.type === plugin.track.EventType.ADD_TO) {
         plugin.track.promptForTrack().then(function(track) {
           if (track) {
-            plugin.track.addFeaturesToTrack(track, features);
+            plugin.track.addToTrack({
+              track: track,
+              features: features
+            });
           }
         });
       }

--- a/test/plugin/track/track.test.js
+++ b/test/plugin/track/track.test.js
@@ -1,0 +1,295 @@
+goog.require('ol.Feature');
+goog.require('os.data.RecordField');
+goog.require('os.feature.DynamicFeature');
+goog.require('os.style');
+goog.require('os.time.TimeInstant');
+goog.require('os.time.TimeRange');
+goog.require('plugin.track');
+
+describe('plugin.track', function() {
+  /**
+   * Generate test track coordinates.
+   * @param {number} count The number of coordinates.
+   * @param {string} sortField The sort field.
+   * @param {number} sortStart The start sort value.
+   * @return {!Array<!Array<number>>}
+   */
+  var generateCoordinates = function(count, sortField, sortStart) {
+    var coordinates = [];
+
+    var i = count;
+    while (i--) {
+      var coordinate = [i * 0.1, i * 0.1, 0];
+      if (sortField === os.data.RecordField.TIME) {
+        coordinate.push(sortStart + i * 1000);
+      } else {
+        coordinate.push(sortStart + i);
+      }
+
+      coordinates.push(coordinate);
+    }
+
+    return coordinates;
+  };
+
+  /**
+   * Generate test track features.
+   * @param {number} count The number of features.
+   * @param {string} sortField The sort field.
+   * @param {number} sortStart The start sort value.
+   * @return {!Array<!ol.Feature>}
+   */
+  var generateFeatures = function(count, sortField, sortStart) {
+    var coordinates = generateCoordinates(count, sortField, sortStart);
+    return coordinates.map(function(coordinate) {
+      var sortValue = coordinate.pop();
+
+      var feature = new ol.Feature(new ol.geom.Point(coordinate));
+      if (sortField === os.data.RecordField.TIME) {
+        feature.set(sortField, new os.time.TimeInstant(sortValue));
+      } else {
+        feature.set(sortField, sortValue);
+      }
+      return feature;
+    });
+  };
+
+  /**
+   * Verifies coordinates are sorted by increasing M value.
+   * @param {!Array<!Array<number>>} coordinates The array of coordinates.
+   */
+  var verifyCoordinateSort = function(coordinates) {
+    for (var i = 1; i < coordinates.length; i++) {
+      var a = coordinates[i - 1];
+      var b = coordinates[i];
+      expect(a[a.length - 1] < b[b.length - 1]).toBe(true);
+    }
+  };
+
+  it('gets a value from a feature by field', function() {
+    var feature = new ol.Feature({
+      field1: 'value1',
+      field2: 'value2'
+    });
+
+    expect(plugin.track.getFeatureValue('field1', feature)).toBe('value1');
+    expect(plugin.track.getFeatureValue('field2', feature)).toBe('value2');
+    expect(plugin.track.getFeatureValue('field3', feature)).toBeUndefined();
+
+    expect(plugin.track.getFeatureValue('field1', undefined)).toBeUndefined();
+    expect(plugin.track.getFeatureValue('field1', null)).toBeUndefined();
+  });
+
+  it('gets the start time from a feature', function() {
+    var feature = new ol.Feature();
+    expect(plugin.track.getStartTime(feature)).toBeUndefined();
+
+    var now = Date.now();
+    feature.set(os.data.RecordField.TIME, new os.time.TimeInstant(now));
+    expect(plugin.track.getStartTime(feature)).toBe(now);
+
+    feature.set(os.data.RecordField.TIME, new os.time.TimeRange(now, now + 1000));
+    expect(plugin.track.getStartTime(feature)).toBe(now);
+  });
+
+  it('sorts coordinates by increasing M value', function() {
+    var coordinates = [
+      [0, 0, 0, 5],
+      [0, 0, 0, 1],
+      [0, 0, 0, 4],
+      [0, 0, 0, 2],
+      [0, 0, 0, 3],
+      [0, 0, 0, 0]
+    ];
+
+    coordinates.sort(plugin.track.sortCoordinatesByValue);
+    verifyCoordinateSort(coordinates);
+  });
+
+  it('gets sorted coordinates from a set of features', function() {
+    var testGetTrackCoordinates = function(sortField, sortStart) {
+      var features = generateFeatures(20, sortField, sortStart);
+      var coordinates = plugin.track.getTrackCoordinates(features, sortField);
+      expect(coordinates.length).toBe(features.length);
+      verifyCoordinateSort(coordinates);
+    };
+
+    // sorts by time
+    testGetTrackCoordinates(os.data.RecordField.TIME, Date.now());
+
+    // sorts by arbitrary sortable values
+    testGetTrackCoordinates('testSortField', 0);
+  });
+
+  it('does not create a track without features or coordinates', function() {
+    var track = plugin.track.createTrack({});
+    expect(track).toBeUndefined();
+
+    track = plugin.track.createTrack({
+      features: []
+    });
+    expect(track).toBeUndefined();
+
+    track = plugin.track.createTrack({
+      coordinates: []
+    });
+    expect(track).toBeUndefined();
+  });
+
+  it('creates a track from a set of features', function() {
+    var sortField = os.data.RecordField.TIME;
+    var features = generateFeatures(20, sortField, Date.now());
+    var color = 'rgba(0, 255, 0, 1)';
+    var id = 'testId';
+    var name = 'Test Track';
+    var label = 'labelField';
+
+    var track = plugin.track.createTrack({
+      color: color,
+      features: features,
+      id: id,
+      label: label,
+      name: name
+    });
+
+    expect(track instanceof os.feature.DynamicFeature).toBe(true);
+
+    var geometry = track.getGeometry();
+    expect(geometry).toBeDefined();
+
+    var coordinates = geometry.getCoordinates();
+    expect(coordinates.length).toBe(features.length);
+    verifyCoordinateSort(coordinates);
+
+    expect(track.getId()).toBe(id);
+    expect(track.get(os.Fields.ID)).toBe(id);
+    expect(track.get(plugin.file.kml.KMLField.NAME)).toBe(name);
+    expect(track.get(plugin.track.TrackField.SORT_FIELD)).toBe(sortField);
+
+    var featureStyle = track.get(os.style.StyleType.FEATURE);
+    expect(featureStyle).toBeDefined();
+    expect(Array.isArray(featureStyle)).toBe(true);
+    expect(featureStyle.length).toBe(2);
+    expect(os.style.getConfigColor(featureStyle[0])).toBe(color);
+    expect(os.style.getConfigColor(featureStyle[1])).toBe(color);
+
+    var labelStyle = featureStyle[1][os.style.StyleField.LABELS];
+    expect(labelStyle).toBeDefined();
+    expect(Array.isArray(labelStyle)).toBe(true);
+    expect(labelStyle.length).toBe(1);
+    expect(labelStyle[0]['column']).toBe(label);
+  });
+
+  it('creates a track with default values', function() {
+    var features = generateFeatures(20, os.data.RecordField.TIME, Date.now());
+    var track = plugin.track.createTrack({
+      features: features
+    });
+
+    var actualId = track.getId();
+    expect(actualId).toBeDefined();
+    expect(track.get(os.Fields.ID)).toBe(actualId);
+    expect(track.get(plugin.file.kml.KMLField.NAME)).toBe(actualId);
+    expect(track.get(plugin.track.TrackField.SORT_FIELD)).toBe(os.data.RecordField.TIME);
+
+    var featureStyle = track.get(os.style.StyleType.FEATURE);
+    expect(featureStyle).toBeDefined();
+    expect(Array.isArray(featureStyle)).toBe(true);
+    expect(featureStyle.length).toBe(2);
+    expect(os.style.getConfigColor(featureStyle[0])).toBe(os.style.DEFAULT_LAYER_COLOR);
+    expect(os.style.getConfigColor(featureStyle[1])).toBe(os.style.DEFAULT_LAYER_COLOR);
+
+    var labelStyle = featureStyle[1][os.style.StyleField.LABELS];
+    expect(labelStyle).toBeDefined();
+    expect(Array.isArray(labelStyle)).toBe(true);
+    expect(labelStyle.length).toBe(1);
+    expect(labelStyle[0]['column']).toBe(plugin.file.kml.KMLField.NAME);
+  });
+
+  it('creates a track from a set of coordinates', function() {
+    var coordinates = generateCoordinates(20, os.data.RecordField.TIME, Date.now());
+    var track = plugin.track.createTrack({
+      coordinates: coordinates
+    });
+
+    expect(track instanceof os.feature.DynamicFeature).toBe(true);
+
+    var geometry = track.getGeometry();
+    expect(geometry).toBeDefined();
+
+    var trackCoordinates = geometry.getCoordinates();
+    expect(trackCoordinates.length).toBe(coordinates.length);
+    verifyCoordinateSort(trackCoordinates);
+  });
+
+  it('creates a track without a time-based sort', function() {
+    var sortField = 'testSortField';
+    var features = generateFeatures(20, sortField, 0);
+    var track = plugin.track.createTrack({
+      features: features,
+      sortField: sortField
+    });
+
+    expect(track instanceof os.feature.DynamicFeature).toBe(false);
+    expect(track.get(plugin.track.TrackField.SORT_FIELD)).toBe(sortField);
+
+    var geometry = track.getGeometry();
+    expect(geometry).toBeDefined();
+
+    var trackCoordinates = geometry.getCoordinates();
+    expect(trackCoordinates.length).toBe(features.length);
+    verifyCoordinateSort(trackCoordinates);
+  });
+
+  it('adds features to an existing track', function() {
+    var startTime = Date.now();
+    var features = generateFeatures(20, os.data.RecordField.TIME, startTime);
+    var track = plugin.track.createTrack({
+      features: features
+    });
+
+    // overlap by 2 features to verify those are skipped
+    startTime += 18 * 1000;
+
+    var moreFeatures = generateFeatures(20, os.data.RecordField.TIME, startTime);
+    var added = plugin.track.addToTrack({
+      features: moreFeatures,
+      track: track
+    });
+
+    expect(added.length).toBe(18);
+
+    var geometry = track.getGeometry();
+    expect(geometry).toBeDefined();
+
+    var trackCoordinates = geometry.getCoordinates();
+    expect(trackCoordinates.length).toBe(features.length + moreFeatures.length - 2);
+    verifyCoordinateSort(trackCoordinates);
+  });
+
+  it('adds coordinates to an existing track', function() {
+    var startTime = Date.now();
+    var coordinates = generateCoordinates(20, os.data.RecordField.TIME, startTime);
+    var track = plugin.track.createTrack({
+      coordinates: coordinates
+    });
+
+    // overlap by 2 coordinates to verify those are skipped
+    startTime += 18 * 1000;
+
+    var moreCoordinates = generateCoordinates(20, os.data.RecordField.TIME, startTime);
+    var added = plugin.track.addToTrack({
+      coordinates: moreCoordinates,
+      track: track
+    });
+
+    expect(added.length).toBe(18);
+
+    var geometry = track.getGeometry();
+    expect(geometry).toBeDefined();
+
+    var trackCoordinates = geometry.getCoordinates();
+    expect(trackCoordinates.length).toBe(coordinates.length + moreCoordinates.length - 2);
+    verifyCoordinateSort(trackCoordinates);
+  });
+});


### PR DESCRIPTION
* Allow passing coordinates directly to `plugin.track.createTrack` instead of features.
* Deprecate `plugin.track.addFeaturesToTrack` in favor of the new `plugin.track.addToTrack`, which allows adding features or coordinates to an existing track.
* Add tests for creating/updating tracks.