### PR TITLE
Add Image Rotation Support

### DIFF
--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -1635,6 +1635,7 @@ Cesium.Polygon.prototype.material;
  * @typedef {{
  *   color: (Cesium.Color|undefined),
  *   horizontal: (boolean|undefined),
+ *   image: (string|undefined),
  *   repeat: (number|undefined),
  *   evenColor: (Cesium.Color|undefined),
  *   oddColor: (Cesium.Color|undefined),
@@ -1798,9 +1799,20 @@ Cesium.Polyline.prototype.width;
 
 
 /**
+ * @param {Cesium.AppearanceOptions=} opt_options
  * @constructor
  */
-Cesium.Appearance = function() {};
+Cesium.Appearance = function(opt_options) {};
+
+
+/**
+ * @typedef {{
+ *  translucent: (boolean|undefined),
+ *  closed: (boolean|undefined),
+ *  material: (Cesium.Material|undefined)
+ * }}
+ */
+Cesium.AppearanceOptions;
 
 
 /**
@@ -1810,10 +1822,17 @@ Cesium.Appearance.prototype.material;
 
 
 /**
+ * @type {boolean}
+ */
+Cesium.Appearance.prototype.translucent;
+
+
+/**
  * @typedef {{
  *   asynchronous: (boolean|undefined),
  *   releaseGeometryInstances: (boolean|undefined),
  *   geometryInstances: !Cesium.GeometryInstance,
+ *   show: (boolean|undefined),
  *   appearance: !Cesium.Appearance
  * }}
  */
@@ -1883,6 +1902,18 @@ Cesium.Primitive.prototype.getGeometryInstanceAttributes = function(opt_id) {};
  * @type {Cesium.Appearance} .
  */
 Cesium.Primitive.prototype.appearance;
+
+
+/**
+ * @type {Promise<!Cesium.Primitive>}
+ */
+Cesium.Primitive.prototype.readyPromise;
+
+
+/**
+ * @type {boolean}
+ */
+Cesium.Primitive.prototype.show;
 
 
 /**
@@ -2615,10 +2646,25 @@ Cesium.PolylineMaterialAppearance.prototype.vertexFormat;
 
 /**
  * @constructor
- * @param {Object} object
+ * @param {Cesium.MaterialAppearanceOptions=} options
  * @extends {Cesium.Appearance}
  */
-Cesium.MaterialAppearance = function(object) {};
+Cesium.MaterialAppearance = function(options) {};
+
+
+/**
+ * @typedef {{
+ *  flat: (boolean|undefined),
+ *  faceForward: (boolean|undefined),
+ *  translucent: (boolean|undefined),
+ *  closed: (boolean|undefined),
+ *  material: (Cesium.Material|HTMLCanvasElement|HTMLVideoElement|Image|undefined),
+ *  vertexShaderSource: (string|undefined),
+ *  fragmentShaderSource: (string|undefined),
+ *  renderState: (Cesium.optionsRenderState|undefined)
+ * }}
+ */
+Cesium.MaterialAppearanceOptions;
 
 
 /**

--- a/src/os/layer/image.js
+++ b/src/os/layer/image.js
@@ -113,7 +113,7 @@ os.layer.Image = function(options) {
    * @type {?string}
    * @private
    */
-  this.syncType_ = os.layer.SynchronizerType.IMAGE;
+  this.syncType_ = null;
 
   /**
    * Image overlays are hidden by default.
@@ -330,12 +330,14 @@ os.layer.Image.prototype.getLayerVisible = function() {
 os.layer.Image.prototype.setLayerVisible = function(value) {
   value = !!value;
 
-  this.visible_ = value;
-  if (!this.mapVisibilityLocked_) {
-    this.setVisible(value);
-  }
+  if (this.visible_ != value) {
+    this.visible_ = value;
+    if (!this.mapVisibilityLocked_) {
+      this.setVisible(value);
+    }
 
-  this.dispatchEvent(new os.events.PropertyChangeEvent('visible', value, !value));
+    this.dispatchEvent(new os.events.PropertyChangeEvent('visible', value, !value));
+  }
 };
 
 
@@ -451,7 +453,13 @@ os.layer.Image.prototype.getGroupUI = function() {
  * @inheritDoc
  */
 os.layer.Image.prototype.getSynchronizerType = function() {
-  return this.syncType_;
+  if (this.syncType_) {
+    return this.syncType_;
+  }
+
+  return this.getSource() instanceof ol.source.ImageStatic ?
+    os.layer.SynchronizerType.IMAGE_STATIC :
+    os.layer.SynchronizerType.IMAGE;
 };
 
 

--- a/src/os/layer/layer.js
+++ b/src/os/layer/layer.js
@@ -19,6 +19,7 @@ os.layer.SynchronizerType = {
   VECTOR: 'vector',
   TILE: 'tile',
   IMAGE: 'image',
+  IMAGE_STATIC: 'imageStatic',
   DRAW: 'draw'
 };
 

--- a/src/os/ol/image.js
+++ b/src/os/ol/image.js
@@ -1,0 +1,71 @@
+goog.provide('os.ol.image');
+
+goog.require('ol.ImageCanvas');
+goog.require('ol.dom');
+goog.require('ol.extent');
+
+
+/**
+ * Rotates an OL Image about the center of the image's extent by the given value.
+ *
+ * @param {ol.ImageBase} image
+ * @param {number} rotation degrees clockwise
+ * @return {ol.ImageCanvas} The rotated image
+ */
+os.ol.image.rotate = function(image, rotation) {
+  var rad = rotation * os.geo.D2R;
+  var origExtent = image.getExtent();
+  var center = ol.extent.getCenter(origExtent);
+  var width = ol.extent.getWidth(origExtent);
+  var height = ol.extent.getHeight(origExtent);
+
+  var resolution = image.getResolution();
+  var pxWidth = width / resolution;
+  var pxHeight = height / resolution;
+  var pxWidth2 = pxWidth / 2;
+  var pxHeight2 = pxHeight / 2;
+
+  // I couldn't find a way to get the extent of all things drawn to the canvas (not its set size),
+  // so calculate it ourselves
+  var rotate = os.ol.image.rotate_;
+  var coords = [
+    rotate(rad, pxWidth2, pxHeight2),
+    rotate(rad, -pxWidth2, pxHeight2),
+    rotate(rad, -pxWidth2, -pxHeight2),
+    rotate(rad, pxWidth2, -pxHeight2)];
+  var pxExtent = ol.extent.boundingExtent(coords);
+
+  var ctx = ol.dom.createCanvasContext2D(ol.extent.getWidth(pxExtent), ol.extent.getHeight(pxExtent));
+
+  var canvas = ctx.canvas;
+  var newWidth2 = canvas.width / 2;
+  var newHeight2 = canvas.height / 2;
+  ctx.translate(newWidth2, newHeight2);
+  ctx.rotate(rad);
+  ctx.drawImage(image.getImage(), -pxWidth2, -pxHeight2);
+
+  var deltaX = newWidth2 * resolution;
+  var deltaY = newHeight2 * resolution;
+
+  var newExtent = [
+    center[0] - deltaX,
+    center[1] - deltaY,
+    center[0] + deltaX,
+    center[1] + deltaY];
+
+  return new ol.ImageCanvas(newExtent, resolution, image.getPixelRatio(), canvas);
+};
+
+
+/**
+ * @param {number} rotation
+ * @param {number} x
+ * @param {number} y
+ * @return {Array<number>}
+ * @private
+ */
+os.ol.image.rotate_ = function(rotation, x, y) {
+  var sin = Math.sin(rotation);
+  var cos = Math.cos(rotation);
+  return [x * cos - y * sin, y * cos + x * sin];
+};

--- a/src/os/source/imagestatic.js
+++ b/src/os/source/imagestatic.js
@@ -50,5 +50,6 @@ os.source.ImageStatic.prototype.handleImageChange = function(evt) {
   var image = /** @type {ol.Image} */ (evt.target);
   if (image.getState() == ol.ImageState.LOADED) {
     this.rotatedImage = this.rotation ? os.ol.image.rotate(image, this.rotation) : image;
+    this.changed();
   }
 };

--- a/src/os/source/imagestatic.js
+++ b/src/os/source/imagestatic.js
@@ -1,0 +1,54 @@
+goog.provide('os.source.ImageStatic');
+
+goog.require('ol.ImageState');
+goog.require('ol.extent');
+goog.require('ol.source.ImageStatic');
+goog.require('os.ol.image');
+
+
+/**
+ * @constructor
+ * @extends {ol.source.ImageStatic}
+ * @param {olx.source.ImageStaticOptions} options
+ * @param {number} rotation
+ */
+os.source.ImageStatic = function(options, rotation) {
+  os.source.ImageStatic.base(this, 'constructor', options);
+
+  /**
+   * @type {ol.ImageBase}
+   * @protected
+   */
+  this.rotatedImage = null;
+
+  /**
+   * @type {number}
+   * @protected
+   */
+  this.rotation = rotation;
+};
+goog.inherits(os.source.ImageStatic, ol.source.ImageStatic);
+
+
+/**
+ * @inheritDoc
+ */
+os.source.ImageStatic.prototype.getImageInternal = function(extent, resolution, pixelRatio, projection) {
+  if (this.rotatedImage && ol.extent.intersects(extent, this.rotatedImage.getExtent())) {
+    return this.rotatedImage;
+  }
+
+  return os.source.ImageStatic.base(this, 'getImageInternal', extent, resolution, pixelRatio, projection);
+};
+
+/**
+ * @inheritDoc
+ */
+os.source.ImageStatic.prototype.handleImageChange = function(evt) {
+  os.source.ImageStatic.base(this, 'handleImageChange', evt);
+
+  var image = /** @type {ol.Image} */ (evt.target);
+  if (image.getState() == ol.ImageState.LOADED) {
+    this.rotatedImage = this.rotation ? os.ol.image.rotate(image, this.rotation) : image;
+  }
+};

--- a/src/plugin/cesium/cesium.js
+++ b/src/plugin/cesium/cesium.js
@@ -469,7 +469,7 @@ plugin.cesium.reduceBoundingSphere = function(sphere, geom) {
       for (var i = 0, n = flats.length; i < n; i += stride) {
         scratchCoord[0] = flats[i];
         scratchCoord[1] = flats[i + 1];
-        scratchCoord[2] = flats[i + 2] || 0;
+        scratchCoord[2] = stride > 2 ? flats[i + 2] || 0 : 0;
 
         if (!ol.proj.equivalent(os.map.PROJECTION, ol.proj.get(os.proj.EPSG4326))) {
           scratchCoord = ol.proj.toLonLat(scratchCoord, os.map.PROJECTION);

--- a/src/plugin/cesium/cesiumplugin.js
+++ b/src/plugin/cesium/cesiumplugin.js
@@ -8,6 +8,7 @@ goog.require('plugin.cesium.CesiumRenderer');
 goog.require('plugin.cesium.menu');
 goog.require('plugin.cesium.mixin.olcs');
 goog.require('plugin.cesium.mixin.renderloop');
+goog.require('plugin.cesium.sync.ImageStaticSynchronizer');
 goog.require('plugin.cesium.sync.ImageSynchronizer');
 goog.require('plugin.cesium.sync.TileSynchronizer');
 goog.require('plugin.cesium.sync.VectorSynchronizer');
@@ -102,6 +103,7 @@ plugin.cesium.Plugin.prototype.init = function() {
   sm.registerSynchronizer(os.layer.SynchronizerType.TILE, plugin.cesium.sync.TileSynchronizer);
   sm.registerSynchronizer(os.layer.SynchronizerType.IMAGE, plugin.cesium.sync.ImageSynchronizer);
   sm.registerSynchronizer(os.layer.SynchronizerType.DRAW, plugin.cesium.sync.VectorSynchronizer);
+  sm.registerSynchronizer(os.layer.SynchronizerType.IMAGE_STATIC, plugin.cesium.sync.ImageStaticSynchronizer);
 
   // add 3D layer group
   var group = new os.layer.Group();

--- a/src/plugin/cesium/sync/imagestaticsynchronizer.js
+++ b/src/plugin/cesium/sync/imagestaticsynchronizer.js
@@ -138,7 +138,7 @@ plugin.cesium.sync.ImageStaticSynchronizer.prototype.resetInternal = function() 
 
   if (this.primitive) {
     this.scene.primitives.remove(this.primitive);
-    this.primitve = null;
+    this.primitive = null;
   }
 };
 

--- a/src/plugin/cesium/sync/imagestaticsynchronizer.js
+++ b/src/plugin/cesium/sync/imagestaticsynchronizer.js
@@ -1,0 +1,157 @@
+goog.provide('plugin.cesium.sync.ImageStaticSynchronizer');
+
+goog.require('ol.source.ImageStatic');
+goog.require('os.MapEvent');
+goog.require('os.source.ImageStatic');
+goog.require('plugin.cesium.sync.CesiumSynchronizer');
+
+
+
+/**
+ * Synchronizes a single OpenLayers ImageStatic source to Cesium
+ *
+ * @param {!ol.layer.Image} layer The OpenLayers image layer
+ * @param {!ol.PluggableMap} map The map
+ * @param {!Cesium.Scene} scene
+ * @extends {plugin.cesium.sync.CesiumSynchronizer<os.layer.Image>}
+ * @constructor
+ */
+plugin.cesium.sync.ImageStaticSynchronizer = function(layer, map, scene) {
+  plugin.cesium.sync.ImageStaticSynchronizer.base(this, 'constructor', layer, map, scene);
+
+  /**
+   * @type {ol.source.Image}
+   * @protected
+   */
+  this.source = this.layer.getSource();
+
+
+  /**
+   * @type {ol.ImageBase}
+   * @protected
+   */
+  this.image;
+
+  /**
+   * @type {Cesium.Primitive}
+   * @protected
+   */
+  this.primitive;
+
+  ol.events.listen(this.layer, goog.events.EventType.PROPERTYCHANGE, this.onLayerPropertyChange, this);
+};
+goog.inherits(plugin.cesium.sync.ImageStaticSynchronizer, plugin.cesium.sync.CesiumSynchronizer);
+
+
+
+/**
+ * @inheritDoc
+ */
+plugin.cesium.sync.ImageStaticSynchronizer.prototype.disposeInternal = function() {
+  this.resetInternal();
+  this.source = null;
+  plugin.cesium.sync.ImageSynchronizer.base(this, 'disposeInternal');
+};
+
+
+
+/**
+ * @inheritDoc
+ * @suppress {accessControls}
+ */
+plugin.cesium.sync.ImageStaticSynchronizer.prototype.synchronize = function() {
+  if (!this.image) {
+    if (!(this.source instanceof ol.source.ImageStatic)) {
+      return;
+    }
+
+    this.image = this.source.image_;
+    ol.events.listen(this.image, ol.events.EventType.CHANGE, this.synchronize, this);
+  }
+
+  if (this.source instanceof os.source.ImageStatic) {
+    // This source supports rotation and must be loaded first. Other source types such as ol.source.ImageStatic
+    // can pass the img.src parameter through to the Cesium material.
+    if (this.image.getState() === ol.ImageState.IDLE) {
+      this.image.load();
+    }
+
+    if (this.image.getState() !== ol.ImageState.LOADED) {
+      return;
+    }
+
+    if (this.image !== this.source.rotatedImage) {
+      ol.events.unlisten(this.image, ol.events.EventType.CHANGE, this.synchronize, this);
+      this.image = this.source.rotatedImage;
+    }
+  }
+
+  var url;
+  var el = this.image.getImage();
+
+  if (el instanceof HTMLVideoElement || el instanceof Image) {
+    url = el.src;
+  } else if (el instanceof HTMLCanvasElement) {
+    url = el.toDataURL();
+  }
+
+  var extent = ol.proj.transformExtent(this.image.getExtent(), os.map.PROJECTION, os.proj.EPSG4326);
+
+  if (!this.primitive && url && extent) {
+    this.primitive = new Cesium.Primitive({
+      geometryInstances: new Cesium.GeometryInstance({
+        geometry: new Cesium.RectangleGeometry({
+          rectangle: Cesium.Rectangle.fromDegrees(extent[0], extent[1], extent[2], extent[3])
+        }),
+        id: this.layer.getId()
+      }),
+      appearance: new Cesium.MaterialAppearance({
+        material: Cesium.Material.fromType('Image', {
+          image: url
+        })
+      }),
+      show: this.layer.getVisible()
+    });
+
+    this.scene.primitives.add(this.primitive);
+  }
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.cesium.sync.ImageStaticSynchronizer.prototype.reset = function() {
+  this.resetInternal();
+  this.synchronize();
+};
+
+
+/**
+ * @protected
+ */
+plugin.cesium.sync.ImageStaticSynchronizer.prototype.resetInternal = function() {
+  if (this.image) {
+    ol.events.unlisten(this.image, ol.events.EventType.CHANGE, this.synchronize, this);
+    this.image = null;
+  }
+
+  if (this.primitive) {
+    this.scene.primitives.remove(this.primitive);
+    this.primitve = null;
+  }
+};
+
+
+/**
+ * Handle visibility
+ *
+ * @param {os.events.PropertyChangeEvent} event
+ * @protected
+ */
+plugin.cesium.sync.ImageStaticSynchronizer.prototype.onLayerPropertyChange = function(event) {
+  if (this.primitive && event instanceof ol.Object.Event && event.key == os.layer.PropertyChange.VISIBLE) {
+    this.primitive.show = this.layer.getVisible();
+    os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
+  }
+};

--- a/src/plugin/cesium/sync/imagesynchronizer.js
+++ b/src/plugin/cesium/sync/imagesynchronizer.js
@@ -154,7 +154,7 @@ plugin.cesium.sync.ImageSynchronizer.prototype.syncInternal = function(opt_force
       url = el.toDataURL();
     }
 
-    var extent = img.getExtent();
+    var extent = ol.proj.transformExtent(img.getExtent(), os.map.PROJECTION, os.proj.EPSG4326);
 
     if (url && extent) {
       var primitive = new Cesium.Primitive({

--- a/src/plugin/file/kml/kml.js
+++ b/src/plugin/file/kml/kml.js
@@ -617,6 +617,11 @@ plugin.file.kml.readLatLonQuad_ = function(node, objectStack) {
       }, ol.extent.createEmpty());
 
       var targetObject = /** @type {Object} */ (objectStack[objectStack.length - 1]);
+
+      if (!os.geo.isClosed(coordinates)) {
+        coordinates.push(coordinates[0].slice());
+      }
+
       if (os.geo.isRectangular(coordinates, extent)) {
         targetObject['extent'] = extent;
       } else {

--- a/src/plugin/file/kml/kmlmenu.js
+++ b/src/plugin/file/kml/kmlmenu.js
@@ -1,5 +1,7 @@
 goog.provide('plugin.file.kml.menu');
 
+goog.require('ol.Feature');
+goog.require('ol.geom.Polygon');
 goog.require('os.buffer');
 goog.require('os.ui.feature.featureInfoDirective');
 goog.require('os.ui.menu.layer');
@@ -186,7 +188,10 @@ plugin.file.kml.menu.onLayerEvent_ = function(event) {
             }
             break;
           case plugin.file.kml.menu.EventType.GOTO:
-            os.feature.flyTo(node.getFeatures());
+            var features = node.getZoomFeatures();
+            if (features) {
+              os.feature.flyTo(features);
+            }
             break;
           case plugin.file.kml.menu.EventType.SELECT:
             source.addToSelected(node.getFeatures());

--- a/src/plugin/file/kml/kmlparser.js
+++ b/src/plugin/file/kml/kmlparser.js
@@ -15,7 +15,6 @@ goog.require('ol.format.XSD');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.flat.inflate');
 goog.require('ol.layer.Image');
-goog.require('ol.source.ImageStatic');
 goog.require('ol.xml');
 goog.require('os.annotation');
 goog.require('os.data.ColumnDefinition');
@@ -26,6 +25,7 @@ goog.require('os.net.Request');
 goog.require('os.object');
 goog.require('os.parse.AsyncZipParser');
 goog.require('os.parse.IParser');
+goog.require('os.source.ImageStatic');
 goog.require('os.ui.file.kml');
 goog.require('os.xml');
 goog.require('plugin.file.kml');
@@ -1239,11 +1239,12 @@ plugin.file.kml.KMLParser.prototype.readGroundOverlay_ = function(el) {
     }
 
     var image = new os.layer.Image({
-      source: new ol.source.ImageStatic({
+      source: new os.source.ImageStatic({
+        crossOrigin: os.net.getCrossOrigin(icon),
         url: icon,
-        imageExtent: extent
-      }),
-      url: icon
+        imageExtent: extent,
+        projection: os.map.PROJECTION
+      }, -(obj['rotation'] || 0))
     });
     image.setId(/** @type {string} */ (feature.getId()));
 

--- a/test/os/ol/image.test.js
+++ b/test/os/ol/image.test.js
@@ -1,0 +1,63 @@
+goog.require('ol.ImageCanvas');
+goog.require('ol.dom');
+goog.require('ol.extent');
+goog.require('os.ol.image');
+
+describe('os.ol.image', function() {
+  var getData = function(imgCanvas) {
+    var canvas = imgCanvas.getImage();
+    // don't want to deal with separate channels so treat the whole pixel as a single 32bit value
+    return new Uint32Array(canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height).data.buffer);
+  };
+
+  // Useful for debugging
+  // var print = function(imgCanvas) {
+  //   var canvas = imgCanvas.getImage();
+  //   var data = getData(imgCanvas);
+
+  //   for (var y = 0; y < canvas.height; y++) {
+  //     var line = '';
+  //     for (var x = 0; x < canvas.width; x++) {
+  //       var px = y * canvas.width + x;
+  //       line += ' ' + (data[px] ? 'x' : ' ');
+  //     }
+  //     console.log(line);
+  //   }
+  // };
+
+  it('should properly rotate images', function() {
+    // create the image to rotate
+    var ctx = ol.dom.createCanvasContext2D(100, 50);
+    ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    var extent = [8, 10, 16, 14];
+    var resolution = ol.extent.getHeight(extent) / ctx.canvas.height;
+    var original = new ol.ImageCanvas(extent, resolution, 1, ctx.canvas);
+
+    // create the expected image when rotated
+    ctx = ol.dom.createCanvasContext2D(50, 100);
+    ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    extent = [10, 8, 14, 16];
+    var expected = new ol.ImageCanvas(extent, resolution, 1, ctx.canvas);
+
+    // spin it
+    var rotated = os.ol.image.rotate(original, 90);
+
+    // test it
+    expect(rotated.getExtent()).toEqual(expected.getExtent());
+    expect(rotated.getResolution()).toEqual(expected.getResolution());
+    expect(rotated.getImage().width).toBe(expected.getImage().width);
+    expect(rotated.getImage().height).toBe(expected.getImage().height);
+
+    var rotatedImageData = getData(rotated);
+    var expectedImageData = getData(expected);
+    expect(rotatedImageData.length).toBe(expectedImageData.length);
+    var diffCount = 0;
+    for (var i = 0, n = expectedImageData.length; i < n; i++) {
+      if (rotatedImageData[i] != expectedImageData[i]) {
+        diffCount++;
+      }
+    }
+
+    expect(diffCount).toBe(0);
+  });
+});


### PR DESCRIPTION
This adds image rotation support and then uses it in KML GroundOverlays to address some of our issues with displaying those.

Additionally, if the GroundOverlay contains an unsupported `LatLonQuad` value, then a warning is issued. I can write a ticket for further support of that. It requires non-affine transforms which are not supported in `CanvasRenderingContext2D` but could be done by us since the image would only need to be redrawn once.

I have not decided what warnings to show or not show regarding the lack of projection information for the raster image. Right now it is simply assumed to be in the application projection (probably a bad assumption).

Test Files (test in 2D/3D and in multiple projections):
[GroundOverlays_etna_rotation_compare.txt](https://github.com/ngageoint/opensphere/files/3341083/GroundOverlays_etna_rotation_compare.txt)
[GroundOverlay_unsupported_quad.txt](https://github.com/ngageoint/opensphere/files/3341084/GroundOverlay_unsupported_quad.txt)
[GroundOverlay_rotation_test.txt](https://github.com/ngageoint/opensphere/files/3341085/GroundOverlay_rotation_test.txt)

- [x] Extent reduction from the KML tree is not working as expected, so I'm going to see if I can clean that up here since it is affecting the ease of viewing GroundOverlay items.
- [x] 3D Image Layer Sync