### PR TITLE
feat(annotation): Add label-like abilities to annotations

### DIFF
--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -23,6 +23,7 @@ osx.annotation;
  * @typedef {{
  *   editable: boolean,
  *   show: boolean,
+ *   showBackground: boolean,
  *   showName: boolean,
  *   showDescription: boolean,
  *   showTail: string,

--- a/scss/os/_utils.scss
+++ b/scss/os/_utils.scss
@@ -393,6 +393,15 @@
   border-color: transparent;
 }
 
+// For a border that appears when the element is hovered
+.u-border-show-on-hover {
+  border-color: transparent;
+}
+
+.u-border-show-on-hover:hover {
+  border-color: $border-color;
+}
+
 // Used for buttons that are styled as form-controls borders
 .u-border-color-input {
   border-color: $input-border-color !important;

--- a/src/os/annotation/abstractannotationctrl.js
+++ b/src/os/annotation/abstractannotationctrl.js
@@ -20,26 +20,27 @@ os.annotation.UI_TEMPLATE =
   '<div class="c-annotation u-hover-container" ' +
     'ng-class="{\'c-annotation__editing\': ctrl.editingDescription || ctrl.editingName}">' +
     '<svg class="c-annotation__svg">' +
-      '<path ng-style="{ fill: ctrl.options.showDescription ? ctrl.options.bodyBG : ctrl.options.headerBG}" />' +
+      '<path ng-style="{ fill: ctrl.options.showDescription ? ctrl.options.bodyBG : ctrl.options.headerBG }"/>' +
     '</svg>' +
-    '<div class="u-card-popup position-absolute text-right animate-fade u-hover-show"' +
+    '<div class="u-card-popup position-absolute text-right animate-fade u-hover-show" ' +
         ' ng-show="ctrl.options.editable">' +
-      '<button class="btn btn-sm btn-outline-primary border-0 bg-transparent"' +
-          'title="Hide text box"' +
+      '<button class="btn btn-sm btn-outline-primary border-0 bg-transparent" ' +
+          'title="Hide text box" ' +
           'ng-click="ctrl.hideAnnotation()">' +
         '<i class="c-glyph fa fa-fw fa-comment"></i>' +
       '</button>' +
-      '<button class="btn btn-sm btn-outline-primary border-0 bg-transparent"' +
-          'title="Edit text box"' +
+      '<button class="btn btn-sm btn-outline-primary border-0 bg-transparent" ' +
+          'title="Edit text box" ' +
           'ng-click="ctrl.launchEditWindow()">' +
         '<i class="c-glyph fa fa-fw fa-pencil"></i>' +
       '</button>' +
     '</div>' +
-    '<div class="js-annotation c-window card h-100">' +
-      '<div class="card-header flex-shrink-0 text-truncate px-1 py-0 js-annotation__header" title="{{ctrl.name}}"' +
-          'ng-show="ctrl.options.showName" ' +
+    '<div class="js-annotation c-window card h-100" ' +
+      'ng-class="!ctrl.options.showBackground && \'bg-transparent u-border-show-on-hover u-text-stroke\'">' +
+      '<div class="card-header flex-shrink-0 text-truncate px-1 py-0 js-annotation__header" title="{{ctrl.name}}" ' +
+          'ng-show="ctrl.options.showName && ctrl.options.showBackground" ' +
           'ng-class="!ctrl.options.showDescription && \'h-100 border-0\'" ' +
-          'ng-style="{background: ctrl.options.headerBG }" ' +
+          'ng-style="{ background: ctrl.options.headerBG }" ' +
           'ng-dblclick="ctrl.editName()">' +
         '<div ng-show="!ctrl.editingName">{{ctrl.name}}</div>' +
         '<div class="form-row p-1" ng-if="ctrl.editingName">' +
@@ -59,11 +60,17 @@ os.annotation.UI_TEMPLATE =
         '</div>' +
       '</div>' +
       '<div class="card-body p-1 u-overflow-y-auto d-flex flex-fill flex-column" ' +
-          'ng-show="ctrl.options.showDescription" ' +
-          'ng-style="{background: ctrl.options.bodyBG }" ' +
+          'ng-show="ctrl.options.showDescription || !ctrl.options.showBackground" ' +
+          'ng-style="{ background: ctrl.options.showBackground ? ctrl.options.bodyBG : transparent }" ' +
           'ng-dblclick="ctrl.editDescription()">' +
-        '<tuieditor text="ctrl.description" edit="ctrl.editingDescription" is-required="false" maxlength="4000">' +
-        '</tuieditor>' +
+        '<div ng-if="ctrl.options.showBackground">' +
+          '<tuieditor text="ctrl.description" edit="ctrl.editingDescription" is-required="false" maxlength="4000">' +
+          '</tuieditor>' +
+        '</div>' +
+        '<div ng-if="!ctrl.options.showBackground" ' +
+          'style="font-size: {{ctrl.labelSize}}px; color: {{ctrl.labelColor}};">' +
+          '<strong><pre>{{ctrl.labelText}}</pre></strong>' +
+        '</div>' +
         '<div class="text-right mt-1" ng-if="ctrl.editingDescription">' +
           '<button class="btn btn-success mr-1" title="Save the text box" ng-click="ctrl.saveAnnotation()">' +
             '<i class="fa fa-check"/> OK' +
@@ -73,7 +80,8 @@ os.annotation.UI_TEMPLATE =
           '</button>' +
         '</div>' +
       '</div>' +
-    '</div>';
+    '</div>' +
+  '</div>';
 
 
 /**
@@ -268,7 +276,8 @@ os.annotation.AbstractAnnotationCtrl.prototype.initDragResize = function() {
       'handles': 'se',
       'start': this.onDragStart_.bind(this),
       'resize': this.updateTail.bind(this),
-      'stop': this.onDragStop_.bind(this)
+      'stop': this.onDragStop_.bind(this),
+      'autoHide': true
     });
   }
 };
@@ -309,7 +318,7 @@ os.annotation.AbstractAnnotationCtrl.prototype.hideAnnotation = function() {};
  * @export
  */
 os.annotation.AbstractAnnotationCtrl.prototype.editDescription = function() {
-  if (this['options'].editable && !this['editingDescription']) {
+  if (this['options'].editable && !this['editingDescription'] && this['options']['showBackground']) {
     this['editingDescription'] = true;
     this.element.parent().draggable('option', 'handle', os.annotation.selectors.HEADER);
 

--- a/src/os/annotation/abstractannotationctrl.js
+++ b/src/os/annotation/abstractannotationctrl.js
@@ -36,11 +36,12 @@ os.annotation.UI_TEMPLATE =
       '</button>' +
     '</div>' +
     '<div class="js-annotation c-window card h-100" ' +
-      'ng-class="!ctrl.options.showBackground && \'bg-transparent u-border-show-on-hover u-text-stroke\'">' +
-      '<div class="card-header flex-shrink-0 text-truncate px-1 py-0 js-annotation__header" title="{{ctrl.name}}" ' +
-          'ng-show="ctrl.options.showName && ctrl.options.showBackground" ' +
-          'ng-class="!ctrl.options.showDescription && \'h-100 border-0\'" ' +
-          'ng-style="{ background: ctrl.options.headerBG }" ' +
+      'ng-class="{ \'bg-transparent u-border-show-on-hover u-text-stroke\': !ctrl.options.showBackground }">' +
+      '<div class="flex-shrink-0 text-truncate px-1 py-0 js-annotation__header" title="{{ctrl.name}}" ' +
+          'ng-show="ctrl.options.showName" ' +
+          'ng-class="{ \'h-100 border-0\': !ctrl.options.showDescription, ' +
+            '\'card-header\': ctrl.options.showBackground }" ' +
+          'ng-style="{ background: ctrl.options.showBackground ? ctrl.options.headerBG : transparent }" ' +
           'ng-dblclick="ctrl.editName()">' +
         '<div ng-show="!ctrl.editingName">{{ctrl.name}}</div>' +
         '<div class="form-row p-1" ng-if="ctrl.editingName">' +
@@ -60,17 +61,11 @@ os.annotation.UI_TEMPLATE =
         '</div>' +
       '</div>' +
       '<div class="card-body p-1 u-overflow-y-auto d-flex flex-fill flex-column" ' +
-          'ng-show="ctrl.options.showDescription || !ctrl.options.showBackground" ' +
+          'ng-show="ctrl.options.showDescription" ' +
           'ng-style="{ background: ctrl.options.showBackground ? ctrl.options.bodyBG : transparent }" ' +
           'ng-dblclick="ctrl.editDescription()">' +
-        '<div ng-if="ctrl.options.showBackground">' +
-          '<tuieditor text="ctrl.description" edit="ctrl.editingDescription" is-required="false" maxlength="4000">' +
-          '</tuieditor>' +
-        '</div>' +
-        '<div ng-if="!ctrl.options.showBackground" ' +
-          'style="font-size: {{ctrl.labelSize}}px; color: {{ctrl.labelColor}};">' +
-          '<strong><pre>{{ctrl.labelText}}</pre></strong>' +
-        '</div>' +
+        '<tuieditor text="ctrl.description" edit="ctrl.editingDescription" is-required="false" maxlength="4000">' +
+        '</tuieditor>' +
         '<div class="text-right mt-1" ng-if="ctrl.editingDescription">' +
           '<button class="btn btn-success mr-1" title="Save the text box" ng-click="ctrl.saveAnnotation()">' +
             '<i class="fa fa-check"/> OK' +
@@ -318,7 +313,7 @@ os.annotation.AbstractAnnotationCtrl.prototype.hideAnnotation = function() {};
  * @export
  */
 os.annotation.AbstractAnnotationCtrl.prototype.editDescription = function() {
-  if (this['options'].editable && !this['editingDescription'] && this['options']['showBackground']) {
+  if (this['options'].editable && !this['editingDescription']) {
     this['editingDescription'] = true;
     this.element.parent().draggable('option', 'handle', os.annotation.selectors.HEADER);
 

--- a/src/os/annotation/annotation.js
+++ b/src/os/annotation/annotation.js
@@ -7,7 +7,6 @@ goog.require('os.annotation.TailStyle');
 goog.require('os.feature');
 goog.require('os.ui');
 goog.require('os.ui.color.colorPickerDirective');
-goog.require('os.ui.text.SimpleMDE');
 
 
 /**
@@ -143,73 +142,6 @@ os.annotation.getDescriptionText = function(feature) {
   if (feature) {
     return /** @type {string|undefined} */ (feature.get(os.ui.FeatureEditCtrl.Field.MD_DESCRIPTION)) ||
     /** @type {string|undefined} */ (feature.get(os.ui.FeatureEditCtrl.Field.DESCRIPTION)) || '';
-  }
-
-  return '';
-};
-
-
-/**
- * Get the description text for an annotation balloon in label mode.
- * @param {ol.Feature} feature The feature.
- * @return {string} The text.
- */
-os.annotation.getLabelText = function(feature) {
-  if (feature) {
-    var columnNames = feature.get(os.style.StyleField.LABELS).split(',');
-    var showColumnNames = feature.get(os.style.StyleField.SHOW_LABEL_COLUMNS).split(',');
-    var columns = columnNames.map(function(columnName, i) {
-      return {columnName: columnName, showColumnName: showColumnNames[i] === '1'};
-    });
-
-    var lines = [];
-    for (var i = 0; i < columns.length; i++) {
-      var column = columns[i];
-      var line = '';
-      if (column.showColumnName) {
-        line = column.columnName + ': ';
-      }
-
-      var value = /** @type {string} */(feature.get(column.columnName));
-      if (column.columnName === os.ui.FeatureEditCtrl.Field.DESCRIPTION) {
-        value = os.ui.text.SimpleMDE.getUnformatedText(value);
-      }
-      line += value;
-
-      if (value) {
-        lines.push(line);
-      }
-    }
-
-    return lines.join('\n');
-  }
-
-  return '';
-};
-
-
-/**
- * Get the font size for an annotation balloon in label mode.
- * @param {ol.Feature} feature The Feature
- * @return {number} The font size in px
- */
-os.annotation.getLabelSize = function(feature) {
-  if (feature) {
-    return /** @type {number|undefined} */(feature.get(os.style.StyleField.LABEL_SIZE)) || 0;
-  }
-
-  return 0;
-};
-
-
-/**
- * Get the name text for an annotation balloon.
- * @param {ol.Feature} feature The feature.
- * @return {string} The text.
- */
-os.annotation.getLabelColor = function(feature) {
-  if (feature) {
-    return /** @type {string|undefined} */ (feature.get(os.style.StyleField.LABEL_COLOR)) || '';
   }
 
   return '';

--- a/src/os/annotation/annotation.js
+++ b/src/os/annotation/annotation.js
@@ -4,8 +4,10 @@ goog.provide('os.annotation.TailType');
 goog.require('ol.geom.GeometryType');
 goog.require('ol.geom.Point');
 goog.require('os.annotation.TailStyle');
+goog.require('os.feature');
 goog.require('os.ui');
 goog.require('os.ui.color.colorPickerDirective');
+goog.require('os.ui.text.SimpleMDE');
 
 
 /**
@@ -26,6 +28,7 @@ os.annotation.TailType = {
 os.annotation.DEFAULT_OPTIONS = {
   editable: true,
   show: true,
+  showBackground: true,
   showName: true,
   showDescription: true,
   showTail: os.annotation.TailStyle.DEFAULT,
@@ -140,6 +143,73 @@ os.annotation.getDescriptionText = function(feature) {
   if (feature) {
     return /** @type {string|undefined} */ (feature.get(os.ui.FeatureEditCtrl.Field.MD_DESCRIPTION)) ||
     /** @type {string|undefined} */ (feature.get(os.ui.FeatureEditCtrl.Field.DESCRIPTION)) || '';
+  }
+
+  return '';
+};
+
+
+/**
+ * Get the description text for an annotation balloon in label mode.
+ * @param {ol.Feature} feature The feature.
+ * @return {string} The text.
+ */
+os.annotation.getLabelText = function(feature) {
+  if (feature) {
+    var columnNames = feature.get(os.style.StyleField.LABELS).split(',');
+    var showColumnNames = feature.get(os.style.StyleField.SHOW_LABEL_COLUMNS).split(',');
+    var columns = columnNames.map(function(columnName, i) {
+      return {columnName: columnName, showColumnName: showColumnNames[i] === '1'};
+    });
+
+    var lines = [];
+    for (var i = 0; i < columns.length; i++) {
+      var column = columns[i];
+      var line = '';
+      if (column.showColumnName) {
+        line = column.columnName + ': ';
+      }
+
+      var value = /** @type {string} */(feature.get(column.columnName));
+      if (column.columnName === os.ui.FeatureEditCtrl.Field.DESCRIPTION) {
+        value = os.ui.text.SimpleMDE.getUnformatedText(value);
+      }
+      line += value;
+
+      if (value) {
+        lines.push(line);
+      }
+    }
+
+    return lines.join('\n');
+  }
+
+  return '';
+};
+
+
+/**
+ * Get the font size for an annotation balloon in label mode.
+ * @param {ol.Feature} feature The Feature
+ * @return {number} The font size in px
+ */
+os.annotation.getLabelSize = function(feature) {
+  if (feature) {
+    return /** @type {number|undefined} */(feature.get(os.style.StyleField.LABEL_SIZE)) || 0;
+  }
+
+  return 0;
+};
+
+
+/**
+ * Get the name text for an annotation balloon.
+ * @param {ol.Feature} feature The feature.
+ * @return {string} The text.
+ */
+os.annotation.getLabelColor = function(feature) {
+  if (feature) {
+    return /** @type {string|undefined} */ (feature.get(os.style.StyleField.LABEL_COLOR)) || '';
   }
 
   return '';

--- a/src/os/annotation/featureannotationui.js
+++ b/src/os/annotation/featureannotationui.js
@@ -175,14 +175,10 @@ os.annotation.FeatureAnnotationCtrl.prototype.saveAnnotation = function() {
 os.annotation.FeatureAnnotationCtrl.prototype.onFeatureChange_ = function() {
   this['name'] = '';
   this['description'] = '';
-  this['labelText'] = '';
 
   if (this.feature && this.scope) {
     this['name'] = os.annotation.getNameText(this.feature);
     this['description'] = os.annotation.getDescriptionText(this.feature);
-    this['labelText'] = os.annotation.getLabelText(this.feature);
-    this['labelSize'] = os.annotation.getLabelSize(this.feature);
-    this['labelColor'] = os.annotation.getLabelColor(this.feature);
     this['options'] = /** @type {!osx.annotation.Options} */ (this.feature.get(os.annotation.OPTIONS_FIELD));
 
     if (this['options'].show) {

--- a/src/os/annotation/featureannotationui.js
+++ b/src/os/annotation/featureannotationui.js
@@ -175,10 +175,14 @@ os.annotation.FeatureAnnotationCtrl.prototype.saveAnnotation = function() {
 os.annotation.FeatureAnnotationCtrl.prototype.onFeatureChange_ = function() {
   this['name'] = '';
   this['description'] = '';
+  this['labelText'] = '';
 
   if (this.feature && this.scope) {
     this['name'] = os.annotation.getNameText(this.feature);
     this['description'] = os.annotation.getDescriptionText(this.feature);
+    this['labelText'] = os.annotation.getLabelText(this.feature);
+    this['labelSize'] = os.annotation.getLabelSize(this.feature);
+    this['labelColor'] = os.annotation.getLabelColor(this.feature);
     this['options'] = /** @type {!osx.annotation.Options} */ (this.feature.get(os.annotation.OPTIONS_FIELD));
 
     if (this['options'].show) {
@@ -346,10 +350,9 @@ os.annotation.FeatureAnnotationCtrl.prototype.updateTailAbsolute = function() {
     var cardCenter = [cardOffsetX + cardRect.width / 2, cardOffsetY + cardRect.height / 2];
     // Changes the annotation tail style
     var anchorWidth = Math.min(cardRect.height, cardRect.width) * .33;
-    if (this['options'].showTail === os.annotation.TailStyle.NOTAIL) {
+    if (this['options'].showTail === os.annotation.TailStyle.NOTAIL || !this['options'].showBackground) {
       anchorWidth = 0;
-    }
-    if (this['options'].showTail === os.annotation.TailStyle.LINETAIL) {
+    } else if (this['options'].showTail === os.annotation.TailStyle.LINETAIL) {
       anchorWidth = 4;
     }
     var linePath = os.annotation.AbstractAnnotationCtrl.createTailPath(cardCenter, pathTarget, anchorWidth);
@@ -414,10 +417,9 @@ os.annotation.FeatureAnnotationCtrl.prototype.updateTailFixed = function() {
     var cardCenter = [cardRect.x + cardRect.width / 2, cardRect.y + cardRect.height / 2];
     // Changes the annotation tail style
     var anchorWidth = Math.min(cardRect.height, cardRect.width) * .33;
-    if (this['options'].showTail === os.annotation.TailStyle.NOTAIL) {
+    if (this['options'].showTail === os.annotation.TailStyle.NOTAIL || !this['options'].showBackground) {
       anchorWidth = 0;
-    }
-    if (this['options'].showTail === os.annotation.TailStyle.LINETAIL) {
+    } else if (this['options'].showTail === os.annotation.TailStyle.LINETAIL) {
       anchorWidth = 4;
     }
     var linePath = os.annotation.AbstractAnnotationCtrl.createTailPath(cardCenter, targetPixel, anchorWidth);

--- a/src/plugin/file/kml/ui/kmlnode.js
+++ b/src/plugin/file/kml/ui/kmlnode.js
@@ -259,7 +259,6 @@ plugin.file.kml.ui.KMLNode.prototype.loadAnnotation = function() {
       this.feature_.get(os.annotation.OPTIONS_FIELD));
     if (annotationOptions && annotationOptions.show) {
       if (annotationOptions['showBackground'] === undefined) {
-        // TODO: Is there a better way to ensure that this is defined to the default?
         annotationOptions['showBackground'] = os.annotation.DEFAULT_OPTIONS['showBackground'];
       }
       this.annotation_ = new os.annotation.FeatureAnnotation(this.feature_);

--- a/src/plugin/file/kml/ui/kmlnode.js
+++ b/src/plugin/file/kml/ui/kmlnode.js
@@ -258,6 +258,10 @@ plugin.file.kml.ui.KMLNode.prototype.loadAnnotation = function() {
     var annotationOptions = /** @type {osx.annotation.Options|undefined} */ (
       this.feature_.get(os.annotation.OPTIONS_FIELD));
     if (annotationOptions && annotationOptions.show) {
+      if (annotationOptions['showBackground'] === undefined) {
+        // TODO: Is there a better way to ensure that this is defined to the default?
+        annotationOptions['showBackground'] = os.annotation.DEFAULT_OPTIONS['showBackground'];
+      }
       this.annotation_ = new os.annotation.FeatureAnnotation(this.feature_);
 
       // set initial visibility based on the tree/animation state

--- a/src/plugin/file/kml/ui/placemarkedit.js
+++ b/src/plugin/file/kml/ui/placemarkedit.js
@@ -103,12 +103,6 @@ plugin.file.kml.ui.PlacemarkEditCtrl = function($scope, $element, $timeout) {
 
     os.ui.list.add(optionsListId,
         '<annotationoptions options="ctrl.annotationOptions"></annotationoptions>');
-    this['bgHelp'] = {};
-    this['bgHelp']['title'] = 'Show Background Option';
-    this['bgHelp']['pos'] = 'right';
-    this['bgHelp']['content'] = 'Show annotation background.\n' +
-       'When unchecked, the annotation acts like a label.\n' +
-       'It gets it\'s text from the label settings. It is also colored and sized like a label.';
 
     if (this.options['annotation']) {
       // if creating a new annotation, expand the Annotation Options section by default

--- a/src/plugin/file/kml/ui/placemarkedit.js
+++ b/src/plugin/file/kml/ui/placemarkedit.js
@@ -103,6 +103,12 @@ plugin.file.kml.ui.PlacemarkEditCtrl = function($scope, $element, $timeout) {
 
     os.ui.list.add(optionsListId,
         '<annotationoptions options="ctrl.annotationOptions"></annotationoptions>');
+    this['bgHelp'] = {};
+    this['bgHelp']['title'] = 'Show Background Option';
+    this['bgHelp']['pos'] = 'right';
+    this['bgHelp']['content'] = 'Show annotation background.\n' +
+       'When unchecked, the annotation acts like a label.\n' +
+       'It gets it\'s text from the label settings. It is also colored and sized like a label.';
 
     if (this.options['annotation']) {
       // if creating a new annotation, expand the Annotation Options section by default

--- a/views/annotation/annotationoptions.html
+++ b/views/annotation/annotationoptions.html
@@ -20,7 +20,7 @@
       </div>
       <div class="col">
         <div class="custom-control custom-checkbox d-inline-block"
-            title="Show annotation background. When unchecked annotation acts like a label.">
+            title="Show background colors behind the annotation text">
           <input type="checkbox" class="custom-control-input" name="showBackground"
               ng-attr-id="showBackground{{ctrl.uid}}"
               ng-change="ctrl.updateAnnotation()"
@@ -29,8 +29,6 @@
           <label class="custom-control-label" ng-attr-for="showBackground{{ctrl.uid}}" ng-disabled="disabled">
             Show Background
           </label>
-          <!-- TODO: I can make Content variable with the current setting if I wanted -->
-          <popover class="ml-3" data-title="ctrl.bgHelp.title" content="ctrl.bgHelp.content" pos="ctrl.bgHelp.pos"></popover>
         </div>
       </div>
     </div>
@@ -40,23 +38,23 @@
             title="Show the Name field as the text box header">
           <input type="checkbox" class="custom-control-input" name="showAnnotationName"
             ng-attr-id="showAnnotationName{{ctrl.uid}}"
-            ng-change="ctrl.updateAnnotation()" ng-disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showBackground"
+            ng-change="ctrl.updateAnnotation()" ng-disabled="!ctrl.annotationOptions.show"
             ng-model="ctrl.annotationOptions.showName"/>
           <label class="custom-control-label" ng-attr-for="showAnnotationName{{ctrl.uid}}">
             Show Name
           </label>
         </div>
       </div>
-      <div class="col">
+      <div class="col ml-5">
         <div title="Change the background color of the header">
             <colorpicker name="headerColor"
                 ng-attr-id="headerColor{{ctrl.uid}}"
                 color="ctrl.tempHeaderBG"
                 show-reset="true"
                 title="Sets the background color for header"
-                disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showName || !ctrl.annotationOptions.showBackground"></colorpicker>
+                disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showName"></colorpicker>
             <label class="col-form-label" ng-attr-for="headerColor{{ctrl.uid}}" ng-disabled="!ctrl.annotationOptions.showBackground">
-              Header Background
+              Header Color
             </label>
           </div>
         </div>
@@ -67,7 +65,7 @@
               title="Show the Description field in the text box">
             <input type="checkbox" class="custom-control-input" name="showAnnotationDescription"
               ng-attr-id="showAnnotationDescription{{ctrl.uid}}"
-              ng-change="ctrl.updateAnnotation()" ng-disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showBackground"
+              ng-change="ctrl.updateAnnotation()" ng-disabled="!ctrl.annotationOptions.show"
               ng-model="ctrl.annotationOptions.showDescription"
             />
             <label class="custom-control-label" ng-attr-for="showAnnotationDescription{{ctrl.uid}}" ng-disabled="disabled">
@@ -75,16 +73,16 @@
             </label>
           </div>
         </div>
-        <div class="col">
+        <div class="col ml-5">
           <div class="d-inline-block" title="Change the background color of the description">
               <colorpicker name="bodyColor"
                   ng-attr-id="bodyColor{{ctrl.uid}}"
                   color="ctrl.tempBodyBG"
                   show-reset="true"
                   title="Sets the background color for body"
-                  disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showDescription || !ctrl.annotationOptions.showBackground"></colorpicker>
+                  disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showDescription"></colorpicker>
               <label class="col-form-label" ng-attr-for="bodyColor{{ctrl.uid}}" ng-disabled="!ctrl.annotationOptions.showBackground">
-                Description Background
+                Description Color
               </label>
             </div>
         </div>

--- a/views/annotation/annotationoptions.html
+++ b/views/annotation/annotationoptions.html
@@ -26,7 +26,7 @@
               ng-change="ctrl.updateAnnotation()"
               ng-model="ctrl.annotationOptions.showBackground"
               ng-disabled="!ctrl.annotationOptions.show" />
-          <label class="custom-control-label" ng-attr-for="showBackground{{ctrl.uid}}" ng-disabled="disabled">
+          <label class="custom-control-label" ng-attr-for="showBackground{{ctrl.uid}}">
             Show Background
           </label>
         </div>
@@ -45,15 +45,15 @@
           </label>
         </div>
       </div>
-      <div class="col ml-5">
+      <div class="col">
         <div title="Change the background color of the header">
             <colorpicker name="headerColor"
                 ng-attr-id="headerColor{{ctrl.uid}}"
                 color="ctrl.tempHeaderBG"
                 show-reset="true"
                 title="Sets the background color for header"
-                disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showName"></colorpicker>
-            <label class="col-form-label" ng-attr-for="headerColor{{ctrl.uid}}" ng-disabled="!ctrl.annotationOptions.showBackground">
+                disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showName || !ctrl.annotationOptions.showBackground"></colorpicker>
+            <label class="col-form-label" ng-attr-for="headerColor{{ctrl.uid}}">
               Header Color
             </label>
           </div>
@@ -68,20 +68,20 @@
               ng-change="ctrl.updateAnnotation()" ng-disabled="!ctrl.annotationOptions.show"
               ng-model="ctrl.annotationOptions.showDescription"
             />
-            <label class="custom-control-label" ng-attr-for="showAnnotationDescription{{ctrl.uid}}" ng-disabled="disabled">
+            <label class="custom-control-label" ng-attr-for="showAnnotationDescription{{ctrl.uid}}">
               Show Description
             </label>
           </div>
         </div>
-        <div class="col ml-5">
+        <div class="col">
           <div class="d-inline-block" title="Change the background color of the description">
               <colorpicker name="bodyColor"
                   ng-attr-id="bodyColor{{ctrl.uid}}"
                   color="ctrl.tempBodyBG"
                   show-reset="true"
                   title="Sets the background color for body"
-                  disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showDescription"></colorpicker>
-              <label class="col-form-label" ng-attr-for="bodyColor{{ctrl.uid}}" ng-disabled="!ctrl.annotationOptions.showBackground">
+                  disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showDescription || !ctrl.annotationOptions.showBackground"></colorpicker>
+              <label class="col-form-label" ng-attr-for="bodyColor{{ctrl.uid}}">
                 Description Color
               </label>
             </div>
@@ -94,18 +94,18 @@
             <input ng-checked="true" type="radio" ng-attr-id="showAnnotationDefaultTail{{ctrl.uid}}" class="form-check-input" name="showAnnotationTail"
               ng-change="ctrl.updateAnnotation()" value="default" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showBackground"
             />
-            <label class="form-check-label" ng-attr-for="showAnnotationDefaultTail{{ctrl.uid}}" ng-disabled="disabled">Default</label>
+            <label class="form-check-label" ng-attr-for="showAnnotationDefaultTail{{ctrl.uid}}">Default</label>
           </div>
           <div class="custom-control custom-checkbox d-inline-block">
             <input type="radio" ng-attr-id="showAnnotationLineTail{{ctrl.uid}}" class="form-check-input" name="showAnnotationTail" value="line"
               ng-change="ctrl.updateAnnotation()" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showBackground"
             />
-            <label class="form-check-label" ng-attr-for="showAnnotationLineTail{{ctrl.uid}}" ng-disabled="disabled">Line</label>
+            <label class="form-check-label" ng-attr-for="showAnnotationLineTail{{ctrl.uid}}">Line</label>
           </div>
           <div class="custom-control custom-checkbox d-inline-block">
             <input type="radio" ng-attr-id="showAnnotationNoTail{{ctrl.uid}}" class="form-check-input" name="showAnnotationTail" ng-change="ctrl.updateAnnotation()"
               value="none" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showBackground" />
-            <label class="form-check-label" ng-attr-for="showAnnotationNoTail{{ctrl.uid}}" ng-disabled="disabled">None</label>
+            <label class="form-check-label" ng-attr-for="showAnnotationNoTail{{ctrl.uid}}">None</label>
           </div>
         </div>
       </div>

--- a/views/annotation/annotationoptions.html
+++ b/views/annotation/annotationoptions.html
@@ -18,6 +18,21 @@
           </label>
         </div>
       </div>
+      <div class="col">
+        <div class="custom-control custom-checkbox d-inline-block"
+            title="Show annotation background. When unchecked annotation acts like a label.">
+          <input type="checkbox" class="custom-control-input" name="showBackground"
+              ng-attr-id="showBackground{{ctrl.uid}}"
+              ng-change="ctrl.updateAnnotation()"
+              ng-model="ctrl.annotationOptions.showBackground"
+              ng-disabled="!ctrl.annotationOptions.show" />
+          <label class="custom-control-label" ng-attr-for="showBackground{{ctrl.uid}}" ng-disabled="disabled">
+            Show Background
+          </label>
+          <!-- TODO: I can make Content variable with the current setting if I wanted -->
+          <popover class="ml-3" data-title="ctrl.bgHelp.title" content="ctrl.bgHelp.content" pos="ctrl.bgHelp.pos"></popover>
+        </div>
+      </div>
     </div>
     <div class="form-row align-items-center">
       <div class="col">
@@ -25,7 +40,7 @@
             title="Show the Name field as the text box header">
           <input type="checkbox" class="custom-control-input" name="showAnnotationName"
             ng-attr-id="showAnnotationName{{ctrl.uid}}"
-            ng-change="ctrl.updateAnnotation()" ng-disabled="!ctrl.annotationOptions.show"
+            ng-change="ctrl.updateAnnotation()" ng-disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showBackground"
             ng-model="ctrl.annotationOptions.showName"/>
           <label class="custom-control-label" ng-attr-for="showAnnotationName{{ctrl.uid}}">
             Show Name
@@ -39,8 +54,8 @@
                 color="ctrl.tempHeaderBG"
                 show-reset="true"
                 title="Sets the background color for header"
-                disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showName"></colorpicker>
-            <label class="col-form-label" ng-attr-for="headerColor{{ctrl.uid}}">
+                disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showName || !ctrl.annotationOptions.showBackground"></colorpicker>
+            <label class="col-form-label" ng-attr-for="headerColor{{ctrl.uid}}" ng-disabled="!ctrl.annotationOptions.showBackground">
               Header Background
             </label>
           </div>
@@ -52,10 +67,10 @@
               title="Show the Description field in the text box">
             <input type="checkbox" class="custom-control-input" name="showAnnotationDescription"
               ng-attr-id="showAnnotationDescription{{ctrl.uid}}"
-              ng-change="ctrl.updateAnnotation()" ng-disabled="!ctrl.annotationOptions.show"
+              ng-change="ctrl.updateAnnotation()" ng-disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showBackground"
               ng-model="ctrl.annotationOptions.showDescription"
             />
-            <label class="custom-control-label" ng-attr-for="showAnnotationDescription{{ctrl.uid}}">
+            <label class="custom-control-label" ng-attr-for="showAnnotationDescription{{ctrl.uid}}" ng-disabled="disabled">
               Show Description
             </label>
           </div>
@@ -67,8 +82,10 @@
                   color="ctrl.tempBodyBG"
                   show-reset="true"
                   title="Sets the background color for body"
-                  disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showDescription"></colorpicker>
-              <label class="col-form-label" ng-attr-for="bodyColor{{ctrl.uid}}">Description Background</label>
+                  disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showDescription || !ctrl.annotationOptions.showBackground"></colorpicker>
+              <label class="col-form-label" ng-attr-for="bodyColor{{ctrl.uid}}" ng-disabled="!ctrl.annotationOptions.showBackground">
+                Description Background
+              </label>
             </div>
         </div>
       </div>
@@ -77,19 +94,19 @@
           <label class="col-form-label mr-2">Tail Style</label>
           <div class="custom-control custom-checkbox d-inline-block">
             <input ng-checked="true" type="radio" ng-attr-id="showAnnotationDefaultTail{{ctrl.uid}}" class="form-check-input" name="showAnnotationTail"
-              ng-change="ctrl.updateAnnotation()" value="default" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show"
+              ng-change="ctrl.updateAnnotation()" value="default" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showBackground"
             />
             <label class="form-check-label" ng-attr-for="showAnnotationDefaultTail{{ctrl.uid}}" ng-disabled="disabled">Default</label>
           </div>
           <div class="custom-control custom-checkbox d-inline-block">
             <input type="radio" ng-attr-id="showAnnotationLineTail{{ctrl.uid}}" class="form-check-input" name="showAnnotationTail" value="line"
-              ng-change="ctrl.updateAnnotation()" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show"
+              ng-change="ctrl.updateAnnotation()" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showBackground"
             />
             <label class="form-check-label" ng-attr-for="showAnnotationLineTail{{ctrl.uid}}" ng-disabled="disabled">Line</label>
           </div>
           <div class="custom-control custom-checkbox d-inline-block">
             <input type="radio" ng-attr-id="showAnnotationNoTail{{ctrl.uid}}" class="form-check-input" name="showAnnotationTail" ng-change="ctrl.updateAnnotation()"
-              value="none" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show" />
+              value="none" ng-model="ctrl.annotationOptions.showTail" ng-disabled="!ctrl.annotationOptions.show || !ctrl.annotationOptions.showBackground" />
             <label class="form-check-label" ng-attr-for="showAnnotationNoTail{{ctrl.uid}}" ng-disabled="disabled">None</label>
           </div>
         </div>


### PR DESCRIPTION
This adds label-like style and text binding to annotations so they can be used as moveable labels.

Known Issue: Using the label controls from the places accordion does not update the annotation text in "label" mode.

fix #535