### PR TITLE
fix(LayerUi): fix save of collapse state and add save call to style tab

### DIFF
--- a/src/os/ui/layer/defaultlayerui.js
+++ b/src/os/ui/layer/defaultlayerui.js
@@ -469,5 +469,6 @@ os.ui.layer.DefaultLayerUICtrl.prototype.reset = function(key) {
  */
 os.ui.layer.DefaultLayerUICtrl.prototype.setOpenSection = function(selector) {
   // save the open section to settings
-  os.settings.set('layercontrols', selector);
+  var current = os.settings.get('layercontrols');
+  os.settings.set('layercontrols', current != selector ? selector : '');
 };


### PR DESCRIPTION
fix #630

To get this to happen:
Click on a feature or map layer in the layers menu.
Click on Style to open the style menu (or zoom).
Click on Style again to close it (or zoom).
Now click on a different layer...
Click on the previous zoom or style tab, it will either be closed or left open as you had it before.