### PR TITLE
chore: Update semantic release deps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,11 +211,12 @@
     "Firefox >= 31"
   ],
   "devDependencies": {
-    "@semantic-release/changelog": "^1.0.0",
+    "@semantic-release/changelog": "^3.0.2",
     "@semantic-release/condition-travis": "^7.1.3",
-    "@semantic-release/git": "^2.0.1",
-    "@semantic-release/github": "^3.0.0",
-    "@semantic-release/npm": "^2.5.0",
+    "@semantic-release/git": "^7.0.8",
+    "@semantic-release/github": "^5.2.10",
+    "@semantic-release/npm": "^5.1.4",
+    "@semantic-release/release-notes-generator": "^7.1.4",
     "angular-mocks": "~1.5.x",
     "autoprefixer": "^8.4.1",
     "clean-css-cli": "^4.1.11",
@@ -253,7 +254,7 @@
     "postcss-cli": "^5.0.0",
     "rimraf": "^2.5.4",
     "sass-lint": "^1.12.1",
-    "semantic-release": "^11.0.2",
+    "semantic-release": "^15.13.3",
     "surge": "^0.20.4",
     "validate-commit-msg": "^2.8.2",
     "xmllint": "^0.1.1"


### PR DESCRIPTION
This uses the same versions as in the other modules. It removes an incorrect peer dependency warning from yarn:

```
opensphere > @semantic-release/changelog@1.1.1" has incorrect peer dependency "semantic-release@>=13.3.0 <15.0.0".
```

I considered just removing the whole semantic release thing, but kept it for possible future use.