### PR TITLE
fix(annotations): fixes annotation positioning/persistence issues

### DIFF
--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -28,6 +28,7 @@ osx.annotation;
  *   showTail: string,
  *   size: !Array<number>,
  *   offset: !Array<number>,
+ *   position: (Array<number>|undefined),
  *   headerBG: (string|undefined),
  *   bodyBG: (string|undefined)
  * }}

--- a/src/os/annotation/abstractannotationctrl.js
+++ b/src/os/annotation/abstractannotationctrl.js
@@ -27,7 +27,7 @@ os.annotation.UI_TEMPLATE =
       '<button class="btn btn-sm btn-outline-primary border-0 bg-transparent"' +
           'title="Hide text box"' +
           'ng-click="ctrl.hideAnnotation()">' +
-        '<i class="c-glyph fa fa-fw fa-comment"></i>' +
+        '<i class="c-glyph fa fa-fw fa-eye-slash"></i>' +
       '</button>' +
       '<button class="btn btn-sm btn-outline-primary border-0 bg-transparent"' +
           'title="Edit text box"' +

--- a/src/os/annotation/annotation.js
+++ b/src/os/annotation/annotation.js
@@ -169,9 +169,6 @@ os.annotation.hasOverlay = function(feature) {
  *
  * @param {!ol.Overlay} overlay The overlay.
  * @param {ol.Feature} feature The feature. Use null to hide the overlay.
- *
- * @suppress {accessControls} To allow access to overlay.setVisible(), which is needed to fix an initial
- *                            positioning edge case.
  */
 os.annotation.setPosition = function(overlay, feature) {
   var position;
@@ -182,9 +179,6 @@ os.annotation.setPosition = function(overlay, feature) {
       // nothing fancy for points, just use the coordinate
       position = /** @type {ol.geom.Point} */ (geometry).getFirstCoordinate();
     } else {
-      // for non-point geometries, calculate the nearest point to the overlay
-      overlay.setVisible(true);
-
       var map = overlay.getMap();
       var element = overlay.getElement();
 

--- a/src/os/annotation/featureannotationui.js
+++ b/src/os/annotation/featureannotationui.js
@@ -425,6 +425,8 @@ os.annotation.FeatureAnnotationCtrl.prototype.updateTailFixed = function() {
     this.element.find('path').attr('d', linePath);
 
     os.annotation.setPosition(this.overlay, this.feature);
+
+    this['options'].position = this.overlay.getPosition();
   }
 
   return true;

--- a/src/os/ui/featureedit.js
+++ b/src/os/ui/featureedit.js
@@ -475,6 +475,8 @@ os.ui.FeatureEditCtrl = function($scope, $element, $timeout) {
   $scope.$watch('ctrl.labelColor', this.updatePreview.bind(this));
   $scope.$watch('ctrl.labelSize', this.updatePreview.bind(this));
   $scope.$watch('ctrl.showLabels', this.updatePreview.bind(this));
+
+  $scope.$on(os.ui.WindowEventType.CANCEL, this.onCancel.bind(this));
   $scope.$on(os.ui.icon.IconPickerEventType.CHANGE, this.onIconChange.bind(this));
   $scope.$on('labelColor.reset', this.onLabelColorReset.bind(this));
   $scope.$on(os.ui.geo.PositionEventType.MAP_ENABLED, this.onMapEnabled_.bind(this));
@@ -655,6 +657,16 @@ os.ui.FeatureEditCtrl.prototype.accept = function() {
  * @export
  */
 os.ui.FeatureEditCtrl.prototype.cancel = function() {
+  this.onCancel();
+  this.close();
+};
+
+
+/**
+ * Handler for canceling the edit. This restores the state of the feature to what it was before any live
+ * edits were applied while the form was up. It's called on clicking both the cancel button and the window X.
+ */
+os.ui.FeatureEditCtrl.prototype.onCancel = function() {
   var feature = this.options['feature'];
   if (feature && this.originalProperties_) {
     feature.setProperties(this.originalProperties_);
@@ -665,9 +677,8 @@ os.ui.FeatureEditCtrl.prototype.cancel = function() {
       os.style.notifyStyleChange(layer, [feature]);
     }
   }
-  os.dispatcher.dispatchEvent(os.action.EventType.RESTORE_FEATURE);
 
-  this.close();
+  os.dispatcher.dispatchEvent(os.action.EventType.RESTORE_FEATURE);
 };
 
 

--- a/src/plugin/file/kml/ui/kmlnode.js
+++ b/src/plugin/file/kml/ui/kmlnode.js
@@ -302,6 +302,7 @@ plugin.file.kml.ui.KMLNode.prototype.onFeatureChange = function(event) {
       case os.annotation.EventType.HIDE:
         this.clearAnnotations();
         this.dispatchEvent(new os.events.PropertyChangeEvent('icons'));
+        this.dispatchEvent(new os.events.PropertyChangeEvent(os.annotation.EventType.CHANGE));
         break;
       default:
         break;

--- a/src/plugin/file/kml/ui/kmlnodeui.js
+++ b/src/plugin/file/kml/ui/kmlnodeui.js
@@ -244,6 +244,7 @@ plugin.file.kml.ui.KMLNodeUICtrl.prototype.removeAnnotation = function() {
       if (options) {
         options.show = false;
         node.dispatchEvent(new os.events.PropertyChangeEvent('icons'));
+        node.dispatchEvent(new os.events.PropertyChangeEvent(os.annotation.EventType.CHANGE));
       }
     }
   }
@@ -270,6 +271,7 @@ plugin.file.kml.ui.KMLNodeUICtrl.prototype.showAnnotation = function() {
 
       node.loadAnnotation();
       node.dispatchEvent(new os.events.PropertyChangeEvent('icons'));
+      node.dispatchEvent(new os.events.PropertyChangeEvent(os.annotation.EventType.CHANGE));
     }
   }
 };


### PR DESCRIPTION
- Adds a position property to annotation options for persisting their position. I'm not exactly sure why this wasn't persisted before, but keeping it around fixes a lot of issues with show/hide and refresh positioning for annotations. They should now no longer reset their position on toggling show/hide nor on refresh.
- Fixes losing the show/hide state on refresh when clicking the toggle buttons on both the node UI and the annotation hover controls.
- Fixes the bug where clicking the top right X on the placemark edit window would cause the annotation hover controls to not show up.