### PR TITLE
fix(kml): Ignore Style elements when nothing is parsed.

### DIFF
--- a/src/plugin/file/kml/kml.js
+++ b/src/plugin/file/kml/kml.js
@@ -238,7 +238,8 @@ plugin.file.kml.replaceParsers_(ol.format.KML.POLY_STYLE_PARSERS_, 'color',
 plugin.file.kml.readStyle = function(node, objectStack) {
   var styleObject = ol.xml.pushParseAndPop(
       {}, ol.format.KML.STYLE_PARSERS_, node, objectStack);
-  if (!styleObject) {
+  if (!styleObject || goog.object.isEmpty(styleObject)) {
+    // don't create a style config if nothing was parsed from the element
     return null;
   }
   var fillStyle = /** @type {ol.style.Fill} */


### PR DESCRIPTION
Fixes case where a default style is applied when a `Style` element is empty or only contains
children that don't impact the feature (`BalloonStyle` or `ListStyle`).