### PR TITLE
chore(css): Disable sass rules at block scope

### DIFF
--- a/scss/os/_mixins.scss
+++ b/scss/os/_mixins.scss
@@ -1,5 +1,5 @@
 @mixin grab-cursor {
-  // sass-lint:disable no-duplicate-properties, no-vendor-prefixes
+  // sass-lint:disable-block no-duplicate-properties, no-vendor-prefixes
   cursor: pointer;
   cursor: -moz-grab;
   cursor: -webkit-grab;
@@ -7,14 +7,14 @@
 }
 
 @mixin grabbing-cursor {
-  // sass-lint:disable no-duplicate-properties, no-vendor-prefixes
+  // sass-lint:disable-block no-duplicate-properties, no-vendor-prefixes
   cursor: grabbing;
   cursor: -moz-grabbing;
   cursor: -webkit-grabbing;
   cursor: -ms-grabbing;
 }
 
-// This extends bootstraps bg-<varents> to also have background colors
+// This extends bootstraps bg-<variants> to also have background colors
 @mixin bg-text-variant($background) {
   color: color-yiq($background);
 }
@@ -51,6 +51,7 @@
 }
 
 @mixin font-awesome {
+  // sass-lint:disable-block no-vendor-prefixes
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   display: inline-block;

--- a/scss/os/_ngvalidate.scss
+++ b/scss/os/_ngvalidate.scss
@@ -1,4 +1,3 @@
-// sass-lint:disable no-extends, placeholder-in-extend
 ng-form,
 *[ng-form],
 form {
@@ -7,12 +6,14 @@ form {
   div:not([ng-form]).ng-invalid.ng-dirty,
   select.ng-invalid.ng-dirty,
   textarea.ng-invalid.ng-dirty {
+    // sass-lint:disable-block no-extends, placeholder-in-extend
     @extend .form-control.is-invalid;
   }
 
   .select2-container.ng-invalid.ng-dirty {
     .select2-choice,
     .select2-choices {
+      // sass-lint:disable-block no-extends, placeholder-in-extend
       @extend .form-control.is-invalid;
     }
   }

--- a/scss/os/_overrides_jqueryui.scss
+++ b/scss/os/_overrides_jqueryui.scss
@@ -97,9 +97,9 @@
 
 // NOTE: we want the ui-menu to be exactly like the dropdown menu. To do this override the jquery defaults, then
 // extend the bootstrap 4 equivalent classes. Ignore all the sass-lint rules because we want it to be exactly this way.
-// sass-lint:disable extends-before-declarations, extends-before-mixins, no-extends, placeholder-in-extend
 .ui-menu.ui-widget,
 .ui-menu {
+  // sass-lint:disable-block extends-before-declarations, extends-before-mixins, no-extends, placeholder-in-extend
   // This part ignores the default jquery styles
   background: $dropdown-bg;
   border: $dropdown-border-width solid $dropdown-border-color;

--- a/scss/os/_overrides_openlayers.scss
+++ b/scss/os/_overrides_openlayers.scss
@@ -194,7 +194,7 @@
 .ol-attribution.ol-uncollapsible {
   bottom: .25rem;
   // Chrome < 41 needs initial
-  // sass-lint:disable no-duplicate-properties
+  // sass-lint:disable-block no-duplicate-properties
   height: initial;
   height: unset;
   left: .25rem;
@@ -260,7 +260,7 @@
     left: auto;
     min-width: 10rem;
     // Chrome < 41 needs initial
-    // sass-lint:disable no-duplicate-properties
+    // sass-lint:disable-block no-duplicate-properties
     padding: initial;
     padding: unset;
   }

--- a/scss/os/_overrides_select2.scss
+++ b/scss/os/_overrides_select2.scss
@@ -5,8 +5,8 @@
     box-shadow: none;
   }
 
-  // sass-lint:disable no-extends, placeholder-in-extend
   .select2-choice {
+    // sass-lint:disable-block no-extends, placeholder-in-extend
     @extend .form-control;
     background-image: none;
     height: $input-height;
@@ -23,8 +23,8 @@
   &.select2-container-multi {
     width: 100%;
 
-    // sass-lint:disable no-extends, placeholder-in-extend
     .select2-choices {
+      // sass-lint:disable-block no-extends, placeholder-in-extend
       @extend .form-control;
       background-image: none;
       min-width: 10rem;
@@ -44,7 +44,6 @@
         }
       }
 
-      // sass-lint:disable no-extends, placeholder-in-extend
       .select2-search-field {
         input.select2-input {
           background: transparent;
@@ -99,6 +98,7 @@
 
   // Single select2
   .select2-search input {
+    // sass-lint:disable-block no-extends, placeholder-in-extend
     @extend .form-control;
     background-image: none;
   }

--- a/scss/os/_overrides_tuieditor.scss
+++ b/scss/os/_overrides_tuieditor.scss
@@ -9,12 +9,12 @@
 
 
 .c-tui-editor {
-  //////////// Contstrain the editor //////////
+  //////////// Constrain the editor //////////
   .CodeMirror,
   .CodeMirror:not(.CodeMirror-fullscreen) .CodeMirror-scroll,
   .te-ww-container .te-editor .tui-editor-contents,
   .te-md-container .te-preview {
-    max-height: 75vh; // the toolbar doesnt scroll with the editor. So its annoying to have to scroll up just to use it
+    max-height: 75vh; // the toolbar doesn't scroll with the editor. So its annoying to have to scroll up just to use it
   }
 
   // BUG (#191) the editor has min height but its buggy
@@ -50,8 +50,8 @@
   }
 
   ////////// DISABLED FEATURES VIA CSS //////////
-  // We dont want to show the tab section OR the block overlay.
-  // Merge / Unmerge is not GFM. So dont allow that feature
+  // We don't want to show the tab section OR the block overlay.
+  // Merge / Unmerge is not GFM. So don't allow that feature
   .te-table-merge,
   .te-table-unmerge,
   .te-table-unmerge + hr,
@@ -94,13 +94,13 @@
       font-family: $font-family-monospace;
     }
 
-    // sass-lint:disable extends-before-declarations, extends-before-mixins, no-extends, placeholder-in-extend
     blockquote {
+      // sass-lint:disable-block no-extends, placeholder-in-extend
       @extend .blockquote;
     }
 
-    // sass-lint:disable extends-before-declarations, extends-before-mixins, no-extends, placeholder-in-extend
     attr {
+      // sass-lint:disable-block no-extends, placeholder-in-extend
       @extend .initialism;
     }
 
@@ -170,7 +170,7 @@
       .CodeMirror-cursor {
         border-left-color: $body-color;
 
-        // Sometimes the cursor doesnt show up (windows?) this fixes that issue
+        // Sometimes the cursor doesn't show up (windows?) this fixes that issue
         width: 1px !important;
       }
 
@@ -258,11 +258,11 @@
         color: color-yiq($u-theme-variables--bg-offset);
       }
 
-      // sass-lint:disable extends-before-declarations, extends-before-mixins, no-extends, placeholder-in-extend
       .te-link-text-input,
       .te-url-input,
       .te-image-url-input,
       .te-alt-text-input {
+        // sass-lint:disable-block no-extends, placeholder-in-extend
         @extend .form-control;
       }
     }
@@ -275,11 +275,13 @@
     }
 
     .te-ok-button {
+      // sass-lint:disable-block no-extends, placeholder-in-extend
       @extend .btn;
       @extend .btn-primary;
     }
 
     .te-close-button {
+      // sass-lint:disable-block no-extends, placeholder-in-extend
       @extend .btn;
       @extend .btn-secondary;
     }
@@ -349,6 +351,7 @@
     }
 
     .tui-scrollsync {
+      // sass-lint:disable-block no-extends, placeholder-in-extend
       @extend .btn;
       @extend .btn-secondary;
 

--- a/scss/os/_timeline.scss
+++ b/scss/os/_timeline.scss
@@ -232,7 +232,7 @@
   text {
     font: 10px sans-serif;
     // Chrome < 41 needs initial
-    // sass-lint:disable no-duplicate-properties
+    // sass-lint:disable-block no-duplicate-properties
     stroke: initial;
     stroke: unset;
   }

--- a/scss/os/_tristate.scss
+++ b/scss/os/_tristate.scss
@@ -64,7 +64,7 @@
 // Tristate checkbox
 
 .c-tristate {
-  // sass-lint:disable no-duplicate-properties
+  // sass-lint:disable-block no-duplicate-properties
   background: #fcfff4;
   background: linear-gradient(#fcfff4 0%, #dfe5d7 40%, #b3bead 100%);
   border-radius: 3px;
@@ -125,7 +125,7 @@
   border-right: 0;
   border-top: 0;
   // Chrome < 41 needs initial
-  // sass-lint:disable no-duplicate-properties
+  // sass-lint:disable-block no-duplicate-properties
   display: initial;
   display: unset;
   height: 5.5px;
@@ -137,7 +137,7 @@
   background: #555;
   border-radius: 2px;
   // Chrome < 41 needs initial
-  // sass-lint:disable no-duplicate-properties
+  // sass-lint:disable-block no-duplicate-properties
   display: initial;
   display: unset;
   height: 9px;

--- a/scss/os/_utils.scss
+++ b/scss/os/_utils.scss
@@ -312,8 +312,8 @@
     .u-form-vertical-at-#{$breakpoint} {
 
       // Wrap all form groups to new lines
-      // sass-lint:disable no-extends
       .form-group {
+        // sass-lint:disable-block no-extends
         flex-wrap: wrap;
 
         // Make all columns 100%
@@ -339,7 +339,7 @@
             }
           }
 
-          // Make all offets ignored
+          // Make all offsets ignored
           @for $i from 0 through ($grid-columns - 1) {
             @if not ($infix == '' and $i == 0) { // Avoid emitting useless .offset-0
               .offset#{$infix}-#{$i} {


### PR DESCRIPTION
The sass-lint:disable variant has file scope.

Relates to #141 - this narrows down the scope.