### PR TITLE
fix(window): Clean up resize handler and avoid errors if called after dispose.

### DIFF
--- a/src/os/ui/config/settingscontainer.js
+++ b/src/os/ui/config/settingscontainer.js
@@ -62,6 +62,8 @@ goog.inherits(os.ui.config.SettingsContainerCtrl, os.ui.config.AbstractSettingsC
  * @inheritDoc
  */
 os.ui.config.SettingsContainerCtrl.prototype.destroy = function() {
+  os.ui.config.SettingsContainerCtrl.base(this, 'destroy');
+
   this.location_ = null;
 };
 

--- a/src/os/ui/config/settingswindow.js
+++ b/src/os/ui/config/settingswindow.js
@@ -65,6 +65,8 @@ goog.inherits(os.ui.config.SettingsWindowCtrl, os.ui.config.AbstractSettingsCtrl
  * @inheritDoc
  */
 os.ui.config.SettingsWindowCtrl.prototype.destroy = function() {
+  os.ui.config.SettingsWindowCtrl.base(this, 'destroy');
+
   this.element_ = null;
 };
 

--- a/src/os/ui/window.js
+++ b/src/os/ui/window.js
@@ -762,6 +762,13 @@ os.ui.WindowCtrl = function($scope, $element, $timeout) {
   this.vsm_.listen(goog.events.EventType.RESIZE, this.onViewportResize_, false, this);
 
   /**
+   * Bound function to handle window resize events.
+   * @type {?function()}
+   * @private
+   */
+  this.resizeFn_ = null;
+
+  /**
    * The last window height, for use with expand/collapse behavior.
    * @type {number}
    * @private
@@ -814,36 +821,11 @@ os.ui.WindowCtrl = function($scope, $element, $timeout) {
   // Stack this new window on top of others
   $timeout(function() {
     this.bringToFront();
-    this.element.resize(function() {
-      var width = this.element.outerWidth();
-      var addClass = 'u-parent-resizer-xs';
-      this.element.removeClass('u-parent-resizer-sm');
-      if (width > 576) {
-        addClass = 'u-parent-resizer-sm';
-        this.element.removeClass('u-parent-resizer-xs');
-        this.element.removeClass('u-parent-resizer-md');
-      }
-      if (width > 768) {
-        addClass = 'u-parent-resizer-md';
-        this.element.removeClass('u-parent-resizer-sm');
-        this.element.removeClass('u-parent-resizer-lg');
-      }
-      if (width > 992) {
-        addClass = 'u-parent-resizer-lg';
-        this.element.removeClass('u-parent-resizer-md');
-        this.element.removeClass('u-parent-resizer-xl');
-      }
-      if (width > 1200) {
-        addClass = 'u-parent-resizer-xl';
-        this.element.removeClass('u-parent-resizer-lg');
-        this.element.removeClass('u-parent-resizer-xxl');
-      }
-      if (width > 1500) {
-        addClass = 'u-parent-resizer-xxl';
-        this.element.removeClass('u-parent-resizer-xl');
-      }
-      this.element.addClass(addClass);
-    }.bind(this));
+
+    if (this.element && !this.resizeFn_) {
+      this.resizeFn_ = this.onWindowResize_.bind(this);
+      this.element.resize(this.resizeFn_);
+    }
   }.bind(this));
 };
 goog.inherits(os.ui.WindowCtrl, goog.Disposable);
@@ -878,6 +860,11 @@ os.ui.WindowCtrl.prototype.disposeInternal = function() {
   if (this.scope['overlay']) {
     goog.events.unlisten(this.element[0], goog.events.EventType.MOUSEOVER, this.showOverlayWindow_, true, this);
     goog.events.unlisten(this.element[0], goog.events.EventType.MOUSEOUT, this.hideOverlayWindow_, true, this);
+  }
+
+  if (this.element && this.resizeFn_) {
+    this.element.removeResize(this.resizeFn_);
+    this.resizeFn_ = null;
   }
 
   if (this.scope['modal']) {
@@ -1202,6 +1189,44 @@ os.ui.WindowCtrl.prototype.updateZIndex_ = function() {
  */
 os.ui.WindowCtrl.prototype.onViewportResize_ = function(opt_e) {
   this.constrainWindow_();
+};
+
+
+/**
+ * Handle window resize events.
+ * @private
+ */
+os.ui.WindowCtrl.prototype.onWindowResize_ = function() {
+  if (this.element) {
+    var width = this.element.outerWidth();
+    var addClass = 'u-parent-resizer-xs';
+    this.element.removeClass('u-parent-resizer-sm');
+    if (width > 576) {
+      addClass = 'u-parent-resizer-sm';
+      this.element.removeClass('u-parent-resizer-xs');
+      this.element.removeClass('u-parent-resizer-md');
+    }
+    if (width > 768) {
+      addClass = 'u-parent-resizer-md';
+      this.element.removeClass('u-parent-resizer-sm');
+      this.element.removeClass('u-parent-resizer-lg');
+    }
+    if (width > 992) {
+      addClass = 'u-parent-resizer-lg';
+      this.element.removeClass('u-parent-resizer-md');
+      this.element.removeClass('u-parent-resizer-xl');
+    }
+    if (width > 1200) {
+      addClass = 'u-parent-resizer-xl';
+      this.element.removeClass('u-parent-resizer-lg');
+      this.element.removeClass('u-parent-resizer-xxl');
+    }
+    if (width > 1500) {
+      addClass = 'u-parent-resizer-xxl';
+      this.element.removeClass('u-parent-resizer-xl');
+    }
+    this.element.addClass(addClass);
+  }
 };
 
 


### PR DESCRIPTION
Fixes an error introduced if the resize handler was called after disposal (`this.element` was no longer defined), and prevents leaking windows due to not removing the event listener.