### PR TITLE
fix(kml): Replace the OpenLayers default icon with OpenSphere's.

### DIFF
--- a/src/plugin/file/kml/kml.js
+++ b/src/plugin/file/kml/kml.js
@@ -93,6 +93,38 @@ plugin.file.kml.replaceParsers_ = function(obj, field, parser) {
 
 
 /**
+ * Create default OpenLayers styles along with OpenSphere overrides.
+ * @suppress {accessControls, const}
+ */
+plugin.file.kml.createStyleDefaults = function() {
+  if (!ol.format.KML.DEFAULT_STYLE_ARRAY_) {
+    ol.format.KML.createStyleDefaults_();
+  }
+
+  if (ol.format.KML.DEFAULT_IMAGE_STYLE_SRC_ != os.ui.file.kml.DEFAULT_ICON_PATH) {
+    // use OpenSphere's default icon, and update all properties to size/position it properly
+    ol.format.KML.DEFAULT_IMAGE_STYLE_SRC_ = os.ui.file.kml.DEFAULT_ICON_PATH;
+    ol.format.KML.DEFAULT_IMAGE_SCALE_MULTIPLIER_ = 1;
+    ol.format.KML.DEFAULT_IMAGE_STYLE_SIZE_ = [32, 32];
+    ol.format.KML.DEFAULT_IMAGE_STYLE_ANCHOR_ = [16, 16];
+
+    // replace the icon style with the new defaults
+    ol.format.KML.DEFAULT_IMAGE_STYLE_ = new ol.style.Icon({
+      anchor: ol.format.KML.DEFAULT_IMAGE_STYLE_ANCHOR_,
+      anchorOrigin: ol.style.IconOrigin.BOTTOM_LEFT,
+      anchorXUnits: ol.format.KML.DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS_,
+      anchorYUnits: ol.format.KML.DEFAULT_IMAGE_STYLE_ANCHOR_Y_UNITS_,
+      crossOrigin: 'anonymous',
+      rotation: 0,
+      scale: ol.format.KML.DEFAULT_IMAGE_SCALE_MULTIPLIER_,
+      size: ol.format.KML.DEFAULT_IMAGE_STYLE_SIZE_,
+      src: ol.format.KML.DEFAULT_IMAGE_STYLE_SRC_
+    });
+  }
+};
+
+
+/**
  * Accessor for private Openlayers code.
  *
  * @return {function(this: T, *, Array<*>, (string|undefined)): (Node|undefined)}

--- a/src/plugin/file/kml/kmlparser.js
+++ b/src/plugin/file/kml/kmlparser.js
@@ -60,14 +60,12 @@ plugin.file.kml.KMLParserStackObj;
  * @implements {os.parse.IParser.<plugin.file.kml.ui.KMLNode>}
  * @template T
  * @constructor
- * @suppress {accessControls}
  */
 plugin.file.kml.KMLParser = function(options) {
   plugin.file.kml.KMLParser.base(this, 'constructor');
 
-  if (!ol.format.KML.DEFAULT_STYLE_ARRAY_) {
-    ol.format.KML.createStyleDefaults_();
-  }
+  // load default KML styles
+  plugin.file.kml.createStyleDefaults();
 
   /**
    * The source document


### PR DESCRIPTION
Fixes #676.

OpenLayers uses the yellow pushpin as the default icon style to match Google Earth's behavior. We prefer the placemark circle, so this replaces their defaults with ours.

To test, load [this file](https://github.com/ngageoint/opensphere/files/3412570/DefaultPointStyle.txt). There should be a single point using the white placemark circle as the icon.

Note the KML node color varies because a `PolyStyle` is defined in the KML, and that color is resolved when the node looks for a color in the style config. This is perhaps a bug since that color doesn't impact the rendered feature, but a separate issue if we want that behavior to change.