### PR TITLE
fix(ui): Use grab cursor instead of pointer cursor when grabbing

### DIFF
--- a/scss/os/_mixins.scss
+++ b/scss/os/_mixins.scss
@@ -1,17 +1,13 @@
 @mixin grab-cursor {
   // sass-lint:disable-block no-duplicate-properties, no-vendor-prefixes
-  cursor: pointer;
-  cursor: -moz-grab;
+  cursor: grab;
   cursor: -webkit-grab;
-  cursor: -ms-grab;
 }
 
 @mixin grabbing-cursor {
   // sass-lint:disable-block no-duplicate-properties, no-vendor-prefixes
   cursor: grabbing;
-  cursor: -moz-grabbing;
   cursor: -webkit-grabbing;
-  cursor: -ms-grabbing;
 }
 
 // This extends bootstraps bg-<variants> to also have background colors


### PR DESCRIPTION
Also remove `-moz-grab` and `-moz-grabbing` cursor vendor prefixes, since Firefox supports the standard
forms from v27 (https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Browser_compatibility).

Also remove mythical `-ms-grab` and `-ms-grabbing` cursor prefixes.