### PR TITLE
test(cypress): Removes options from http-server startup that were not needed

### DIFF
--- a/cypress/support/execute-tests.sh
+++ b/cypress/support/execute-tests.sh
@@ -136,10 +136,10 @@ function startWebServer() {
     SERVER_STARTED=true
     if [ "$ENVIRONMENT" == "ci" ]; then
       echo 'INFO: starting web server in continuous integration environment'
-      $(npm bin)/http-server -p 8282 -c-1 -o -U -s &
+      $(npm bin)/http-server -p 8282 -c-1 -s &
     else
       echo 'INFO: starting web server in local development environment'
-      $(npm bin)/http-server ../../ -p 8282 -c-1 -o -U -s &
+      $(npm bin)/http-server ../../ -p 8282 -c-1 -s &
     fi
   else
     echo 'INFO: web server already running'


### PR DESCRIPTION
- No longer specifies time format; didn't matter since all log output was suppressed anyhow
- Stops opening browser window on starting the server; wasn't needed

This only affects Cypress startup.  Scripts in package.json unmodified.