### PR TITLE
Create config providers and add layer configs

### DIFF
--- a/src/os/data/configdescriptor.js
+++ b/src/os/data/configdescriptor.js
@@ -3,10 +3,13 @@ goog.provide('os.data.ConfigDescriptor');
 goog.require('goog.object');
 goog.require('os.array');
 goog.require('os.command.LayerAdd');
+goog.require('os.data');
 goog.require('os.data.IReimport');
 goog.require('os.data.LayerSyncDescriptor');
 goog.require('os.im.ImportProcess');
 goog.require('os.implements');
+goog.require('os.layer.LayerType');
+goog.require('os.ui.Icons');
 goog.require('os.ui.im.ImportEvent');
 goog.require('os.ui.im.ImportEventType');
 
@@ -22,10 +25,18 @@ os.data.ConfigDescriptor = function() {
   this.descriptorType = os.data.ConfigDescriptor.ID;
 
   /**
-   * @type {?(Array<Object<string, *>>|Object<string, *>)}
+   * The original layer configuration(s) for the descriptor.
+   * @type {!(Array<Object>|Object)}
    * @protected
    */
-  this.baseConfig = null;
+  this.baseConfig = {};
+
+  /**
+   * Cached icons from the base config.
+   * @type {?string}
+   * @protected
+   */
+  this.icons = null;
 };
 goog.inherits(os.data.ConfigDescriptor, os.data.LayerSyncDescriptor);
 os.implements(os.data.ConfigDescriptor, 'os.data.IReimport');
@@ -41,28 +52,52 @@ os.data.ConfigDescriptor.ID = 'config';
 /**
  * @inheritDoc
  */
-os.data.ConfigDescriptor.prototype.getId = function() {
-  var ids = /** @type {string} */ (os.data.ConfigDescriptor.getAll_(this.baseConfig, 'id'));
-
-  if (Array.isArray(ids)) {
-    if (ids.length > 1) {
-      var done = false;
-      for (var x = 0, xx = ids[0].length; x < xx && !done; x++) {
-        var char = ids[0].charAt(x);
-        for (var i = 1, ii = ids.length; i < ii && !done; i++) {
-          if (ids[i].charAt(x) !== char) {
-            done = true;
-          }
-        }
-      }
-
-      ids = ids[0].substring(0, x - 1);
-    } else if (ids.length) {
-      ids = ids[0];
+os.data.ConfigDescriptor.prototype.getAliases = function() {
+  var aliases = [this.getId()];
+  var ids = /** @type {Array<string>|string} */ (os.data.ConfigDescriptor.getAll_(this.baseConfig, 'id'));
+  if (ids) {
+    if (Array.isArray(ids)) {
+      aliases = aliases.concat(ids);
+    } else {
+      aliases.push(ids);
     }
   }
 
-  return ids || os.data.ConfigDescriptor.base(this, 'getId');
+  return aliases;
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.data.ConfigDescriptor.prototype.getId = function() {
+  // if an id is explicitly set on the descriptor, use that. otherwise determine one from the configs.
+  var id = os.data.ConfigDescriptor.base(this, 'getId');
+  if (!id) {
+    var ids = /** @type {string} */ (os.data.ConfigDescriptor.getAll_(this.baseConfig, 'id'));
+
+    if (Array.isArray(ids)) {
+      if (ids.length > 1) {
+        var done = false;
+        for (var x = 0, xx = ids[0].length; x < xx && !done; x++) {
+          var char = ids[0].charAt(x);
+          for (var i = 1, ii = ids.length; i < ii && !done; i++) {
+            if (ids[i].charAt(x) !== char) {
+              done = true;
+            }
+          }
+        }
+
+        ids = ids[0].substring(0, x - 1);
+      } else if (ids.length) {
+        ids = ids[0];
+      }
+    }
+
+    id = ids;
+  }
+
+  return id;
 };
 
 
@@ -147,13 +182,29 @@ os.data.ConfigDescriptor.prototype.getDescriptorType = function() {
  * @inheritDoc
  */
 os.data.ConfigDescriptor.prototype.getIcons = function() {
-  var icons = /** @type {Array<string>|string} */ (os.data.ConfigDescriptor.getAll_(this.baseConfig, 'icons'));
-  icons = Array.isArray(icons) ? icons.join('') : icons;
-  icons = icons || os.data.ConfigDescriptor.base(this, 'getIcons');
-  icons = os.string.removeDuplicates(icons, os.ui.Icons.TILES);
-  icons = os.string.removeDuplicates(icons, os.ui.Icons.FEATURES);
-  icons = os.string.removeDuplicates(icons, os.ui.Icons.TIME);
-  return icons;
+  if (this.icons == null) {
+    var icons = /** @type {Array<string>|string} */ (os.data.ConfigDescriptor.getAll_(this.baseConfig, 'icons', ''));
+    if (Array.isArray(icons)) {
+      icons = icons.join('');
+    }
+
+    if (!icons) {
+      // icons were not defined in configs, so determine them based on other config values
+      if (Array.isArray(this.baseConfig)) {
+        icons = this.baseConfig.reduce(os.data.ConfigDescriptor.reduceConfigIcons_, '');
+      } else {
+        icons = os.data.ConfigDescriptor.reduceConfigIcons_('', this.baseConfig);
+      }
+
+      icons = os.string.removeDuplicates(icons, os.ui.Icons.TILES);
+      icons = os.string.removeDuplicates(icons, os.ui.Icons.FEATURES);
+      icons = os.string.removeDuplicates(icons, os.ui.Icons.TIME);
+    }
+
+    this.icons = icons || os.data.ConfigDescriptor.base(this, 'getIcons') || '';
+  }
+
+  return this.icons;
 };
 
 
@@ -174,7 +225,6 @@ os.data.ConfigDescriptor.prototype.getSearchType = function() {
 /**
  * @param {string} key
  * @return {*}
- * @protected
  */
 os.data.ConfigDescriptor.prototype.getFirst = function(key) {
   var val = os.data.ConfigDescriptor.getAll_(this.baseConfig, key);
@@ -183,35 +233,43 @@ os.data.ConfigDescriptor.prototype.getFirst = function(key) {
 
 
 /**
- * @param {Array|Object} objOrArr
- * @param {string} key
+ * @param {Array|Object} objOrArr The config object/array.
+ * @param {string} key The config key.
+ * @param {*=} opt_default The default value.
  * @return {*}
  * @private
  */
-os.data.ConfigDescriptor.getAll_ = function(objOrArr, key) {
+os.data.ConfigDescriptor.getAll_ = function(objOrArr, key, opt_default) {
+  var defaultValue = opt_default != null ? opt_default : null;
   if (Array.isArray(objOrArr)) {
     return objOrArr.map(function(item) {
-      return os.data.ConfigDescriptor.getAll_(item, key);
+      return os.data.ConfigDescriptor.getAll_(item, key, defaultValue);
     });
-  } else {
-    return key in objOrArr ? objOrArr[key] : null;
+  } else if (objOrArr) {
+    return key in objOrArr ? objOrArr[key] : defaultValue;
   }
+  return defaultValue;
 };
 
 
 /**
- * @return {!Object<string, *>}
+ * Get the base layer config(s) for the descriptor.
+ * @return {!(Array<Object>|Object)} The layer config(s).
  */
 os.data.ConfigDescriptor.prototype.getBaseConfig = function() {
-  return this.baseConfig || {};
+  return this.baseConfig;
 };
 
 
 /**
- * @param {Object<string, *>} config
+ * Set the base layer config(s) for the descriptor.
+ * @param {Array<Object>|Object} config The layer config(s).
  */
 os.data.ConfigDescriptor.prototype.setBaseConfig = function(config) {
-  this.baseConfig = config;
+  this.baseConfig = config || {};
+
+  // update icons on next call to getIcons
+  this.icons = null;
 };
 
 
@@ -343,4 +401,29 @@ os.data.ConfigDescriptor.prototype.restore = function(conf) {
     // descriptor
     this.updateActiveFromTemp();
   }
+};
+
+
+/**
+ * Reduce function to determine icons from layer configs.
+ * @param {string} icons The accumulated icons.
+ * @param {Object} config The layer config.
+ * @return {string} The icons for the config.
+ */
+os.data.ConfigDescriptor.reduceConfigIcons_ = function(icons, config) {
+  if (config) {
+    var layerType = config['layerType'];
+    if (layerType === os.layer.LayerType.TILES || layerType === os.layer.LayerType.GROUPS) {
+      icons += os.ui.Icons.TILES;
+    }
+    if (layerType === os.layer.LayerType.FEATURES || layerType === os.layer.LayerType.GROUPS) {
+      icons += os.ui.Icons.FEATURES;
+    }
+
+    if (config['animate']) {
+      icons += os.ui.Icons.TIME;
+    }
+  }
+
+  return icons;
 };

--- a/src/os/data/data.js
+++ b/src/os/data/data.js
@@ -1,0 +1,11 @@
+goog.provide('os.data');
+
+
+/**
+ * Settings keys for data providers.
+ * @enum {string}
+ */
+os.data.ProviderKey = {
+  ADMIN: 'providers',
+  USER: 'userProviders'
+};

--- a/src/os/data/datamanager.js
+++ b/src/os/data/datamanager.js
@@ -4,6 +4,7 @@ goog.require('goog.async.Delay');
 goog.require('goog.events.EventTarget');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
+goog.require('os.data');
 goog.require('os.data.DataProviderEvent');
 goog.require('os.data.DescriptorEvent');
 goog.require('os.data.DescriptorEventType');
@@ -303,9 +304,10 @@ os.data.DataManager.prototype.getProviderRoot = function() {
  * @inheritDoc
  */
 os.data.DataManager.prototype.updateFromSettings = function(settings) {
-  var sets = ['providers', 'userProviders'];
+  var sets = Object.values(os.data.ProviderKey);
   for (var s = 0, ss = sets.length; s < ss; s++) {
-    var set = /** @type {Object} */ (settings.get([sets[s]]));
+    var providerKey = sets[s];
+    var set = /** @type {Object} */ (settings.get([providerKey]));
 
     for (var id in set) {
       var item = /** @type {Object} */ (set[id]);
@@ -313,6 +315,7 @@ os.data.DataManager.prototype.updateFromSettings = function(settings) {
       // make sure the item is an object, in case Closure adds a UID key to the set
       if (typeof item == 'object') {
         item['id'] = id;
+        item['providerKey'] = providerKey;
         var on = true;
 
         if ('enabled' in item) {

--- a/src/os/state/state.js
+++ b/src/os/state/state.js
@@ -100,11 +100,11 @@ os.state.deleteStates = function(list) {
       // deactivate and remove the state without putting a command on the stack
       list[i].setActive(false);
       // If its a local state file, remove it.
-      if (list[i].descriptorType === 'state') {
+      if (list[i].getDescriptorType() === 'state') {
         // remove the descriptor from the data manager
         dataManager.removeDescriptor(list[i]);
         var provider = /** @type {os.ui.data.DescriptorProvider} */
-            (dataManager.getProvider(list[i].getDescriptorType()));
+            (dataManager.getProvider(list[i].getId()));
         if (provider && provider instanceof os.ui.data.DescriptorProvider) {
           // remove the descriptor from the provider
           provider.removeDescriptor(list[i], true);

--- a/src/os/state/statemanager.js
+++ b/src/os/state/statemanager.js
@@ -135,40 +135,6 @@ os.state.StateManager.prototype.deleteStates = function() {
 
 
 /**
- * @param {?Array<!os.data.IDataDescriptor>} list The list of state descriptors
- * @protected
- */
-os.state.StateManager.prototype.deleteStatesInternal = function(list) {
-  var dataManager = os.dataManager;
-  if (list) {
-    var i = list.length;
-    while (i--) {
-      // deactivate and remove the state without putting a command on the stack
-      list[i].setActive(false);
-      // If its a local state file, remove it.
-      if (list[i].descriptorType === 'state') {
-        // remove the descriptor from the data manager
-        dataManager.removeDescriptor(list[i]);
-        var provider = /** @type {os.ui.data.DescriptorProvider} */
-            (dataManager.getProvider(list[i].getDescriptorType()));
-        if (provider && provider instanceof os.ui.data.DescriptorProvider) {
-          // remove the descriptor from the provider
-          provider.removeDescriptor(list[i], true);
-        }
-
-        // since the file has been removed from indexedDB, we can no longer depend on anything in the command
-        // history since it may reference a file we can no longer access, so clear it
-        setTimeout(function() {
-          var cp = os.command.CommandProcessor.getInstance();
-          cp.clearHistory();
-        }, 1);
-      }
-    }
-  }
-};
-
-
-/**
  * @inheritDoc
  */
 os.state.StateManager.prototype.hasState = function(title) {

--- a/src/os/ui/data/descriptornodeui.js
+++ b/src/os/ui/data/descriptornodeui.js
@@ -1,0 +1,145 @@
+goog.provide('os.ui.data.DescriptorNodeUICtrl');
+goog.provide('os.ui.data.descriptorNodeUIDirective');
+
+goog.require('os.ui.Module');
+goog.require('os.ui.data.DescriptorProvider');
+goog.require('os.ui.slick.AbstractNodeUICtrl');
+goog.require('os.ui.window.confirmDirective');
+
+
+/**
+ * Generic node UI for descriptors.
+ * @return {angular.Directive}
+ */
+os.ui.data.descriptorNodeUIDirective = function() {
+  return {
+    restrict: 'AE',
+    replace: true,
+    templateUrl: os.ROOT + 'views/data/descriptornodeui.html',
+    controller: os.ui.data.DescriptorNodeUICtrl,
+    controllerAs: 'nodeUi'
+  };
+};
+
+
+/**
+ * Add the directive to the module
+ */
+os.ui.Module.directive('descriptornodeui', [os.ui.data.descriptorNodeUIDirective]);
+
+
+
+/**
+ * Controller for descriptor node UI.
+ *
+ * @param {!angular.Scope} $scope
+ * @param {!angular.JQLite} $element
+ * @extends {os.ui.slick.AbstractNodeUICtrl}
+ * @constructor
+ * @ngInject
+ */
+os.ui.data.DescriptorNodeUICtrl = function($scope, $element) {
+  os.ui.data.DescriptorNodeUICtrl.base(this, 'constructor', $scope, $element);
+};
+goog.inherits(os.ui.data.DescriptorNodeUICtrl, os.ui.slick.AbstractNodeUICtrl);
+
+
+/**
+ * Prompt the user to remove the descriptor from the application.
+ * @export
+ */
+os.ui.data.DescriptorNodeUICtrl.prototype.tryRemove = function() {
+  os.ui.window.launchConfirm(/** @type {osx.window.ConfirmOptions} */ ({
+    confirm: this.remove.bind(this),
+    cancel: goog.nullFunction,
+    prompt: this.getRemoveWindowText(),
+    yesText: 'Remove',
+    yesIcon: 'fa fa-trash-o',
+    yesButtonClass: 'btn-danger',
+    windowOptions: this.getRemoveWindowOptions()
+  }));
+};
+
+
+/**
+ * Get the window options for the remove prompt.
+ * @return {Object<string, string>} The window options.
+ * @protected
+ */
+os.ui.data.DescriptorNodeUICtrl.prototype.getRemoveWindowOptions = function() {
+  var title = '';
+  var descriptor = this.getDescriptor();
+  if (descriptor) {
+    title = descriptor.getTitle();
+  }
+
+  return {
+    'label': 'Remove ' + title + '?',
+    'icon': 'fa fa-trash-o',
+    'headerClass': 'bg-danger u-bg-danger-text',
+    'x': 'center',
+    'y': 'center',
+    'width': '325',
+    'height': 'auto',
+    'modal': 'true',
+    'no-scroll': 'true'
+  };
+};
+
+
+/**
+ * Get the text to display in the remove prompt.
+ * @return {!string} The text.
+ * @protected
+ */
+os.ui.data.DescriptorNodeUICtrl.prototype.getRemoveWindowText = function() {
+  return 'Are you sure you want to remove this layer from the application?';
+};
+
+
+/**
+ * Get the descriptor for the node.
+ * @return {os.data.IDataDescriptor} The descriptor.
+ * @protected
+ */
+os.ui.data.DescriptorNodeUICtrl.prototype.getDescriptor = function() {
+  // the node should be on the scope as 'item'
+  var node = /** @type {os.ui.data.DescriptorNode} */ (this.scope['item']);
+  return node.getDescriptor();
+};
+
+
+/**
+ * Remove the descriptor.
+ * @protected
+ */
+os.ui.data.DescriptorNodeUICtrl.prototype.remove = function() {
+  this.removeDescriptor();
+};
+
+
+/**
+ * Permanently remove the descriptor and associated data from the application.
+ * @return {boolean} If the descriptor was removed.
+ * @protected
+ */
+os.ui.data.DescriptorNodeUICtrl.prototype.removeDescriptor = function() {
+  var descriptor = this.getDescriptor();
+  var dm = os.dataManager;
+  if (descriptor && descriptor instanceof os.data.BaseDescriptor) {
+    // remove the descriptor from the data manager
+    dm.removeDescriptor(descriptor);
+
+    var provider = /** @type {os.ui.data.DescriptorProvider} */ (dm.getProvider(descriptor.getId()));
+    if (provider && provider instanceof os.ui.data.DescriptorProvider) {
+      // remove the descriptor from the provider
+      provider.removeDescriptor(descriptor, true);
+    }
+
+    descriptor.dispose();
+
+    return true;
+  }
+
+  return false;
+};

--- a/src/os/ui/data/descriptornodeui.js
+++ b/src/os/ui/data/descriptornodeui.js
@@ -93,7 +93,8 @@ os.ui.data.DescriptorNodeUICtrl.prototype.getRemoveWindowOptions = function() {
  * @protected
  */
 os.ui.data.DescriptorNodeUICtrl.prototype.getRemoveWindowText = function() {
-  return 'Are you sure you want to remove this layer from the application?';
+  return 'Are you sure you want to remove this layer from the application?' +
+      '<b>This action cannot be undone</b>, and will clear the application history.';
 };
 
 
@@ -120,7 +121,6 @@ os.ui.data.DescriptorNodeUICtrl.prototype.remove = function() {
 
 /**
  * Permanently remove the descriptor and associated data from the application.
- * @return {boolean} If the descriptor was removed.
  * @protected
  */
 os.ui.data.DescriptorNodeUICtrl.prototype.removeDescriptor = function() {
@@ -138,8 +138,7 @@ os.ui.data.DescriptorNodeUICtrl.prototype.removeDescriptor = function() {
 
     descriptor.dispose();
 
-    return true;
+    // restoring descriptors is currently not supported, so clear the application stack to avoid conflicts
+    os.command.CommandProcessor.getInstance().clearHistory();
   }
-
-  return false;
 };

--- a/src/os/ui/file/ui/defaultfilenodeui.js
+++ b/src/os/ui/file/ui/defaultfilenodeui.js
@@ -46,18 +46,3 @@ os.ui.file.ui.DefaultFileNodeUICtrl.prototype.getRemoveWindowText = function() {
   return 'Are you sure you want to remove this file from the application? ' +
       '<b>This action cannot be undone</b>, and will clear the application history.';
 };
-
-
-/**
- * @inheritDoc
- */
-os.ui.file.ui.DefaultFileNodeUICtrl.prototype.removeDescriptor = function() {
-  var removed = os.ui.file.ui.DefaultFileNodeUICtrl.base(this, 'removeDescriptor');
-  if (removed) {
-    // since the file has been removed from indexedDB, we can no longer depend on anything in the command
-    // history since it may reference a file we can no longer access, so clear it
-    os.command.CommandProcessor.getInstance().clearHistory();
-  }
-
-  return removed;
-};

--- a/src/os/ui/file/ui/defaultfilenodeui.js
+++ b/src/os/ui/file/ui/defaultfilenodeui.js
@@ -1,97 +1,46 @@
 goog.provide('os.ui.file.ui.DefaultFileNodeUICtrl');
 goog.provide('os.ui.file.ui.defaultFileNodeUIDirective');
 
-goog.require('goog.events.EventType');
-goog.require('os.file.FileStorage');
 goog.require('os.ui.Module');
-goog.require('os.ui.data.DescriptorProvider');
-goog.require('os.ui.slick.AbstractNodeUICtrl');
-goog.require('os.ui.window.confirmDirective');
+goog.require('os.ui.data.DescriptorNodeUICtrl');
 
 
 /**
- * The selected/highlighted file node UI directive
+ * The selected/highlighted file node UI directive.
  *
  * @return {angular.Directive}
  */
 os.ui.file.ui.defaultFileNodeUIDirective = function() {
-  return {
-    restrict: 'AE',
-    replace: true,
-    templateUrl: os.ROOT + 'views/file/defaultfilenodeui.html',
-    controller: os.ui.file.ui.DefaultFileNodeUICtrl,
-    controllerAs: 'nodeUi'
-  };
+  var directive = os.ui.data.descriptorNodeUIDirective();
+  directive.controller = os.ui.file.ui.DefaultFileNodeUICtrl;
+  return directive;
 };
 
 
 /**
- * Add the directive to the module
+ * Add the directive to the module.
  */
 os.ui.Module.directive('defaultfilenodeui', [os.ui.file.ui.defaultFileNodeUIDirective]);
 
 
 
 /**
- * Controller for selected/highlighted file node UI
+ * Controller for selected/highlighted file node UI.
  *
  * @param {!angular.Scope} $scope
  * @param {!angular.JQLite} $element
- * @extends {os.ui.slick.AbstractNodeUICtrl}
+ * @extends {os.ui.data.DescriptorNodeUICtrl}
  * @constructor
  * @ngInject
  */
 os.ui.file.ui.DefaultFileNodeUICtrl = function($scope, $element) {
   os.ui.file.ui.DefaultFileNodeUICtrl.base(this, 'constructor', $scope, $element);
-
-  /**
-   * @type {boolean}
-   */
-  this['confirmRemove'] = false;
 };
-goog.inherits(os.ui.file.ui.DefaultFileNodeUICtrl, os.ui.slick.AbstractNodeUICtrl);
+goog.inherits(os.ui.file.ui.DefaultFileNodeUICtrl, os.ui.data.DescriptorNodeUICtrl);
 
 
 /**
- * Prompt the user to remove the file from the application
- *
- * @export
- */
-os.ui.file.ui.DefaultFileNodeUICtrl.prototype.tryRemove = function() {
-  os.ui.window.launchConfirm(/** @type {osx.window.ConfirmOptions} */ ({
-    confirm: this.remove.bind(this),
-    cancel: goog.nullFunction,
-    prompt: this.getRemoveWindowText(),
-    yesText: 'Remove',
-    yesIcon: 'fa fa-trash-o',
-    yesButtonClass: 'btn-danger',
-    windowOptions: this.getRemoveWindowOptions()
-  }));
-};
-
-
-/**
- * @return {Object<string, string>} The window options for the remove dialog
- * @protected
- */
-os.ui.file.ui.DefaultFileNodeUICtrl.prototype.getRemoveWindowOptions = function() {
-  return {
-    'label': 'Remove File',
-    'icon': 'fa fa-trash-o',
-    'headerClass': 'bg-danger u-bg-danger-text',
-    'x': 'center',
-    'y': 'center',
-    'width': '325',
-    'height': 'auto',
-    'modal': 'true',
-    'no-scroll': 'true'
-  };
-};
-
-
-/**
- * @return {!string}
- * @protected
+ * @inheritDoc
  */
 os.ui.file.ui.DefaultFileNodeUICtrl.prototype.getRemoveWindowText = function() {
   return 'Are you sure you want to remove this file from the application? ' +
@@ -100,39 +49,15 @@ os.ui.file.ui.DefaultFileNodeUICtrl.prototype.getRemoveWindowText = function() {
 
 
 /**
- * @return {os.data.IDataDescriptor}
- * @protected
+ * @inheritDoc
  */
-os.ui.file.ui.DefaultFileNodeUICtrl.prototype.getDescriptor = function() {
-  // the node should be on the scope as 'item'
-  var node = /** @type {os.ui.data.DescriptorNode} */ (this.scope['item']);
-  return node.getDescriptor();
-};
-
-
-/**
- * Permanently remove the file layer and associated data from the application.
- *
- * @protected
- */
-os.ui.file.ui.DefaultFileNodeUICtrl.prototype.remove = function() {
-  var descriptor = this.getDescriptor();
-  var dm = os.dataManager;
-  if (descriptor && descriptor instanceof os.data.BaseDescriptor) {
-    // remove the descriptor from the data manager
-    dm.removeDescriptor(descriptor);
-
-    var provider = /** @type {os.ui.data.DescriptorProvider} */ (dm.getProvider(descriptor.getDescriptorType()));
-    if (provider && provider instanceof os.ui.data.DescriptorProvider) {
-      // remove the descriptor from the provider
-      provider.removeDescriptor(descriptor, true);
-    }
-
-    descriptor.dispose();
-
+os.ui.file.ui.DefaultFileNodeUICtrl.prototype.removeDescriptor = function() {
+  var removed = os.ui.file.ui.DefaultFileNodeUICtrl.base(this, 'removeDescriptor');
+  if (removed) {
     // since the file has been removed from indexedDB, we can no longer depend on anything in the command
     // history since it may reference a file we can no longer access, so clear it
-    var cp = os.command.CommandProcessor.getInstance();
-    cp.clearHistory();
+    os.command.CommandProcessor.getInstance().clearHistory();
   }
+
+  return removed;
 };

--- a/src/os/ui/ol/olmap.js
+++ b/src/os/ui/ol/olmap.js
@@ -28,6 +28,7 @@ goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('ol.tilegrid.TileGrid');
 goog.require('os.control.ScaleLine');
+goog.require('os.data');
 goog.require('os.fn');
 goog.require('os.map');
 goog.require('os.map.IMapContainer');
@@ -394,7 +395,7 @@ os.ui.ol.OLMap.prototype.getInteractions_ = function() {
  * @private
  */
 os.ui.ol.OLMap.prototype.getLayers_ = function() {
-  var provider = /** @type {Object<string, *>} */ (os.settings.get(['providers', 'basemap']));
+  var provider = /** @type {Object<string, *>} */ (os.settings.get([os.data.ProviderKey.ADMIN, 'basemap']));
   var baseMapConfigs = /** @type {Object<string, Object<string, *>>} */ (provider['maps']);
   var layers = [];
   var hasDefault = false;

--- a/src/os/ui/providerimport.js
+++ b/src/os/ui/providerimport.js
@@ -3,6 +3,7 @@ goog.provide('os.ui.ProviderImportCtrl');
 goog.require('goog.events.EventType');
 goog.require('goog.string');
 goog.require('os.config.Settings');
+goog.require('os.data');
 goog.require('os.ui.window');
 
 
@@ -145,7 +146,7 @@ os.ui.ProviderImportCtrl.prototype.onTestFinished = function(event) {
  */
 os.ui.ProviderImportCtrl.prototype.saveAndClose = function() {
   var config = this.getConfig();
-  os.settings.set(['userProviders', this.dp.getId()], config);
+  os.settings.set([os.data.ProviderKey.USER, this.dp.getId()], config);
   // We want to add the test instance as replacement rather than re-configuring the old
   // povider. This avoids reloading the provider again after we just did that to test it.
   os.dataManager.removeProvider(this.dp.getId());

--- a/src/os/ui/servers.js
+++ b/src/os/ui/servers.js
@@ -7,6 +7,7 @@ goog.require('goog.log.Logger');
 goog.require('os.alert.AlertEventSeverity');
 goog.require('os.alert.AlertManager');
 goog.require('os.config.Settings');
+goog.require('os.data');
 goog.require('os.data.DataManager');
 goog.require('os.defines');
 goog.require('os.im.ImportProcess');
@@ -212,8 +213,8 @@ os.ui.ServersCtrl.prototype.update = function(opt_prompt) {
         }
       }
 
-      os.settings.set([
-        provider.getEditable() ? 'userProviders' : 'providers', provider.getId(), 'enabled'], enabled);
+      var providerKey = provider.getEditable() ? os.data.ProviderKey.USER : os.data.ProviderKey.ADMIN;
+      os.settings.set([providerKey, provider.getId(), 'enabled'], enabled);
 
       if (!enabled) {
         this.checkForActiveDescriptors_(provider, true);
@@ -380,7 +381,7 @@ os.ui.ServersCtrl.prototype.remove = function(provider, opt_prompt) {
   for (var i = 0, ii = descList.length; i < ii; i++) {
     os.dataManager.removeDescriptor(descList[i]);
   }
-  os.settings.delete(['userProviders', provider.getId()]);
+  os.settings.delete([os.data.ProviderKey.USER, provider.getId()]);
 
   os.dataManager.removeProvider(provider.getId());
   goog.log.info(os.ui.ServersCtrl.LOGGER_, 'Removed provider "' + provider.getLabel() + '"');

--- a/src/plugin/config/configprovider.js
+++ b/src/plugin/config/configprovider.js
@@ -3,6 +3,7 @@ goog.provide('plugin.config.Provider');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('os.MapEvent');
+goog.require('os.data');
 goog.require('os.data.BaseDescriptor');
 goog.require('os.data.ConfigDescriptor');
 goog.require('os.data.DataManager');
@@ -35,10 +36,18 @@ plugin.config.Provider = function() {
   this.setId(plugin.config.ID);
 
   /**
-   * @type {Object|Array<Object>}
+   * Map of layer group ID to the layer configs.
+   * @type {!Object<string, (Array<Object>|Object)>}
    * @private
    */
-  this.layers_;
+  this.layers_ = {};
+
+  /**
+   * The base provider key for settings.
+   * @type {os.data.ProviderKey}
+   * @private
+   */
+  this.providerKey_ = os.data.ProviderKey.USER;
 };
 goog.inherits(plugin.config.Provider, os.ui.data.DescriptorProvider);
 os.implements(plugin.config.Provider, os.data.IDataProvider.ID);
@@ -59,7 +68,8 @@ plugin.config.Provider.LOGGER_ = goog.log.getLogger('plugin.config.Provider');
 plugin.config.Provider.prototype.configure = function(config) {
   plugin.config.Provider.base(this, 'configure', config);
   this.setToolTip(/** @type {?string} */ (config['tooltip'] || config['description']));
-  this.layers_ = /** @type {Object} */ (config['layers']);
+  this.layers_ = /** @type {Object} */ (config['layers']) || {};
+  this.providerKey_ = /** @type {os.data.ProviderKey} */ (config['providerKey']) || os.data.ProviderKey.USER;
 };
 
 
@@ -70,13 +80,30 @@ plugin.config.Provider.prototype.load = function(ping) {
   this.dispatchEvent(new os.data.DataProviderEvent(os.data.DataProviderEventType.LOADING, this));
   this.setChildren(null);
 
-  if (this.layers_) {
-    for (var id in this.layers_) {
-      this.loadConfig(id, this.layers_[id]);
-    }
+  for (var id in this.layers_) {
+    this.loadConfig(id, this.layers_[id]);
   }
 
   this.dispatchEvent(new os.data.DataProviderEvent(os.data.DataProviderEventType.LOADED, this));
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.config.Provider.prototype.removeDescriptor = function(descriptor, opt_clear) {
+  var result = plugin.config.Provider.base(this, 'removeDescriptor', descriptor, opt_clear);
+
+  var id = descriptor.getId();
+  var configId = id.replace(this.getId() + os.data.BaseDescriptor.ID_DELIMITER, '');
+  if (configId && configId in this.layers_) {
+    delete this.layers_[configId];
+
+    var settingsKey = this.getSettingsKey() + '.layers';
+    os.settings.set(settingsKey, this.layers_);
+  }
+
+  return result;
 };
 
 
@@ -91,15 +118,15 @@ plugin.config.Provider.prototype.loadConfig = function(id, config) {
   var descriptor = null;
 
   try {
-    var fullId = this.getId() + os.data.BaseDescriptor.ID_DELIMITER + id;
-    descriptor = /** @type {os.data.ConfigDescriptor} */ (os.dataManager.getDescriptor(fullId));
+    var descriptorId = this.getId() + os.data.BaseDescriptor.ID_DELIMITER + id;
+    descriptor = /** @type {os.data.ConfigDescriptor} */ (os.dataManager.getDescriptor(descriptorId));
 
     if (!descriptor) {
       descriptor = new os.data.ConfigDescriptor();
+      descriptor.setId(descriptorId);
     }
 
-    this.fixId(fullId, config);
-    this.addIcons(config);
+    this.fixId(descriptorId, config);
 
     descriptor.setBaseConfig(config);
     os.dataManager.addDescriptor(descriptor);
@@ -113,90 +140,60 @@ plugin.config.Provider.prototype.loadConfig = function(id, config) {
 
 
 /**
+ * Ensure layer config id's are prefixed with the descriptor id.
+ * @param {string} id The descriptor id.
+ * @param {Array<Object>|Object} config The layer config(s).
+ * @protected
+ */
+plugin.config.Provider.prototype.fixId = function(id, config) {
+  if (Array.isArray(config)) {
+    config.forEach(this.fixId.bind(this, id));
+  } else if (config) {
+    if (!('id' in config)) {
+      throw new Error('Config for "' + id + '" does not contain the "id" field!');
+    }
+    if (!config['id'].startsWith(id)) {
+      config['id'] = id + os.data.BaseDescriptor.ID_DELIMITER + config['id'];
+    }
+  }
+};
+
+
+/**
  * Get the settings key for the provider.
  * @return {string} The key.
+ * @protected
  */
 plugin.config.Provider.prototype.getSettingsKey = function() {
-  return 'userProviders.' + this.getId();
+  return this.providerKey_ + '.' + this.getId();
 };
 
 
 /**
  * Add a layer group to the provider and create a descriptor.
- * @param {string} groupId The layer group id.
- * @param {Object|Array<Object>} config The layer config(s) to add to the group.
- * @return {os.data.IDataDescriptor} The descriptor. If `groupId` is already registered with the provider, the existing
+ * @param {string} id The layer group id.
+ * @param {Array<Object>|Object} config The layer config(s) to add to the group.
+ * @return {os.data.IDataDescriptor} The descriptor. If `id` is already registered with the provider, the existing
  *                                   descriptor will be returned.
  */
-plugin.config.Provider.prototype.addLayerGroup = function(groupId, config) {
-  var fullId = this.getId() + os.data.BaseDescriptor.ID_DELIMITER + groupId;
-  var descriptor = os.dataManager.getDescriptor(fullId);
-  if (descriptor) {
-    return descriptor;
-  }
+plugin.config.Provider.prototype.addLayerGroup = function(id, config) {
+  var descriptor = null;
 
-  if (!this.layers_) {
-    this.layers_ = {};
-  }
+  if (config) {
+    if (!(id in this.layers_)) {
+      this.layers_[id] = config;
 
-  if (!(groupId in this.layers_)) {
-    this.layers_[groupId] = config;
+      var layersKey = this.getSettingsKey() + '.layers';
+      os.settings.set(layersKey, this.layers_);
 
-    // save a copy of the config from settings, so changes made by loadConfig aren't persisted
-    var layersKey = this.getSettingsKey() + '.layers';
-    os.settings.set(layersKey + '.' + groupId, os.object.unsafeClone(config));
-
-    descriptor = this.loadConfig(groupId, config);
+      descriptor = this.loadConfig(id, config);
+    } else {
+      var descriptorId = [this.getId(), id].join(os.data.BaseDescriptor.ID_DELIMITER);
+      descriptor = os.dataManager.getDescriptor(descriptorId);
+    }
   }
 
   return descriptor;
-};
-
-
-/**
- * @param {string} fullId
- * @param {Object|Array} conf
- * @protected
- */
-plugin.config.Provider.prototype.fixId = function(fullId, conf) {
-  if (Array.isArray(conf)) {
-    conf.forEach(this.fixId.bind(this, fullId));
-  } else {
-    if (!('id' in conf)) {
-      throw new Error('Config for "' + fullId + '" does not contain the "id" field!');
-    }
-    // ensure this isn't done more than once
-    var prefix = fullId + os.data.BaseDescriptor.ID_DELIMITER;
-    if (!conf['id'].startsWith(prefix)) {
-      conf['id'] = prefix + conf['id'];
-    }
-  }
-};
-
-
-/**
- * @param {Object|Array} conf
- */
-plugin.config.Provider.prototype.addIcons = function(conf) {
-  if (Array.isArray(conf)) {
-    conf.forEach(this.addIcons, this);
-  } else if (!conf['icons']) {
-    var icons = '';
-
-    var layerType = conf['layerType'];
-    if (layerType === os.layer.LayerType.TILES || layerType === os.layer.LayerType.GROUPS) {
-      icons += os.ui.Icons.TILES;
-    }
-    if (layerType === os.layer.LayerType.FEATURES || layerType === os.layer.LayerType.GROUPS) {
-      icons += os.ui.Icons.FEATURES;
-    }
-
-    if (conf['animate']) {
-      icons += os.ui.Icons.TIME;
-    }
-
-    conf['icons'] = icons;
-  }
 };
 
 

--- a/src/plugin/ogc/ogclayerdescriptor.js
+++ b/src/plugin/ogc/ogclayerdescriptor.js
@@ -6,6 +6,7 @@ goog.require('os.alert.AlertManager');
 goog.require('os.command.LayerAdd');
 goog.require('os.command.LayerRemove');
 goog.require('os.command.SequenceCommand');
+goog.require('os.data');
 goog.require('os.data.IAreaTest');
 goog.require('os.data.LayerSyncDescriptor');
 goog.require('os.events.LayerConfigEvent');
@@ -958,7 +959,8 @@ plugin.ogc.OGCLayerDescriptor.prototype.getWmsOptions = function() {
 
   if (options['provider']) {
     // check to see if the visibility is configured to false, if not visibility should be true
-    options['visible'] = os.settings.get(['providers', this.getProvider().toLowerCase(), 'visible'], true);
+    options['visible'] = os.settings.get(
+        [os.data.ProviderKey.ADMIN, this.getProvider().toLowerCase(), 'visible'], true);
   }
 
   return options;
@@ -1011,7 +1013,8 @@ plugin.ogc.OGCLayerDescriptor.prototype.getWfsOptions = function(opt_options) {
 
   if (options['provider']) {
     // check to see if the visibility is configured to false, if not visibility should be true
-    options['visible'] = os.settings.get(['providers', this.getProvider().toLowerCase(), 'visible'], true);
+    options['visible'] = os.settings.get(
+        [os.data.ProviderKey.ADMIN, this.getProvider().toLowerCase(), 'visible'], true);
   }
 
   return options;

--- a/test/os/data/configdescriptor.test.js
+++ b/test/os/data/configdescriptor.test.js
@@ -5,7 +5,7 @@ describe('os.data.ConfigDescriptor', function() {
   var tileConfig = {
     'id': 'config#descriptor#tiles',
     'type': 'WMS',
-    'layerType': 'Tile Layers',
+    'layerType': os.layer.LayerType.TILES,
     'crossOrigin': 'none',
     'description': 'This is a test of a tile layer',
     'descriptorType': 'testType',
@@ -26,7 +26,7 @@ describe('os.data.ConfigDescriptor', function() {
   var featureConfig = {
     'id': 'config#descriptor#features',
     'type': 'GeoJSON',
-    'layerType': 'Feature Layers',
+    'layerType': os.layer.LayerType.FEATURES,
     'crossOrigin': 'anonymous',
     'description': 'This is a test of a GeoJSON layer.',
     'provider': 'Some Service\'s GeoJSON stuff',
@@ -47,6 +47,14 @@ describe('os.data.ConfigDescriptor', function() {
       var d = new os.data.ConfigDescriptor();
       d.setBaseConfig(config);
       expect(d.getId()).toEqual(config.id);
+    });
+
+    it('should get own id if set', function() {
+      var id = 'test#descriptor#id';
+      var d = new os.data.ConfigDescriptor();
+      d.setBaseConfig(config);
+      d.setId(id);
+      expect(d.getId()).toEqual(id);
     });
 
     it('should get title from config', function() {
@@ -169,6 +177,25 @@ describe('os.data.ConfigDescriptor', function() {
     var d = new os.data.ConfigDescriptor();
     d.setBaseConfig([tileConfig, featureConfig]);
     expect(d.getIcons()).toBe(tileConfig.icons + featureConfig.icons);
+  });
+
+  it('should determine icons from multiple configs', function() {
+    var config1 = Object.assign({}, tileConfig);
+    delete config1['icons'];
+    var config2 = Object.assign({}, featureConfig);
+    delete config2['icons'];
+
+    var d = new os.data.ConfigDescriptor();
+    d.setBaseConfig([config1]);
+    expect(d.getIcons()).toBe(os.ui.Icons.TILES);
+
+    d.setBaseConfig([config1, config2]);
+    expect(d.getIcons()).toBe(os.ui.Icons.TILES + os.ui.Icons.FEATURES);
+
+    config1['animate'] = true;
+    config2['animate'] = true;
+    d.setBaseConfig([config1, config2]);
+    expect(d.getIcons()).toBe(os.ui.Icons.TILES + os.ui.Icons.FEATURES + os.ui.Icons.TIME);
   });
 
   it('should get search type from multiple configs', function() {

--- a/test/os/data/osdatamanager.test.js
+++ b/test/os/data/osdatamanager.test.js
@@ -1,14 +1,15 @@
+goog.require('ol.source.TileWMS');
+goog.require('os.MapContainer');
 goog.require('os.config.Settings');
 goog.require('os.config.storage.SettingsObjectStorage');
-goog.require('os.data.ProviderEntry');
+goog.require('os.data');
 goog.require('os.data.BaseDescriptor');
-goog.require('os.MapContainer');
-goog.require('os.data.OSDataManager');
 goog.require('os.data.LayerSyncDescriptor');
 goog.require('os.data.MockProvider');
+goog.require('os.data.OSDataManager');
+goog.require('os.data.ProviderEntry');
 goog.require('os.layer.Tile');
 goog.require('os.mock');
-goog.require('ol.source.TileWMS');
 goog.require('test.os.config.SettingsUtil');
 
 
@@ -56,13 +57,13 @@ describe('os.data.OSDataManager', function() {
     test.os.config.SettingsUtil.initAndLoad(settings);
 
     runs(function() {
-      settings.set(['providers', 'thing1', 'type'], 'mock');
-      settings.set(['providers', 'thing1', 'test'], 'A');
-      settings.set(['userProviders', 'thing2', 'type'], 'mock');
-      settings.set(['userProviders', 'thing2', 'test'], 'B');
-      settings.set(['userProviders', 'thing2', 'enabled'], false);
-      settings.set(['userProviders', 'ufo', 'type'], 'unknown');
-      settings.set(['userProviders', 'ufo', 'probingYou'], true);
+      settings.set([os.data.ProviderKey.ADMIN, 'thing1', 'type'], 'mock');
+      settings.set([os.data.ProviderKey.ADMIN, 'thing1', 'test'], 'A');
+      settings.set([os.data.ProviderKey.USER, 'thing2', 'type'], 'mock');
+      settings.set([os.data.ProviderKey.USER, 'thing2', 'test'], 'B');
+      settings.set([os.data.ProviderKey.USER, 'thing2', 'enabled'], false);
+      settings.set([os.data.ProviderKey.USER, 'ufo', 'type'], 'unknown');
+      settings.set([os.data.ProviderKey.USER, 'ufo', 'probingYou'], true);
 
       dm.updateFromSettings(settings);
 

--- a/views/data/descriptornodeui.html
+++ b/views/data/descriptornodeui.html
@@ -1,0 +1,3 @@
+<span ng-if="nodeUi.show()" class="flex-shrink-0" ng-click="nodeUi.tryRemove()">
+  <i class="fa fa-trash-o fa-fw c-glyph" title="Remove this layer from the application"></i>
+</span>

--- a/views/file/defaultfilenodeui.html
+++ b/views/file/defaultfilenodeui.html
@@ -1,3 +1,0 @@
-<span ng-if="nodeUi.show()" class="flex-shrink-0" ng-click="nodeUi.tryRemove()">
-  <i class="fa fa-trash-o fa-fw c-glyph" title="Remove the file"></i>
-</span>


### PR DESCRIPTION
Adds API's to:
* Create a config provider (`plugin.config.Provider.create`) and save it to settings.
* Add layers to a config provider (`plugin.config.Provider#addLayerGroup`).

Existing config provider/descriptor behavior should be unchanged. Existing config descriptor unit tests should cover old behavior, and additional tests have been added for new behavior.

Other changes:
* Most of `os.ui.file.ui.DefaultFileNodeUICtrl` has been abstracted out to `os.ui.data.DescriptorNodeUICtrl`. The former has been maintained to avoid a breaking change and for a minor adjustment to the removal warning.
* A few places were using `dataManager.getProvider(descriptor.getDescriptorType())` to locate a provider. This method requires the provider ID to match the descriptor type, which is not guaranteed to be true. This code has been cleaned up to use `descriptor.getId()` instead.
* Provider storage keys have been moved to an enum (`os.data.ProviderKey`) instead of using the strings directly.

Testing:
* Verify existing configuration with config providers functions as it did before.
* Configure a WMTS layer and verify it functions normally:
```
"wmts-test": {
  "type": "wmts",
  "label": "NASA GIBS WMTS",
  "url": "https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi"
}
```
* Build with https://github.com/wallw-bits/opensphere-plugin-geopackage and test loading GPKG files.