### PR TITLE
test(karma): Use test loader to avoid Chrome resource limit errors.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,15 +2,18 @@
 /* eslint-disable max-len */
 
 const path = require('path');
-const helper = require('opensphere-build-closure-helper');
 const resolver = require('opensphere-build-resolver/utils');
 
+/**
+ * Karma configuration for OpenSphere.
+ *
+ * Development Note:
+ * This configuration uses a script loader to avoid pending request limits in Chrome. To limit which tests run during
+ * development, use `ddescribe` and `iit` to instruct Jasmine to only run those specs.
+ *
+ * @param {Object} config The config.
+ */
 module.exports = function(config) {
-  var closureFiles = helper.readManifest(path.resolve('.build', 'gcc-test-manifest'))
-      .filter(function(item) {
-        return item.indexOf(__dirname + '/test/') !== 0;
-      });
-
   config.set({
     // base path, that will be used to resolve files and exclude
     basePath: '',
@@ -52,24 +55,34 @@ module.exports = function(config) {
       {pattern: resolver.resolveModulePath('zip-js/WebContent/z-worker.js', __dirname), watched: false, included: false, served: true},
       {pattern: resolver.resolveModulePath('opensphere-state-schema/src/main/**/*.xsd', __dirname), watched: false, included: false, served: true},
       {pattern: resolver.resolveModulePath('suncalc/suncalc.js', __dirname), watched: false, included: true, served: true},
-      {pattern: resolver.resolveModulePath('markdown-it/dist/markdown-it.min.js', __dirname), watched: false, included: true, served: true}
-    ].concat(closureFiles).concat([
-      // init
-      'test/init.js',
+      {pattern: resolver.resolveModulePath('markdown-it/dist/markdown-it.min.js', __dirname), watched: false, included: true, served: true},
 
-      // tests and mocks
-      'test/**/*.mock.js',
-      'test/**/*.test.js',
+      // initialization to run prior to tests
+      'test/init.js',
 
       // test resources
       {pattern: 'test/**/*.test.worker.js', included: false},
       {pattern: 'test/**/*.json', included: false},
       {pattern: 'test/**/*.xml', included: false},
       {pattern: 'test/resources/**/*', included: false},
-      {pattern: resolver.resolveModulePath('google-closure-library/closure/goog/bootstrap/webworkers.js', __dirname), included: false}
-    ]),
+
+      // source files for the script loader
+      {pattern: 'src/**/*.js', watched: false, included: false, served: true},
+      {pattern: 'test/**/*.js', watched: false, included: false, served: true},
+      {pattern: resolver.resolveModulePath('google-closure-library/**/*.js', __dirname), watched: false, included: false, served: true},
+      {pattern: resolver.resolveModulePath('openlayers/**/*.js', __dirname), watched: false, included: false, served: true},
+      {pattern: resolver.resolveModulePath('ol-cesium/**/*.js', __dirname), watched: false, included: false, served: true},
+
+      // serve the test manifest and include the script loader
+      {pattern: '.build/gcc-test-manifest', watched: false, included: false, served: true},
+      resolver.resolveModulePath('opensphere-build-index/karma-test-loader.js', __dirname)
+    ],
 
     proxies: {
+      // the test loader uses this path to resolve the manifest
+      '/karma-test-scripts': path.resolve(__dirname, '.build', 'gcc-test-manifest'),
+      // some tests load resources with an absolute path from these modules
+      '/opensphere': path.resolve(__dirname),
       '/google-closure-library': resolver.resolveModulePath('google-closure-library', __dirname),
       '/opensphere-state-schema': resolver.resolveModulePath('opensphere-state-schema', __dirname)
     },

--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     "node-sass": "^4.12.0",
     "opensphere-build-closure-helper": "^3.0.0",
     "opensphere-build-docs": "^1.0.0",
-    "opensphere-build-index": "^2.1.0",
+    "opensphere-build-index": "^2.2.0",
     "opensphere-build-resolver": "^5.2.0",
     "opensphere-state-schema": "^2.4.0",
     "postcss-cli": "^5.0.0",

--- a/src/os/file/file.js
+++ b/src/os/file/file.js
@@ -285,8 +285,9 @@ goog.define('os.file.ZIP_PATH', 'vendor/zip-js');
       // load the inflate/deflate scripts locally
       goog.net.jsloader.safeLoad(zipPath + 'inflate.js');
       goog.net.jsloader.safeLoad(zipPath + 'deflate.js');
-    } else {
-      // set the relative path to worker scripts so zip.js can find them
+    } else if (!zip.workerScriptsPath) {
+      // set the relative path to worker scripts so zip.js can find them. zip.js defaults this value to null, so do
+      // not replace the value if one was already set.
       zip.workerScriptsPath = zipPath;
     }
   }

--- a/test/init.js
+++ b/test/init.js
@@ -1,5 +1,3 @@
-goog.require('os.ui.Module');
-
 // Init angular app before all tests
 angular.module('app', ['os.ui']);
 module('app');
@@ -7,6 +5,6 @@ module('app');
 (function() {
   if (window.zip) {
     var script = document.querySelector('script[src*=\'/zip.js\']');
-    zip.workerScriptsPath = script.src.replace(/\/zip.js(\?.*)?$/, '/');
+    zip.workerScriptsPath = script.src.replace(/\/zip\.js(\?.*)?$/, '/');
   }
 })();


### PR DESCRIPTION
Resolves #709.

Testing should verify zip files load in debug/compiled builds. A minor change was made to `os.file` to avoid setting `zip.workerScriptsPath` (default value `null`) if it was already set. Tests set the value in `test/init.js` which used to load after `os.file`, but the script loader reversed the load order.

WIP:
- [x] Update `package.json` when https://github.com/ngageoint/opensphere-build-index/pull/7 is merged.