### PR TITLE
Fix icon zoom scale

### DIFF
--- a/src/os/mixin/zoomscalemixin.js
+++ b/src/os/mixin/zoomscalemixin.js
@@ -1,44 +1,54 @@
 /**
- * @fileoverview This recreates behavior from Google Earth in the 2D map, where icons and labels are scaled/hidden
- *               based on the zoom level/camera distance.
+ * @fileoverview This recreates behavior from Google Earth in the 2D map, where icons are scaled/hidden based on the
+ *               zoom level/camera distance.
  *
  * @suppress {accessControls} To allow access to private properties in OpenLayers classes.
  */
 goog.provide('os.mixin.zoomscale');
 
 goog.require('goog.math');
+goog.require('ol.render.EventType');
 goog.require('ol.render.canvas.ImageReplay');
-goog.require('ol.render.canvas.TextReplay');
+goog.require('os.MapContainer');
 goog.require('os.MapEvent');
 goog.require('os.map');
 
 
 (function() {
-  // cache the zoom scale to reduce how often it's computed, resetting on map view change.
+  // cache values to reduce how often the zoom scale is computed
   var zoomScale;
+  var lastAltitude;
+
   var mapContainer = os.MapContainer.getInstance();
-  mapContainer.listen(os.MapEvent.VIEW_CHANGE, function() {
-    zoomScale = undefined;
-    mapContainer.render();
-  });
 
   /**
-   * Get the scale value for the current map zoom.
-   *
-   * @return {number|undefined} The scale value, or undefined when the current zoom is not rescaled.
+   * Update the scale value for the current map zoom.
    */
-  var getZoomScale = function() {
+  var updateZoomScale = function() {
     var altitude = mapContainer.getAltitude();
-    if (altitude > os.map.ZoomScale.NEAR) {
-      // don't scale beyond the far altitude value
-      altitude = Math.min(altitude, os.map.ZoomScale.FAR);
+    if (lastAltitude != altitude) {
+      lastAltitude = altitude;
 
-      zoomScale = goog.math.lerp(os.map.ZoomScale.NEAR_SCALE, os.map.ZoomScale.FAR_SCALE,
-          (altitude - os.map.ZoomScale.NEAR) / (os.map.ZoomScale.FAR - os.map.ZoomScale.NEAR));
+      if (altitude <= os.map.ZoomScale.NEAR) {
+        // don't scale icons beyond the near limit
+        zoomScale = undefined;
+      } else {
+        // don't scale beyond the far altitude value
+        altitude = Math.min(altitude, os.map.ZoomScale.FAR);
+
+        zoomScale = goog.math.lerp(os.map.ZoomScale.NEAR_SCALE, os.map.ZoomScale.FAR_SCALE,
+            (altitude - os.map.ZoomScale.NEAR) / (os.map.ZoomScale.FAR - os.map.ZoomScale.NEAR));
+      }
     }
-
-    return zoomScale;
   };
+
+  // update the zoom scale when the precompose event is fired, which will happen once per frame.
+  mapContainer.listenOnce(os.MapEvent.MAP_READY, function() {
+    var map = mapContainer.getMap();
+    if (map) {
+      ol.events.listen(map, ol.render.EventType.PRECOMPOSE, updateZoomScale);
+    }
+  });
 
   var oldSetImageStyle = ol.render.canvas.ImageReplay.prototype.setImageStyle;
 
@@ -53,7 +63,6 @@ goog.require('os.map');
       return;
     }
 
-    var zoomScale = getZoomScale();
     if (zoomScale != null) {
       this.scale_ *= zoomScale;
     }

--- a/src/plugin/wmts/mime.js
+++ b/src/plugin/wmts/mime.js
@@ -1,6 +1,7 @@
 goog.provide('plugin.wmts.mime');
 
 goog.require('os.file.mime.xml');
+goog.require('plugin.wmts');
 
 
 os.file.mime.register(


### PR DESCRIPTION
The previous method was both updating the scale too often (once per point), and prone to timing issues. It would fail to render the updated icon scale if the map container view change event fired after OL had already rendered the current extent/resolution.

This approach updates the scale in a `precompose` handler, if the altitude has changed since the last scale update.