### PR TITLE
fix(resize): remove resize listener correctly and support jQuery resize

### DIFF
--- a/externs/jquery-plugins.js
+++ b/externs/jquery-plugins.js
@@ -42,7 +42,7 @@ jQuery.prototype.modal;
 jQuery.prototype.popover;
 
 /**
- * @param {function()} listener
+ * @param {Function} listener
  * @return {!jQuery}
  */
 jQuery.prototype.removeResize;

--- a/src/os/ui/nav/navbarctrl.js
+++ b/src/os/ui/nav/navbarctrl.js
@@ -2,6 +2,7 @@ goog.provide('os.ui.NavBarCtrl');
 
 goog.require('goog.Disposable');
 goog.require('goog.events.Event');
+goog.require('os.ui');
 goog.require('os.ui.list');
 goog.require('os.ui.nav.EventType');
 
@@ -39,7 +40,7 @@ os.ui.NavBarCtrl = function($scope, $element) {
    * @private
    */
   this.resizeFn_ = this.onResize_.bind(this);
-  $element.resize(this.resizeFn_);
+  this.element.resize(this.resizeFn_);
 
   $scope.$on('$destroy', this.dispose.bind(this));
 };
@@ -51,6 +52,10 @@ goog.inherits(os.ui.NavBarCtrl, goog.Disposable);
  */
 os.ui.NavBarCtrl.prototype.disposeInternal = function() {
   os.ui.NavBarCtrl.base(this, 'disposeInternal');
+
+  if (this.element && this.resizeFn_) {
+    os.ui.removeResize(this.element, this.resizeFn_);
+  }
 
   this.scope = null;
   this.element = null;

--- a/src/os/ui/slick/slickgrid.js
+++ b/src/os/ui/slick/slickgrid.js
@@ -17,6 +17,7 @@ goog.require('ol.array');
 goog.require('os.data.ColumnDefinition');
 goog.require('os.events');
 goog.require('os.string');
+goog.require('os.ui');
 goog.require('os.ui.Module');
 goog.require('os.ui.column.columnManagerDirective');
 goog.require('os.ui.globalMenuDirective');
@@ -404,10 +405,10 @@ os.ui.slick.SlickGridCtrl.prototype.disposeInternal = function() {
   goog.dispose(this.resizeDelay);
 
   if (this.container_) {
-    this.container_.off('resize');
+    os.ui.removeResize(this.container_, this.resizeFn);
     this.container_ = null;
   } else {
-    this.element.off('resize');
+    os.ui.removeResize(this.element, this.resizeFn);
   }
 
   if (this.selectionModel_) {

--- a/src/os/ui/timeline/timeline.js
+++ b/src/os/ui/timeline/timeline.js
@@ -20,6 +20,7 @@ goog.require('os.time.TimeInstant');
 goog.require('os.time.TimelineController');
 goog.require('os.time.TimelineEventType');
 goog.require('os.time.timeline');
+goog.require('os.ui');
 goog.require('os.ui.Module');
 goog.require('os.ui.hist.IHistogramChart');
 goog.require('os.ui.timeline.Brush');
@@ -545,7 +546,7 @@ os.ui.timeline.TimelineCtrl.prototype.destroyBrushCollection_ = function(brushCo
  */
 os.ui.timeline.TimelineCtrl.prototype.destroy_ = function() {
   if (this.element_ && this.resizeFn_) {
-    this.element_.removeResize(this.resizeFn_);
+    os.ui.removeResize(this.element_, this.resizeFn_);
     this.resizeFn_ = null;
   }
 

--- a/src/os/ui/ui.js
+++ b/src/os/ui/ui.js
@@ -258,6 +258,25 @@ os.ui.sortDirectives_ = function(a, b) {
 
 
 /**
+ * Remove resize listener from an element.
+ * @param {?(angular.JQLite|jQuery)} el The element.
+ * @param {?Function} fn The callback to remove.
+ */
+os.ui.removeResize = function(el, fn) {
+  if (el && fn) {
+    try {
+      // remove function for the jquery.resize.js vendor library
+      el.removeResize(fn);
+    } catch (e) {
+      // either jquery.resize.js wasn't loaded, or a listener wasn't attached with that library. in either case, also
+      // attempt removing the jQuery-style resize listener.
+      el.off(goog.events.EventType.RESIZE, fn);
+    }
+  }
+};
+
+
+/**
  * Replace a directive already registered with Angular. The directive name and module should be identical to the
  * original.
  *

--- a/src/os/ui/util/autoheight.js
+++ b/src/os/ui/util/autoheight.js
@@ -121,13 +121,11 @@ os.ui.util.AutoHeightCtrl = function($scope, $element, $injector) {
  */
 os.ui.util.AutoHeightCtrl.prototype.onDestroy_ = function() {
   if (this.parent_) {
-    this.parent_.removeResize(this.resizeFn_);
+    os.ui.removeResize(this.parent_, this.resizeFn_);
 
     var siblings = /** @type {string} */ (this.scope_['siblings']);
     if (siblings) {
-      try {
-        this.parent_.find(siblings).removeResize(this.resizeFn_);
-      } catch (e) {}
+      os.ui.removeResize(this.parent_.find(siblings), this.resizeFn_);
     }
 
     this.parent_ = null;

--- a/src/os/ui/util/autovheight.js
+++ b/src/os/ui/util/autovheight.js
@@ -224,11 +224,9 @@ os.ui.util.AutoVHeightCtrl.prototype.removeResizeListeners_ = function() {
     // add resize to common elements
     goog.object.getValues(os.ui.windowCommonElements).forEach(function(sibling) {
       if (this.resizeFn_) {
-        try {
-          $(/** @type {string} */ (sibling)).off(goog.events.EventType.RESIZE, this.resizeFn_);
-        } catch (e) {}
+        os.ui.removeResize($(/** @type {string} */ (sibling)), this.resizeFn_);
       }
-    }.bind(this));
+    }, this);
 
     var siblings = /** @type {string} */ (this.scope_['siblings']);
     if (siblings && this.resizeFn_) {

--- a/src/os/ui/util/offsetmargin.js
+++ b/src/os/ui/util/offsetmargin.js
@@ -1,5 +1,6 @@
 goog.provide('os.ui.util.OffsetMarginCtrl');
 goog.provide('os.ui.util.offsetMarginDirective');
+
 goog.require('goog.Throttle');
 goog.require('os.config.ThemeSettingsChangeEvent');
 goog.require('os.ui');
@@ -100,12 +101,12 @@ os.ui.util.OffsetMarginCtrl.prototype.onDestroy_ = function() {
   }
 
   if (this.bufferTopElement_) {
-    this.bufferTopElement_.removeResize(this.resizeFn_);
+    os.ui.removeResize(this.bufferTopElement_, this.resizeFn_);
     this.bufferTopElement_ = null;
   }
 
   if (this.bufferBotElement_) {
-    this.bufferBotElement_.removeResize(this.resizeFn_);
+    os.ui.removeResize(this.bufferBotElement_, this.resizeFn_);
     this.bufferBotElement_ = null;
   }
 

--- a/src/os/ui/util/punyparent.js
+++ b/src/os/ui/util/punyparent.js
@@ -1,6 +1,8 @@
 goog.provide('os.ui.util.PunyParentCtrl');
 goog.provide('os.ui.util.punyParentDirective');
+
 goog.require('goog.Throttle');
+goog.require('os.ui');
 goog.require('os.ui.Module');
 
 
@@ -72,7 +74,8 @@ os.ui.util.PunyParentCtrl = function($scope, $element) {
  * @private
  */
 os.ui.util.PunyParentCtrl.prototype.destroy_ = function() {
-  this.element_.removeResize(this.resizeFn_);
+  os.ui.removeResize(this.element_, this.resizeFn_);
+
   if (this.throttle_) {
     this.throttle_.dispose();
     this.throttle_ = null;

--- a/src/os/ui/window.js
+++ b/src/os/ui/window.js
@@ -16,6 +16,7 @@ goog.require('goog.events.KeyHandler');
 goog.require('goog.log');
 goog.require('ol.array');
 goog.require('os.array');
+goog.require('os.ui');
 goog.require('os.ui.Module');
 goog.require('os.ui.events.UIEvent');
 goog.require('os.ui.onboarding.contextOnboardingDirective');
@@ -863,7 +864,7 @@ os.ui.WindowCtrl.prototype.disposeInternal = function() {
   }
 
   if (this.element && this.resizeFn_) {
-    this.element.removeResize(this.resizeFn_);
+    os.ui.removeResize(this.element, this.resizeFn_);
     this.resizeFn_ = null;
   }
 

--- a/src/os/ui/wiz/wizardpreview.js
+++ b/src/os/ui/wiz/wizardpreview.js
@@ -3,6 +3,7 @@ goog.provide('os.ui.wiz.wizardPreviewDirective');
 
 goog.require('os.data.ColumnDefinition');
 goog.require('os.im.mapping');
+goog.require('os.ui');
 goog.require('os.ui.Module');
 goog.require('os.ui.slick.slickGridDirective');
 goog.require('os.ui.slick.slickHeaderButtonDirective');
@@ -108,7 +109,7 @@ os.ui.wiz.WizardPreviewCtrl = function($scope, $element, $timeout) {
 os.ui.wiz.WizardPreviewCtrl.prototype.destroy_ = function() {
   if (this.container_) {
     if (this.resizeFn_) {
-      this.container_.removeResize(this.resizeFn_);
+      os.ui.removeResize(this.container_, this.resizeFn_);
       this.resizeFn_ = null;
     }
 

--- a/src/plugin/suncalc/lightstrip.js
+++ b/src/plugin/suncalc/lightstrip.js
@@ -3,6 +3,7 @@ goog.provide('plugin.suncalc.lightStripDirective');
 
 goog.require('goog.async.ConditionalDelay');
 goog.require('os.defines');
+goog.require('os.ui');
 goog.require('os.ui.Module');
 goog.require('plugin.suncalc.LightStripSettings');
 goog.require('plugin.suncalc.LightStripSettingsCtrl');
@@ -104,7 +105,7 @@ plugin.suncalc.LightStripCtrl.prototype.destroy_ = function() {
   this.updateDelay_ = null;
 
   if (this.element_ && this.resizeFn_) {
-    this.element_.parent().removeResize(this.resizeFn_);
+    os.ui.removeResize(this.element_.parent(), this.resizeFn_);
     this.resizeFn_ = null;
   }
 

--- a/test/os/ui.test.js
+++ b/test/os/ui.test.js
@@ -1,0 +1,31 @@
+goog.require('os.ui');
+
+describe('os.ui', function() {
+  it('should remove resize listeners from elements', function() {
+    var callback = function() {};
+    var el = $('<div></div>');
+
+    // doesn't fail when one or both params is null
+    expect(os.ui.removeResize.bind(undefined, null, null)).not.toThrow();
+    expect(os.ui.removeResize.bind(undefined, el, null)).not.toThrow();
+    expect(os.ui.removeResize.bind(undefined, null, callback)).not.toThrow();
+
+    // or when a listener isn't attached
+    expect(os.ui.removeResize.bind(undefined, el, callback)).not.toThrow();
+
+    // doesn't fail when jquery.resize.js isn't loaded, and calls the jQuery remove function
+    spyOn(el, 'off');
+    el.removeResize = undefined;
+    expect(os.ui.removeResize.bind(undefined, el, callback)).not.toThrow();
+    expect(el.off).toHaveBeenCalledWith('resize', callback);
+
+    /**
+     * Don't care what the function is, just that it's called.
+     * @param {Function} fn The callback.
+     */
+    el.removeResize = function(fn) {};
+    spyOn(el, 'removeResize');
+    expect(os.ui.removeResize.bind(undefined, el, callback)).not.toThrow();
+    expect(el.removeResize).toHaveBeenCalledWith(callback);
+  });
+});

--- a/vendor/jquery/jquery.resize.js
+++ b/vendor/jquery/jquery.resize.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
 * Detect Element Resize Plugin for jQuery
 *
@@ -10,9 +11,9 @@
 (function ( $ ) {
 	var attachEvent = document.attachEvent,
 		stylesCreated = false;
-	
+
 	var jQuery_resize = $.fn.resize;
-	
+
 	$.fn.resize = function(callback) {
 		return this.each(function() {
 			if(this == window)
@@ -27,14 +28,14 @@
 			removeResizeListener(this, callback);
 		});
 	}
-	
+
 	if (!attachEvent) {
 		var requestFrame = (function(){
 			var raf = window.requestAnimationFrame || window.mozRequestAnimationFrame || window.webkitRequestAnimationFrame ||
 								function(fn){ return window.setTimeout(fn, 20); };
 			return function(fn){ return raf(fn); };
 		})();
-		
+
 		var cancelFrame = (function(){
 			var cancel = window.cancelAnimationFrame || window.mozCancelAnimationFrame || window.webkitCancelAnimationFrame ||
 								   window.clearTimeout;
@@ -58,7 +59,7 @@
 			return element.offsetWidth != element.__resizeLast__.width ||
 						 element.offsetHeight != element.__resizeLast__.height;
 		}
-		
+
 		function scrollListener(e){
 			var element = this;
 			resetTriggers(this);
@@ -73,7 +74,7 @@
 				}
 			});
 		};
-		
+
 		/* Detect CSS Animations support to detect element display/re-attach */
 		var animation = false,
 			animationstring = 'animation',
@@ -84,8 +85,8 @@
 			pfx  = '';
 		{
 			var elm = document.createElement('fakeelement');
-			if( elm.style.animationName !== undefined ) { animation = true; }    
-			
+			if( elm.style.animationName !== undefined ) { animation = true; }
+
 			if( animation === false ) {
 				for( var i = 0; i < domPrefixes.length; i++ ) {
 					if( elm.style[ domPrefixes[i] + 'AnimationName' ] !== undefined ) {
@@ -99,12 +100,12 @@
 				}
 			}
 		}
-		
+
 		var animationName = 'resizeanim';
 		var animationKeyframes = '@' + keyframeprefix + 'keyframes ' + animationName + ' { from { opacity: 0; } to { opacity: 0; } } ';
 		var animationStyle = keyframeprefix + 'animation: 1ms ' + animationName + '; ';
 	}
-	
+
 	function createStyles() {
 		if (!stylesCreated) {
 			//opacity:0 works around a chrome bug https://code.google.com/p/chromium/issues/detail?id=286360
@@ -113,7 +114,7 @@
 					'.resize-triggers, .resize-triggers > div, .contract-trigger:before { content: \" \"; display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; } .resize-triggers > div { background: #eee; overflow: auto; } .contract-trigger:before { width: 200%; height: 200%; }',
 				head = document.head || document.getElementsByTagName('head')[0],
 				style = document.createElement('style');
-			
+
 			style.type = 'text/css';
 			if (style.styleSheet) {
 				style.styleSheet.cssText = css;
@@ -125,7 +126,7 @@
 			stylesCreated = true;
 		}
 	}
-	
+
 	window.addResizeListener = function(element, fn){
 		if (attachEvent) element.attachEvent('onresize', fn);
 		else {
@@ -140,7 +141,7 @@
 				element.appendChild(element.__resizeTriggers__);
 				resetTriggers(element);
 				element.addEventListener('scroll', scrollListener, true);
-				
+
 				/* Listen for a css animation to detect element display/re-attach */
 				animationstartevent && element.__resizeTriggers__.addEventListener(animationstartevent, function(e) {
 					if(e.animationName == animationName)
@@ -150,13 +151,13 @@
 			element.__resizeListeners__.push(fn);
 		}
 	};
-	
+
 	window.removeResizeListener = function(element, fn){
 		if (attachEvent) element.detachEvent('onresize', fn);
 		else {
 			element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn), 1);
 			if (!element.__resizeListeners__.length) {
-					element.removeEventListener('scroll', scrollListener);
+					element.removeEventListener('scroll', scrollListener, true);
 					element.__resizeTriggers__ = !element.removeChild(element.__resizeTriggers__);
 			}
 		}


### PR DESCRIPTION
The `jquery.resize.js` vendor library we've been using forever has a bug in that it adds an event listener with `capture = true`, and removes it with `capture = false`. This prevents the listener from being removed.

This was manifesting in Cypress tests, which triggered the scroll event after `removeResize` was called and threw an error. It's unlikely this could be reproduced by a user because the element is typically being removed from the DOM when `removeResize` is called, but in the debug build you can call `someEl.removeResize(callbackFn)` and resize the element to see the error.