### PR TITLE
Add Cypress Windows Support under Git Bash

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,6 +12,7 @@
 // the project's config changing)
 
 var addMatchImageSnapshotPlugin = require('cypress-image-snapshot/plugin').addMatchImageSnapshotPlugin;
+os = require('os');
 
 /** This is a description of the foo function.
  *
@@ -22,7 +23,11 @@ module.exports = function(on, config) {
   addMatchImageSnapshotPlugin(on, config);
   on('before:browser:launch', function(browser, args) {
     if (browser.name === 'chrome') {
-      args.push('--window-size=1280,1200');
+      if (os.platform() === 'win32') {
+        args.push('--window-size=1295,1200');
+      } else {
+        args.push('--window-size=1280,1200');
+      }
       return args;
     }
 

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,7 +12,7 @@
 // the project's config changing)
 
 var addMatchImageSnapshotPlugin = require('cypress-image-snapshot/plugin').addMatchImageSnapshotPlugin;
-os = require('os');
+var os = require('os');
 
 /** This is a description of the foo function.
  *

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -58,7 +58,7 @@ Cypress.Commands.add('login', function(clearLocalStorage) {
     indexedDB.deleteDatabase(config.IndexedDB.FILES);
     indexedDB.deleteDatabase(config.IndexedDB.SETTINGS);
   }
-  cy.visit(config.HIDE_TIPS);
+  cy.visit('index.html' + config.HIDE_TIPS); // TODO: Windows 10 issue. Remove index.html after fixed: https://github.com/http-party/http-server/issues/525
   cy.get(layers.layersTab.Tree.STREET_MAP_TILES, {timeout: 15000}).should('be.visible');
   cy.get(layers.layersTab.Tree.LOADING_SPINNER, {timeout: 20000}).should('not.be.visible');
 });

--- a/cypress/support/execute-tests.sh
+++ b/cypress/support/execute-tests.sh
@@ -131,7 +131,7 @@ function overrideSettings() {
 
 function startWebServer() {
   if [ "$OSTYPE" == "msys" ]; then
-    webServerProcess="$(netstat -ano | findstr 0.0.0.0:8282 | awk '{print $5}')"
+    webServerProcess="$(netstat -ano | findstr 0.0.0.0:8282 | awk '{print $5}')" # TODO: Use a process name instead after this is fixed: https://github.com/http-party/http-server/issues/333
   else
     webServerProcess=$(ps -ef | grep http-server | grep -v grep)
   fi
@@ -198,7 +198,7 @@ function stopWebServer() {
   if $SERVER_STARTED; then
     echo 'INFO: terminating web server'
     if [ "$OSTYPE" == "msys" ]; then
-      webServerProcess="$(netstat -ano | findstr 0.0.0.0:8282 | awk '{print $5}')"
+      webServerProcess="$(netstat -ano | findstr 0.0.0.0:8282 | awk '{print $5}')" # TODO: Use a process name instead after this is fixed: https://github.com/http-party/http-server/issues/333
       taskkill //PID $webServerProcess //F
     else
       npm run stop-server

--- a/cypress/support/execute-tests.sh
+++ b/cypress/support/execute-tests.sh
@@ -130,7 +130,11 @@ function overrideSettings() {
 }
 
 function startWebServer() {
-  webServerProcess=$(ps -ef | grep http-server | grep -v grep)
+  if [ "$OSTYPE" == "msys" ]; then
+    webServerProcess="$(netstat -ano | findstr 0.0.0.0:8282 | awk '{print $5}')"
+  else
+    webServerProcess=$(ps -ef | grep http-server | grep -v grep)
+  fi
   
   if [ -z "$webServerProcess" ]; then
     SERVER_STARTED=true
@@ -191,15 +195,16 @@ function runTests() {
 }
 
 function stopWebServer() {
-  if pgrep "node" > /dev/null; then
-    if $SERVER_STARTED; then
-      echo 'INFO: terminating web server'
-      npm run stop-server
+  if $SERVER_STARTED; then
+    echo 'INFO: terminating web server'
+    if [ "$OSTYPE" == "msys" ]; then
+      webServerProcess="$(netstat -ano | findstr 0.0.0.0:8282 | awk '{print $5}')"
+      taskkill //PID $webServerProcess //F
     else
-      echo 'INFO: server was running before tests started, leaving it running'
+      npm run stop-server
     fi
   else
-    echo 'INFO: web server is not running, nothing to terminate'
+    echo 'INFO: server was running before tests started, leaving it running'
   fi
 }
 

--- a/package.json
+++ b/package.json
@@ -132,7 +132,9 @@
     "perms": "chmod -R u+rwX,go+rX,go-w .",
     "semantic-release": "semantic-release --dry-run",
     "start-server": "http-server ../../ -p 8282 -c-1 -o -U -s &",
-    "stop-server": "pkill -f http-server"
+    "stop-server": "run-script-os",
+    "stop-server:macos:linux": "pkill -f http-server",
+    "stop-server:windows": "taskkill -F -PID $(netstat -ano | findstr 0.0.0.0:8282 | awk '{print $5}')"
   },
   "keywords": [
     "geospatial",
@@ -264,6 +266,7 @@
     "opensphere-state-schema": "^2.4.0",
     "postcss-cli": "^5.0.0",
     "rimraf": "^2.5.4",
+    "run-script-os": "^1.0.7",
     "sass-lint": "^1.12.1",
     "semantic-release": "^15.13.18",
     "surge": "^0.20.4",


### PR DESCRIPTION
Changes:

- Added support for image comparisons under Windows.  Image comparisons are off by 15 pixels under Windows, and was throwing `Error: Image size (1279x1000) different than saved snapshot size (1264x1000)`.
- Added workaround for a bug with http-server where Cypress was stuck in an endless redirect loop under Windows http-party/http-server#525
- Added a Windows compatible method of detecting running instances of a web server and terminating those instances automatically or on demand (via `yarn stop-server`)

Tests:

Note: There may be failures with the test scripts, those are fixed here: #735 

- Windows: Cypress tests running via GUI (`npm run cypress:test`) AND CLI (any other cypress script; e.g. `npm run cypress:test-spec smoke-tests/smoke-test.spec.js`) do not immediately fail with a redirect error.  Only need to try one test.
- Linux and MacOS: Web server can be stopped via `yarn stop-server`. Windows: Web server can be stopped via `npm run stop-server`. (not using `yarn stop-server` under Windows due to https://github.com/yarnpkg/yarn/issues/5699)
- Windows: Cypress tests startup without web server already running AND with web server already running (GUI or CLI, doesn't matter)
- Windows and Linux/MacOS: Test scripts containing image comparisons work when launched via GUI. (if there is an image failure, it isn't failing due to snapshot size difference)