### PR TITLE
fix(wfs): tighten up parsing and handling of WFS URLs and output formats

### DIFF
--- a/src/os/ui/ogc/ogcserver.js
+++ b/src/os/ui/ogc/ogcserver.js
@@ -9,6 +9,7 @@ goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('ol.array');
 goog.require('ol.format.WMSCapabilities');
+goog.require('ol.format.XLink');
 goog.require('os.alert.AlertEventSeverity');
 goog.require('os.alert.AlertManager');
 goog.require('os.color');
@@ -182,13 +183,6 @@ os.ui.ogc.OGCServer.LOGGER_ = goog.log.getLogger('os.ui.ogc.OGCServer');
  * @type {string}
  */
 os.ui.ogc.OGCServer.DEFAULT_WMS_VERSION = '1.3.0';
-
-
-/**
- * @const
- * @type {string}
- */
-os.ui.ogc.OGCServer.XLINK_NAMESPACE = 'http://www.w3.org/1999/xlink';
 
 
 /**
@@ -863,8 +857,8 @@ os.ui.ogc.OGCServer.prototype.parseWfsCapabilities = function(response, uri) {
     if (op) {
       var getFeatureEl = op.querySelector('Post');
       if (getFeatureEl != null) {
-        if (getFeatureEl.hasAttributeNS(os.ui.ogc.OGCServer.XLINK_NAMESPACE, 'href')) {
-          this.setWfsUrl(getFeatureEl.getAttributeNS(os.ui.ogc.OGCServer.XLINK_NAMESPACE, 'href'));
+        if (getFeatureEl.hasAttributeNS(ol.format.XLink.NAMESPACE_URI, 'href')) {
+          this.setWfsUrl(getFeatureEl.getAttributeNS(ol.format.XLink.NAMESPACE_URI, 'href'));
         } else {
           var attr = getFeatureEl.attributes[0];
           // Attr.value is the DOM4 property, while Attr.nodeValue inherited from Node should work on older browsers
@@ -874,8 +868,8 @@ os.ui.ogc.OGCServer.prototype.parseWfsCapabilities = function(response, uri) {
       } else {
         getFeatureEl = op.querySelector('Get');
         if (getFeatureEl != null) {
-          if (getFeatureEl.hasAttributeNS(os.ui.ogc.OGCServer.XLINK_NAMESPACE, 'href')) {
-            this.setWfsUrl(getFeatureEl.getAttributeNS(os.ui.ogc.OGCServer.XLINK_NAMESPACE, 'href'));
+          if (getFeatureEl.hasAttributeNS(ol.format.XLink.NAMESPACE_URI, 'href')) {
+            this.setWfsUrl(getFeatureEl.getAttributeNS(ol.format.XLink.NAMESPACE_URI, 'href'));
           } else {
             var attr = getFeatureEl.attributes[0];
             // Attr.value is the DOM4 property, while Attr.nodeValue inherited from Node should work on older browsers

--- a/src/os/ui/ogc/ogcserver.js
+++ b/src/os/ui/ogc/ogcserver.js
@@ -185,6 +185,13 @@ os.ui.ogc.OGCServer.DEFAULT_WMS_VERSION = '1.3.0';
 
 
 /**
+ * @const
+ * @type {string}
+ */
+os.ui.ogc.OGCServer.XLINK_NAMESPACE = 'http://www.w3.org/1999/xlink';
+
+
+/**
  * Default color for OGC descriptors.
  * @const
  * @type {string}
@@ -856,16 +863,24 @@ os.ui.ogc.OGCServer.prototype.parseWfsCapabilities = function(response, uri) {
     if (op) {
       var getFeatureEl = op.querySelector('Post');
       if (getFeatureEl != null) {
-        // Attr.value is the DOM4 property, while Attr.nodeValue inherited from Node should work on older browsers
-        var attr = getFeatureEl.attributes[0];
-        this.setWfsUrl(attr.value || attr.nodeValue);
+        if (getFeatureEl.hasAttributeNS(os.ui.ogc.OGCServer.XLINK_NAMESPACE, 'href')) {
+          this.setWfsUrl(getFeatureEl.getAttributeNS(os.ui.ogc.OGCServer.XLINK_NAMESPACE, 'href'));
+        } else {
+          var attr = getFeatureEl.attributes[0];
+          // Attr.value is the DOM4 property, while Attr.nodeValue inherited from Node should work on older browsers
+          this.setWfsUrl(attr.value || attr.nodeValue);
+        }
         this.setWfsPost(true);
       } else {
         getFeatureEl = op.querySelector('Get');
         if (getFeatureEl != null) {
-          // Attr.value is the DOM4 property, while Attr.nodeValue inherited from Node should work on older browsers
-          var attr = getFeatureEl.attributes[0];
-          this.setWfsUrl(attr.value || attr.nodeValue);
+          if (getFeatureEl.hasAttributeNS(os.ui.ogc.OGCServer.XLINK_NAMESPACE, 'href')) {
+            this.setWfsUrl(getFeatureEl.getAttributeNS(os.ui.ogc.OGCServer.XLINK_NAMESPACE, 'href'));
+          } else {
+            var attr = getFeatureEl.attributes[0];
+            // Attr.value is the DOM4 property, while Attr.nodeValue inherited from Node should work on older browsers
+            this.setWfsUrl(attr.value || attr.nodeValue);
+          }
         }
       }
 

--- a/src/plugin/ogc/wfs/wfslayerconfig.js
+++ b/src/plugin/ogc/wfs/wfslayerconfig.js
@@ -345,8 +345,8 @@ plugin.ogc.wfs.WFSLayerConfig.prototype.addMappings = function(layer, options) {
  */
 plugin.ogc.wfs.WFSLayerConfig.PREFERRED_TYPES = [
   /^application\/json$/,
-  /gml\\?3/i,
-  /gml\\?2/i
+  /gml\/?3/i,
+  /gml\/?2/i
 ];
 
 
@@ -367,18 +367,15 @@ plugin.ogc.wfs.WFSLayerConfig.TYPES = {
  */
 plugin.ogc.wfs.WFSLayerConfig.prototype.getBestType = function(options) {
   var formats = /** @type {Array<string>} */ (options['formats']);
-  var format = this.params.get('outputformat');
+  var format = /** @type {string} */ (this.params.get('outputformat'));
   var preferred = plugin.ogc.wfs.WFSLayerConfig.PREFERRED_TYPES;
 
-  // see if the given format is one we support
-  if (format) {
+  // see if the given format is one mutually supported by the layer and this plugin
+  if (format && formats.includes(format)) {
     for (var i = 0, n = preferred.length; i < n; i++) {
       var regex = preferred[i];
-
-      if (format) {
-        if (regex.test(format)) {
-          return i;
-        }
+      if (regex.test(format)) {
+        return i;
       }
     }
   }


### PR DESCRIPTION
Trying to integrate with a [MapServer](https://mapserver.org/ogc/wfs_server.html) WFS server uncovered some discrepancies in the way the capabilities metadata was parsed and handled.

MapServer provides the URLs in the operations metadata in the following way:

```xml
    <ows:Operation name="GetFeature">
      <ows:DCP>
        <ows:HTTP>
          <ows:Get xlink:type="simple" xlink:href="https://osm-wfs-eric.dev.geointservices.io/wfs?"/>
          <ows:Post xlink:type="simple" xlink:href="https://osm-wfs-eric.dev.geointservices.io/wfs?"/>
        </ows:HTTP>
      </ows:DCP>
      …
    </ows:Operation>
```
This failed to parse correctly in the baseline logic, which assumes the `href` attribute will be the first attribute:
```javascript
         // Attr.value is the DOM4 property, while Attr.nodeValue inherited from Node should work on older browsers
        var attr = getFeatureEl.attributes[0];
        this.setWfsUrl(attr.value || attr.nodeValue);
```
The fix is to explicitly look for the `href` attribute by namespace and name, and fall back to the baseline logic if that fails.

MapServer also does not support JSON output format, which is the OpenSphere default. MapServer does support GML3, included in the `GetFeature` metadata in the following way:
```xml
    <ows:Operation name="GetFeature">
      …
      <ows:Parameter name="outputFormat">
        <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
      </ows:Parameter>
    </ows:Operation>
```
OpenSphere did not recognize the GML3 support, however, due to a discrepancy in the regular expression used to identify the format:
```javascript
plugin.ogc.wfs.WFSLayerConfig.PREFERRED_TYPES = [
  /^application\/json$/,
  /gml\\?3/i,
  /gml\\?2/i
];
```
This will look for `gml\3` instead of `gml/3` in the format string. The fix is to correct the backslash to a slash.
Additionally, the logic in `plugin.ogc.wfs.WFSLayerConfig.prototype.getBestType` failed to recognize that the default format type (`application/json`) was not supported by the layer. I added logic to that function to double-check the inclusion of the defaulted format in the layer-supported formats.
