### PR TITLE
Move filter/feature action import code to importers

### DIFF
--- a/src/os/filter/im/osfilterimport.js
+++ b/src/os/filter/im/osfilterimport.js
@@ -1,10 +1,8 @@
 goog.provide('os.filter.im.OSFilterImportCtrl');
 goog.provide('os.filter.im.osFilterImportDirective');
 
-goog.require('os.color');
-goog.require('os.data.BaseDescriptor');
+goog.require('os.filter.im.OSFilterImporter');
 goog.require('os.implements');
-goog.require('os.layer.ILayer');
 goog.require('os.ui.Module');
 goog.require('os.ui.filter.im.FilterImportCtrl');
 
@@ -45,6 +43,15 @@ goog.inherits(os.filter.im.OSFilterImportCtrl, os.ui.filter.im.FilterImportCtrl)
 
 
 /**
+ * @inheritDoc
+ */
+os.filter.im.OSFilterImportCtrl.prototype.getImporter = function() {
+  var layerId = /** @type {string|undefined} */ (this.scope['layerId']);
+  return new os.filter.im.OSFilterImporter(this.getParser(), layerId);
+};
+
+
+/**
  * Get the base filterable descriptors and add in the filterable layers.
  * @inheritDoc
  */
@@ -65,35 +72,4 @@ os.filter.im.OSFilterImportCtrl.prototype.getFilterables = function() {
   }
 
   return filterables;
-};
-
-
-/**
- * @inheritDoc
- */
-os.filter.im.OSFilterImportCtrl.prototype.getProviderFromFilterable = function(filterable) {
-  var provider = os.filter.im.OSFilterImportCtrl.base(this, 'getProviderFromFilterable', filterable);
-
-  // if the filterable implements a provider name interface function, add that to the title
-  if (!provider && os.implements(filterable, os.layer.ILayer.ID)) {
-    provider = /** @type {!os.layer.ILayer} */ (filterable).getProvider();
-  }
-
-  return provider;
-};
-
-
-/**
- * @inheritDoc
- */
-os.filter.im.OSFilterImportCtrl.prototype.getIconsFromFilterable = function(filterable) {
-  if (os.implements(filterable, os.layer.ILayer.ID)) {
-    var options = /** @type {!os.layer.ILayer} */ (filterable).getLayerOptions();
-    var color = /** @type {string|undefined} */ (options['color']);
-    if (color) {
-      return '<i class="fa fa-bars" style="color:' + os.color.toHexString(color) + '"></i>';
-    }
-  }
-
-  return os.filter.im.OSFilterImportCtrl.base(this, 'getIconsFromFilterable', filterable);
 };

--- a/src/os/filter/im/osfilterimporter.js
+++ b/src/os/filter/im/osfilterimporter.js
@@ -1,0 +1,50 @@
+goog.provide('os.filter.im.OSFilterImporter');
+
+goog.require('os.color');
+goog.require('os.implements');
+goog.require('os.layer.ILayer');
+goog.require('os.ui.filter.im.FilterImporter');
+
+
+/**
+ * @param {os.parse.IParser<T>} parser The parser.
+ * @param {string=} opt_layerId The layer id.
+ * @extends {os.ui.filter.im.FilterImporter}
+ * @constructor
+ * @template T
+ */
+os.filter.im.OSFilterImporter = function(parser, opt_layerId) {
+  os.filter.im.OSFilterImporter.base(this, 'constructor', parser, opt_layerId);
+};
+goog.inherits(os.filter.im.OSFilterImporter, os.ui.filter.im.FilterImporter);
+
+
+/**
+ * @inheritDoc
+ */
+os.filter.im.OSFilterImporter.prototype.getProviderFromFilterable = function(filterable) {
+  var provider = os.filter.im.OSFilterImporter.base(this, 'getProviderFromFilterable', filterable);
+
+  // if the filterable implements a provider name interface function, add that to the title
+  if (!provider && os.implements(filterable, os.layer.ILayer.ID)) {
+    provider = /** @type {!os.layer.ILayer} */ (filterable).getProvider();
+  }
+
+  return provider;
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.filter.im.OSFilterImporter.prototype.getIconsFromFilterable = function(filterable) {
+  if (os.implements(filterable, os.layer.ILayer.ID)) {
+    var options = /** @type {!os.layer.ILayer} */ (filterable).getLayerOptions();
+    var color = /** @type {string|undefined} */ (options['color']);
+    if (color) {
+      return '<i class="fa fa-bars" style="color:' + os.color.toHexString(color) + '"></i>';
+    }
+  }
+
+  return os.filter.im.OSFilterImporter.base(this, 'getIconsFromFilterable', filterable);
+};

--- a/src/os/ui/filter/im/filterimporter.js
+++ b/src/os/ui/filter/im/filterimporter.js
@@ -1,0 +1,288 @@
+goog.provide('os.ui.filter.im.FilterImporter');
+
+goog.require('os.im.Importer');
+goog.require('os.ui');
+
+
+/**
+ * Imports filters.
+ * @param {os.parse.IParser<T>} parser The parser.
+ * @param {string=} opt_layerId The layer id.
+ * @extends {os.im.Importer}
+ * @constructor
+ * @template T
+ */
+os.ui.filter.im.FilterImporter = function(parser, opt_layerId) {
+  os.ui.filter.im.FilterImporter.base(this, 'constructor', parser);
+
+  /**
+   * The layer id.
+   * @type {string|undefined}
+   * @protected
+   */
+  this.layerId = opt_layerId;
+
+  /**
+   * The matched filters.
+   * @type {Object}
+   */
+  this.matched = {};
+
+  /**
+   * The matched filters.
+   * @type {Object}
+   */
+  this.unmatched = {};
+};
+goog.inherits(os.ui.filter.im.FilterImporter, os.im.Importer);
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.filter.im.FilterImporter.prototype.reset = function() {
+  os.ui.filter.im.FilterImporter.base(this, 'reset');
+  this.matched = {};
+  this.unmatched = {};
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.filter.im.FilterImporter.prototype.onParsingComplete = function(opt_event) {
+  this.processData();
+  os.ui.filter.im.FilterImporter.base(this, 'onParsingComplete');
+};
+
+
+/**
+ * Process the parsed filters.
+ * @protected
+ */
+os.ui.filter.im.FilterImporter.prototype.processData = function() {
+  var filters = /** @type {Array<!os.filter.FilterEntry>} */ (this.getData());
+
+  var matched = {};
+  var unmatched = [];
+  var matchedCount = 0;
+
+  for (var i = 0, ii = filters.length; i < ii; i++) {
+    var filter = filters[i];
+    var filterTitle = filter.getTitle();
+    var typeOrFilterKey = filter.getType();
+    var tooltip = this.getFilterTooltip(filter);
+    var icons;
+    var layerTitle;
+    var filterModel;
+    var layerModel;
+
+    if (this.layerId) {
+      // if we have a layer ID, we were passed some context from a filter window, so use it
+      var impliedFilterable = os.ui.filter.getFilterableByType(this.layerId);
+      var columns = impliedFilterable && impliedFilterable.getFilterColumns();
+
+      if (impliedFilterable && columns && filter.matches(columns)) {
+        // this filter matches the columns of the passed in context, so add it as such
+        var clone = filter.clone();
+        clone.setId(goog.string.getRandomString());
+        clone.setType(this.layerId);
+
+        filterModel = this.getFilterModel(filterTitle, clone, tooltip);
+
+        if (matched[this.layerId]) {
+          // add to the existing layer item
+          matched[this.layerId]['filterModels'].push(filterModel);
+        } else {
+          // define a new layer item
+          icons = this.getIconsFromFilterable(impliedFilterable);
+          layerTitle = this.getTitleFromFilterable(impliedFilterable, this.layerId);
+          layerModel = this.getLayerModel(layerTitle, icons, clone.getMatch(), filterModel);
+          matched[this.layerId] = layerModel;
+        }
+
+        matchedCount = os.ui.filter.im.FilterImporter.getFilterCount(filterModel, matchedCount);
+      }
+    } else {
+      var filterableTypes = os.ui.filter.getFilterableTypes(typeOrFilterKey);
+      var filterables = filterableTypes.map(os.ui.filter.getFilterableByType);
+
+      filterables.forEach(function(filterable) {
+        if (filterable) {
+          // we matched it by filter key, so clone the filter and set the internal filterable ID as its type
+          var clone = filter.clone();
+          var type = filterable.getFilterableTypes()[0];
+          clone.setId(goog.string.getRandomString());
+          clone.setType(type);
+
+          filterModel = this.getFilterModel(filterTitle, clone, tooltip);
+
+          if (matched[type]) {
+            matched[type]['filterModels'].push(filterModel);
+          } else {
+            icons = this.getIconsFromFilterable(filterable);
+            layerTitle = this.getTitleFromFilterable(filterable, type);
+            layerModel = this.getLayerModel(layerTitle, icons, clone.getMatch(), filterModel);
+            matched[type] = layerModel;
+          }
+
+          matchedCount = os.ui.filter.im.FilterImporter.getFilterCount(filterModel, matchedCount);
+        }
+      }, this);
+
+      // always allow the user to try to assign the filter to other layers
+      var readableType = filterables[0] ? filterables[0].getTitle() :
+          (filterableTypes[0] || typeOrFilterKey).replace(/\_/g, ' ');
+      filterModel = this.getFilterModel(filter.getTitle(), filter, tooltip, readableType, false);
+      unmatched.push(filterModel);
+    }
+  }
+
+  // assign all the display values
+  this.matched = matched;
+  this.unmatched = unmatched;
+  this.matchedCount = matchedCount;
+};
+
+
+/**
+ * Get the tooltip to display for a filter entry.
+ *
+ * @param {!os.filter.IFilterEntry} entry The filter entry.
+ * @return {string}
+ * @protected
+ */
+os.ui.filter.im.FilterImporter.prototype.getFilterTooltip = function(entry) {
+  return os.ui.filter.toFilterString(entry.getFilterNode(), 1000);
+};
+
+
+/**
+ * Gets a filter model for the UI.
+ *
+ * @param {string} title
+ * @param {os.filter.IFilterEntry} filter
+ * @param {string} tooltip
+ * @param {?string=} opt_type
+ * @param {?boolean=} opt_match
+ * @return {Object}
+ */
+os.ui.filter.im.FilterImporter.prototype.getFilterModel = function(title, filter, tooltip, opt_type, opt_match) {
+  return {
+    'title': title,
+    'filter': filter,
+    'tooltip': tooltip,
+    'type': opt_type,
+    'matches': opt_match
+  };
+};
+
+
+/**
+ * Gets a layer model for the UI.
+ *
+ * @param {?string} layerTitle
+ * @param {string} icons
+ * @param {boolean} match
+ * @param {Object} filterModel
+ * @return {Object}
+ */
+os.ui.filter.im.FilterImporter.prototype.getLayerModel = function(layerTitle, icons, match, filterModel) {
+  var sce = os.ui.injector.get('$sce');
+  var layerIcon = sce ? sce.trustAsHtml(icons) : icons;
+  return {
+    'layerTitle': layerTitle,
+    'layerIcon': layerIcon,
+    'match': match,
+    'filterModels': [filterModel]
+  };
+};
+
+
+/**
+ * Gets icons from a filterable item.
+ *
+ * @param {!os.filter.IFilterable} filterable
+ * @return {string}
+ */
+os.ui.filter.im.FilterImporter.prototype.getIconsFromFilterable = function(filterable) {
+  var icons = '';
+
+  if (os.implements(filterable, os.data.IDataDescriptor.ID)) {
+    var color = /** @type {!os.data.IDataDescriptor} */ (filterable).getColor();
+    if (color) {
+      color = os.color.toHexString(color);
+    } else {
+      color = '#fff';
+    }
+
+    icons = '<i class="fa fa-bars" style="color:' + os.color.toHexString(color) + '"></i>';
+  }
+
+  return icons;
+};
+
+
+/**
+ * Get the parent provider of a filterable, if available.
+ *
+ * @param {!os.filter.IFilterable} filterable The filterable object.
+ * @return {?string} The provider name, or null if not available.
+ */
+os.ui.filter.im.FilterImporter.prototype.getProviderFromFilterable = function(filterable) {
+  var provider = null;
+
+  if (os.implements(filterable, os.data.IDataDescriptor.ID)) {
+    provider = /** @type {!os.data.IDataDescriptor} */ (filterable).getProvider();
+  }
+
+  return provider;
+};
+
+
+/**
+ * Gets as descriptive a title as possible from a filterable item.
+ *
+ * @param {!os.filter.IFilterable} filterable
+ * @param {string} type
+ * @return {?string}
+ */
+os.ui.filter.im.FilterImporter.prototype.getTitleFromFilterable = function(filterable, type) {
+  var title = filterable.getTitle();
+  var firstDelimiter = type.indexOf(os.ui.data.BaseProvider.ID_DELIMITER);
+  var lastDelimiter = type.lastIndexOf(os.ui.data.BaseProvider.ID_DELIMITER);
+
+  if (firstDelimiter !== lastDelimiter) {
+    // tack on the explicit type
+    title += ' ' + goog.string.toTitleCase(type.substring(lastDelimiter + 1));
+  }
+
+  var provider = this.getProviderFromFilterable(filterable);
+  if (provider) {
+    title += ' (' + provider + ')';
+  }
+
+  return title;
+};
+
+
+/**
+ * Gets the total count of filters from a filter model or array of filter models
+ *
+ * @param {(Object|Array<Object>)} filters The filters.
+ * @param {number=} opt_count The current count.
+ * @return {number} The total count.
+ */
+os.ui.filter.im.FilterImporter.getFilterCount = function(filters, opt_count) {
+  var count = opt_count || 0;
+  filters = goog.isArray(filters) ? filters : [filters];
+  filters.forEach(function(filter) {
+    count++;
+
+    if (filter['children']) {
+      count = os.ui.filter.im.FilterImporter.getFilterCount(filter['children'], count);
+    }
+  });
+
+  return count;
+};

--- a/src/os/ui/filter/im/filterimporter.js
+++ b/src/os/ui/filter/im/filterimporter.js
@@ -29,10 +29,10 @@ os.ui.filter.im.FilterImporter = function(parser, opt_layerId) {
   this.matched = {};
 
   /**
-   * The matched filters.
-   * @type {Object}
+   * The unmatched filters.
+   * @type {Array}
    */
-  this.unmatched = {};
+  this.unmatched = [];
 };
 goog.inherits(os.ui.filter.im.FilterImporter, os.im.Importer);
 
@@ -43,7 +43,7 @@ goog.inherits(os.ui.filter.im.FilterImporter, os.im.Importer);
 os.ui.filter.im.FilterImporter.prototype.reset = function() {
   os.ui.filter.im.FilterImporter.base(this, 'reset');
   this.matched = {};
-  this.unmatched = {};
+  this.unmatched = [];
 };
 
 

--- a/src/os/ui/filter/im/filterimportmodel.js
+++ b/src/os/ui/filter/im/filterimportmodel.js
@@ -15,6 +15,7 @@ os.ui.filter.im.filterImportModelDirective = function() {
     // this directive needs to be replace: false to display properly as it is recursive
     replace: false,
     scope: {
+      'layerSelected': '=',
       'models': '=',
       'icon': '=',
       'found': '=',

--- a/src/os/ui/im/action/filteractionimport.js
+++ b/src/os/ui/im/action/filteractionimport.js
@@ -10,6 +10,7 @@ goog.require('os.layer.Drawing');
 goog.require('os.ui.Module');
 goog.require('os.ui.filter');
 goog.require('os.ui.filter.im.filterImportDirective');
+goog.require('os.ui.im.action.FilterActionImporter');
 
 
 /**
@@ -51,6 +52,32 @@ goog.inherits(os.ui.im.action.FilterActionImportCtrl, os.filter.im.OSFilterImpor
 
 /**
  * @inheritDoc
+ * @export
+ */
+os.ui.im.action.FilterActionImportCtrl.prototype.getFilterIcon = function() {
+  return os.im.action.ICON;
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.im.action.FilterActionImportCtrl.prototype.getImporter = function() {
+  var layerId = /** @type {string|undefined} */ (this.scope['layerId']);
+  return new os.ui.im.action.FilterActionImporter(this.getParser(), layerId);
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.im.action.FilterActionImportCtrl.prototype.getParser = function() {
+  return new os.im.action.FilterActionParser();
+};
+
+
+/**
+ * @inheritDoc
  */
 os.ui.im.action.FilterActionImportCtrl.prototype.getFilterables = function() {
   var descriptors = os.dataManager.getDescriptors();
@@ -74,32 +101,6 @@ os.ui.im.action.FilterActionImportCtrl.prototype.getFilterables = function() {
   }
 
   return /** @type {!Array<!os.filter.IFilterable>} */ (filterables);
-};
-
-
-/**
- * @inheritDoc
- */
-os.ui.im.action.FilterActionImportCtrl.prototype.getParser = function() {
-  return new os.im.action.FilterActionParser();
-};
-
-
-/**
- * @inheritDoc
- */
-os.ui.im.action.FilterActionImportCtrl.prototype.getFilterTooltip = function(entry) {
-  var tooltip = 'Filter: ' + os.ui.filter.toFilterString(entry.getFilterNode(), 1000);
-
-  if (entry instanceof os.im.action.FilterActionEntry && entry.actions.length > 0) {
-    var actionText = entry.actions.map(function(action) {
-      return action.getLabel();
-    }).join(', ') || 'None';
-
-    tooltip += '\nActions: ' + actionText;
-  }
-
-  return tooltip;
 };
 
 
@@ -181,39 +182,4 @@ os.ui.im.action.FilterActionImportCtrl.prototype.finish = function() {
   }
 
   os.ui.window.close(this.element);
-};
-
-
-/**
- * @inheritDoc
- * @export
- */
-os.ui.im.action.FilterActionImportCtrl.prototype.getFilterIcon = function() {
-  return os.im.action.ICON;
-};
-
-
-/**
- * @inheritDoc
- */
-os.ui.im.action.FilterActionImportCtrl.prototype.getFilterModel = function(
-    title, filter, tooltip, opt_type, opt_match) {
-  var children = filter.getChildren();
-  var childModels;
-  if (children) {
-    childModels = [];
-    children.forEach(function(child) {
-      var model = this.getFilterModel(child.getTitle(), child, this.getFilterTooltip(child), opt_type);
-      childModels.push(model);
-    }, this);
-  }
-
-  return {
-    'title': title,
-    'filter': filter,
-    'tooltip': tooltip,
-    'type': opt_type,
-    'matches': opt_match,
-    'children': childModels
-  };
 };

--- a/src/os/ui/im/action/filteractionimporter.js
+++ b/src/os/ui/im/action/filteractionimporter.js
@@ -1,0 +1,63 @@
+goog.provide('os.ui.im.action.FilterActionImporter');
+
+goog.require('os.color');
+goog.require('os.filter.im.OSFilterImporter');
+goog.require('os.implements');
+goog.require('os.layer.ILayer');
+
+
+/**
+ * @param {os.parse.IParser<T>} parser The parser.
+ * @param {string=} opt_layerId The layer id.
+ * @extends {os.filter.im.OSFilterImporter}
+ * @constructor
+ * @template T
+ */
+os.ui.im.action.FilterActionImporter = function(parser, opt_layerId) {
+  os.ui.im.action.FilterActionImporter.base(this, 'constructor', parser, opt_layerId);
+};
+goog.inherits(os.ui.im.action.FilterActionImporter, os.filter.im.OSFilterImporter);
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.im.action.FilterActionImporter.prototype.getFilterModel = function(
+    title, filter, tooltip, opt_type, opt_match) {
+  var children = filter.getChildren();
+  var childModels;
+  if (children) {
+    childModels = [];
+    children.forEach(function(child) {
+      var model = this.getFilterModel(child.getTitle(), child, this.getFilterTooltip(child), opt_type);
+      childModels.push(model);
+    }, this);
+  }
+
+  return {
+    'title': title,
+    'filter': filter,
+    'tooltip': tooltip,
+    'type': opt_type,
+    'matches': opt_match,
+    'children': childModels
+  };
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.im.action.FilterActionImporter.prototype.getFilterTooltip = function(entry) {
+  var tooltip = 'Filter: ' + os.ui.filter.toFilterString(entry.getFilterNode(), 1000);
+
+  if (entry instanceof os.im.action.FilterActionEntry && entry.actions.length > 0) {
+    var actionText = entry.actions.map(function(action) {
+      return action.getLabel();
+    }).join(', ') || 'None';
+
+    tooltip += '\nActions: ' + actionText;
+  }
+
+  return tooltip;
+};

--- a/src/os/ui/layer/layerpicker.js
+++ b/src/os/ui/layer/layerpicker.js
@@ -272,6 +272,18 @@ os.ui.layer.LayerPickerCtrl.prototype.getGroup = function(layer) {
 
 
 /**
+ * Returns the ID for the layer.
+ *
+ * @param {os.data.IDataDescriptor|os.filter.IFilterable} layer The layer.
+ * @return {?string}
+ * @export
+ */
+os.ui.layer.LayerPickerCtrl.prototype.getLayerId = function(layer) {
+  return layer ? layer.getId() : null;
+};
+
+
+/**
  * Search result formatter. The select is actually storing the ID of each
  * descriptor. This function allows us to display the actual layer title.
  *

--- a/views/filter/im/filterimport.html
+++ b/views/filter/im/filterimport.html
@@ -14,11 +14,17 @@
       </div>
     </div>
     <div ng-if="ctrl.hasUnmatchedFilters">
-      The file contains the following {{ctrl.getFilterTitle(ctrl.matchedCount)}}. Any {{ctrl.getFilterTitle(1)}} with an <i class="fa fa-times text-danger"></i> does not match the selected layer.
+      The file contains the following {{ctrl.getFilterTitle(ctrl.unmatched.length)}}.
+      <span ng-if="ctrl.layer">Any {{ctrl.getFilterTitle(1)}} with an <i class="fa fa-times text-danger"></i> does not match the selected layer.</span>
     </div>
 
-    <div class="u-table u-table__no-hover my-1 border" ng-if="ctrl.unmatched.length">
-      <filterimportmodel models="ctrl.unmatched" icon="ctrl.getFilterIcon()" found="false"></filterimportmodel>
+    <div class="u-table u-table__no-hover my-1 border" ng-if="ctrl.hasUnmatchedFilters && ctrl.unmatched.length">
+      <filterimportmodel
+          layer-selected="!!ctrl.layer"
+          models="ctrl.unmatched"
+          icon="ctrl.getFilterIcon()"
+          found="false">
+      </filterimportmodel>
     </div>
 
     <div ng-if="ctrl.matchedCount > 0" class="u-table u-table-striped u-table__no-hover border">

--- a/views/filter/im/filterimportmodel.html
+++ b/views/filter/im/filterimportmodel.html
@@ -1,15 +1,17 @@
-<div ng-repeat="filter in models" title="{{filter.tooltip}}" class="text-truncate u-table__row" ng-class="isChild ? 'ml-4' : ''">
+<div ng-repeat="filter in models" title="{{filter.tooltip}}" class="col text-truncate u-table__row" ng-class="isChild ? 'ml-4' : ''">
   <div ng-if="found">
     <i class="fa" ng-class="icon"></i> {{filter.title}}
   </div>
   <div class="d-flex" ng-if="!found">
     <span class="flex-fill text-truncate">
-      <i class="fa mx-1" ng-class="{'fa-times text-danger': !filter.matches, 'fa-check text-success': filter.matches}"
+      <i ng-show="layerSelected" class="fa"
+          ng-class="{'fa-times text-danger': !filter.matches, 'fa-check text-success': filter.matches}"
           title="{{{false: 'This filter does not match the selected layer', true: 'This filter matches the columns for the selected layer'}[filter.matches]}}"></i>
       {{filter.title}}
     </span>
-    <span class="mr-1" title="This {{ctrl.getFilterTitle(1)}} most likely matches {{filter.type}}">
-      ({{filter.type}})
+    <span class="mr-1" title="This filter most likely matches {{filter.type}}">
+      <i class="fa fa-question-circle"></i>
+      {{filter.type}}
     </span>
   </div>
   <filterimportmodel ng-if="filter.children" models="filter.children" icon="icon" found="found" is-child="true"></filterimportmodel>

--- a/views/layer/layerpicker.html
+++ b/views/layer/layerpicker.html
@@ -1,6 +1,6 @@
 <div>
-  <select ng-if="!pickerCtrl.multiple()" ng-model="layer" ng-options="l.getId() group by pickerCtrl.getGroup(l) for l in pickerCtrl.layersList"
+  <select ng-if="!pickerCtrl.multiple()" ng-model="layer" ng-options="pickerCtrl.getLayerId(l) group by pickerCtrl.getGroup(l) for l in pickerCtrl.layersList"
     ng-change="pickerCtrl.layerPicked(layer)" class="js-layer-picker w-100" ng-required="isRequired"/>
-  <select ng-if="pickerCtrl.multiple()" ng-model="layers" ng-options="l.getId() group by pickerCtrl.getGroup(l) for l in pickerCtrl.layersList"
+  <select ng-if="pickerCtrl.multiple()" ng-model="layers" ng-options="pickerCtrl.getLayerId(l) group by pickerCtrl.getGroup(l) for l in pickerCtrl.layersList"
     ng-change="pickerCtrl.layersChanged(layers)" class="js-layer-picker w-100" ng-required="isRequired" multiple/>
 </div>


### PR DESCRIPTION
The code used to import filters and feature actions was within the UI controllers, preventing reuse of the code outside those UI's. To allow importing these elsewhere, all import code has been extracted to importers and the UI's now have a `getImporter` function to provide the appropriate importer.

To test, verify filters and feature actions import as they did before.

Additional changes:
* The filter import UI will no longer show the check/X icons until a layer has been selected, or the text explaining the red X. This is intended to avoid potential confusion because the UI previously showed the red X when no layer was selected.
* The layer picker was using the layer/descriptor `getId` function in the Angular template, and those functions are not exported. This prevented the layer function from working in the compiled app, though the descriptor function was not minified so that part was working. Active layers will now appear in the select dropdown in the compiled app.