### PR TITLE
build(windows): fix font path in Windows

### DIFF
--- a/scss/fontloader.scss
+++ b/scss/fontloader.scss
@@ -17,7 +17,7 @@
 
   // Replace the url to be local
   $web-font-path: str-replace($web-font-path,
-    'https://fonts.googleapis.com/css?family=', '../../vendor/fonts/typeface-');
+    'https://fonts.googleapis.com/css?family=', '../../../opensphere/vendor/fonts/typeface-');
 
   // Replace + with -
   $web-font-path: str-replace($web-font-path, '+', '-');
@@ -42,7 +42,7 @@
   $web-font-path: to-lower-case($web-font-path);
 
   // Example End
-  // $web-font-path: '../../vendor/fonts/typeface-source-sans-pro/index.css'
+  // $web-font-path: '../../../opensphere/vendor/fonts/typeface-source-sans-pro/index.css'
 
   // Final import paths
   @import url($web-font-path);


### PR DESCRIPTION
The old setup was only suitable if a project had a symlink from `project/vendor/fonts` to `opensphere/vendor/fonts`. Symlinks do not work in Windows.

Therefore, this change uses a well-defined path to opensphere within the workspace.

Note that I do not believe that this method is compatible with using opensphere as a library within `node_modules`. That will need to be a follow-on for later investigation.