### PR TITLE
fix(arc): fix multipolygon parsing from oriented rings

### DIFF
--- a/src/os/geo/geo2.js
+++ b/src/os/geo/geo2.js
@@ -176,3 +176,38 @@ os.geo2.normalizeGeometryCoordinates = function(geometry, opt_to, opt_proj) {
   return false;
 };
 
+/**
+ * @enum {boolean}
+ */
+os.geo2.WindingOrder = {
+  CLOCKWISE: true,
+  COUNTER_CLOCKWISE: false
+};
+
+/**
+ * @param {Array<Array<number>>} ring
+ * @return {number}
+ */
+os.geo2.computeArea = function(ring) {
+  var length = ring.length;
+  var area = 0.0;
+  for (var i0 = length - 1, i1 = 0; i1 < length; i0 = i1++) {
+    var v0 = ring[i0];
+    var v1 = ring[i1];
+
+    area += (v0[0] * v1[1]) - (v1[0] * v0[1]);
+  }
+  return area * 0.5;
+};
+
+/**
+ * @param {Array<Array<number>>} ring The linear or polygon ring to check
+ * @return {os.geo2.WindingOrder}
+ */
+os.geo2.computeWindingOrder = function(ring) {
+  var area = os.geo2.computeArea(ring);
+  if (area > 0.0) {
+    return os.geo2.WindingOrder.COUNTER_CLOCKWISE;
+  }
+  return os.geo2.WindingOrder.CLOCKWISE;
+};

--- a/src/plugin/arc/arcjsonparser.js
+++ b/src/plugin/arc/arcjsonparser.js
@@ -3,10 +3,13 @@ goog.provide('plugin.arc.ArcJSONParser');
 goog.require('goog.Disposable');
 goog.require('ol.Feature');
 goog.require('ol.geom.LineString');
+goog.require('ol.geom.LinearRing');
 goog.require('ol.geom.MultiPoint');
+goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
 goog.require('os.feature');
+goog.require('os.geo2');
 goog.require('os.parse.IParser');
 
 
@@ -167,12 +170,40 @@ plugin.arc.ArcJSONParser.prototype.parseLineStringGeometry_ = function(item) {
  * Parses a Polygon geometry out from an Arc Geometry.
  *
  * @param {Object} item
- * @return {ol.geom.Polygon}
+ * @return {ol.geom.Polygon|ol.geom.MultiPolygon}
  * @private
  */
 plugin.arc.ArcJSONParser.prototype.parsePolygonGeometry_ = function(item) {
-  var coords = item['rings'];
-  return new ol.geom.Polygon(coords);
+  var rings = item['rings'];
+  var polygons = [];
+  // for (var i in rings) {
+  //   polygons[i] = new ol.geom.Polygon([rings[i]]);
+  // }
+  for (var i = 0; i < rings.length; i++) {
+    if (os.geo2.computeWindingOrder(rings[i]) == os.geo2.WindingOrder.CLOCKWISE) {
+      // polygons[i] = new ol.geom.Polygon([rings[i]]);
+      polygons.push(new ol.geom.Polygon([rings[i]]));
+    }
+  }
+  for (var i = 0; i < rings.length; i++) {
+    if (os.geo2.computeWindingOrder(rings[i]) == os.geo2.WindingOrder.COUNTER_CLOCKWISE) {
+      var x = rings[i][0][0];
+      var y = rings[i][0][1];
+      for (var j = 0; j < polygons.length; j++) {
+        if (polygons[j].containsXY(x, y)) {
+          polygons[j].appendLinearRing(new ol.geom.LinearRing(rings[i]));
+          break;
+        }
+      }
+    }
+  }
+
+  if (polygons.length > 1) {
+    var multi = new ol.geom.MultiPolygon(null);
+    multi.setPolygons(polygons);
+    return multi;
+  }
+  return polygons[0];
 };
 
 

--- a/test/os/geo/geo2.test.js
+++ b/test/os/geo/geo2.test.js
@@ -114,4 +114,19 @@ describe('os.geo2', function() {
       }
     });
   });
+
+
+  it('should properly compute the area of a ring', function() { 
+    var ring = [[0,0], [2,0], [2,2], [0,2], [0,0]];
+    var csRing = ring.map(function(coord) {
+      return {x: coord[0], y: coord[1]};
+    });
+    expect(os.geo2.computeArea(ring)).toBe(Cesium.PolygonPipeline.computeArea2D(csRing));
+  });
+
+  it('should properly compute winding order', function() {
+    var ring = [[0, 0], [2,0], [2,2], [0,2], [0,0]];
+    expect(os.geo2.computeWindingOrder(ring)).toBe(os.geo2.WindingOrder.COUNTER_CLOCKWISE);
+  });
+
 });

--- a/test/plugin/arc/arcjsonparser.test.js
+++ b/test/plugin/arc/arcjsonparser.test.js
@@ -49,9 +49,29 @@ describe('plugin.arc.ArcJSONParser', function() {
     expect(olGeom.getCoordinates()[3][0]).toBe(9);
   });
 
-  it('should parse Arc polygon geometries', function() {
+  iit('should parse Arc polygon geometries', function() {
     var parser = new plugin.arc.ArcJSONParser();
+
+    // Testing one Polygon
     var arcPolygon = {
+      'rings': [
+        [
+          [0, 18],
+          [-32, 5],
+          [-56, 56],
+          [0, 18]
+        ]
+      ]
+    }
+    var olGeom = parser.parsePolygonGeometry_(arcPolygon);
+    expect(olGeom instanceof ol.geom.Polygon).toBe(true);
+    expect(olGeom.getCoordinates()[0][0][0]).toBe(0);
+    expect(olGeom.getCoordinates()[0][0][1]).toBe(18);
+    expect(olGeom.getCoordinates()[0][3][0]).toBe(0);
+    expect(olGeom.getCoordinates()[0][3][1]).toBe(18);
+
+    // Testing a MultiPolygon
+    arcPolygon = {
       'rings': [
         [
           [0, 18],
@@ -68,17 +88,17 @@ describe('plugin.arc.ArcJSONParser', function() {
       ]
     };
 
-    var olGeom = parser.parsePolygonGeometry_(arcPolygon);
-    expect(olGeom instanceof ol.geom.Polygon).toBe(true);
-    expect(olGeom.getCoordinates()[0][0][0]).toBe(0);
-    expect(olGeom.getCoordinates()[0][0][1]).toBe(18);
-    expect(olGeom.getCoordinates()[0][3][0]).toBe(0);
-    expect(olGeom.getCoordinates()[0][3][1]).toBe(18);
+    olGeom = parser.parsePolygonGeometry_(arcPolygon);
+    expect(olGeom instanceof ol.geom.MultiPolygon).toBe(true);
+    expect(olGeom.getCoordinates()[0][0][0][0]).toBe(0);
+    expect(olGeom.getCoordinates()[0][0][0][1]).toBe(18);
+    expect(olGeom.getCoordinates()[0][0][3][0]).toBe(0);
+    expect(olGeom.getCoordinates()[0][0][3][1]).toBe(18);
 
-    expect(olGeom.getCoordinates()[1][0][0]).toBe(-185);
-    expect(olGeom.getCoordinates()[1][0][1]).toBe(290);
-    expect(olGeom.getCoordinates()[1][2][1]).toBe(-20);
-    expect(olGeom.getCoordinates()[1][1][1]).toBe(50);
+    expect(olGeom.getCoordinates()[1][0][0][0]).toBe(-185);
+    expect(olGeom.getCoordinates()[1][0][0][1]).toBe(290);
+    expect(olGeom.getCoordinates()[1][0][2][1]).toBe(-20);
+    expect(olGeom.getCoordinates()[1][0][1][1]).toBe(50);
   });
 
   it('should parse Arc multipoint geometries', function() {


### PR DESCRIPTION
resolves #739

Added computeWindingOrder function and updated parsePolygonGeometry to sort internal and external rings into Polygon and MultiPolygon objects. Added or updated utests.