### PR TITLE
Add sortable search result interface

### DIFF
--- a/src/os/search/abstractsearchresult.js
+++ b/src/os/search/abstractsearchresult.js
@@ -15,21 +15,23 @@ goog.require('os.search.ISearchResult');
  * @template T
  */
 os.search.AbstractSearchResult = function(result, opt_score, opt_id) {
-  os.search.AbstractSearchResult.nextId_++;
-
+  // allow truthy values or explicit 0, not an empty string
   /**
+   * The result id.
    * @type {number|string}
    * @private
    */
-  this.id_ = opt_id || os.search.AbstractSearchResult.nextId_;
+  this.id_ = opt_id || opt_id === 0 ? opt_id : os.search.AbstractSearchResult.nextId_++;
 
   /**
+   * The result.
    * @type {T}
    * @protected
    */
   this.result = result;
 
   /**
+   * The result score.
    * @type {number}
    * @protected
    */
@@ -38,6 +40,7 @@ os.search.AbstractSearchResult = function(result, opt_score, opt_id) {
 
 
 /**
+ * Incrementing counter for results that do not specify an id.
  * @type {number}
  * @private
  */

--- a/src/os/search/isortableresult.js
+++ b/src/os/search/isortableresult.js
@@ -1,0 +1,25 @@
+goog.provide('os.search.ISortableResult');
+
+
+
+/**
+ * Interface representing a sortable search result.
+ * @interface
+ * @template T
+ */
+os.search.ISortableResult = function() {};
+
+
+/**
+ * ID for {@see os.implements}
+ * @const {string}
+ */
+os.search.ISortableResult.ID = 'os.search.ISortableResult';
+
+
+/**
+ * Get the value for a sort type.
+ * @param {string} sortType The sort type.
+ * @return {?string} The sort value, or null if the value doesn't exist or sort type is not supported.
+ */
+os.search.ISortableResult.prototype.getSortValue;

--- a/src/os/search/search.js
+++ b/src/os/search/search.js
@@ -37,7 +37,9 @@ os.search.SearchSetting = {
  */
 os.search.SortType = {
   DATE: 'Date',
-  RELEVANCE: 'Relevance'
+  RECENTLY_USED: 'Recently Used',
+  RELEVANCE: 'Relevance',
+  TITLE: 'Title'
 };
 
 

--- a/src/os/ui/search/place/coordinateresult.js
+++ b/src/os/ui/search/place/coordinateresult.js
@@ -1,10 +1,15 @@
 goog.provide('os.ui.search.place.CoordinateResult');
 
 goog.require('ol.Feature');
+goog.require('os.data.RecordField');
 goog.require('os.feature');
+goog.require('os.implements');
 goog.require('os.search.AbstractSearchResult');
+goog.require('os.search.ISortableResult');
+goog.require('os.search.SortType');
 goog.require('os.style');
 goog.require('os.style.label');
+goog.require('os.time.ITime');
 goog.require('os.ui.search.place.coordResultCardDirective');
 
 
@@ -16,6 +21,7 @@ goog.require('os.ui.search.place.coordResultCardDirective');
  * @param {string=} opt_label The feature label field.
  * @param {number=} opt_score The search result score.
  * @extends {os.search.AbstractSearchResult<!ol.Feature>}
+ * @implements {os.search.ISortableResult}
  * @constructor
  */
 os.ui.search.place.CoordinateResult = function(result, opt_label, opt_score) {
@@ -46,6 +52,7 @@ os.ui.search.place.CoordinateResult = function(result, opt_label, opt_score) {
   }
 };
 goog.inherits(os.ui.search.place.CoordinateResult, os.search.AbstractSearchResult);
+os.implements(os.ui.search.place.CoordinateResult, os.search.ISortableResult.ID);
 
 
 /**
@@ -99,6 +106,32 @@ os.ui.search.place.CoordinateResult.prototype.performAction = function() {
  */
 os.ui.search.place.CoordinateResult.prototype.getSearchUI = function() {
   return '<coordresultcard></coordresultcard>';
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.search.place.CoordinateResult.prototype.getSortValue = function(sortType) {
+  var value;
+
+  if (this.result) {
+    switch (sortType) {
+      case os.search.SortType.DATE:
+        var time = this.result.get(os.data.RecordField.TIME);
+        if (os.implements(time, os.time.ITime.ID)) {
+          value = /** @type {os.time.ITime} */ (time.getStart());
+        }
+        break;
+      case os.search.SortType.TITLE:
+        value = os.feature.getTitle(this.result) || null;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return value != null ? String(value) : null;
 };
 
 

--- a/test/os/search/abstractsearchresult.test.js
+++ b/test/os/search/abstractsearchresult.test.js
@@ -1,0 +1,61 @@
+goog.require('os.search.AbstractSearchResult');
+
+describe('os.search.AbstractSearchResult', function() {
+  it('auto increments ids when not specified', function() {
+    os.search.AbstractSearchResult.nextId_ = 0;
+
+    // no id provided
+    expect(new os.search.AbstractSearchResult().getId()).toBe(0);
+    expect(new os.search.AbstractSearchResult().getId()).toBe(1);
+    expect(new os.search.AbstractSearchResult().getId()).toBe(2);
+
+    // empty string provided
+    expect(new os.search.AbstractSearchResult(null, 0, '').getId()).toBe(3);
+    expect(new os.search.AbstractSearchResult(null, 0, '').getId()).toBe(4);
+
+    // null provided
+    expect(new os.search.AbstractSearchResult(null, 0, null).getId()).toBe(5);
+    expect(new os.search.AbstractSearchResult(null, 0, null).getId()).toBe(6);
+  });
+
+  it('sets the id from parameters', function() {
+    os.search.AbstractSearchResult.nextId_ = 10;
+
+    expect(new os.search.AbstractSearchResult(null, 0, 0).getId()).toBe(0);
+    expect(new os.search.AbstractSearchResult(null, 0, 100).getId()).toBe(100);
+    expect(new os.search.AbstractSearchResult(null, 0, 'testId').getId()).toBe('testId');
+
+    // no id provided uses the next id
+    expect(new os.search.AbstractSearchResult().getId()).toBe(10);
+  });
+
+  it('sets the score from parameters', function() {
+    expect(new os.search.AbstractSearchResult().getScore()).toBe(0);
+    expect(new os.search.AbstractSearchResult(null, null).getScore()).toBe(0);
+    expect(new os.search.AbstractSearchResult(null, 100).getScore()).toBe(100);
+  });
+
+  it('sets the score', function() {
+    var result = new os.search.AbstractSearchResult();
+    expect(result.getScore()).toBe(0);
+
+    result.setScore(100);
+    expect(result.getScore()).toBe(100);
+  });
+
+  it('sets the result from parameters', function() {
+    var data = {};
+    expect(new os.search.AbstractSearchResult().getResult()).toBeUndefined();
+    expect(new os.search.AbstractSearchResult(null).getResult()).toBeNull();
+    expect(new os.search.AbstractSearchResult(data).getResult()).toBe(data);
+  });
+
+  it('sets the result', function() {
+    var data = {};
+    var result = new os.search.AbstractSearchResult();
+    expect(result.getResult()).toBeUndefined();
+
+    result.setResult(data);
+    expect(result.getResult()).toBe(data);
+  });
+});

--- a/test/os/ui/search/place/coordinateresult.test.js
+++ b/test/os/ui/search/place/coordinateresult.test.js
@@ -1,0 +1,63 @@
+goog.require('ol.Feature');
+goog.require('os.search.ISortableResult');
+goog.require('os.search.SortType');
+goog.require('os.time.TimeInstant');
+goog.require('os.time.TimeRange');
+goog.require('os.ui.search.place.CoordinateResult');
+
+describe('os.ui.search.place.CoordinateResult', function() {
+  var createResult = function(opt_options) {
+    var options = opt_options || {};
+    var featureOptions = options.featureOptions || {};
+    var feature = new ol.Feature(featureOptions);
+
+    var label = options.label != null ? options.label : undefined;
+    var score = options.score != null ? options.score : 0;
+    return new os.ui.search.place.CoordinateResult(feature, label, score);
+  };
+
+  describe('os.search.ISortableResult', function() {
+    it('implements the sortable result interface', function() {
+      var result = createResult();
+      expect(os.implements(result, os.search.ISortableResult.ID)).toBe(true);
+    });
+
+    it('gets sort values for the title', function() {
+      expect(createResult().getSortValue(os.search.SortType.TITLE)).toBeNull();
+      expect(createResult({
+        featureOptions: {
+          name: 'testTitle'
+        }
+      }).getSortValue(os.search.SortType.TITLE)).toBe('testTitle');
+      expect(createResult({
+        featureOptions: {
+          title: 'testTitle'
+        }
+      }).getSortValue(os.search.SortType.TITLE)).toBe('testTitle');
+    });
+
+    it('gets sort values for the date', function() {
+      expect(createResult().getSortValue(os.search.SortType.DATE)).toBeNull();
+      expect(createResult({
+        featureOptions: {
+          recordTime: Date.now()
+        }
+      }).getSortValue(os.search.SortType.DATE)).toBeNull();
+
+      var start = Date.now();
+      var end = start + 1000;
+
+      expect(createResult({
+        featureOptions: {
+          recordTime: new os.time.TimeInstant(start)
+        }
+      }).getSortValue(os.search.SortType.DATE)).toBe(String(start));
+
+      expect(createResult({
+        featureOptions: {
+          recordTime: new os.time.TimeRange(start, end)
+        }
+      }).getSortValue(os.search.SortType.DATE)).toBe(String(start));
+    });
+  });
+});


### PR DESCRIPTION
* Adds a new interface to allow search results to provide sort values.
* Fixes a bug in the abstract search result preventing setting the `id` to literal `0`.