### PR TITLE
Layers Search Grid

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -146,7 +146,11 @@
       }
     },
     "search": {
-      "enableAll": true
+      "enableAll": true,
+      "grid" : {
+        "detail": 0.25,
+        "detailMax": 350
+      }
     },
     "facetedSearch": {
       "categories": {

--- a/src/os/geo/geo2.js
+++ b/src/os/geo/geo2.js
@@ -176,3 +176,38 @@ os.geo2.normalizeGeometryCoordinates = function(geometry, opt_to, opt_proj) {
   return false;
 };
 
+/**
+ * @enum {boolean}
+ */
+os.geo2.WindingOrder = {
+  CLOCKWISE: true,
+  COUNTER_CLOCKWISE: false
+};
+
+/**
+ * @param {Array<Array<number>>} ring
+ * @return {number}
+ */
+os.geo2.computeArea = function(ring) {
+  var length = ring.length;
+  var area = 0.0;
+  for (var i0 = length - 1, i1 = 0; i1 < length; i0 = i1++) {
+    var v0 = ring[i0];
+    var v1 = ring[i1];
+
+    area += (v0[0] * v1[1]) - (v1[0] * v0[1]);
+  }
+  return area * 0.5;
+};
+
+/**
+ * @param {Array<Array<number>>} ring The linear or polygon ring to check
+ * @return {os.geo2.WindingOrder}
+ */
+os.geo2.computeWindingOrder = function(ring) {
+  var area = os.geo2.computeArea(ring);
+  if (area > 0.0) {
+    return os.geo2.WindingOrder.COUNTER_CLOCKWISE;
+  }
+  return os.geo2.WindingOrder.CLOCKWISE;
+};

--- a/src/os/search/abstractsearchresult.js
+++ b/src/os/search/abstractsearchresult.js
@@ -15,21 +15,23 @@ goog.require('os.search.ISearchResult');
  * @template T
  */
 os.search.AbstractSearchResult = function(result, opt_score, opt_id) {
-  os.search.AbstractSearchResult.nextId_++;
-
+  // allow truthy values or explicit 0, not an empty string
   /**
+   * The result id.
    * @type {number|string}
    * @private
    */
-  this.id_ = opt_id || os.search.AbstractSearchResult.nextId_;
+  this.id_ = opt_id || opt_id === 0 ? opt_id : os.search.AbstractSearchResult.nextId_++;
 
   /**
+   * The result.
    * @type {T}
    * @protected
    */
   this.result = result;
 
   /**
+   * The result score.
    * @type {number}
    * @protected
    */
@@ -38,6 +40,7 @@ os.search.AbstractSearchResult = function(result, opt_score, opt_id) {
 
 
 /**
+ * Incrementing counter for results that do not specify an id.
  * @type {number}
  * @private
  */

--- a/src/os/search/isortableresult.js
+++ b/src/os/search/isortableresult.js
@@ -1,0 +1,25 @@
+goog.provide('os.search.ISortableResult');
+
+
+
+/**
+ * Interface representing a sortable search result.
+ * @interface
+ * @template T
+ */
+os.search.ISortableResult = function() {};
+
+
+/**
+ * ID for {@see os.implements}
+ * @const {string}
+ */
+os.search.ISortableResult.ID = 'os.search.ISortableResult';
+
+
+/**
+ * Get the value for a sort type.
+ * @param {string} sortType The sort type.
+ * @return {?string} The sort value, or null if the value doesn't exist or sort type is not supported.
+ */
+os.search.ISortableResult.prototype.getSortValue;

--- a/src/os/search/search.js
+++ b/src/os/search/search.js
@@ -37,7 +37,9 @@ os.search.SearchSetting = {
  */
 os.search.SortType = {
   DATE: 'Date',
-  RELEVANCE: 'Relevance'
+  RECENTLY_USED: 'Recently Used',
+  RELEVANCE: 'Relevance',
+  TITLE: 'Title'
 };
 
 

--- a/src/os/style/areastyle.js
+++ b/src/os/style/areastyle.js
@@ -107,6 +107,23 @@ os.style.area.SEARCH_AREA_STYLE = new ol.style.Style({
 
 
 /**
+ * Style for the search grid.
+ *
+ * @type {ol.style.Style}
+ * @const
+ */
+os.style.area.SEARCH_GRID_STYLE = new ol.style.Style({
+  stroke: new ol.style.Stroke({
+    color: 'rgba(245,245,245,1.0)',
+    lineCap: 'square',
+    width: 2
+  }),
+  fill: new ol.style.Fill({
+    color: 'rgba(255,255,255,0.15)'
+  })
+});
+
+/**
  * @type {Object}
  * @const
  */

--- a/src/os/track.js
+++ b/src/os/track.js
@@ -101,15 +101,7 @@ os.track.AddOptions;
  *   color: (string|undefined),
  *   name: (string|undefined),
  *   sortField: (string|undefined),
-<<<<<<< HEAD
-<<<<<<< HEAD
  *   label: (string|null|undefined),
-=======
- *   label: (string|undefined),
->>>>>>> b2822792... feat(track): add function to split features into tracks
-=======
- *   label: (string|null|undefined),
->>>>>>> fc74c7b2... refactor(track): disable labels when splitting features into tracks
  *   includeMetadata: (boolean|undefined),
  *   useLayerStyle: (boolean|undefined)
  * }}
@@ -120,17 +112,8 @@ os.track.CreateOptions;
 /**
  * @typedef {{
  *   features: Array<ol.Feature>,
-<<<<<<< HEAD
-<<<<<<< HEAD
  *   field: (string|undefined),
  *   bucketFn: ((function(ol.Feature):?)|undefined),
-=======
- *   field: string,
->>>>>>> b2822792... feat(track): add function to split features into tracks
-=======
- *   field: (string|undefined),
- *   bucketFn: ((function(ol.Feature):?)|undefined),
->>>>>>> 266f3457... feat(track): add/expand track API's
  *   getTrackFn: ((function((string|number)):ol.Feature)|undefined),
  *   result: (Array<ol.Feature>|undefined)
  * }}
@@ -310,22 +293,9 @@ os.track.getTrackCoordinates = function(features, sortField, opt_metadataMap) {
       if (opt_metadataMap) {
         opt_metadataMap[value] = {};
 
-<<<<<<< HEAD
-<<<<<<< HEAD
         for (var key in feature.values_) {
           if (!os.feature.isInternalField(key)) {
             opt_metadataMap[value][key] = feature.values_[key];
-=======
-        var props = feature.getProperties();
-        for (var key in props) {
-          if (!os.feature.isInternalField(key)) {
-            opt_metadataMap[value][key] = props[key];
->>>>>>> b2822792... feat(track): add function to split features into tracks
-=======
-        for (var key in feature.values_) {
-          if (!os.feature.isInternalField(key)) {
-            opt_metadataMap[value][key] = feature.values_[key];
->>>>>>> c17a160b... perf(track): optimizations for clamp and getTrackCoordinates
           }
         }
       }
@@ -593,16 +563,11 @@ os.track.clamp = function(track, start, end) {
     endIndex += stride;
   }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> c17a160b... perf(track): optimizations for clamp and getTrackCoordinates
   if (endIndex - startIndex != geometry.flatCoordinates.length) {
     var prevLength = geometry.flatCoordinates.length;
     if (startIndex < endIndex) {
       // splice the clamped range from the array
       var newCoords = geometry.flatCoordinates.splice(startIndex, endIndex - startIndex);
-<<<<<<< HEAD
 
       // remove metadata for remaining coordinates
       os.track.pruneMetadata_(track, geometry.flatCoordinates, stride);
@@ -618,101 +583,6 @@ os.track.clamp = function(track, start, end) {
     if (geometry.flatCoordinates.length !== prevLength) {
       os.track.setGeometry(track, geometry);
     }
-=======
-  var prevLength = flatCoordinates.length;
-  if (startIndex < endIndex) {
-    // splice the clamped range from the array
-    var newCoords = flatCoordinates.splice(startIndex, endIndex - startIndex);
-=======
->>>>>>> c17a160b... perf(track): optimizations for clamp and getTrackCoordinates
-
-      // remove metadata for remaining coordinates
-      os.track.pruneMetadata_(track, geometry.flatCoordinates, stride);
-
-<<<<<<< HEAD
-    // set flat coordinates to the clamped list
-    geometry.flatCoordinates = newCoords;
-  } else {
-    flatCoordinates.length = 0;
-    track.values_[os.track.TrackField.METADATA_MAP] = {};
->>>>>>> eeabfa7f... fix(track): clean up metadata when clamping tracks
-  }
-};
-
-
-/**
- * Truncate a track to a maximum number of points. Keeps the most recent points.
- *
- * @param {!ol.Feature} track The track.
- * @param {number} size The size.
- *
- * @suppress {accessControls} To allow direct access to feature metadata and line coordinates.
- */
-os.track.truncate = function(track, size) {
-  // ensure size is >= 0
-  size = Math.max(0, size);
-
-  // add point(s) to the original geometry, in case the track was interpolated
-  var geometry = /** @type {!(os.track.TrackLike)} */ (track.values_[os.interpolate.ORIGINAL_GEOM_FIELD] ||
-      track.getGeometry());
-
-  if (geometry.getType() === ol.geom.GeometryType.MULTI_LINE_STRING) {
-    // merge the split line so coordinates can be truncated to the correct size
-    geometry.toLonLat();
-    geometry = os.geo.mergeLineGeometry(geometry);
-    geometry.osTransform();
-  }
-
-  var flatCoordinates = geometry.flatCoordinates;
-  var stride = geometry.stride;
-  var numCoords = size * stride;
-
-  if (flatCoordinates.length > numCoords) {
-    var removed = flatCoordinates.splice(0, flatCoordinates.length - numCoords);
-    os.track.setGeometry(track, geometry);
-
-    // remove old metadata fields from the track
-    os.track.pruneMetadata_(track, removed, stride);
-  }
-};
-
-
-/**
- * Prune the metadata map for a track, removing metadata by indexed sort values.
- * @param {!ol.Feature} track The track.
- * @param {!Array} values The values to remove.
- * @param {number=} opt_stride If provided, the `values` array stride. Use if providing a list of flat coordinates that
- *                             contain sort values as the last coordinate value.
- * @private
- *
- * @suppress {accessControls} To allow direct access to feature metadata.
- */
-os.track.pruneMetadata_ = function(track, values, opt_stride) {
-  var stride = Math.max(0, opt_stride || 1);
-
-  var metadataMap = /** @type {Object|undefined} */ (track.values_[os.track.TrackField.METADATA_MAP]);
-  if (metadataMap) {
-    for (var i = 0; i < values.length; i += stride) {
-      var next = values[i + stride - 1];
-      if (next != null) {
-        metadataMap[next] = undefined;
-      }
-    }
-
-    track.values_[os.track.TrackField.METADATA_MAP] = os.object.prune(metadataMap);
-=======
-      // set flat coordinates to the clamped list
-      geometry.flatCoordinates = newCoords;
-    } else {
-      geometry.flatCoordinates.length = 0;
-      track.values_[os.track.TrackField.METADATA_MAP] = {};
-    }
-
-    // update the geometry on the track
-    if (geometry.flatCoordinates.length !== prevLength) {
-      os.track.setGeometry(track, geometry);
-    }
->>>>>>> c17a160b... perf(track): optimizations for clamp and getTrackCoordinates
   }
 };
 
@@ -1678,10 +1548,6 @@ os.track.updateTrackZIndex = function(tracks) {
 
 
 /**
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 266f3457... feat(track): add/expand track API's
  * Bucket features by a field.
  * @param {string} field The field.
  * @param {ol.Feature} feature The feature.
@@ -1702,7 +1568,6 @@ os.track.bucketByField = function(field, feature) {
 
 
 /**
-<<<<<<< HEAD
  * Split features into tracks.
  * @param {os.track.SplitOptions} options The options.
  * @return {!Array<!ol.Feature>} The resulting tracks. Also contains any features not used to create tracks.
@@ -1715,31 +1580,6 @@ os.track.splitIntoTracks = function(options) {
 
   if (features && bucketFn) {
     var buckets = goog.array.bucket(features, bucketFn);
-=======
-=======
->>>>>>> 266f3457... feat(track): add/expand track API's
- * Split features into tracks.
- * @param {os.track.SplitOptions} options The options.
- * @return {!Array<!ol.Feature>} The resulting tracks. Also contains any features not used to create tracks.
- */
-os.track.splitIntoTracks = function(options) {
-  var features = options.features;
-  var result = options.result || [];
-  var bucketFn = options.bucketFn || (options.field ? os.track.bucketByField.bind(undefined, options.field) : null);
-  var getTrackFn = options.getTrackFn || goog.nullFunction;
-
-<<<<<<< HEAD
-  if (features && field) {
-    var buckets = goog.array.bucket(features, function(feature) {
-      // if the feature does not have a value for the field, add it to the ignore bucket so it can be included in the
-      // result. this avoids dropping features that aren't added to a track.
-      return feature ? (feature.values_[field] != null ? feature.values_[field] : os.object.IGNORE_VAL) : undefined;
-    });
->>>>>>> b2822792... feat(track): add function to split features into tracks
-=======
-  if (features && bucketFn) {
-    var buckets = goog.array.bucket(features, bucketFn);
->>>>>>> 266f3457... feat(track): add/expand track API's
 
     for (var id in buckets) {
       var bucketFeatures = buckets[id];
@@ -1763,14 +1603,7 @@ os.track.splitIntoTracks = function(options) {
             name: id,
             features: bucketFeatures,
             includeMetadata: true,
-<<<<<<< HEAD
-<<<<<<< HEAD
             label: null,
-=======
->>>>>>> b2822792... feat(track): add function to split features into tracks
-=======
-            label: null,
->>>>>>> fc74c7b2... refactor(track): disable labels when splitting features into tracks
             useLayerStyle: true
           });
 

--- a/src/os/track.js
+++ b/src/os/track.js
@@ -101,7 +101,15 @@ os.track.AddOptions;
  *   color: (string|undefined),
  *   name: (string|undefined),
  *   sortField: (string|undefined),
+<<<<<<< HEAD
+<<<<<<< HEAD
  *   label: (string|null|undefined),
+=======
+ *   label: (string|undefined),
+>>>>>>> b2822792... feat(track): add function to split features into tracks
+=======
+ *   label: (string|null|undefined),
+>>>>>>> fc74c7b2... refactor(track): disable labels when splitting features into tracks
  *   includeMetadata: (boolean|undefined),
  *   useLayerStyle: (boolean|undefined)
  * }}
@@ -112,8 +120,17 @@ os.track.CreateOptions;
 /**
  * @typedef {{
  *   features: Array<ol.Feature>,
+<<<<<<< HEAD
+<<<<<<< HEAD
  *   field: (string|undefined),
  *   bucketFn: ((function(ol.Feature):?)|undefined),
+=======
+ *   field: string,
+>>>>>>> b2822792... feat(track): add function to split features into tracks
+=======
+ *   field: (string|undefined),
+ *   bucketFn: ((function(ol.Feature):?)|undefined),
+>>>>>>> 266f3457... feat(track): add/expand track API's
  *   getTrackFn: ((function((string|number)):ol.Feature)|undefined),
  *   result: (Array<ol.Feature>|undefined)
  * }}
@@ -293,9 +310,22 @@ os.track.getTrackCoordinates = function(features, sortField, opt_metadataMap) {
       if (opt_metadataMap) {
         opt_metadataMap[value] = {};
 
+<<<<<<< HEAD
+<<<<<<< HEAD
         for (var key in feature.values_) {
           if (!os.feature.isInternalField(key)) {
             opt_metadataMap[value][key] = feature.values_[key];
+=======
+        var props = feature.getProperties();
+        for (var key in props) {
+          if (!os.feature.isInternalField(key)) {
+            opt_metadataMap[value][key] = props[key];
+>>>>>>> b2822792... feat(track): add function to split features into tracks
+=======
+        for (var key in feature.values_) {
+          if (!os.feature.isInternalField(key)) {
+            opt_metadataMap[value][key] = feature.values_[key];
+>>>>>>> c17a160b... perf(track): optimizations for clamp and getTrackCoordinates
           }
         }
       }
@@ -563,11 +593,16 @@ os.track.clamp = function(track, start, end) {
     endIndex += stride;
   }
 
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> c17a160b... perf(track): optimizations for clamp and getTrackCoordinates
   if (endIndex - startIndex != geometry.flatCoordinates.length) {
     var prevLength = geometry.flatCoordinates.length;
     if (startIndex < endIndex) {
       // splice the clamped range from the array
       var newCoords = geometry.flatCoordinates.splice(startIndex, endIndex - startIndex);
+<<<<<<< HEAD
 
       // remove metadata for remaining coordinates
       os.track.pruneMetadata_(track, geometry.flatCoordinates, stride);
@@ -583,6 +618,101 @@ os.track.clamp = function(track, start, end) {
     if (geometry.flatCoordinates.length !== prevLength) {
       os.track.setGeometry(track, geometry);
     }
+=======
+  var prevLength = flatCoordinates.length;
+  if (startIndex < endIndex) {
+    // splice the clamped range from the array
+    var newCoords = flatCoordinates.splice(startIndex, endIndex - startIndex);
+=======
+>>>>>>> c17a160b... perf(track): optimizations for clamp and getTrackCoordinates
+
+      // remove metadata for remaining coordinates
+      os.track.pruneMetadata_(track, geometry.flatCoordinates, stride);
+
+<<<<<<< HEAD
+    // set flat coordinates to the clamped list
+    geometry.flatCoordinates = newCoords;
+  } else {
+    flatCoordinates.length = 0;
+    track.values_[os.track.TrackField.METADATA_MAP] = {};
+>>>>>>> eeabfa7f... fix(track): clean up metadata when clamping tracks
+  }
+};
+
+
+/**
+ * Truncate a track to a maximum number of points. Keeps the most recent points.
+ *
+ * @param {!ol.Feature} track The track.
+ * @param {number} size The size.
+ *
+ * @suppress {accessControls} To allow direct access to feature metadata and line coordinates.
+ */
+os.track.truncate = function(track, size) {
+  // ensure size is >= 0
+  size = Math.max(0, size);
+
+  // add point(s) to the original geometry, in case the track was interpolated
+  var geometry = /** @type {!(os.track.TrackLike)} */ (track.values_[os.interpolate.ORIGINAL_GEOM_FIELD] ||
+      track.getGeometry());
+
+  if (geometry.getType() === ol.geom.GeometryType.MULTI_LINE_STRING) {
+    // merge the split line so coordinates can be truncated to the correct size
+    geometry.toLonLat();
+    geometry = os.geo.mergeLineGeometry(geometry);
+    geometry.osTransform();
+  }
+
+  var flatCoordinates = geometry.flatCoordinates;
+  var stride = geometry.stride;
+  var numCoords = size * stride;
+
+  if (flatCoordinates.length > numCoords) {
+    var removed = flatCoordinates.splice(0, flatCoordinates.length - numCoords);
+    os.track.setGeometry(track, geometry);
+
+    // remove old metadata fields from the track
+    os.track.pruneMetadata_(track, removed, stride);
+  }
+};
+
+
+/**
+ * Prune the metadata map for a track, removing metadata by indexed sort values.
+ * @param {!ol.Feature} track The track.
+ * @param {!Array} values The values to remove.
+ * @param {number=} opt_stride If provided, the `values` array stride. Use if providing a list of flat coordinates that
+ *                             contain sort values as the last coordinate value.
+ * @private
+ *
+ * @suppress {accessControls} To allow direct access to feature metadata.
+ */
+os.track.pruneMetadata_ = function(track, values, opt_stride) {
+  var stride = Math.max(0, opt_stride || 1);
+
+  var metadataMap = /** @type {Object|undefined} */ (track.values_[os.track.TrackField.METADATA_MAP]);
+  if (metadataMap) {
+    for (var i = 0; i < values.length; i += stride) {
+      var next = values[i + stride - 1];
+      if (next != null) {
+        metadataMap[next] = undefined;
+      }
+    }
+
+    track.values_[os.track.TrackField.METADATA_MAP] = os.object.prune(metadataMap);
+=======
+      // set flat coordinates to the clamped list
+      geometry.flatCoordinates = newCoords;
+    } else {
+      geometry.flatCoordinates.length = 0;
+      track.values_[os.track.TrackField.METADATA_MAP] = {};
+    }
+
+    // update the geometry on the track
+    if (geometry.flatCoordinates.length !== prevLength) {
+      os.track.setGeometry(track, geometry);
+    }
+>>>>>>> c17a160b... perf(track): optimizations for clamp and getTrackCoordinates
   }
 };
 
@@ -1548,6 +1678,10 @@ os.track.updateTrackZIndex = function(tracks) {
 
 
 /**
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 266f3457... feat(track): add/expand track API's
  * Bucket features by a field.
  * @param {string} field The field.
  * @param {ol.Feature} feature The feature.
@@ -1568,6 +1702,7 @@ os.track.bucketByField = function(field, feature) {
 
 
 /**
+<<<<<<< HEAD
  * Split features into tracks.
  * @param {os.track.SplitOptions} options The options.
  * @return {!Array<!ol.Feature>} The resulting tracks. Also contains any features not used to create tracks.
@@ -1580,6 +1715,31 @@ os.track.splitIntoTracks = function(options) {
 
   if (features && bucketFn) {
     var buckets = goog.array.bucket(features, bucketFn);
+=======
+=======
+>>>>>>> 266f3457... feat(track): add/expand track API's
+ * Split features into tracks.
+ * @param {os.track.SplitOptions} options The options.
+ * @return {!Array<!ol.Feature>} The resulting tracks. Also contains any features not used to create tracks.
+ */
+os.track.splitIntoTracks = function(options) {
+  var features = options.features;
+  var result = options.result || [];
+  var bucketFn = options.bucketFn || (options.field ? os.track.bucketByField.bind(undefined, options.field) : null);
+  var getTrackFn = options.getTrackFn || goog.nullFunction;
+
+<<<<<<< HEAD
+  if (features && field) {
+    var buckets = goog.array.bucket(features, function(feature) {
+      // if the feature does not have a value for the field, add it to the ignore bucket so it can be included in the
+      // result. this avoids dropping features that aren't added to a track.
+      return feature ? (feature.values_[field] != null ? feature.values_[field] : os.object.IGNORE_VAL) : undefined;
+    });
+>>>>>>> b2822792... feat(track): add function to split features into tracks
+=======
+  if (features && bucketFn) {
+    var buckets = goog.array.bucket(features, bucketFn);
+>>>>>>> 266f3457... feat(track): add/expand track API's
 
     for (var id in buckets) {
       var bucketFeatures = buckets[id];
@@ -1603,7 +1763,14 @@ os.track.splitIntoTracks = function(options) {
             name: id,
             features: bucketFeatures,
             includeMetadata: true,
+<<<<<<< HEAD
+<<<<<<< HEAD
             label: null,
+=======
+>>>>>>> b2822792... feat(track): add function to split features into tracks
+=======
+            label: null,
+>>>>>>> fc74c7b2... refactor(track): disable labels when splitting features into tracks
             useLayerStyle: true
           });
 

--- a/src/os/ui/draw/draw.js
+++ b/src/os/ui/draw/draw.js
@@ -1,4 +1,12 @@
 goog.provide('os.ui.draw');
+goog.provide('os.ui.draw.utils');
+
+goog.require('ol.Feature');
+goog.require('ol.geom.Polygon');
+goog.require('ol.style.Fill');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
+goog.require('os.geo.jsts.OLParser');
 
 
 /**
@@ -6,3 +14,110 @@ goog.provide('os.ui.draw');
  * @type {os.ui.menu.Menu|undefined}
  */
 os.ui.draw.MENU = undefined;
+os.ui.draw.GRID_DETAIL = 'search.grid.detail';
+os.ui.draw.GRID_DETAIL_MAX = 'search.grid.detailMax';
+
+
+/**
+ * Build a list of features to represent the search grid that intersects with the drawn geometry
+ *
+ * @param {ol.Feature} feature The source feature to trace.
+ * @param {number} detail The number of degrees to which to "snap" the grid
+ * @return {Array.<ol.Feature>}
+ *
+ * @suppress {accessControls} To allow direct access to feature metadata.
+ */
+os.ui.draw.utils.getGridFromFeature = function(feature, detail) {
+  if (!feature) return null;
+
+  var features = [];
+  var geo = feature.getGeometry();
+
+  geo.toLonLat(); // convert to lon/lat so grid 'detail' (in degrees) can be applied easily
+  var extent = geo.getExtent(); // build a simplified box around the search geometry
+  geo.osTransform(); // undo transformation so copyFeature() succeeds
+
+  // the number of boxes (X * Y) at which to skip this grid feature; from settings.json
+  var mult = os.ui.draw.utils.getGridSetting(os.ui.draw.GRID_DETAIL_MAX, 100.0);
+
+  // don't continue building the grid if it would create too many boxes
+  if ((Math.ceil(Math.abs(extent[2] - extent[0]) / detail) *
+      Math.ceil(Math.abs(extent[3] - extent[1]) / detail)) > mult) return null;
+
+  // snap box coordinates to the nearest "detail" degrees
+  var snap = function(l, d, ceil) {
+    if ((l % d) != 0.0) return Math.floor(l / d) * d + (ceil ? d : 0.0);
+    return l;
+  };
+
+  extent[0] = snap(extent[0], detail, false); // lon min
+  extent[1] = snap(extent[1], detail, false); // lat min
+  extent[2] = snap(extent[2], detail, true); // lon max
+  extent[3] = snap(extent[3], detail, true); // lat max
+
+  var style = os.style.area.SEARCH_GRID_STYLE;
+  var cfg = {
+    lon: {
+      n: (extent[0] < extent[2]) ? extent[0] : extent[2],
+      x: (extent[0] < extent[2]) ? extent[2] : extent[0]
+    },
+    lat: {
+      n: (extent[1] < extent[3]) ? extent[1] : extent[3],
+      x: (extent[1] < extent[3]) ? extent[3] : extent[1]
+    }
+  }; // sort the data so the loops later are faster
+
+  var prop = {};
+  goog.object.extend(prop, feature.values_);
+  delete prop['geometry'];
+  delete prop['_node'];
+
+  // TODO research a better, faster way to create/approximate the grid
+  // build detail x detail degree boxes that fit the "snapped" extent
+  for (var lon = cfg.lon.n; lon < cfg.lon.x; lon += detail) {
+    for (var lat = cfg.lat.n; lat < cfg.lat.x; lat += detail) {
+      var gridExtent = ol.proj.transformExtent(
+          [lon, lat, lon + detail, lat + detail],
+          os.proj.EPSG4326,
+          os.map.PROJECTION);
+
+      // only add this to the grid if the original polygon intersects it
+      if (feature.getGeometry().intersectsExtent(gridExtent)) {
+        // new() is faster than doing os.feature.copyFeature(feature)
+        var g = ol.geom.Polygon.fromExtent(gridExtent);
+        var prop_ = {'geometry': g};
+        goog.object.extend(prop_, prop);
+
+        var f = new ol.Feature(prop_);
+        f.setId(goog.string.getRandomString());
+        f.setStyle(style);
+        f.set(os.data.RecordField.DRAWING_LAYER_NODE, true);
+        f.set(os.data.RecordField.INTERACTIVE, false);
+
+        features.push(f);
+      }
+    }
+  }
+
+  // TODO build a union-ed multipolygon of this 'grid'
+
+  return features;
+};
+
+
+/**
+ * Helper function; gets a numeric representation of the JSON setting
+ *
+ * @param {string} key
+ * @param {number} defaultValue
+ * @return {number}
+ */
+os.ui.draw.utils.getGridSetting = function(key, defaultValue) {
+  var value = defaultValue;
+  try {
+    value = parseFloat(os.settings.get(key, defaultValue));
+  } catch (e) {
+    // do nothing
+  }
+  return value;
+};

--- a/src/os/ui/search/place/coordinateresult.js
+++ b/src/os/ui/search/place/coordinateresult.js
@@ -1,10 +1,15 @@
 goog.provide('os.ui.search.place.CoordinateResult');
 
 goog.require('ol.Feature');
+goog.require('os.data.RecordField');
 goog.require('os.feature');
+goog.require('os.implements');
 goog.require('os.search.AbstractSearchResult');
+goog.require('os.search.ISortableResult');
+goog.require('os.search.SortType');
 goog.require('os.style');
 goog.require('os.style.label');
+goog.require('os.time.ITime');
 goog.require('os.ui.search.place.coordResultCardDirective');
 
 
@@ -16,6 +21,7 @@ goog.require('os.ui.search.place.coordResultCardDirective');
  * @param {string=} opt_label The feature label field.
  * @param {number=} opt_score The search result score.
  * @extends {os.search.AbstractSearchResult<!ol.Feature>}
+ * @implements {os.search.ISortableResult}
  * @constructor
  */
 os.ui.search.place.CoordinateResult = function(result, opt_label, opt_score) {
@@ -46,6 +52,7 @@ os.ui.search.place.CoordinateResult = function(result, opt_label, opt_score) {
   }
 };
 goog.inherits(os.ui.search.place.CoordinateResult, os.search.AbstractSearchResult);
+os.implements(os.ui.search.place.CoordinateResult, os.search.ISortableResult.ID);
 
 
 /**
@@ -99,6 +106,32 @@ os.ui.search.place.CoordinateResult.prototype.performAction = function() {
  */
 os.ui.search.place.CoordinateResult.prototype.getSearchUI = function() {
   return '<coordresultcard></coordresultcard>';
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.search.place.CoordinateResult.prototype.getSortValue = function(sortType) {
+  var value;
+
+  if (this.result) {
+    switch (sortType) {
+      case os.search.SortType.DATE:
+        var time = this.result.get(os.data.RecordField.TIME);
+        if (os.implements(time, os.time.ITime.ID)) {
+          value = /** @type {os.time.ITime} */ (time.getStart());
+        }
+        break;
+      case os.search.SortType.TITLE:
+        value = os.feature.getTitle(this.result) || null;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return value != null ? String(value) : null;
 };
 
 

--- a/src/plugin/file/shp/shpexporter.js
+++ b/src/plugin/file/shp/shpexporter.js
@@ -132,6 +132,15 @@ plugin.file.shp.SHPExporter.LOGGER_ = goog.log.getLogger('plugin.file.shp.SHPExp
 
 
 /**
+ * PRJ content for WGS84.
+ * @type {string}
+ * @const
+ */
+plugin.file.shp.SHPExporter.PRJ_WGS84 = 'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",' +
+    'SPHEROID["WGS_1984",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]]';
+
+
+/**
  * @inheritDoc
  */
 plugin.file.shp.SHPExporter.prototype.getExtension = function() {
@@ -250,9 +259,9 @@ plugin.file.shp.SHPExporter.prototype.parseColumn_ = function(item, col) {
     }
 
     // determine the precision for numeric columns
-    if (this.columnTypes_[name] == 'N' && value.match(/^\d*\.\d+$/)) {
+    if (this.columnTypes_[name] == 'N' && value.match(/^[+-]?\d*\.\d+$/)) {
       var currentPrecision = this.columnPrecisions_[name] || 0;
-      this.columnPrecisions_[name] = Math.min(Math.max(currentPrecision, value.replace(/^\d*\./, '').length), 255);
+      this.columnPrecisions_[name] = Math.min(Math.max(currentPrecision, value.replace(/^[+-]?\d*\./, '').length), 255);
     } else {
       this.columnPrecisions_[name] = 0;
     }
@@ -565,6 +574,9 @@ plugin.file.shp.SHPExporter.prototype.appendDBFHeader = function() {
 
   // write record size
   this.dvDbf_.setUint16(10, recordSize + 1, true);
+
+  // language driver ID (ANSI)
+  this.dvDbf_.setUint16(29, 0x57, true);
 
   // write header (column info)
   os.array.forEach(this.columns_, function(col, index) {
@@ -1090,6 +1102,11 @@ plugin.file.shp.SHPExporter.prototype.appendFooter = function() {
   shxFile.setContent(this.header_.shx.data.slice(0, this.header_.shx.position));
   shxFile.setFileName(this.name + '.shx');
   this.addFile(shxFile);
+
+  var prjFile = new os.file.File();
+  prjFile.setContent(plugin.file.shp.SHPExporter.PRJ_WGS84);
+  prjFile.setFileName(this.name + '.prj');
+  this.addFile(prjFile);
 };
 
 

--- a/test/os/geo/geo2.test.js
+++ b/test/os/geo/geo2.test.js
@@ -114,4 +114,26 @@ describe('os.geo2', function() {
       }
     });
   });
+
+
+  it('should properly compute the area of a ring', function() {
+    var ring = [[0,0], [2,0], [2,2], [0,2], [0,0]];
+    var csRing = ring.map(function(coord) {
+      return {x: coord[0], y: coord[1]};
+    });
+    expect(os.geo2.computeArea(ring)).toBe(Cesium.PolygonPipeline.computeArea2D(csRing));
+
+    ring = ring.reverse();
+    csRing = csRing.reverse();
+    expect(os.geo2.computeArea(ring)).toBe(Cesium.PolygonPipeline.computeArea2D(csRing));
+  });
+
+  it('should properly compute winding order', function() {
+    var ring = [[0, 0], [2,0], [2,2], [0,2], [0,0]];
+    expect(os.geo2.computeWindingOrder(ring)).toBe(os.geo2.WindingOrder.COUNTER_CLOCKWISE);
+
+    ring = ring.reverse();
+    expect(os.geo2.computeWindingOrder(ring)).toBe(os.geo2.WindingOrder.CLOCKWISE);
+  });
+
 });

--- a/test/os/search/abstractsearchresult.test.js
+++ b/test/os/search/abstractsearchresult.test.js
@@ -1,0 +1,61 @@
+goog.require('os.search.AbstractSearchResult');
+
+describe('os.search.AbstractSearchResult', function() {
+  it('auto increments ids when not specified', function() {
+    os.search.AbstractSearchResult.nextId_ = 0;
+
+    // no id provided
+    expect(new os.search.AbstractSearchResult().getId()).toBe(0);
+    expect(new os.search.AbstractSearchResult().getId()).toBe(1);
+    expect(new os.search.AbstractSearchResult().getId()).toBe(2);
+
+    // empty string provided
+    expect(new os.search.AbstractSearchResult(null, 0, '').getId()).toBe(3);
+    expect(new os.search.AbstractSearchResult(null, 0, '').getId()).toBe(4);
+
+    // null provided
+    expect(new os.search.AbstractSearchResult(null, 0, null).getId()).toBe(5);
+    expect(new os.search.AbstractSearchResult(null, 0, null).getId()).toBe(6);
+  });
+
+  it('sets the id from parameters', function() {
+    os.search.AbstractSearchResult.nextId_ = 10;
+
+    expect(new os.search.AbstractSearchResult(null, 0, 0).getId()).toBe(0);
+    expect(new os.search.AbstractSearchResult(null, 0, 100).getId()).toBe(100);
+    expect(new os.search.AbstractSearchResult(null, 0, 'testId').getId()).toBe('testId');
+
+    // no id provided uses the next id
+    expect(new os.search.AbstractSearchResult().getId()).toBe(10);
+  });
+
+  it('sets the score from parameters', function() {
+    expect(new os.search.AbstractSearchResult().getScore()).toBe(0);
+    expect(new os.search.AbstractSearchResult(null, null).getScore()).toBe(0);
+    expect(new os.search.AbstractSearchResult(null, 100).getScore()).toBe(100);
+  });
+
+  it('sets the score', function() {
+    var result = new os.search.AbstractSearchResult();
+    expect(result.getScore()).toBe(0);
+
+    result.setScore(100);
+    expect(result.getScore()).toBe(100);
+  });
+
+  it('sets the result from parameters', function() {
+    var data = {};
+    expect(new os.search.AbstractSearchResult().getResult()).toBeUndefined();
+    expect(new os.search.AbstractSearchResult(null).getResult()).toBeNull();
+    expect(new os.search.AbstractSearchResult(data).getResult()).toBe(data);
+  });
+
+  it('sets the result', function() {
+    var data = {};
+    var result = new os.search.AbstractSearchResult();
+    expect(result.getResult()).toBeUndefined();
+
+    result.setResult(data);
+    expect(result.getResult()).toBe(data);
+  });
+});

--- a/test/os/track.test.js
+++ b/test/os/track.test.js
@@ -400,20 +400,42 @@ describe('os.track', function() {
       expect(tracks[i]).toBe(featuresC[i - 2]);
     }
   });
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 266f3457... feat(track): add/expand track API's
 
   it('truncates a track to a fixed size', function() {
     var features = generateFeatures(20, os.data.RecordField.TIME, Date.now());
     var track = os.track.createTrack({
+<<<<<<< HEAD
+<<<<<<< HEAD
       features: features,
       includeMetadata: true
+=======
+      features: features
+>>>>>>> 266f3457... feat(track): add/expand track API's
+=======
+      features: features,
+      includeMetadata: true
+>>>>>>> 51985312... fix(track): clean up metadata when truncating tracks
     });
 
     var geometry = track.getGeometry();
     expect(geometry.flatCoordinates.length).toBe(20 * geometry.stride);
 
+<<<<<<< HEAD
+<<<<<<< HEAD
     var metadataMap = track.get(os.track.TrackField.METADATA_MAP);
     expect(goog.object.getCount(metadataMap)).toBe(20);
 
+=======
+>>>>>>> 266f3457... feat(track): add/expand track API's
+=======
+    var metadataMap = track.get(os.track.TrackField.METADATA_MAP);
+    expect(goog.object.getCount(metadataMap)).toBe(20);
+
+>>>>>>> 51985312... fix(track): clean up metadata when truncating tracks
     var lastTimeValue = geometry.flatCoordinates[geometry.flatCoordinates.length - 1];
 
     // does nothing if the size is greater than the number of coordinates
@@ -422,26 +444,54 @@ describe('os.track', function() {
     expect(geometry.flatCoordinates.length).toBe(20 * geometry.stride);
     expect(geometry.flatCoordinates[geometry.flatCoordinates.length - 1]).toBe(lastTimeValue);
 
+<<<<<<< HEAD
+<<<<<<< HEAD
     metadataMap = track.get(os.track.TrackField.METADATA_MAP);
     expect(goog.object.getCount(metadataMap)).toBe(20);
 
     verifyMetadata(geometry.flatCoordinates, geometry.stride, metadataMap);
 
+=======
+>>>>>>> 266f3457... feat(track): add/expand track API's
+=======
+    metadataMap = track.get(os.track.TrackField.METADATA_MAP);
+    expect(goog.object.getCount(metadataMap)).toBe(20);
+
+<<<<<<< HEAD
+>>>>>>> 51985312... fix(track): clean up metadata when truncating tracks
+=======
+    verifyMetadata(geometry.flatCoordinates, geometry.stride, metadataMap);
+
+>>>>>>> eeabfa7f... fix(track): clean up metadata when clamping tracks
     // truncates to the number of coordinates specified
     os.track.truncate(track, 10);
     geometry = track.getGeometry();
     expect(geometry.flatCoordinates.length).toBe(10 * geometry.stride);
     expect(geometry.flatCoordinates[geometry.flatCoordinates.length - 1]).toBe(lastTimeValue);
 
+<<<<<<< HEAD
+<<<<<<< HEAD
     metadataMap = track.get(os.track.TrackField.METADATA_MAP);
     expect(goog.object.getCount(metadataMap)).toBe(10);
 
     verifyMetadata(geometry.flatCoordinates, geometry.stride, metadataMap);
 
+<<<<<<< HEAD
+=======
+>>>>>>> 266f3457... feat(track): add/expand track API's
+=======
+    metadataMap = track.get(os.track.TrackField.METADATA_MAP);
+    expect(goog.object.getCount(metadataMap)).toBe(10);
+
+>>>>>>> 51985312... fix(track): clean up metadata when truncating tracks
+=======
+>>>>>>> eeabfa7f... fix(track): clean up metadata when clamping tracks
     // truncates to zero if a negative value is provided
     os.track.truncate(track, 0);
     geometry = track.getGeometry();
     expect(geometry.flatCoordinates.length).toBe(0);
+<<<<<<< HEAD
+<<<<<<< HEAD
 
     metadataMap = track.get(os.track.TrackField.METADATA_MAP);
     expect(goog.object.getCount(metadataMap)).toBe(0);
@@ -497,4 +547,68 @@ describe('os.track', function() {
     metadataMap = track.get(os.track.TrackField.METADATA_MAP);
     expect(goog.object.getCount(metadataMap)).toBe(0);
   });
+=======
+>>>>>>> b2822792... feat(track): add function to split features into tracks
+=======
+=======
+
+    metadataMap = track.get(os.track.TrackField.METADATA_MAP);
+    expect(goog.object.getCount(metadataMap)).toBe(0);
+>>>>>>> 51985312... fix(track): clean up metadata when truncating tracks
+  });
+<<<<<<< HEAD
+>>>>>>> 266f3457... feat(track): add/expand track API's
+=======
+
+  it('clamps a track within a sort range', function() {
+    var start = Date.now();
+    var features = generateFeatures(20, os.data.RecordField.TIME, start);
+    var track = os.track.createTrack({
+      features: features,
+      includeMetadata: true
+    });
+
+    var geometry = track.getGeometry();
+    expect(geometry.flatCoordinates.length).toBe(20 * geometry.stride);
+
+    var metadataMap = track.get(os.track.TrackField.METADATA_MAP);
+    expect(goog.object.getCount(metadataMap)).toBe(20);
+
+    var originalCoordinates = geometry.flatCoordinates.slice();
+
+    // does nothing if the clamp range includes the entire track
+    os.track.clamp(track, start, start * sortIncrement * 20);
+    geometry = track.getGeometry();
+    expect(geometry.flatCoordinates.length).toBe(20 * geometry.stride);
+    expect(geometry.flatCoordinates[geometry.flatCoordinates.length - 1])
+        .toBe(originalCoordinates[originalCoordinates.length - 1]);
+
+    metadataMap = track.get(os.track.TrackField.METADATA_MAP);
+    expect(goog.object.getCount(metadataMap)).toBe(20);
+
+    verifyMetadata(geometry.flatCoordinates, geometry.stride, metadataMap);
+
+    // clamps the track within the provided sort range
+    os.track.clamp(track, start + sortIncrement * 5, start + sortIncrement * 14);
+    geometry = track.getGeometry();
+    expect(geometry.flatCoordinates.length).toBe(10 * geometry.stride);
+    expect(geometry.flatCoordinates[geometry.stride - 1])
+        .toBe(originalCoordinates[6 * geometry.stride - 1]);
+    expect(geometry.flatCoordinates[geometry.flatCoordinates.length - 1])
+        .toBe(originalCoordinates[15 * geometry.stride - 1]);
+
+    metadataMap = track.get(os.track.TrackField.METADATA_MAP);
+    expect(goog.object.getCount(metadataMap)).toBe(10);
+
+    verifyMetadata(geometry.flatCoordinates, geometry.stride, metadataMap);
+
+    // result is empty if the clamp range does not contain any points
+    os.track.clamp(track, start + sortIncrement * 5 + 1, start + sortIncrement * 5 + 2);
+    geometry = track.getGeometry();
+    expect(geometry.flatCoordinates.length).toBe(0);
+
+    metadataMap = track.get(os.track.TrackField.METADATA_MAP);
+    expect(goog.object.getCount(metadataMap)).toBe(0);
+  });
+>>>>>>> eeabfa7f... fix(track): clean up metadata when clamping tracks
 });

--- a/test/os/ui/draw/draw.test.js
+++ b/test/os/ui/draw/draw.test.js
@@ -1,0 +1,41 @@
+goog.require('ol.Feature');
+goog.require('ol.geom.Polygon');
+goog.require('ol.proj');
+goog.require('os.map');
+goog.require('os.ui.draw');
+
+describe('os.ui.draw', function() {
+  window.localStorage.clear();
+  os.net.RequestHandlerFactory.addHandler(os.net.SameDomainHandler);
+
+  beforeEach(function() {
+    window.localStorage.clear();
+  });
+
+  it('should read grid settings as numbers', function() {
+    runs(function() {
+      var gridDetail = os.ui.draw.utils.getGridSetting(os.ui.draw.GRID_DETAIL, 0.1);
+      expect(gridDetail).toBeDefined();
+      expect(typeof gridDetail == 'number').toBeTruthy();
+    });
+  });
+
+  it('should create a "detail x detail" grid around a feature, snapped to the world Lat/Lon coodinates', function() {
+    runs(function() {
+      var gridDetail = os.ui.draw.utils.getGridSetting(os.ui.draw.GRID_DETAIL, 0.1);
+
+      var g = ol.geom.Polygon
+        .fromExtent(
+          ol.proj.transformExtent(
+            [0.05, 0.05, 0.15, 0.15],
+            os.proj.EPSG4326,
+            os.map.PROJECTION));
+      var feature = new ol.Feature({geometry: g});
+
+      var grid = os.ui.draw.utils.getGridFromFeature(feature, gridDetail);
+
+      expect(grid).toBeDefined();
+      expect(grid.length).toBe(4); // since detail is 0.1, the 0.05 to 0.15 extent will get a 2x2 grid from 0.0 to 0.2 drawn around it
+    });
+  });
+});

--- a/test/os/ui/search/place/coordinateresult.test.js
+++ b/test/os/ui/search/place/coordinateresult.test.js
@@ -1,0 +1,63 @@
+goog.require('ol.Feature');
+goog.require('os.search.ISortableResult');
+goog.require('os.search.SortType');
+goog.require('os.time.TimeInstant');
+goog.require('os.time.TimeRange');
+goog.require('os.ui.search.place.CoordinateResult');
+
+describe('os.ui.search.place.CoordinateResult', function() {
+  var createResult = function(opt_options) {
+    var options = opt_options || {};
+    var featureOptions = options.featureOptions || {};
+    var feature = new ol.Feature(featureOptions);
+
+    var label = options.label != null ? options.label : undefined;
+    var score = options.score != null ? options.score : 0;
+    return new os.ui.search.place.CoordinateResult(feature, label, score);
+  };
+
+  describe('os.search.ISortableResult', function() {
+    it('implements the sortable result interface', function() {
+      var result = createResult();
+      expect(os.implements(result, os.search.ISortableResult.ID)).toBe(true);
+    });
+
+    it('gets sort values for the title', function() {
+      expect(createResult().getSortValue(os.search.SortType.TITLE)).toBeNull();
+      expect(createResult({
+        featureOptions: {
+          name: 'testTitle'
+        }
+      }).getSortValue(os.search.SortType.TITLE)).toBe('testTitle');
+      expect(createResult({
+        featureOptions: {
+          title: 'testTitle'
+        }
+      }).getSortValue(os.search.SortType.TITLE)).toBe('testTitle');
+    });
+
+    it('gets sort values for the date', function() {
+      expect(createResult().getSortValue(os.search.SortType.DATE)).toBeNull();
+      expect(createResult({
+        featureOptions: {
+          recordTime: Date.now()
+        }
+      }).getSortValue(os.search.SortType.DATE)).toBeNull();
+
+      var start = Date.now();
+      var end = start + 1000;
+
+      expect(createResult({
+        featureOptions: {
+          recordTime: new os.time.TimeInstant(start)
+        }
+      }).getSortValue(os.search.SortType.DATE)).toBe(String(start));
+
+      expect(createResult({
+        featureOptions: {
+          recordTime: new os.time.TimeRange(start, end)
+        }
+      }).getSortValue(os.search.SortType.DATE)).toBe(String(start));
+    });
+  });
+});

--- a/test/plugin/arc/arcjsonparser.test.js
+++ b/test/plugin/arc/arcjsonparser.test.js
@@ -51,7 +51,27 @@ describe('plugin.arc.ArcJSONParser', function() {
 
   it('should parse Arc polygon geometries', function() {
     var parser = new plugin.arc.ArcJSONParser();
+
+    // Testing one Polygon
     var arcPolygon = {
+      'rings': [
+        [
+          [0, 18],
+          [-32, 5],
+          [-56, 56],
+          [0, 18]
+        ]
+      ]
+    }
+    var olGeom = parser.parsePolygonGeometry_(arcPolygon);
+    expect(olGeom instanceof ol.geom.Polygon).toBe(true);
+    expect(olGeom.getCoordinates()[0][0][0]).toBe(0);
+    expect(olGeom.getCoordinates()[0][0][1]).toBe(18);
+    expect(olGeom.getCoordinates()[0][3][0]).toBe(0);
+    expect(olGeom.getCoordinates()[0][3][1]).toBe(18);
+
+    // Testing a MultiPolygon
+    arcPolygon = {
       'rings': [
         [
           [0, 18],
@@ -68,17 +88,17 @@ describe('plugin.arc.ArcJSONParser', function() {
       ]
     };
 
-    var olGeom = parser.parsePolygonGeometry_(arcPolygon);
-    expect(olGeom instanceof ol.geom.Polygon).toBe(true);
-    expect(olGeom.getCoordinates()[0][0][0]).toBe(0);
-    expect(olGeom.getCoordinates()[0][0][1]).toBe(18);
-    expect(olGeom.getCoordinates()[0][3][0]).toBe(0);
-    expect(olGeom.getCoordinates()[0][3][1]).toBe(18);
+    olGeom = parser.parsePolygonGeometry_(arcPolygon);
+    expect(olGeom instanceof ol.geom.MultiPolygon).toBe(true);
+    expect(olGeom.getCoordinates()[0][0][0][0]).toBe(0);
+    expect(olGeom.getCoordinates()[0][0][0][1]).toBe(18);
+    expect(olGeom.getCoordinates()[0][0][3][0]).toBe(0);
+    expect(olGeom.getCoordinates()[0][0][3][1]).toBe(18);
 
-    expect(olGeom.getCoordinates()[1][0][0]).toBe(-185);
-    expect(olGeom.getCoordinates()[1][0][1]).toBe(290);
-    expect(olGeom.getCoordinates()[1][2][1]).toBe(-20);
-    expect(olGeom.getCoordinates()[1][1][1]).toBe(50);
+    expect(olGeom.getCoordinates()[1][0][0][0]).toBe(-185);
+    expect(olGeom.getCoordinates()[1][0][0][1]).toBe(290);
+    expect(olGeom.getCoordinates()[1][0][2][1]).toBe(-20);
+    expect(olGeom.getCoordinates()[1][0][1][1]).toBe(50);
   });
 
   it('should parse Arc multipoint geometries', function() {


### PR DESCRIPTION
NOTE: This needs the additional plugin to be testable as part of the original ticket.  This capability can still be used in plain Opensphere when the "supportsGrid" flag on the DrawControlsCtrl is set to 'true'; or if a future plugin/feature wants to reuse this grid code as well.

Testing steps:

1. Set "supportsGrid" to true (this is NOT how it's committed), or use provided Surge link
2. Lower the brightness or opacity of the "Street Map Tiles" layer 
3. Draw a box, circle, and/or polygon
4. Remember, this is NOT how it's committed; the grid will NOT be shown normally
5. Verify a grid snapped to 0.25 degree lat/lon coordinates is drawn around the shape (this can be changed to 1-degree or 0.1-degree grid boxes by changing the setting in settings.json)
6. Verify the grid is not drawn when the search area is large