### PR TITLE
test(cypress): adjusts projection handling

### DIFF
--- a/cypress/support/execute-tests.sh
+++ b/cypress/support/execute-tests.sh
@@ -161,17 +161,17 @@ function overrideSettings() {
   cp -r $SETTINGS_SOURCE $SETTINGS_TARGET
 
   echo 'INFO: writing projection to settings file'
-  sed -i.bak 's@CYPRESS_PROJECTION@'$CYPRESS_PROJECTION'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
+  sed -i 's@CYPRESS_PROJECTION@'$CYPRESS_PROJECTION'@g' $OPENSPHERE_CONFIG_TESTER
 
   echo 'INFO: writing map urls to settings file'
-  sed -i.bak 's@STREET_MAP_URL@'$STREET_MAP_URL'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
-  sed -i.bak 's@WORLD_IMAGERY_URL@'$WORLD_IMAGERY_URL'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
+  sed -i 's@STREET_MAP_URL@'$STREET_MAP_URL'@g' $OPENSPHERE_CONFIG_TESTER
+  sed -i 's@WORLD_IMAGERY_URL@'$WORLD_IMAGERY_URL'@g' $OPENSPHERE_CONFIG_TESTER
 
   echo 'INFO: zoom offset to settings file'
   if [ "$CYPRESS_PROJECTION" = 3857 ]; then
-    sed -i.bak 's@"ZOOM_OFFSET"@'0'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
+    sed -i 's@"ZOOM_OFFSET"@'0'@g' $OPENSPHERE_CONFIG_TESTER
   else
-    sed -i.bak 's@"ZOOM_OFFSET"@'-1'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
+    sed -i 's@"ZOOM_OFFSET"@'-1'@g' $OPENSPHERE_CONFIG_TESTER
   fi
 
   echo 'INFO: all settings adjustments finished'

--- a/cypress/support/execute-tests.sh
+++ b/cypress/support/execute-tests.sh
@@ -109,13 +109,21 @@ function checkArguments() {
   fi
 
   if [ -z "$STREET_MAP_URL" ]; then
-    echo 'INFO: STREET_MAP_URL environment variable set, using default'
-    export STREET_MAP_URL="http://services.arcgisonline.com/ArcGIS/rest/services/ESRI_StreetMap_World_2D/MapServer/tile/{z}/{y}/{x}"
+    echo "INFO: STREET_MAP_URL environment variable not set, using default for $CYPRESS_PROJECTION"
+    if [ "$CYPRESS_PROJECTION" = 3857 ]; then
+      export STREET_MAP_URL="http://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}"
+    else
+      export STREET_MAP_URL="http://services.arcgisonline.com/ArcGIS/rest/services/ESRI_StreetMap_World_2D/MapServer/tile/{z}/{y}/{x}"
+    fi
   fi
 
   if [ -z "$WORLD_IMAGERY_URL" ]; then
-    echo 'INFO: WORLD_IMAGERY_URL environment variable not set, using default'
-    export WORLD_IMAGERY_URL="https://wi.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+    echo "INFO: WORLD_IMAGERY_URL environment variable not set, using default for $CYPRESS_PROJECTION"
+    if [ "$CYPRESS_PROJECTION" = 3857 ]; then
+      export WORLD_IMAGERY_URL="http://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+    else
+      export WORLD_IMAGERY_URL="https://wi.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+    fi
   fi
 }
 
@@ -158,6 +166,13 @@ function overrideSettings() {
   echo 'INFO: writing map urls to settings file'
   sed -i.bak 's@STREET_MAP_URL@'$STREET_MAP_URL'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
   sed -i.bak 's@WORLD_IMAGERY_URL@'$WORLD_IMAGERY_URL'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
+
+  echo 'INFO: zoom offset to settings file'
+  if [ "$CYPRESS_PROJECTION" = 3857 ]; then
+    sed -i.bak 's@"ZOOM_OFFSET"@'0'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
+  else
+    sed -i.bak 's@"ZOOM_OFFSET"@'-1'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
+  fi
 
   echo 'INFO: all settings adjustments finished'
 }

--- a/cypress/support/execute-tests.sh
+++ b/cypress/support/execute-tests.sh
@@ -161,17 +161,17 @@ function overrideSettings() {
   cp -r $SETTINGS_SOURCE $SETTINGS_TARGET
 
   echo 'INFO: writing projection to settings file'
-  sed -i 's@CYPRESS_PROJECTION@'$CYPRESS_PROJECTION'@g' $OPENSPHERE_CONFIG_TESTER
+  sed -i.bak 's@CYPRESS_PROJECTION@'$CYPRESS_PROJECTION'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
 
   echo 'INFO: writing map urls to settings file'
-  sed -i 's@STREET_MAP_URL@'$STREET_MAP_URL'@g' $OPENSPHERE_CONFIG_TESTER
-  sed -i 's@WORLD_IMAGERY_URL@'$WORLD_IMAGERY_URL'@g' $OPENSPHERE_CONFIG_TESTER
+  sed -i.bak 's@STREET_MAP_URL@'$STREET_MAP_URL'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
+  sed -i.bak 's@WORLD_IMAGERY_URL@'$WORLD_IMAGERY_URL'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
 
   echo 'INFO: zoom offset to settings file'
   if [ "$CYPRESS_PROJECTION" = 3857 ]; then
-    sed -i 's@"ZOOM_OFFSET"@'0'@g' $OPENSPHERE_CONFIG_TESTER
+    sed -i.bak 's@"ZOOM_OFFSET"@'0'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
   else
-    sed -i 's@"ZOOM_OFFSET"@'-1'@g' $OPENSPHERE_CONFIG_TESTER
+    sed -i.bak 's@"ZOOM_OFFSET"@'-1'@g' $OPENSPHERE_CONFIG_TESTER && rm $OPENSPHERE_CONFIG_TESTER.bak
   fi
 
   echo 'INFO: all settings adjustments finished'

--- a/cypress/support/settings/opensphere-config-tester.json
+++ b/cypress/support/settings/opensphere-config-tester.json
@@ -11,17 +11,13 @@
         "maps": {
           "streetmap": {
             "projection": "EPSG:CYPRESS_PROJECTION",
-            "urls": [
-              "STREET_MAP_URL"
-            ],
-            "zoomOffset": -1
+            "url": "STREET_MAP_URL",
+            "zoomOffset": "ZOOM_OFFSET"
           },
           "worldimagery": {
             "projection": "EPSG:CYPRESS_PROJECTION",
-            "urls": [
-              "WORLD_IMAGERY_URL"
-            ],
-            "zoomOffset": -1
+            "url": "WORLD_IMAGERY_URL",
+            "zoomOffset": "ZOOM_OFFSET"
           }
         }
       }


### PR DESCRIPTION
- default urls on default projection (3857) were incorrect; fixed
- default urls now provided for both 3857 and 4326
- `zoomOffset` previously incorrectly always set for 3857; fixed, now handles 3857 and 4326