### PR TITLE
fix(logger): the logger in firefox no longer randomly opens GEOVIZ-1

### DIFF
--- a/src/os/debug/fancierwindow.js
+++ b/src/os/debug/fancierwindow.js
@@ -42,34 +42,22 @@ os.debug.FancierWindow.STYLE_RULES_ = goog.string.Const.from(
  * @inheritDoc
  */
 os.debug.FancierWindow.prototype.writeInitialDocument = function() {
-  goog.events.unlisten(this.win, goog.events.EventType.BEFOREUNLOAD, this.onBeforeUnload_, false, this);
+  goog.events.unlisten(this.win, goog.events.EventType.BEFOREUNLOAD, this.closeLogger, false, this);
   os.debug.FancierWindow.superClass_.writeInitialDocument.call(this);
   // close button should set the debug window to disabled
   if (this.win) {
-    goog.events.listenOnce(this.win, goog.events.EventType.BEFOREUNLOAD, this.onBeforeUnload_, false, this);
+    goog.events.listenOnce(this.win, goog.events.EventType.BEFOREUNLOAD, this.closeLogger, false, this);
   }
 };
 
 
 /**
- * @private
- */
-os.debug.FancierWindow.prototype.onBeforeUnload_ = function() {
-  // this.exit_ is private (grr), so copy it here
-  this.setEnabled(false);
-  if (this.win) {
-    this.win.close();
-  }
-};
-
-
-/**
- * @public
+ * @suppress {accessControls}
  */
 os.debug.FancierWindow.prototype.closeLogger = function() {
-  // this.exit_ is private (grr), so copy it here
-  this.onBeforeUnload_();
+  this.exit_(null);
 };
+
 
 /**
  * @inheritDoc

--- a/src/os/debug/fancierwindow.js
+++ b/src/os/debug/fancierwindow.js
@@ -42,10 +42,11 @@ os.debug.FancierWindow.STYLE_RULES_ = goog.string.Const.from(
  * @inheritDoc
  */
 os.debug.FancierWindow.prototype.writeInitialDocument = function() {
+  goog.events.unlisten(this.win, goog.events.EventType.BEFOREUNLOAD, this.onBeforeUnload_, false, this);
   os.debug.FancierWindow.superClass_.writeInitialDocument.call(this);
   // close button should set the debug window to disabled
-  if (window) {
-    goog.events.listenOnce(window, goog.events.EventType.BEFOREUNLOAD, this.onBeforeUnload_, false, this);
+  if (this.win) {
+    goog.events.listenOnce(this.win, goog.events.EventType.BEFOREUNLOAD, this.onBeforeUnload_, false, this);
   }
 };
 
@@ -61,6 +62,14 @@ os.debug.FancierWindow.prototype.onBeforeUnload_ = function() {
   }
 };
 
+
+/**
+ * @public
+ */
+os.debug.FancierWindow.prototype.closeLogger = function() {
+  // this.exit_ is private (grr), so copy it here
+  this.onBeforeUnload_();
+};
 
 /**
  * @inheritDoc

--- a/src/os/mainctrl.js
+++ b/src/os/mainctrl.js
@@ -432,7 +432,7 @@ os.MainCtrl.prototype.initialize = function() {
  */
 os.MainCtrl.prototype.onClose = function() {
   // close the log window
-  os.logWindow.setEnabled(false);
+  os.logWindow.closeLogger();
 };
 
 


### PR DESCRIPTION
This bug was caused by the fix to another one: [issue 574](https://github.com/ngageoint/opensphere/issues/574)

For testing this ticket, make sure to open the branch in firefox. Then check and make sure that:
• Log window doesn't reopen on its own when closed via the X (current bug).
• Log window doesn't close in Firefox when you click Clear (bug from 574).
• Log window closes when the application is closed (additional bug prior to 574).