### PR TITLE
docs(rtd): fix content type tests and add external instructions

### DIFF
--- a/docs/guides/plugin_file_type_guide/content_type.rst
+++ b/docs/guides/plugin_file_type_guide/content_type.rst
@@ -10,6 +10,15 @@ The first thing we need to do for a file type is to detect the file type given a
 
 As always, let's test it.
 
+External Plugins
+  If you are working with an external plugin, you will need to add the following two lines to the files list in ``karma.conf.js``:
+
+  .. code-block:: javascript
+
+      {pattern: resolver.resolveModulePath('jschardet/dist/jschardet.min.js'), watched: false, included: true, served: true},
+      {pattern: '../opensphere/.build/xml-lexer.min.js', watched: false, included: true, served: true},
+
+
 .. literalinclude:: test/plugin/georss/mime.test.js
   :caption: ``test/plugin/georss/mime.test.js``
   :linenos:

--- a/docs/guides/plugin_file_type_guide/test/plugin/georss/mime.test.js
+++ b/docs/guides/plugin_file_type_guide/test/plugin/georss/mime.test.js
@@ -7,7 +7,7 @@ describe('plugin.georss.mime', function() {
     var feed = '<?xml version="1.0" encoding="utf-8"?>' +
       '<feed xmlns="http://www.w3.org/2005/Atom"/>';
 
-    var buffer = new TextEncoder().encode(feed);
+    var buffer = new TextEncoder().encode(feed).buffer;
 
     // pretend this came from a file
     var file = new os.file.File();
@@ -20,7 +20,7 @@ describe('plugin.georss.mime', function() {
 
   it('should not detect other XML as GeoRSS', function() {
     var xml = '<?xml version="1.0" encoding="utf-8"?><something xmlns="http://something.com/schema"/>';
-    var buffer = new TextEncoder().encode(xml);
+    var buffer = new TextEncoder().encode(xml).buffer;
 
     // pretend this came from a file
     var file = new os.file.File();

--- a/src/os/file/mime/xml.js
+++ b/src/os/file/mime/xml.js
@@ -28,6 +28,7 @@ os.file.mime.xml.TYPE = 'text/xml';
  */
 os.file.mime.xml.Types = {
   OPEN_TAG: 'open-tag',
+  CLOSE_TAG: 'close-tag',
   ATTRIBUTE_NAME: 'attribute-name',
   ATTRIBUTE_VALUE: 'attribute-value'
 };
@@ -76,6 +77,7 @@ os.file.mime.xml.isXML = function(buffer, opt_file, opt_context) {
             });
           }
 
+          expectedTypes.push(os.file.mime.xml.Types.CLOSE_TAG);
           expectedTypes.push(os.file.mime.xml.Types.ATTRIBUTE_NAME);
         } else if (data.type === os.file.mime.xml.Types.ATTRIBUTE_NAME) {
           expectedTypes.pop();
@@ -94,6 +96,9 @@ os.file.mime.xml.isXML = function(buffer, opt_file, opt_context) {
 
           namespaceIncoming = false;
           expectedTypes.push(os.file.mime.xml.Types.ATTRIBUTE_NAME);
+        } else if (data.type === os.file.mime.xml.Types.CLOSE_TAG) {
+          expectedTypes.pop();
+          expectedTypes.push(os.file.mime.xml.Types.OPEN_TAG);
         }
       } else {
         // malformed nonsense

--- a/test/os/file/mime/xml.test.js
+++ b/test/os/file/mime/xml.test.js
@@ -8,7 +8,7 @@ describe('os.file.mime.xml', function() {
       '/base/test/plugin/file/geojson/10k.json',
       '/base/test/resources/bin/rand.bin',
       '/base/test/resources/xml/ERROR_text-before-root.xml'],
-        os.file.mime.mock.testNo(os.file.mime.xml.TYPE));
+    os.file.mime.mock.testNo(os.file.mime.xml.TYPE));
   });
 
   it('should detect files that are xml files', function() {
@@ -50,6 +50,19 @@ describe('os.file.mime.xml', function() {
             }
           });
         });
+  });
+
+  it('should detect empty root tags as xml', function() {
+    var test = '<something/>';
+    var buffer = new TextEncoder().encode(test).buffer;
+
+    // pretend this came from a file
+    var file = new os.file.File();
+    file.setFileName('something.xml');
+    file.setUrl(file.getFileName());
+
+    var testFunc = os.file.mime.mock.testYes(os.file.mime.xml.TYPE);
+    testFunc(buffer, file);
   });
 
   it('should register itself with mime detection', function() {


### PR DESCRIPTION
The content type tests were not running due to an error:

```
var buffer = new TextEncoder().encode(str).buffer;
                                           ^added this
```
They were also causing a subsequent test failure because the test xml has empty root tags and the xml mime detection was not concluding those were xml. This has been fixed.

Additionally, running this from an external plugin requires that the plugin's `karma.conf.js` pull in the necessary dependencies for the mime stack. Those instructions have now been added.