### PR TITLE
feat(list): add ability to pass dynamic attributes to list directive

### DIFF
--- a/conformance_config.textproto
+++ b/conformance_config.textproto
@@ -128,13 +128,6 @@ requirement: {
 
 requirement: {
   type: BANNED_NAME
-  value: 'Object.assign'
-  error_message: 'Object.assign is not permitted. Use '
-                 'ol.obj.assign instead.'
-}
-
-requirement: {
-  type: BANNED_NAME
   value: 'goog.abstractMethod'
   error_message: 'goog.abstractMethod is not permitted. Use @abstract on the class and method instead.'
 }


### PR DESCRIPTION
List directive was modified to allow attributes to be passed from a parent scope to a directive with isolated scope compiled in the list directive using list-attr-* convention to map attributes, and with support for two-way binding.

template:
`<div list list-id="my-list" list-attr-my-item="myItem"></div>`

plugin:
`os.ui.list.add('my-list', '<my-directive item="myItem"></my-directive>');`
