### PR TITLE
fix(feature actions): using import button on filter actions works

### DIFF
--- a/src/os/im/action/importaction.js
+++ b/src/os/im/action/importaction.js
@@ -55,3 +55,24 @@ os.im.action.sortByLabel = function(a, b) {
   var bLabel = b ? b.getLabel() : '';
   return goog.array.defaultCompare(aLabel, bLabel);
 };
+
+
+/**
+ * Get columns from a filterable.
+ *
+ * @param {os.filter.IFilterable} filterable
+ * @return {Array<os.ogc.FeatureTypeColumn>} columns of the  filterable
+ */
+os.im.action.getColumnsFromFilterable = function(filterable) {
+  var columns = null;
+
+  if (filterable instanceof os.layer.Vector) {
+    var source = /** @type {os.source.ISource} */ (filterable.getSource());
+    columns = os.source.getFilterColumns(source, true, true);
+    columns = columns.map(os.source.definitionsToFeatureTypes);
+  } else {
+    columns = filterable.getFilterColumns();
+  }
+
+  return columns;
+};

--- a/src/os/ui/filter/im/filterimporter.js
+++ b/src/os/ui/filter/im/filterimporter.js
@@ -92,6 +92,15 @@ os.ui.filter.im.FilterImporter.prototype.onParsingComplete = function(opt_event)
 
 
 /**
+ * @param {os.filter.IFilterable} filterable
+ * @return {Array<os.ogc.FeatureTypeColumn>}
+ */
+os.ui.filter.im.FilterImporter.prototype.getFilterColumnsFromFilterable = function(filterable) {
+  return filterable ? filterable.getFilterColumns() : null;
+};
+
+
+/**
  * Process the parsed filters.
  * @protected
  */
@@ -115,7 +124,7 @@ os.ui.filter.im.FilterImporter.prototype.processData = function() {
     if (this.layerId) {
       // if we have a layer ID, we were passed some context from a filter window, so use it
       var impliedFilterable = os.ui.filter.getFilterableByType(this.layerId);
-      var columns = impliedFilterable ? impliedFilterable.getFilterColumns() : null;
+      var columns = this.getFilterColumnsFromFilterable(impliedFilterable);
 
       if (impliedFilterable && columns && (this.ignoreColumns || filter.matches(columns))) {
         // this filter matches the columns of the passed in context, so add it as such

--- a/src/os/ui/im/action/filteractionimport.js
+++ b/src/os/ui/im/action/filteractionimport.js
@@ -118,15 +118,7 @@ os.ui.im.action.FilterActionImportCtrl.prototype.onLayerChange = function(layer)
   if (os.implements(layer, os.filter.IFilterable.ID)) {
     var filterable = /** @type {os.filter.IFilterable} */ (layer);
 
-    if (layer instanceof os.layer.Vector) {
-      // its a layer but for filter actions, we want to get the columns a little differently
-      var source = /** @type {os.source.ISource} */ (layer.getSource());
-      var columns = os.source.getFilterColumns(source, true, true);
-      this.columns = columns.map(os.source.definitionsToFeatureTypes);
-    } else {
-      // it's another filterable descriptor, so just get its columns
-      this.columns = filterable.getFilterColumns();
-    }
+    this.columns = os.im.action.getColumnsFromFilterable(filterable);
   }
 
   this.testColumns();

--- a/src/os/ui/im/action/filteractionimporter.js
+++ b/src/os/ui/im/action/filteractionimporter.js
@@ -65,6 +65,14 @@ os.ui.im.action.FilterActionImporter.prototype.getFilterTooltip = function(entry
 
 
 /**
+ * @inheritDoc
+ */
+os.ui.im.action.FilterActionImporter.prototype.getFilterColumnsFromFilterable = function(filterable) {
+  return os.im.action.getColumnsFromFilterable(filterable);
+};
+
+
+/**
  * Get all filter action entries from matched results.
  * @param {Object} matched The matched entries.
  * @return {!Array<!os.im.action.FilterActionEntry>}


### PR DESCRIPTION
Before when you would use import from feature actions, it wouldn't find any layers to re import. 