### PR TITLE
fix(net): fix double encoding issue

### DIFF
--- a/src/os/net/baseservermodifier.js
+++ b/src/os/net/baseservermodifier.js
@@ -1,68 +1,15 @@
-goog.provide('os.net.BaseServerExpression');
 goog.provide('os.net.BaseServerModifier');
 goog.require('goog.Uri');
 goog.require('os.net.URLModifier');
-
-
-
-/**
- * @extends {os.net.URLModifier}
- * @constructor
- */
-os.net.BaseServerModifier = function() {
-  os.net.BaseServerModifier.base(this, 'constructor', 'baseServer');
-};
-goog.inherits(os.net.BaseServerModifier, os.net.URLModifier);
-
-
-/**
- * @type {!Array<{search: RegExp, replace: string}>}
- * @private
- */
-os.net.BaseServerModifier.replace_ = [];
-
-
-/**
- * The expression to remove https and trailing slashes
- * @type {RegExp}
- */
-os.net.BaseServerExpression = /(https:\/\/)?(.*[^\/])\/?/;
 
 
 /**
  * @param {string} server
  */
 os.net.BaseServerModifier.configure = function(server) {
-  os.net.BaseServerModifier.replace_.length = 0;
-
   if (server) {
-    os.net.BaseServerModifier.replace_.push({
-      search: new RegExp(os.settings.get('baseServerRegex', '^\\/(.*)$')),
-      replace: server.replace(/\/$/, '') + '/$1'
-    });
+    var config = {};
+    config[os.settings.get('baseServerRegex', '^\\/([^\\/].*)$')] = server.replace(/\/$/, '') + '/$1';
+    os.net.URLModifier.configure(config);
   }
-};
-
-
-/**
- * @inheritDoc
- */
-os.net.BaseServerModifier.prototype.getList = function() {
-  return os.net.BaseServerModifier.replace_;
-};
-
-
-/**
- * Due to a bug in urlModifier changing the query,
- * lets decode the query to be correct without fixing bugs others might rely on
- * @inheritDoc
- */
-os.net.BaseServerModifier.prototype.applyModifications = function(uri, modifiedUri) {
-  uri.setScheme(modifiedUri.getScheme());
-  uri.setDomain(modifiedUri.getDomain());
-  uri.setPort(modifiedUri.getPort());
-  uri.setPath(modifiedUri.getPath());
-  /// ISSUE WITH URL ENCODER. It does getQuery which returns the encoded query
-  uri.setQuery(modifiedUri.getQuery(), true);
-  uri.setFragment(modifiedUri.getFragment());
 };

--- a/src/os/net/request.js
+++ b/src/os/net/request.js
@@ -11,7 +11,6 @@ goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('goog.net.EventType');
 goog.require('os');
-goog.require('os.net.BaseServerModifier');
 goog.require('os.net.IDataFormatter');
 goog.require('os.net.IModifier');
 goog.require('os.net.IRequestHandler');
@@ -168,7 +167,6 @@ os.net.Request = function(opt_uri, opt_method, opt_timeout) {
 
   this.addModifier(new os.net.VariableReplacer());
   this.addModifier(new os.net.URLModifier());
-  this.addModifier(new os.net.BaseServerModifier());
 };
 goog.inherits(os.net.Request, goog.events.EventTarget);
 

--- a/src/os/net/urlmodifier.js
+++ b/src/os/net/urlmodifier.js
@@ -100,6 +100,6 @@ os.net.URLModifier.prototype.applyModifications = function(uri, modifiedUri) {
   uri.setDomain(modifiedUri.getDomain());
   uri.setPort(modifiedUri.getPort());
   uri.setPath(modifiedUri.getPath());
-  uri.setQuery(modifiedUri.getQuery());
+  uri.setQuery(modifiedUri.getQuery(), true);
   uri.setFragment(modifiedUri.getFragment());
 };

--- a/test/os/net/baseservermodifier.test.js
+++ b/test/os/net/baseservermodifier.test.js
@@ -1,9 +1,10 @@
 goog.require('os.net.BaseServerModifier');
+goog.require('os.net.URLModifier');
 
 
 describe('os.net.BaseServerModifier', function() {
   it('should not modify if not configured', function() {
-    var mod = new os.net.BaseServerModifier();
+    var mod = new os.net.URLModifier();
 
     // set no replacements
     os.net.BaseServerModifier.configure();
@@ -16,7 +17,7 @@ describe('os.net.BaseServerModifier', function() {
   });
 
   it('should not modify if is an absolute path', function() {
-    var mod = new os.net.BaseServerModifier();
+    var mod = new os.net.URLModifier();
     var server = 'http://example.com';
 
     // set a replacement
@@ -27,11 +28,11 @@ describe('os.net.BaseServerModifier', function() {
 
     mod.modify(uri);
     expect(uri.toString()).toBe(expectedString);
-    os.net.BaseServerModifier.configure();
+    os.net.URLModifier.configure();
   });
 
   it('should modify relative services requests', function() {
-    var mod = new os.net.BaseServerModifier();
+    var mod = new os.net.URLModifier();
     var server = 'http://example.com';
 
     // set a replacement
@@ -46,7 +47,7 @@ describe('os.net.BaseServerModifier', function() {
   });
 
   it('should not modify relative application requests', function() {
-    var mod = new os.net.BaseServerModifier();
+    var mod = new os.net.URLModifier();
     var server = 'http://example.com';
 
     // set a replacement

--- a/test/os/net/baseservermodifier.test.js
+++ b/test/os/net/baseservermodifier.test.js
@@ -31,6 +31,21 @@ describe('os.net.BaseServerModifier', function() {
     os.net.URLModifier.configure();
   });
 
+  it('should not modify scheme-relative URLs', function() {
+    var mod = new os.net.URLModifier();
+    var server = 'http://example.com';
+
+    // set a replacement
+    os.net.BaseServerModifier.configure(server);
+
+    var expectedString = '//example2.com/path/to/thing?someQuery=text%20with%20%25%20spaces#someFragment';
+    var uri = new goog.Uri(expectedString);
+
+    mod.modify(uri);
+    expect(uri.toString()).toBe(expectedString);
+    os.net.URLModifier.configure();
+  });
+
   it('should modify relative services requests', function() {
     var mod = new os.net.URLModifier();
     var server = 'http://example.com';
@@ -59,11 +74,5 @@ describe('os.net.BaseServerModifier', function() {
     mod.modify(uri);
     expect(uri.toString()).toBe(relativeString);
     os.net.BaseServerModifier.configure();
-  });
-
-  it('should remove https and trailling /', function() {
-    expect('example.com'.replace(os.net.BaseServerExpression, '$2')).toBe('example.com');
-    expect('https://example.com'.replace(os.net.BaseServerExpression, '$2')).toBe('example.com');
-    expect('https://example.com/'.replace(os.net.BaseServerExpression, '$2')).toBe('example.com');
   });
 });


### PR DESCRIPTION
The `uri.setQuery()` method takes an argument for whether or not to decode that was not being used. Because of this fix, `BaseServerModifier` is no longer necessary (although the API for configuring it has been left the same to avoid breaking its usage).

BREAKING CHANGE: `UrlModifier` now avoids doubly encoding the query string. Any steps taken on the receiving end of these requests to code around that bug need to be reviewed and possibly removed.

BREAKING CHANGE: `os.net.BaseServerExpression` was removed because it was not fully featured for parsing out domain names. Please use `new goog.Uri(str).getDomain()` or `new URL(str).hostname` instead.