### PR TITLE
feat(search): added text transform capability to search input

### DIFF
--- a/src/os/mainctrl.js
+++ b/src/os/mainctrl.js
@@ -162,6 +162,7 @@ goog.require('plugin.pelias.geocoder.Plugin');
 goog.require('plugin.places.PlacesPlugin');
 goog.require('plugin.position.PositionPlugin');
 goog.require('plugin.suncalc.Plugin');
+goog.require('plugin.text.transformer.TextTransformerPlugin');
 goog.require('plugin.track.TrackPlugin');
 goog.require('plugin.vectortools.VectorToolsPlugin');
 goog.require('plugin.weather.WeatherPlugin');
@@ -540,6 +541,7 @@ os.MainCtrl.prototype.addPlugins = function() {
   os.ui.pluginManager.addPlugin(plugin.suncalc.Plugin.getInstance());
   os.ui.pluginManager.addPlugin(plugin.track.TrackPlugin.getInstance());
   os.ui.pluginManager.addPlugin(plugin.openpage.Plugin.getInstance());
+  os.ui.pluginManager.addPlugin(plugin.text.transformer.TextTransformerPlugin.getInstance());
 };
 
 

--- a/src/os/ui/search/searchbox.js
+++ b/src/os/ui/search/searchbox.js
@@ -14,6 +14,7 @@ goog.require('os.search.SearchManager');
 goog.require('os.ui');
 goog.require('os.ui.Module');
 goog.require('os.ui.dragDropDirective');
+goog.require('os.ui.text.transformers.transformInputDirective');
 
 
 /**

--- a/src/os/ui/text/transformers/dashestransformer.js
+++ b/src/os/ui/text/transformers/dashestransformer.js
@@ -1,0 +1,44 @@
+goog.provide('os.ui.text.transformer.DashesTransformer');
+
+goog.require('os.ui.text.transformer.ITextTransformer');
+goog.require('os.ui.text.transformer.TextTransformerManager');
+
+
+/**
+ * @implements {os.ui.text.transformer.ITextTransformer}
+ * @constructor
+ */
+os.ui.text.transformer.DashesTransformer = function() {
+  /**
+   * @type {Object<string, RegExp>}
+   * @private
+   */
+  this.dashesMap_ = {
+    '-': /[\u002d\u058a\u05be\u2011\u2012\u2013\u2014\u2015\u2e3a\u2e3b\uff0d]/g
+  };
+};
+goog.addSingletonGetter(os.ui.text.transformer.DashesTransformer);
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.text.transformer.DashesTransformer.prototype.test = function(text) {
+  for (const key in this.dashesMap_) {
+    if (text.match(this.dashesMap_[key])) {
+      return true;
+    }
+  }
+  return false;
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.text.transformer.DashesTransformer.prototype.transform = function(text) {
+  for (const key in this.dashesMap_) {
+    text = text.replace(this.dashesMap_[key], key);
+  }
+  return text;
+};

--- a/src/os/ui/text/transformers/itexttranformer.js
+++ b/src/os/ui/text/transformers/itexttranformer.js
@@ -1,0 +1,23 @@
+goog.provide('os.ui.text.transformer.ITextTransformer');
+
+
+/**
+ * @interface
+ */
+os.ui.text.transformer.ITextTransformer = function() {};
+
+
+/**
+ * Test the text for patterns to replace
+ * @param {string} text
+ * @return {boolean}
+ */
+os.ui.text.transformer.ITextTransformer.prototype.test;
+
+
+/**
+ * Transform the text
+ * @param {string} text
+ * @return {string}
+ */
+os.ui.text.transformer.ITextTransformer.prototype.transform;

--- a/src/os/ui/text/transformers/quotestransformer.js
+++ b/src/os/ui/text/transformers/quotestransformer.js
@@ -1,0 +1,45 @@
+goog.provide('os.ui.text.transformer.QuotesTransformer');
+
+goog.require('os.ui.text.transformer.ITextTransformer');
+goog.require('os.ui.text.transformer.TextTransformerManager');
+
+
+/**
+ * @implements {os.ui.text.transformer.ITextTransformer}
+ * @constructor
+ */
+os.ui.text.transformer.QuotesTransformer = function() {
+  /**
+   * @type {Object<string, RegExp>}
+   * @private
+   */
+  this.quotesMap_ = {
+    '\'': /[\u2018\u2019]/g,
+    '"': /[\u201C\u201D]/g
+  };
+};
+goog.addSingletonGetter(os.ui.text.transformer.QuotesTransformer);
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.text.transformer.QuotesTransformer.prototype.test = function(text) {
+  for (const key in this.quotesMap_) {
+    if (text.match(this.quotesMap_[key])) {
+      return true;
+    }
+  }
+  return false;
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.text.transformer.QuotesTransformer.prototype.transform = function(text) {
+  for (const key in this.quotesMap_) {
+    text = text.replace(this.quotesMap_[key], key);
+  }
+  return text;
+};

--- a/src/os/ui/text/transformers/texttranformermanager.js
+++ b/src/os/ui/text/transformers/texttranformermanager.js
@@ -1,0 +1,56 @@
+goog.provide('os.ui.text.transformer.TextTransformerManager');
+
+goog.require('os.ui.text.transformer.ITextTransformer');
+
+
+/**
+ * @constructor
+ */
+os.ui.text.transformer.TextTransformerManager = function() {
+  /**
+   * @type {Object<string, !os.ui.text.transformer.ITextTransformer>}
+   * @private
+   */
+  this.textTransformers_ = {};
+};
+goog.addSingletonGetter(os.ui.text.transformer.TextTransformerManager);
+
+
+/**
+ * @param {string} name
+ * @param {!os.ui.text.transformer.ITextTransformer} textTransformers
+ */
+os.ui.text.transformer.TextTransformerManager.prototype.registerTextTransformer = function(name, textTransformers) {
+  this.textTransformers_[name] = textTransformers;
+};
+
+
+/**
+ * @param {string} name
+ * @return {?os.ui.text.transformer.ITextTransformer}
+ */
+os.ui.text.transformer.TextTransformerManager.prototype.getTextTransformer = function(name) {
+  return this.textTransformers_[name];
+};
+
+
+/**
+ * @param {Array<string>=} opt_names
+ * @return {!Array<!os.ui.text.transformer.ITextTransformer>}
+ */
+os.ui.text.transformer.TextTransformerManager.prototype.getTextTransformers = function(opt_names) {
+  const transformers = [];
+  if (opt_names) {
+    opt_names.forEach((name) => {
+      const transformer = this.textTransformers_[name];
+      if (transformer) {
+        transformers.push(this.textTransformers_[name]);
+      }
+    });
+  } else {
+    for (const name in this.textTransformers_) {
+      transformers.push(this.textTransformers_[name]);
+    }
+  }
+  return transformers;
+};

--- a/src/os/ui/text/transformers/transforminput.js
+++ b/src/os/ui/text/transformers/transforminput.js
@@ -1,0 +1,60 @@
+goog.provide('os.ui.text.transformer.TransformInputController');
+goog.provide('os.ui.text.transformers.transformInputDirective');
+
+goog.require('os.ui.Module');
+goog.require('os.ui.text.transformer.TextTransformerManager');
+
+
+/**
+ * @return {angular.Directive}
+ */
+os.ui.text.transformers.transformInputDirective = function() {
+  return {
+    restrict: 'A',
+    scope: {
+      'transformTextOptions': '@?'
+    },
+    controller: os.ui.text.transformer.TransformInputController
+  };
+};
+
+
+/**
+ * Add the directive to the os.ui module
+ */
+os.ui.Module.directive('transformInput', [os.ui.text.transformers.transformInputDirective]);
+
+
+/**
+ * @param {!angular.Scope} $scope
+ * @param {!angular.JQLite} $element
+ * @param {angular.$timeout} $timeout
+ * @constructor
+ * @ngInject
+ */
+os.ui.text.transformer.TransformInputController = function($scope, $element, $timeout) {
+  /**
+   * @type {Array<os.ui.text.transformer.ITextTransformer>}
+   * @private
+   */
+  this.transformers_ = $scope['transformTextOptions'] ?
+    os.ui.text.transformer.TextTransformerManager.getInstance().getTextTransformers(
+        $scope['transformTextOptions'].split(/\s*,\s*/)) :
+    os.ui.text.transformer.TextTransformerManager.getInstance().getTextTransformers();
+
+  const transformers = this.transformers_;
+  $element.on('change paste keyup', function() {
+    $timeout(() => {
+      const val = $(this).val();
+      if (typeof val == 'string') {
+        let val_ = /** @type {string} */ (val);
+        transformers.forEach((transformer) => {
+          val_ = transformer.transform(val_);
+        });
+        if (val_ != val) {
+          $(this).val(val_);
+        }
+      }
+    });
+  });
+};

--- a/src/plugin/text/transformer/texttransformerplugin.js
+++ b/src/plugin/text/transformer/texttransformerplugin.js
@@ -1,0 +1,37 @@
+goog.provide('plugin.text.transformer.TextTransformerPlugin');
+
+goog.require('os.plugin.AbstractPlugin');
+goog.require('os.ui.text.transformer.DashesTransformer');
+goog.require('os.ui.text.transformer.QuotesTransformer');
+goog.require('os.ui.text.transformer.TextTransformerManager');
+
+
+/**
+ * Provides text transformer support
+ *
+ * @extends {os.plugin.AbstractPlugin}
+ * @constructor
+ */
+plugin.text.transformer.TextTransformerPlugin = function() {
+  plugin.text.transformer.TextTransformerPlugin.base(this, 'constructor');
+  this.id = plugin.text.transformer.TextTransformerPlugin.ID;
+};
+goog.inherits(plugin.text.transformer.TextTransformerPlugin, os.plugin.AbstractPlugin);
+goog.addSingletonGetter(plugin.text.transformer.TextTransformerPlugin);
+
+
+/**
+ * @type {string}
+ * @const
+ */
+plugin.text.transformer.TextTransformerPlugin.ID = 'textTransformer';
+
+
+/**
+ * @inheritDoc
+ */
+plugin.text.transformer.TextTransformerPlugin.prototype.init = function() {
+  const manager = os.ui.text.transformer.TextTransformerManager.getInstance();
+  manager.registerTextTransformer('quotes', os.ui.text.transformer.QuotesTransformer.getInstance());
+  manager.registerTextTransformer('dashes', os.ui.text.transformer.DashesTransformer.getInstance());
+};

--- a/test/os/ui/text/transformer/dashestransformer.test.js
+++ b/test/os/ui/text/transformer/dashestransformer.test.js
@@ -1,0 +1,26 @@
+goog.require('os.ui.text.transformer.DashesTransformer');
+
+
+describe('os.ui.text.transform.Dashes', function() {
+  const dashesTransformer = os.ui.text.transformer.DashesTransformer.getInstance();
+  const standard = 'abcdefghijklmnopqrstuvwxyz' +
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZ' +
+    '0123456789' +
+    '!@#$%^&*()+={}[]<>?/\\|`~-,. \'"';
+
+  it('should handle empty strings', function() {
+    const output = dashesTransformer.transform('');
+    expect(output).toBe('');
+  });
+
+  it('shouldn\'t affect text without \\u2010 (hyphen) dashes', function() {
+    const output = dashesTransformer.transform(standard);
+    expect(output).toBe(standard);
+  });
+
+  it('should replace non-\\u2010 (hyphen) dashes with a hyphen', function() {
+    const dashes = '\u002d\u058a\u05be\u2011\u2012\u2013\u2014\u2015\u2e3a\u2e3b\uff0d';
+    const output = dashesTransformer.transform(standard + dashes);
+    expect(output).toBe(standard + '-----------');
+  });
+});

--- a/test/os/ui/text/transformer/quotestransformer.test.js
+++ b/test/os/ui/text/transformer/quotestransformer.test.js
@@ -1,0 +1,30 @@
+goog.require('os.ui.text.transformer.QuotesTransformer');
+
+
+describe('os.ui.text.transform.Quotes', function() {
+  const quotesTransformer = os.ui.text.transformer.QuotesTransformer.getInstance();
+  const standard = 'abcdefghijklmnopqrstuvwxyz' +
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZ' +
+    '0123456789' +
+    '!@#$%^&*()+={}[]<>?/\\|`~-,. \'"';
+
+  it('should handle empty strings', function() {
+    const output = quotesTransformer.transform('');
+    expect(output).toBe('');
+  });
+
+  it('shouldn\'t affect text without smart quotes', function() {
+    const output = quotesTransformer.transform(standard);
+    expect(output).toBe(standard);
+  });
+
+  it('should replace smart quotes with dumb quotes', function() {
+    const quotesTransformer = os.ui.text.transformer.QuotesTransformer.getInstance();
+    let input = '“' + standard + '”';
+    let output = quotesTransformer.transform(input);
+    expect(output).toBe('"' + standard + '"');
+    input = '““' + standard + '””';
+    output = quotesTransformer.transform(input);
+    expect(output).toBe('""' + standard + '""');
+  });
+});

--- a/views/search/searchbox.html
+++ b/views/search/searchbox.html
@@ -77,7 +77,8 @@
           ng-model="searchBox.searchTerm"
           ng-change="searchBox.refreshAutocomplete()"
           placeholder="{{searchBox.getPlaceholderText()}}"
-          data-provide="typeahead" />
+          data-provide="typeahead"
+          transform-input />
       <div class="input-group-append">
         <button ng-if="showClear" class="btn border border-left-0 form-control w-auto"
             type="button"


### PR DESCRIPTION
Added a directive and text transformers to transform input text. Transformers are registered with a manager via a plugin.
Search indexing will disregard punctuation that it doesn't recognize. Text copied from a word processing application may have smart quotes, which will be disregarded by a search analyzer while the actual intent is the treat the quoted text as a search phrase. The result is that each symbol is considered independently and the results are a union instead of being treated as a phrase. Adding the text-transform attribute to an input, and optionally, specifying a comma-separated list of transformers to text-transform-options to apply, provides a mechanism to prevent these cases by applying text transforms to the input text.

UUOM-435