### PR TITLE
fix(places): clean up fill management

### DIFF
--- a/src/os/ui/featureedit.js
+++ b/src/os/ui/featureedit.js
@@ -480,11 +480,6 @@ os.ui.FeatureEditCtrl = function($scope, $element, $timeout) {
     this.previewFeature = feature;
     this.originalProperties_ = feature.getProperties();
 
-    if (!this.isPolygon()) {
-      delete this['fillColor'];
-      delete this['fillOpacity'];
-    }
-
     if (this.originalProperties_) {
       // we don't care about or want these sticking around, so remove them
       delete this.originalProperties_[os.style.StyleType.SELECT];
@@ -781,34 +776,42 @@ os.ui.FeatureEditCtrl.prototype.isEllipse = function() {
 
 
 /**
- * If a polygon is selected.
+ * If the feature has a polygonal geometry.
  *
  * @return {boolean}
  * @export
  */
 os.ui.FeatureEditCtrl.prototype.isPolygon = function() {
-  var geometry = this.previewFeature.getGeometry();
-
-  if (geometry) {
-    return os.geo.isGeometryPolygonal(geometry) || this.isEllipse();
-  } else {
-    return false;
+  if (this.isEllipse()) {
+    return true;
   }
+
+  if (this.previewFeature) {
+    return os.geo.isGeometryPolygonal(this.previewFeature.getGeometry());
+  }
+
+  return false;
 };
 
 
 /**
- * If a line or polygon is selected.
+ * If the feature has a line or polygonal geometry.
  *
  * @return {boolean}
  * @export
  */
 os.ui.FeatureEditCtrl.prototype.isPolygonOrLine = function() {
-  var geometry = this.previewFeature.getGeometry();
-  var type = geometry.getType();
+  if (this.previewFeature) {
+    var geometry = this.previewFeature.getGeometry();
+    if (geometry) {
+      var type = geometry.getType();
 
-  return type == ol.geom.GeometryType.POLYGON || type == ol.geom.GeometryType.MULTI_POLYGON ||
-    type == ol.geom.GeometryType.LINE_STRING || type == ol.geom.GeometryType.MULTI_LINE_STRING;
+      return type == ol.geom.GeometryType.POLYGON || type == ol.geom.GeometryType.MULTI_POLYGON ||
+        type == ol.geom.GeometryType.LINE_STRING || type == ol.geom.GeometryType.MULTI_LINE_STRING;
+    }
+  }
+
+  return false;
 };
 
 
@@ -918,14 +921,6 @@ os.ui.FeatureEditCtrl.prototype.onMapClick_ = function(mapBrowserEvent) {
  */
 os.ui.FeatureEditCtrl.prototype.updatePreview = function() {
   if (this.previewFeature) {
-    if (this.isPolygon()) {
-      this['fillOpacity'] = this['fillOpacity'] || os.style.DEFAULT_FILL_ALPHA;
-      this['fillColor'] = this['fillColor'] || os.color.toHexString(os.style.DEFAULT_LAYER_COLOR);
-    } else {
-      this['fillOpacity'] = undefined;
-      this['fillColor'] = undefined;
-    }
-
     this.saveToFeature(this.previewFeature);
 
     var osMap = os.MapContainer.getInstance();
@@ -959,38 +954,35 @@ os.ui.FeatureEditCtrl.prototype.createPreviewFeature = function() {
   }
 
   var geometry = /** @type {ol.geom.SimpleGeometry|undefined} */ (this.options['geometry']);
-  if (!geometry) {
-    // new place without a geometry, initialize as a point
-    this['pointGeometry'] = {
-      'lat': NaN,
-      'lon': NaN,
-      'alt': NaN
-    };
-  } else if (geometry instanceof ol.geom.Point) {
-    // geometry is a point, so allow editing it
-    geometry = /** @type {ol.geom.SimpleGeometry} */ (geometry.clone().toLonLat());
-
-    var coordinate = geometry.getFirstCoordinate();
-    if (coordinate) {
-      this['altitude'] = coordinate[2] || 0;
-
+  var geometryType = geometry ? geometry.getType() : '';
+  switch (geometryType) {
+    case '':
+      // new place without a geometry, initialize as a point
       this['pointGeometry'] = {
-        'lon': coordinate[0],
-        'lat': coordinate[1],
-        'alt': this['altitude']
+        'lat': NaN,
+        'lon': NaN,
+        'alt': NaN
       };
-    }
+      break;
+    case ol.geom.GeometryType.POINT:
+      // geometry is a point, so allow editing it
+      geometry = /** @type {ol.geom.Point} */ (geometry.clone().toLonLat());
 
-    delete this['fillColor'];
-    delete this['fillOpacity'];
-  } else {
-    // not a point, so disable geometry edit
-    this.originalGeometry = geometry;
+      var coordinate = geometry.getFirstCoordinate();
+      if (coordinate) {
+        this['altitude'] = coordinate[2] || 0;
 
-    if (geometry instanceof ol.geom.LineString) {
-      delete this['fillColor'];
-      delete this['fillOpacity'];
-    }
+        this['pointGeometry'] = {
+          'lon': coordinate[0],
+          'lat': coordinate[1],
+          'alt': this['altitude']
+        };
+      }
+      break;
+    default:
+      // not a point, so disable geometry edit
+      this.originalGeometry = geometry || null;
+      break;
   }
 
   // default feature to show the name field
@@ -1063,22 +1055,21 @@ os.ui.FeatureEditCtrl.prototype.loadFromFeature = function(feature) {
       this['labelColor'] = this['color'];
     }
 
+    // initialize fill color and opacity
+    if (config['fill']['color']) {
+      // use the color from config
+      this['fillColor'] = os.color.toHexString(config['fill']['color']);
+      this['fillOpacity'] = os.color.toRgbArray(config['fill']['color'])[3];
+    } else {
+      // use default values
+      this['fillColor'] = os.color.toHexString(os.style.DEFAULT_LAYER_COLOR);
+      this['fillOpacity'] = os.style.DEFAULT_FILL_ALPHA;
+    }
+
     var icon = os.style.getConfigIcon(config);
     if (icon) {
       this['icon'] = icon;
       this['centerIcon'] = icon;
-    }
-
-    // Make sure we have a fill color and opacity for polygons, and don't have them otherwise
-    if (config['fill'] && config['fill']['color']) {
-      if (this.isPolygon()) {
-        this['fillColor'] = os.color.toHexString(config['fill']['color']);
-        var opacity = os.color.toRgbArray(config['fill']['color']);
-        this['fillOpacity'] = opacity[3];
-      } else {
-        delete this['fillColor'];
-        delete this['fillOpacity'];
-      }
     }
 
     var lineDash = os.style.getConfigLineDash(config);
@@ -1323,15 +1314,13 @@ os.ui.FeatureEditCtrl.prototype.setFeatureConfig_ = function(config) {
     os.style.setConfigOpacityColor(config, 0);
   }
 
-  if (this['fillColor'] && this['fillOpacity'] != null) {
+  // set fill color for polygons
+  if (this.isPolygon()) {
     var fillColor = ol.color.asArray(this['fillColor']);
     var fillOpacity = os.color.normalizeOpacity(this['fillOpacity']);
     fillColor[3] = fillOpacity;
     fillColor = os.style.toRgbaString(fillColor);
-
-    if (color != fillColor) {
-      os.style.setFillColor(config, fillColor);
-    }
+    os.style.setFillColor(config, fillColor);
   }
 
   // set icon config if selected

--- a/src/os/ui/layer/vectorlayerui.js
+++ b/src/os/ui/layer/vectorlayerui.js
@@ -332,19 +332,6 @@ os.ui.layer.VectorLayerUICtrl.prototype.showRotationOption = function() {
 
 
 /**
- * Decide if we show the fill controls
- * @return {boolean}
- * @export
- */
-os.ui.layer.VectorLayerUICtrl.prototype.showFillStyleControls = function() {
-  if (this.scope && this.scope['fillOpacity'] !== undefined) {
-    return true;
-  }
-  return false;
-};
-
-
-/**
  * Updates the layer preset state on the UI.
  *
  * @private

--- a/src/os/ui/layer/vectorstylecontrols.js
+++ b/src/os/ui/layer/vectorstylecontrols.js
@@ -175,19 +175,6 @@ os.ui.layer.VectorStyleControlsCtrl.prototype.hasCenter = function() {
 
 
 /**
- * Decide if we show the fill controls
- * @return {boolean}
- * @export
- */
-os.ui.layer.VectorStyleControlsCtrl.prototype.showFillStyleControls = function() {
-  if (this.scope && this.scope['fillOpacity'] !== undefined) {
-    return true;
-  }
-  return false;
-};
-
-
-/**
  * Fire a scope event when the ellipse center shape is changed by the user.
  *
  * @param {string} shape

--- a/views/layer/vectorstylecontrols.html
+++ b/views/layer/vectorstylecontrols.html
@@ -40,7 +40,7 @@
     </div>
   </div>
 
-  <div class="form-group row flex-shrink-0" title="Sets the opacity (inverse transparency) and color of the fill style." ng-if="ctrl.showFillStyleControls()">
+  <div class="form-group row flex-shrink-0" title="Sets the opacity (inverse transparency) and color of the fill style." ng-if="fillOpacity !== undefined">
     <label class="col-3 col-form-label">Fill Style</label>
     <div class="col-auto">
         <colorpicker name="fillColor" class="no-text" color="fillColor" show-reset="true"></colorpicker>

--- a/views/windows/featureedit.html
+++ b/views/windows/featureedit.html
@@ -140,8 +140,8 @@
         <vectorstylecontrols
             color="ctrl.color"
             opacity="ctrl.opacity"
-            fill-color="ctrl.fillColor"
-            fill-opacity="ctrl.fillOpacity"
+            fill-color="ctrl.isPolygon() ? ctrl.fillColor : undefined"
+            fill-opacity="ctrl.isPolygon() ? ctrl.fillOpacity : undefined"
             icon="ctrl.icon"
             center-icon="ctrl.centerIcon"
             show-center-icon="ctrl.showCenterIcon()"


### PR DESCRIPTION
This PR cleans up fill management within Places:

- Fixes issue where new polygonal places were initially displayed with a fill opacity of 1 in 3D mode. This was a race condition caused by fill management in `updatePreview`.
- Removed the need to delete (or set to undefined) `fillColor` and `fillOpacity` to hide the Fill control. This is now based off the `isPolygon` function. This change removed/simplified a lot of the fill management, and has the side effect of remembering fill color/opacity when switching between point shapes (ellipse vs non-ellipse).
- Removed unnecessary `showFillStyleControls` functions in vector UI's.

To test:

1. Create polygonal places. Fill should be initialized to white with an opacity of 0. It should be displayed as such in both 2D/3D. Changes to fill controls should be reflected on the map.
2. Edit polygonal places. The fill color/opacity controls should be initialized properly. Changes to fill controls should be reflected on the map.
3. Create point/line places. Fill controls should not be displayed.
4. Change the shape on a point place to Ellipse. Fill controls should be displayed and functional.
5. Switch to a non-ellipse shape. Fill controls should be hidden.
6. Switch back to an ellipse shape. Fill controls should be displayed and maintain their previous values.