### PR TITLE
fix(cesium): only pick unfilled polygons from outline

### DIFF
--- a/src/plugin/cesium/sync/featureconverter.js
+++ b/src/plugin/cesium/sync/featureconverter.js
@@ -272,7 +272,10 @@ plugin.cesium.sync.FeatureConverter.prototype.wrapFillAndOutlineGeometries = fun
     var fillColor = this.extractColorFromOlStyle(style, false);
     fillColor.alpha *= layerOpacity;
 
-    primitives.add(this.createColoredPrimitive(fill, fillColor, undefined, undefined, primitiveType));
+    // hide the primitive when alpha is 0 so it isn't picked
+    var fillPrimitive = this.createColoredPrimitive(fill, fillColor, undefined, undefined, primitiveType);
+    fillPrimitive.show = fillColor.alpha > 0;
+    primitives.add(fillPrimitive);
   }
 
   if (outline) {
@@ -1181,6 +1184,8 @@ plugin.cesium.sync.FeatureConverter.prototype.olPolygonGeometryToCesiumPolyline 
 
       var p = this.createColoredPrimitive(fillGeometry, fillColor, undefined, undefined,
           heightReference === Cesium.HeightReference.CLAMP_TO_GROUND ? Cesium.GroundPrimitive : Cesium.Primitive);
+      // hide the primitive when alpha is 0 so it isn't picked
+      p.show = fillColor.alpha > 0;
       primitives.add(p);
     }
 
@@ -1543,6 +1548,9 @@ plugin.cesium.sync.FeatureConverter.prototype.updatePrimitive = function(feature
           }
 
           if (color) {
+            // hide the primitive when alpha is 0 so it isn't picked
+            primitive.show = color.alpha > 0;
+
             if (material && material.uniforms) {
               material.uniforms.color = color;
             } else {


### PR DESCRIPTION
Cesium GroundPrimitive is picked when alpha is 0. This is inconsistent with 2D and polygons using Primitive.

Test steps:
- Switch to 3D mode.
- Draw polygons/circles and save them to places.
- Set the altitude mode to Clamp to Ground. Verify the polygon is not picked from the center when it has a fill opacity of 0. It should be picked if the opacity is non-zero.
- Repeat with other altitude modes.
- Load [PolygonStyles.txt](https://github.com/ngageoint/opensphere/files/3880539/PolygonStyles.txt) (rename to `.kml` first).
- Verify all polygons are picked correctly. There is a separate issue causing extruded polygons to flicker at times on hover. That is unrelated to these changes and not being addressed here.

