### PR TITLE
Investigate refactor to goog.module

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -98,7 +98,7 @@ module.exports = function(config) {
     reporters: ['dots', 'junit', 'coverage'],
 
     preprocessors: {
-      'src/**/*.js': ['coverage']
+      'src/**/*.js': ['googmodule', 'coverage']
     },
 
     junitReporter: {

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.1",
     "karma-firefox-launcher": "^1.2.0",
+    "karma-googmodule-preprocessor": "^1.0.1",
     "karma-jasmine": "^0.1.0",
     "karma-junit-reporter": "^1.2.0",
     "lolex": "=2.3.2",

--- a/package.json
+++ b/package.json
@@ -242,7 +242,7 @@
     "cypress": "=3.5.0",
     "cypress-image-snapshot": "^3.0.1",
     "eslint": "^6.0.0",
-    "eslint-config-opensphere": "^3.0.0",
+    "eslint-config-opensphere": "^3.2.0",
     "google-closure-compiler": "^20190415.0.0",
     "http-server": "^0.11.1",
     "husky": "^3.0.1",

--- a/src/os/alert/alert.js
+++ b/src/os/alert/alert.js
@@ -1,41 +1,48 @@
-goog.provide('os.alert.Alert');
-goog.require('os.alert.AlertEventSeverity');
+goog.module('os.alert.Alert');
+goog.module.declareLegacyNamespace();
 
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity'); // eslint-disable-line no-unused-vars
 
 
 /**
- * Object to carry around alert details
- *
- * @param {string} message The alert to send and add to the window
- * @param {os.alert.AlertEventSeverity=} opt_severity Severity of the event, defaults to error
- * @constructor
+ * Object to carry around alert details.
  */
-os.alert.Alert = function(message, opt_severity) {
+class Alert {
   /**
-   * @type {string}
-   * @private
+   * @param {string} message The alert to send and add to the window
+   * @param {AlertEventSeverity=} opt_severity Severity of the event, defaults to error
    */
-  this.message_ = message;
+  constructor(message, opt_severity) {
+    /**
+     * The alert message.
+     * @type {string}
+     * @private
+     */
+    this.message_ = message;
+
+    /**
+     * The alert severity.
+     * @type {AlertEventSeverity|undefined}
+     * @private
+     */
+    this.severity_ = opt_severity;
+  }
 
   /**
-   * @type {os.alert.AlertEventSeverity|undefined}
-   * @private
+   * Get the alert message.
+   * @return {string}
    */
-  this.severity_ = opt_severity;
-};
+  getMessage() {
+    return this.message_;
+  }
 
+  /**
+   * Get the alert severity.
+   * @return {AlertEventSeverity|undefined}
+   */
+  getSeverity() {
+    return this.severity_;
+  }
+}
 
-/**
- * @return {string}
- */
-os.alert.Alert.prototype.getMessage = function() {
-  return this.message_;
-};
-
-
-/**
- * @return {os.alert.AlertEventSeverity|undefined}
- */
-os.alert.Alert.prototype.getSeverity = function() {
-  return this.severity_;
-};
+exports = Alert;

--- a/src/os/alert/alertevent.js
+++ b/src/os/alert/alertevent.js
@@ -1,160 +1,106 @@
-goog.provide('os.alert.AlertEvent');
-goog.provide('os.alert.AlertEventLevel');
-goog.provide('os.alert.AlertEventSeverity');
-goog.provide('os.alert.AlertEventTypes');
+goog.module('os.alert.AlertEvent');
+goog.module.declareLegacyNamespace();
+
 goog.require('goog.date.DateTime');
 goog.require('goog.events.Event');
 goog.require('goog.events.EventTarget');
-goog.require('os.alert.EventType');
 
-
-
-/**
- * An alert level
- *
- * @param {string} name The name of the level.
- * @param {number} value The numeric value of the level.
- * @constructor
- */
-os.alert.AlertEventLevel = function(name, value) {
-  /**
-   * The name of the level
-   * @type {string}
-   */
-  this.name = name;
-
-  /**
-   * The numeric value of the level
-   * @type {number}
-   */
-  this.value = value;
-};
-
-
-/**
- * @return {string} String representation of the alert level.
- * @override
- */
-os.alert.AlertEventLevel.prototype.toString = function() {
-  return this.name;
-};
-
-
-/**
- * Severity levels of alert events.
- * @enum {os.alert.AlertEventLevel}
- */
-os.alert.AlertEventSeverity = {
-  ERROR: new os.alert.AlertEventLevel('Error', 400),
-  WARNING: new os.alert.AlertEventLevel('Warning', 300),
-  SUCCESS: new os.alert.AlertEventLevel('Success', 200),
-  INFO: new os.alert.AlertEventLevel('Info', 100)
-};
-
-
-/**
- * @enum {string}
- */
-os.alert.AlertEventTypes = {
-  DISMISS_ALERT: 'dismissAlert'
-};
-
-
-
-/**
- * @extends {goog.events.Event}
- * @constructor
- * @param {string} message The alert message
- * @param {os.alert.AlertEventSeverity} severity The alert severity
- * @param {number=} opt_limit Maximum number of identical messages to display at once
- * @param {goog.events.EventTarget=} opt_dismissDispatcher
- */
-os.alert.AlertEvent = function(message, severity, opt_limit, opt_dismissDispatcher) {
-  os.alert.AlertEvent.base(this, 'constructor', os.alert.EventType.ALERT);
-
-  /**
-   * @type {string}
-   * @private
-   */
-  this.message_ = message;
-
-  /**
-   * @type {goog.date.DateTime}
-   * @private
-   */
-  this.time_ = new goog.date.DateTime();
-
-  /**
-   * @type {number}
-   * @private
-   */
-  this.limit_ = opt_limit || os.alert.AlertEvent.DEFAULT_LIMIT;
-
-  /**
-   * @type {goog.events.EventTarget}
-   * @private
-   */
-  this.dismissDispatcher_ = opt_dismissDispatcher || null;
-
-  /**
-   * @type {os.alert.AlertEventSeverity}
-   * @private
-   */
-  this.severity_ = severity;
-  this['id'] = os.alert.AlertEvent.id_++;
-};
-goog.inherits(os.alert.AlertEvent, goog.events.Event);
-
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity'); // eslint-disable-line no-unused-vars
+const EventType = goog.require('os.alert.EventType');
 
 /**
  * @type {number}
  * @const
  */
-os.alert.AlertEvent.DEFAULT_LIMIT = 5;
-
+const DEFAULT_LIMIT = 5;
 
 /**
  * @type {number}
  * @private
  */
-os.alert.AlertEvent.id_ = 0;
-
-
-/**
- * @return {number}
- */
-os.alert.AlertEvent.prototype.getLimit = function() {
-  return this.limit_;
-};
-
+let id_ = 0;
 
 /**
- * @return {string}
+ * @extends {goog.events.Event}
+ * @unrestricted
  */
-os.alert.AlertEvent.prototype.getMessage = function() {
-  return this.message_;
-};
+class AlertEvent extends goog.events.Event {
+  /**
+   * @param {string} message The alert message
+   * @param {AlertEventSeverity} severity The alert severity
+   * @param {number=} opt_limit Maximum number of identical messages to display at once
+   * @param {goog.events.EventTarget=} opt_dismissDispatcher
+   */
+  constructor(message, severity, opt_limit, opt_dismissDispatcher) {
+    super(EventType.ALERT);
 
+    /**
+     * @type {string}
+     * @private
+     */
+    this.message_ = message;
 
-/**
- * @return {goog.date.DateTime}
- */
-os.alert.AlertEvent.prototype.getTime = function() {
-  return this.time_;
-};
+    /**
+     * @type {goog.date.DateTime}
+     * @private
+     */
+    this.time_ = new goog.date.DateTime();
 
+    /**
+     * @type {number}
+     * @private
+     */
+    this.limit_ = opt_limit || DEFAULT_LIMIT;
 
-/**
- * @return {os.alert.AlertEventSeverity}
- */
-os.alert.AlertEvent.prototype.getSeverity = function() {
-  return this.severity_;
-};
+    /**
+     * @type {goog.events.EventTarget}
+     * @private
+     */
+    this.dismissDispatcher_ = opt_dismissDispatcher || null;
 
+    /**
+     * @type {AlertEventSeverity}
+     * @private
+     */
+    this.severity_ = severity;
+    this['id'] = id_++;
+  }
 
-/**
- * @return {goog.events.EventTarget}
- */
-os.alert.AlertEvent.prototype.getDismissDispatcher = function() {
-  return this.dismissDispatcher_;
-};
+  /**
+   * @return {number}
+   */
+  getLimit() {
+    return this.limit_;
+  }
+
+  /**
+   * @return {string}
+   */
+  getMessage() {
+    return this.message_;
+  }
+
+  /**
+   * @return {goog.date.DateTime}
+   */
+  getTime() {
+    return this.time_;
+  }
+
+  /**
+   * @return {AlertEventSeverity}
+   */
+  getSeverity() {
+    return this.severity_;
+  }
+
+  /**
+   * @return {goog.events.EventTarget}
+   */
+  getDismissDispatcher() {
+    return this.dismissDispatcher_;
+  }
+}
+
+exports = AlertEvent;
+exports.DEFAULT_LIMIT = DEFAULT_LIMIT;

--- a/src/os/alert/alerteventlevel.js
+++ b/src/os/alert/alerteventlevel.js
@@ -1,0 +1,36 @@
+goog.module('os.alert.AlertEventLevel');
+goog.module.declareLegacyNamespace();
+
+
+/**
+ * An alert level.
+ */
+class AlertEventLevel {
+  /**
+   * @param {string} name The name of the level.
+   * @param {number} value The numeric value of the level.
+   */
+  constructor(name, value) {
+    /**
+     * The name of the level.
+     * @type {string}
+     */
+    this.name = name;
+
+    /**
+     * The numeric value of the level.
+     * @type {number}
+     */
+    this.value = value;
+  }
+
+  /**
+   * @return {string} String representation of the alert level.
+   * @override
+   */
+  toString() {
+    return this.name;
+  }
+}
+
+exports = AlertEventLevel;

--- a/src/os/alert/alerteventseverity.js
+++ b/src/os/alert/alerteventseverity.js
@@ -1,0 +1,17 @@
+goog.module('os.alert.AlertEventSeverity');
+goog.module.declareLegacyNamespace();
+
+const AlertEventLevel = goog.require('os.alert.AlertEventLevel');
+
+/**
+ * Severity levels of alert events.
+ * @enum {AlertEventLevel}
+ */
+const AlertEventSeverity = {
+  ERROR: new AlertEventLevel('Error', 400),
+  WARNING: new AlertEventLevel('Warning', 300),
+  SUCCESS: new AlertEventLevel('Success', 200),
+  INFO: new AlertEventLevel('Info', 100)
+};
+
+exports = AlertEventSeverity;

--- a/src/os/alert/alerteventtypes.js
+++ b/src/os/alert/alerteventtypes.js
@@ -1,0 +1,11 @@
+goog.module('os.alert.AlertEventTypes');
+goog.module.declareLegacyNamespace();
+
+/**
+ * @enum {string}
+ */
+const AlertEventTypes = {
+  DISMISS_ALERT: 'dismissAlert'
+};
+
+exports = AlertEventTypes;

--- a/src/os/alert/alertmanager.js
+++ b/src/os/alert/alertmanager.js
@@ -77,10 +77,10 @@ class AlertManager extends goog.events.EventTarget {
    *   by dispatching a {@code os.alert.AlertEventTypes.DISMISS_ALERT} event
    */
   sendAlert(alert, opt_severity, opt_logger, opt_limit, opt_dismissDispatcher) {
-    var severity = opt_severity || AlertEventSeverity.ERROR;
+    const severity = opt_severity || AlertEventSeverity.ERROR;
 
     // fire off the alert
-    var alertEvent = new os.alert.AlertEvent(alert, severity, opt_limit, opt_dismissDispatcher);
+    const alertEvent = new os.alert.AlertEvent(alert, severity, opt_limit, opt_dismissDispatcher);
     this.savedAlerts_.add(alertEvent);
     this.dispatchEvent(alertEvent);
 
@@ -148,8 +148,8 @@ class AlertManager extends goog.events.EventTarget {
    */
   processMissedAlerts(clientId, handler, opt_context) {
     if (!this.missedAlertsProcessed_) {
-      var beforeCount = this.processedByClientCount_[clientId] || 0;
-      var alerts = goog.array.slice(this.savedAlerts_.getValues(), 0, this.savedAlerts_.getCount() - beforeCount);
+      const beforeCount = this.processedByClientCount_[clientId] || 0;
+      const alerts = goog.array.slice(this.savedAlerts_.getValues(), 0, this.savedAlerts_.getCount() - beforeCount);
       os.array.forEach(alerts, handler, opt_context);
       this.processedByClientCount_[clientId] = this.savedAlerts_.getCount();
       this.missedAlertsProcessed_ = true;

--- a/src/os/alert/alertmanager.js
+++ b/src/os/alert/alertmanager.js
@@ -1,163 +1,161 @@
-goog.provide('os.alert.AlertManager');
-goog.provide('os.alertManager');
+goog.module('os.alert.AlertManager');
+goog.module.declareLegacyNamespace();
+
 goog.require('goog.events.EventTarget');
 goog.require('goog.log');
 goog.require('goog.structs.CircularBuffer');
 goog.require('os.alert.AlertEvent');
-goog.require('os.alert.AlertEventSeverity');
 goog.require('os.array');
 goog.require('os.structs.EventType');
 
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const AlertEventType = goog.require('os.alert.EventType');
 
+
+/**
+ * Maximum number of alerts to be saved.
+ * @type {number}
+ * @private
+ */
+const maxSaved_ = 10000;
 
 /**
  * Responsible for receiving, logging and reporting alerts
- *
  * @extends {goog.events.EventTarget}
- * @constructor
  */
-os.alert.AlertManager = function() {
-  os.alert.AlertManager.base(this, 'constructor');
+class AlertManager extends goog.events.EventTarget {
+  /**
+   */
+  constructor() {
+    super();
+
+    /**
+     * @type {!goog.structs.CircularBuffer.<!os.alert.AlertEvent>}
+     * @private
+     */
+    this.savedAlerts_ = new goog.structs.CircularBuffer(maxSaved_);
+
+    /**
+     * Tracks the number of alerts process by any given client so the client can get all alerts even if it comes online
+     * later.
+     * @type {!Object.<!string, !number>}
+     * @private
+     */
+    this.processedByClientCount_ = {};
+
+    /**
+     * Ensures that processMissedAlerts is only called once
+     * @type {boolean}
+     * @private
+     */
+    this.missedAlertsProcessed_ = false;
+
+    /**
+     * Ensures that an alert is only sent once
+     * @type {Object<string, boolean>}
+     * @private
+     */
+    this.onceMap_ = {};
+  }
 
   /**
-   * @type {!goog.structs.CircularBuffer.<!os.alert.AlertEvent>}
-   * @private
+   * Maximum number of alerts to be saved.
+   * @return {number}
    */
-  this.savedAlerts_ = new goog.structs.CircularBuffer(os.alert.AlertManager.MAX_SAVED);
+  static get MAX_SAVED() {
+    return maxSaved_;
+  }
 
   /**
-   * Tracks the number of alerts process by any given client so the client can get all alerts even if it comes online
-   * later.
-   * @type {!Object.<!string, !number>}
-   * @private
+   * Takes a string and converts it into an alert event, then dispatches it
+   *
+   * @param {string} alert The alert to send and add to the window
+   * @param {AlertEventSeverity=} opt_severity Severity of the event, defaults to error
+   * @param {goog.log.Logger=} opt_logger If provided, writes the message to this logger
+   * @param {number=} opt_limit Maximum number of duplicate alerts to display, defaults to 5
+   * @param {goog.events.EventTarget=} opt_dismissDispatcher Event target which will indicate when to dismiss the alert
+   *   by dispatching a {@code os.alert.AlertEventTypes.DISMISS_ALERT} event
    */
-  this.processedByClientCount_ = {};
+  sendAlert(alert, opt_severity, opt_logger, opt_limit, opt_dismissDispatcher) {
+    var severity = opt_severity || AlertEventSeverity.ERROR;
 
-  /**
-   * Ensures that processMissedAlerts is only called once
-   * @type {boolean}
-   * @private
-   */
-  this.missedAlertsProcessed_ = false;
+    // fire off the alert
+    var alertEvent = new os.alert.AlertEvent(alert, severity, opt_limit, opt_dismissDispatcher);
+    this.savedAlerts_.add(alertEvent);
+    this.dispatchEvent(alertEvent);
 
-  /**
-   * Ensures that an alert is only sent once
-   * @type {Object<string, boolean>}
-   * @private
-   */
-  this.onceMap_ = {};
-};
-goog.inherits(os.alert.AlertManager, goog.events.EventTarget);
-goog.addSingletonGetter(os.alert.AlertManager);
-
-
-/**
- * Max number of alerts to be saved
- * @type {number}
- * @const
- */
-os.alert.AlertManager.MAX_SAVED = 10000;
-
-
-/**
- * Takes a string and converts it into an alert event, then dispatches it
- *
- * @param {string} alert The alert to send and add to the window
- * @param {os.alert.AlertEventSeverity=} opt_severity Severity of the event, defaults to error
- * @param {goog.log.Logger=} opt_logger If provided, writes the message to this logger
- * @param {number=} opt_limit Maximum number of duplicate alerts to display, defaults to 5
- * @param {goog.events.EventTarget=} opt_dismissDispatcher Event target which will indicate when to dismiss the alert
- *   by dispatching a {@code os.alert.AlertEventTypes.DISMISS_ALERT} event
- */
-os.alert.AlertManager.prototype.sendAlert = function(alert, opt_severity, opt_logger, opt_limit,
-    opt_dismissDispatcher) {
-  var severity = opt_severity || os.alert.AlertEventSeverity.ERROR;
-
-  // fire off the alert
-  var alertEvent = new os.alert.AlertEvent(alert, severity, opt_limit, opt_dismissDispatcher);
-  this.savedAlerts_.add(alertEvent);
-  this.dispatchEvent(alertEvent);
-
-  // write the message to the logger if defined
-  if (opt_logger != null) {
-    switch (severity) {
-      case os.alert.AlertEventSeverity.ERROR:
-        goog.log.error(opt_logger, alert);
-        break;
-      case os.alert.AlertEventSeverity.WARNING:
-        goog.log.warning(opt_logger, alert);
-        break;
-      case os.alert.AlertEventSeverity.INFO:
-      case os.alert.AlertEventSeverity.SUCCESS:
-      default:
-        goog.log.info(opt_logger, alert);
-        break;
+    // write the message to the logger if defined
+    if (opt_logger != null) {
+      switch (severity) {
+        case AlertEventSeverity.ERROR:
+          goog.log.error(opt_logger, alert);
+          break;
+        case AlertEventSeverity.WARNING:
+          goog.log.warning(opt_logger, alert);
+          break;
+        case AlertEventSeverity.INFO:
+        case AlertEventSeverity.SUCCESS:
+        default:
+          goog.log.info(opt_logger, alert);
+          break;
+      }
     }
   }
-};
 
-
-/**
- * Check an alert string against onceMap_ before sending an alert
- *
- * @param {string} alert The alert to send and add to the window
- * @param {os.alert.AlertEventSeverity=} opt_severity Severity of the event, defaults to error
- * @param {goog.log.Logger=} opt_logger If provided, writes the message to this logger
- * @param {number=} opt_limit Maximum number of duplicate alerts to display, defaults to 5
- * @param {goog.events.EventTarget=} opt_dismissDispatcher Event target which will indicate when to dismiss the alert
- *   by dispatching a {@code os.alert.AlertEventTypes.DISMISS_ALERT} event
- */
-os.alert.AlertManager.prototype.sendAlertOnce = function(alert, opt_severity, opt_logger, opt_limit,
-    opt_dismissDispatcher) {
-  if (this.onceMap_[alert]) {
-    return;
-  } else {
-    this.onceMap_[alert] = true;
-    opt_limit = 1;
-    this.sendAlert(alert, opt_severity, opt_logger, opt_limit, opt_dismissDispatcher);
+  /**
+   * Check an alert string against onceMap_ before sending an alert
+   *
+   * @param {string} alert The alert to send and add to the window
+   * @param {AlertEventSeverity=} opt_severity Severity of the event, defaults to error
+   * @param {goog.log.Logger=} opt_logger If provided, writes the message to this logger
+   * @param {number=} opt_limit Maximum number of duplicate alerts to display, defaults to 5
+   * @param {goog.events.EventTarget=} opt_dismissDispatcher Event target which will indicate when to dismiss the alert
+   *   by dispatching a {@code os.alert.AlertEventTypes.DISMISS_ALERT} event
+   */
+  sendAlertOnce(alert, opt_severity, opt_logger, opt_limit, opt_dismissDispatcher) {
+    if (this.onceMap_[alert]) {
+      return;
+    } else {
+      this.onceMap_[alert] = true;
+      opt_limit = 1;
+      this.sendAlert(alert, opt_severity, opt_logger, opt_limit, opt_dismissDispatcher);
+    }
   }
-};
 
-
-/**
- * Clear the alert buffer
- */
-os.alert.AlertManager.prototype.clearAlerts = function() {
-  this.savedAlerts_.clear();
-  this.dispatchEvent(os.alert.EventType.CLEAR_ALERTS);
-};
-
-
-/**
- * Get the alert buffer
- *
- * @return {!goog.structs.CircularBuffer.<!os.alert.AlertEvent>} Object containing the parsed record
- */
-os.alert.AlertManager.prototype.getAlerts = function() {
-  return this.savedAlerts_;
-};
-
-
-/**
- * Process alerts that AlertManager may have already generated before this class has initialized.
- *
- * @param {!string} clientId An arbitrary string to identify the client that is processing alerts
- * @param {!function(os.alert.AlertEvent)} handler
- * @param {*=} opt_context
- */
-os.alert.AlertManager.prototype.processMissedAlerts = function(clientId, handler, opt_context) {
-  if (!this.missedAlertsProcessed_) {
-    var beforeCount = this.processedByClientCount_[clientId] || 0;
-    var alerts = goog.array.slice(this.savedAlerts_.getValues(), 0, this.savedAlerts_.getCount() - beforeCount);
-    os.array.forEach(alerts, handler, opt_context);
-    this.processedByClientCount_[clientId] = this.savedAlerts_.getCount();
-    this.missedAlertsProcessed_ = true;
+  /**
+   * Clear the alert buffer
+   */
+  clearAlerts() {
+    this.savedAlerts_.clear();
+    this.dispatchEvent(AlertEventType.CLEAR_ALERTS);
   }
-};
 
+  /**
+   * Get the alert buffer
+   *
+   * @return {!goog.structs.CircularBuffer.<!os.alert.AlertEvent>} Object containing the parsed record
+   */
+  getAlerts() {
+    return this.savedAlerts_;
+  }
 
-/**
- * Global alert manager reference.
- * @type {os.alert.AlertManager}
- */
-os.alertManager = os.alert.AlertManager.getInstance();
+  /**
+   * Process alerts that AlertManager may have already generated before this class has initialized.
+   *
+   * @param {!string} clientId An arbitrary string to identify the client that is processing alerts
+   * @param {!function(os.alert.AlertEvent)} handler
+   * @param {*=} opt_context
+   */
+  processMissedAlerts(clientId, handler, opt_context) {
+    if (!this.missedAlertsProcessed_) {
+      var beforeCount = this.processedByClientCount_[clientId] || 0;
+      var alerts = goog.array.slice(this.savedAlerts_.getValues(), 0, this.savedAlerts_.getCount() - beforeCount);
+      os.array.forEach(alerts, handler, opt_context);
+      this.processedByClientCount_[clientId] = this.savedAlerts_.getCount();
+      this.missedAlertsProcessed_ = true;
+    }
+  }
+}
+goog.addSingletonGetter(AlertManager);
+
+exports = AlertManager;

--- a/src/os/alert/alertmanager.js
+++ b/src/os/alert/alertmanager.js
@@ -15,7 +15,6 @@ const AlertEventType = goog.require('os.alert.EventType');
 /**
  * Maximum number of alerts to be saved.
  * @type {number}
- * @private
  */
 const maxSaved_ = 10000;
 
@@ -64,6 +63,14 @@ class AlertManager extends goog.events.EventTarget {
    */
   static get MAX_SAVED() {
     return maxSaved_;
+  }
+
+  /**
+   * Global alert manager instance.
+   * @return {AlertManager}
+   */
+  static getInstance() {
+    return instance_;
   }
 
   /**
@@ -156,6 +163,11 @@ class AlertManager extends goog.events.EventTarget {
     }
   }
 }
-goog.addSingletonGetter(AlertManager);
+
+/**
+ * Global alert manager instance.
+ * @type {AlertManager}
+ */
+const instance_ = new AlertManager();
 
 exports = AlertManager;

--- a/src/os/alert/alertmanagerinstance.js
+++ b/src/os/alert/alertmanagerinstance.js
@@ -1,0 +1,12 @@
+goog.module('os.alertManager');
+goog.module.declareLegacyNamespace();
+
+const AlertManager = goog.require('os.alert.AlertManager');
+
+/**
+ * Global alert manager reference.
+ * @type {AlertManager}
+ */
+const instance = AlertManager.getInstance();
+
+exports = instance;

--- a/src/os/alert/alertmanagerinstance.js
+++ b/src/os/alert/alertmanagerinstance.js
@@ -1,12 +1,10 @@
+/**
+ * This is added for backward compatibility with files that goog.require('os.alertManager'). This can be removed if
+ * those are replaced with `goog.require('os.alert.AlertManager')` and use `getInstance()`.
+ */
 goog.module('os.alertManager');
 goog.module.declareLegacyNamespace();
 
 const AlertManager = goog.require('os.alert.AlertManager');
 
-/**
- * Global alert manager reference.
- * @type {AlertManager}
- */
-const instance = AlertManager.getInstance();
-
-exports = instance;
+exports = AlertManager.getInstance();

--- a/src/os/alert/eventtype.js
+++ b/src/os/alert/eventtype.js
@@ -1,10 +1,12 @@
-goog.provide('os.alert.EventType');
-
+goog.module('os.alert.EventType');
+goog.module.declareLegacyNamespace();
 
 /**
  * @enum {string}
  */
-os.alert.EventType = {
+const EventType = {
   ALERT: 'alert',
   CLEAR_ALERTS: 'clearAlerts'
 };
+
+exports = EventType;

--- a/src/os/arraybuf.js
+++ b/src/os/arraybuf.js
@@ -41,9 +41,9 @@ const isText = function(ab) {
     return true;
   }
 
-  var dv = new DataView(ab);
-  var n = Math.min(64000, dv.byteLength);
-  var has32 = n >= 4;
+  const dv = new DataView(ab);
+  const n = Math.min(64000, dv.byteLength);
+  const has32 = n >= 4;
 
   if (n == 0) {
     // empty files are considered text
@@ -55,19 +55,19 @@ const isText = function(ab) {
     return false;
   }
 
-  var nonTextBytes = 0;
-  var pdfMax = Math.min(1021, n - 3);
-  for (var i = 0; i < n; i++) {
+  let nonTextBytes = 0;
+  const pdfMax = Math.min(1021, n - 3);
+  for (let i = 0; i < n; i++) {
     if (has32 && i < pdfMax) {
       // PDF magic number can occur anywhere in the first 1024 bytes according to the spec, so check each one
-      var int32 = dv.getUint32(i);
+      const int32 = dv.getUint32(i);
       if (int32 === MagicNumber.PDF) {
         // PDF files are also considered binary regardless of contents
         return false;
       }
     }
 
-    var b = dv.getUint8(i);
+    const b = dv.getUint8(i);
 
     if (b == 0) {
       // files with null bytes are likely binary
@@ -108,19 +108,19 @@ const isTextCharacter = function(b) {
  * @deprecated Please use os.file.mime.text.getText() instead
  */
 const toString = function(ab) {
-  var s = '';
+  let s = '';
   // strip the BOM if the content has one
   if (goog.array.equals(new Uint8Array(ab.slice(0, 3)), BYTE_ORDER_MARKER)) {
     ab = ab.slice(3);
   }
 
   // TextDecoder.decode only works with a DataView in earlier versions of Firefox
-  var dv = new DataView(ab);
+  const dv = new DataView(ab);
 
-  var toTry = ['utf-8', 'latin2', 'latin3', 'latin4', 'cyrillic', 'utf-16'];
-  for (var i = 0, ii = toTry.length; i < ii; i++) {
+  const toTry = ['utf-8', 'latin2', 'latin3', 'latin4', 'cyrillic', 'utf-16'];
+  for (let i = 0, ii = toTry.length; i < ii; i++) {
     // this is poly-filled by the text-encoding package
-    var decoder = new TextDecoder(toTry[i], {fatal: true});
+    const decoder = new TextDecoder(toTry[i], {fatal: true});
 
     try {
       s = decoder.decode(dv);

--- a/src/os/arraybuf.js
+++ b/src/os/arraybuf.js
@@ -1,28 +1,21 @@
-goog.provide('os.arraybuf');
+goog.module('os.arraybuf');
+goog.module.declareLegacyNamespace();
 
-
-/**
- * Maximum ArrayBuffer size for string conversion. Larger buffers will be converted a chunk at a time.
- * @type {number}
- * @const
- * @private
- */
-os.arraybuf.MAX_STRING_CHUNK_ = 65536;
+goog.require('goog.array');
 
 
 /**
  * The Byte Order Marker (BOM) sequence.
  * @type {!Array<number>}
- * @const
  */
-os.arraybuf.BYTE_ORDER_MARKER = [0xef, 0xbb, 0xbf];
+const BYTE_ORDER_MARKER = [0xef, 0xbb, 0xbf];
 
 
 /**
  * Enumeration of magic numbers for array buffer type checking.
  * @enum {number}
  */
-os.arraybuf.MagicNumber = {
+const MagicNumber = {
   ZIP: 0x504b0304,
   PDF: 0x25504446
 };
@@ -41,9 +34,9 @@ os.arraybuf.MagicNumber = {
  * @return {boolean}
  * @deprecated Please use Boolean(os.file.mime.text.getText()) instead
  */
-os.arraybuf.isText = function(ab) {
+const isText = function(ab) {
   // If UTF-8 Byte Order Mark exists
-  if (goog.array.equals(new Uint8Array(ab.slice(0, 3)), os.arraybuf.BYTE_ORDER_MARKER)) {
+  if (goog.array.equals(new Uint8Array(ab.slice(0, 3)), BYTE_ORDER_MARKER)) {
     // just assume it is text
     return true;
   }
@@ -57,7 +50,7 @@ os.arraybuf.isText = function(ab) {
     return true;
   }
 
-  if (has32 && dv.getUint32(0) == os.arraybuf.MagicNumber.ZIP) {
+  if (has32 && dv.getUint32(0) == MagicNumber.ZIP) {
     // zip files are considered binary regardless of contents
     return false;
   }
@@ -68,7 +61,7 @@ os.arraybuf.isText = function(ab) {
     if (has32 && i < pdfMax) {
       // PDF magic number can occur anywhere in the first 1024 bytes according to the spec, so check each one
       var int32 = dv.getUint32(i);
-      if (int32 === os.arraybuf.MagicNumber.PDF) {
+      if (int32 === MagicNumber.PDF) {
         // PDF files are also considered binary regardless of contents
         return false;
       }
@@ -81,7 +74,7 @@ os.arraybuf.isText = function(ab) {
       return false;
     }
 
-    if (!os.arraybuf.isTextCharacter(b)) {
+    if (!isTextCharacter(b)) {
       nonTextBytes++;
     }
   }
@@ -102,7 +95,7 @@ os.arraybuf.isText = function(ab) {
  * @return {boolean}
  * @deprecated Please see the os.file.mime.text package instead
  */
-os.arraybuf.isTextCharacter = function(b) {
+const isTextCharacter = function(b) {
   return b == 10 || b == 13 || b == 9 || b == 8 || (b >= 32 && b <= 127);
 };
 
@@ -114,10 +107,10 @@ os.arraybuf.isTextCharacter = function(b) {
  * @return {string} The string
  * @deprecated Please use os.file.mime.text.getText() instead
  */
-os.arraybuf.toString = function(ab) {
+const toString = function(ab) {
   var s = '';
   // strip the BOM if the content has one
-  if (goog.array.equals(new Uint8Array(ab.slice(0, 3)), os.arraybuf.BYTE_ORDER_MARKER)) {
+  if (goog.array.equals(new Uint8Array(ab.slice(0, 3)), BYTE_ORDER_MARKER)) {
     ab = ab.slice(3);
   }
 
@@ -140,3 +133,5 @@ os.arraybuf.toString = function(ab) {
   // trim nulls from the beginning/end
   return s.replace(/(^\x00+)|(\x00+$)/g, '');
 };
+
+exports = {BYTE_ORDER_MARKER, MagicNumber, isText, isTextCharacter, toString};

--- a/src/os/capture/capture.js
+++ b/src/os/capture/capture.js
@@ -13,6 +13,7 @@ goog.require('os.defines');
 goog.require('os.file.persist.FilePersistence');
 goog.require('os.job.Job');
 goog.require('os.string');
+goog.require('os.worker');
 
 
 /**

--- a/src/os/debug/fancierwindow.js
+++ b/src/os/debug/fancierwindow.js
@@ -52,7 +52,7 @@ class FancierWindow extends goog.debug.FancyWindow {
     super.writeInitialDocument();
 
     /** @suppress {accessControls} To access the private dom helper for the logging window to get the save button */
-    var saveButton = this.dh_.getElement('savebutton');
+    const saveButton = this.dh_.getElement('savebutton');
     saveButton.addEventListener(goog.events.EventType.CLICK, this.exportLogs_.bind(this));
 
     // close button should set the debug window to disabled
@@ -72,8 +72,8 @@ class FancierWindow extends goog.debug.FancyWindow {
    * @inheritDoc
    */
   getStyleRules() {
-    var baseRules = super.getStyleRules();
-    var extraRules = goog.html.SafeStyleSheet.fromConstant(styleRules);
+    const baseRules = super.getStyleRules();
+    const extraRules = goog.html.SafeStyleSheet.fromConstant(styleRules);
     return goog.html.SafeStyleSheet.concat(baseRules, extraRules);
   }
 
@@ -82,17 +82,17 @@ class FancierWindow extends goog.debug.FancyWindow {
    * @suppress {accessControls} To overwrite private method getHtml_ to add save button
    */
   getHtml_() {
-    var baseHtml = super.getHtml_();
+    const baseHtml = super.getHtml_();
 
-    var SafeHtml = goog.html.SafeHtml;
+    const SafeHtml = goog.html.SafeHtml;
 
-    var body = SafeHtml.create(
+    const body = SafeHtml.create(
         'body', {},
         SafeHtml.create(
             'div', {'id': 'head'},
             SafeHtml.create('span', {'id': 'savebutton'}, 'save')));
 
-    var additionalHtml = SafeHtml.create('html', {}, body);
+    const additionalHtml = SafeHtml.create('html', {}, body);
     return goog.html.SafeHtml.concat(baseHtml, additionalHtml);
   }
 
@@ -101,22 +101,22 @@ class FancierWindow extends goog.debug.FancyWindow {
    * @private
    */
   exportLogs_() {
-    var SafeHtml = goog.html.SafeHtml;
-    var head = SafeHtml.create(
+    const SafeHtml = goog.html.SafeHtml;
+    const head = SafeHtml.create(
         'head', {},
         SafeHtml.concat(
             SafeHtml.create('title', {}, 'Logging: ' + this.identifier),
             SafeHtml.createStyle(this.getStyleRules())));
 
-    var htmlMessages = [];
+    const htmlMessages = [];
 
     /** @suppress {accessControls} To access the private log messages (savedMessges_) */
-    var messages = this.savedMessages_.getValues();
-    for (var i = 0; i < messages.length; i++) {
+    const messages = this.savedMessages_.getValues();
+    for (let i = 0; i < messages.length; i++) {
       htmlMessages.push(SafeHtml.create('div', {'class': 'logmsg'}, messages[i]));
     }
 
-    var body = SafeHtml.create(
+    const body = SafeHtml.create(
         'body', {},
         SafeHtml.concat(
             SafeHtml.create(
@@ -124,9 +124,10 @@ class FancierWindow extends goog.debug.FancyWindow {
                 {'id': 'log', 'style': goog.string.Const.from('overflow:auto;height:100%;')},
                 SafeHtml.concat(htmlMessages))));
 
-    var logOutput = SafeHtml.create('html', {}, SafeHtml.concat(head, body));
+    const logOutput = SafeHtml.create('html', {}, SafeHtml.concat(head, body));
 
-    var outFileName = this.identifier + 'LoggingOutput_' + moment(goog.now()).utc().format('YYYYMMDD_Hmmss') + 'Z.html';
+    const outFileName = this.identifier + 'LoggingOutput_' + moment(goog.now()).utc().format('YYYYMMDD_Hmmss') +
+        'Z.html';
     if (os.file.persist.saveFile(outFileName, goog.html.SafeHtml.unwrap(logOutput), 'text/html')) {
       os.alert.AlertManager.getInstance().sendAlert('Created ' + outFileName, os.alert.AlertEventSeverity.SUCCESS);
     } else {

--- a/src/os/debug/fancierwindow.js
+++ b/src/os/debug/fancierwindow.js
@@ -1,4 +1,6 @@
-goog.provide('os.debug.FancierWindow');
+goog.module('os.debug.FancierWindow');
+goog.module.declareLegacyNamespace();
+
 goog.require('goog.debug.FancyWindow');
 goog.require('goog.html.SafeStyleSheet');
 goog.require('goog.string.Const');
@@ -7,27 +9,12 @@ goog.require('os.file.persist.FilePersistence');
 goog.require('os.ui');
 
 
-
-/**
- * Makes FancyWindow fancier by making the window close button do the same thing as clicking the exit button
- *
- * @param {string=} opt_identifier Identifier for this logging class
- * @param {string=} opt_prefix Prefix pre-pended to the messages
- * @extends {goog.debug.FancyWindow}
- * @constructor
- */
-os.debug.FancierWindow = function(opt_identifier, opt_prefix) {
-  os.debug.FancierWindow.base(this, 'constructor', opt_identifier, opt_prefix);
-};
-goog.inherits(os.debug.FancierWindow, goog.debug.FancyWindow);
-
-
 /**
  * @type {!goog.string.Const}
  * @private
  * @const
  */
-os.debug.FancierWindow.STYLE_RULES_ = goog.string.Const.from(
+const styleRules = goog.string.Const.from(
     '#log{background-color:#000;}' +
     '.logmsg{color:#eee;}' +
     '.dbg-i{color:#0f0;}' +
@@ -42,108 +29,122 @@ os.debug.FancierWindow.STYLE_RULES_ = goog.string.Const.from(
     '#savebutton{text-decoration:underline;color:#eee;cursor:' +
     'pointer;position:absolute;top:0px;right:115px;font:x-small arial;}');
 
-/**
- * @inheritDoc
- */
-os.debug.FancierWindow.prototype.writeInitialDocument = function() {
-  goog.events.unlisten(this.win, goog.events.EventType.BEFOREUNLOAD, this.closeLogger, false, this);
-  os.debug.FancierWindow.superClass_.writeInitialDocument.call(this);
-
-  /** @suppress {accessControls} To access the private dom helper for the logging window to get the save button */
-  var saveButton = this.dh_.getElement('savebutton');
-  saveButton.addEventListener(goog.events.EventType.CLICK, this.exportLogs_.bind(this));
-
-  // close button should set the debug window to disabled
-  if (this.win) {
-    goog.events.listenOnce(this.win, goog.events.EventType.BEFOREUNLOAD, this.closeLogger, false, this);
-  }
-};
-
 
 /**
- * @suppress {accessControls}
+ * Makes FancyWindow fancier by making the window close button do the same thing as clicking the exit button
+ * @extends {goog.debug.FancyWindow}
  */
-os.debug.FancierWindow.prototype.closeLogger = function() {
-  this.exit_(null);
-};
-
-
-/**
- * @inheritDoc
- */
-os.debug.FancierWindow.prototype.getStyleRules = function() {
-  var baseRules = os.debug.FancierWindow.base(this, 'getStyleRules');
-  var extraRules = goog.html.SafeStyleSheet.fromConstant(os.debug.FancierWindow.STYLE_RULES_);
-  return goog.html.SafeStyleSheet.concat(baseRules, extraRules);
-};
-
-
-/**
- * @inheritDoc
- * @suppress {accessControls} To overwrite private method getHtml_ to add save button
- */
-os.debug.FancierWindow.prototype.getHtml_ = function() {
-  var baseHtml = os.debug.FancierWindow.superClass_.getHtml_.call(this);
-
-  var SafeHtml = goog.html.SafeHtml;
-
-  var body = SafeHtml.create(
-      'body', {},
-      SafeHtml.create(
-          'div', {'id': 'head'},
-          SafeHtml.create('span', {'id': 'savebutton'}, 'save')));
-
-  var additionalHtml = SafeHtml.create('html', {}, body);
-  return goog.html.SafeHtml.concat(baseHtml, additionalHtml);
-};
-
-
-/**
- * Export the logs to a file.
- * @private
- */
-os.debug.FancierWindow.prototype.exportLogs_ = function() {
-  var SafeHtml = goog.html.SafeHtml;
-  var head = SafeHtml.create(
-      'head', {},
-      SafeHtml.concat(
-          SafeHtml.create('title', {}, 'Logging: ' + this.identifier),
-          SafeHtml.createStyle(this.getStyleRules())));
-
-  var htmlMessages = [];
-
-  /** @suppress {accessControls} To access the private log messages (savedMessges_) */
-  var messages = this.savedMessages_.getValues();
-  for (var i = 0; i < messages.length; i++) {
-    htmlMessages.push(SafeHtml.create('div', {'class': 'logmsg'}, messages[i]));
+class FancierWindow extends goog.debug.FancyWindow {
+  /**
+   * Constructor.
+   * @param {string=} opt_identifier Identifier for this logging class
+   * @param {string=} opt_prefix Prefix pre-pended to the messages
+   */
+  constructor(opt_identifier, opt_prefix) {
+    super(opt_identifier, opt_prefix);
   }
 
-  var body = SafeHtml.create(
-      'body', {},
-      SafeHtml.concat(
-          SafeHtml.create(
-              'div',
-              {'id': 'log', 'style': goog.string.Const.from('overflow:auto;height:100%;')},
-              SafeHtml.concat(htmlMessages))));
+  /**
+   * @inheritDoc
+   */
+  writeInitialDocument() {
+    goog.events.unlisten(this.win, goog.events.EventType.BEFOREUNLOAD, this.closeLogger, false, this);
+    super.writeInitialDocument();
 
-  var logOutput = SafeHtml.create('html', {}, SafeHtml.concat(head, body));
+    /** @suppress {accessControls} To access the private dom helper for the logging window to get the save button */
+    var saveButton = this.dh_.getElement('savebutton');
+    saveButton.addEventListener(goog.events.EventType.CLICK, this.exportLogs_.bind(this));
 
-  var outFileName = this.identifier + 'LoggingOutput_' + moment(goog.now()).utc().format('YYYYMMDD_Hmmss') + 'Z.html';
-  if (os.file.persist.saveFile(outFileName, goog.html.SafeHtml.unwrap(logOutput), 'text/html')) {
-    os.alert.AlertManager.getInstance().sendAlert('Created ' + outFileName, os.alert.AlertEventSeverity.SUCCESS);
-  } else {
-    os.alert.AlertManager.getInstance().sendAlert('Could not create ' + outFileName, os.alert.AlertEventSeverity.ERROR);
+    // close button should set the debug window to disabled
+    if (this.win) {
+      goog.events.listenOnce(this.win, goog.events.EventType.BEFOREUNLOAD, this.closeLogger, false, this);
+    }
   }
-};
 
-
-/**
- * @inheritDoc
- */
-os.debug.FancierWindow.prototype.addLogRecord = function(logRecord) {
-  // If this window is not opened but enabled (the X button was clicked), then disable it
-  if (!this.hasActiveWindow() && this.isEnabled()) {
-    this.setEnabled(false);
+  /**
+   * @suppress {accessControls}
+   */
+  closeLogger() {
+    this.exit_(null);
   }
-  os.debug.FancierWindow.superClass_.addLogRecord.call(this, logRecord);
-};
+
+  /**
+   * @inheritDoc
+   */
+  getStyleRules() {
+    var baseRules = super.getStyleRules();
+    var extraRules = goog.html.SafeStyleSheet.fromConstant(styleRules);
+    return goog.html.SafeStyleSheet.concat(baseRules, extraRules);
+  }
+
+  /**
+   * @inheritDoc
+   * @suppress {accessControls} To overwrite private method getHtml_ to add save button
+   */
+  getHtml_() {
+    var baseHtml = super.getHtml_();
+
+    var SafeHtml = goog.html.SafeHtml;
+
+    var body = SafeHtml.create(
+        'body', {},
+        SafeHtml.create(
+            'div', {'id': 'head'},
+            SafeHtml.create('span', {'id': 'savebutton'}, 'save')));
+
+    var additionalHtml = SafeHtml.create('html', {}, body);
+    return goog.html.SafeHtml.concat(baseHtml, additionalHtml);
+  }
+
+  /**
+   * Export the logs to a file.
+   * @private
+   */
+  exportLogs_() {
+    var SafeHtml = goog.html.SafeHtml;
+    var head = SafeHtml.create(
+        'head', {},
+        SafeHtml.concat(
+            SafeHtml.create('title', {}, 'Logging: ' + this.identifier),
+            SafeHtml.createStyle(this.getStyleRules())));
+
+    var htmlMessages = [];
+
+    /** @suppress {accessControls} To access the private log messages (savedMessges_) */
+    var messages = this.savedMessages_.getValues();
+    for (var i = 0; i < messages.length; i++) {
+      htmlMessages.push(SafeHtml.create('div', {'class': 'logmsg'}, messages[i]));
+    }
+
+    var body = SafeHtml.create(
+        'body', {},
+        SafeHtml.concat(
+            SafeHtml.create(
+                'div',
+                {'id': 'log', 'style': goog.string.Const.from('overflow:auto;height:100%;')},
+                SafeHtml.concat(htmlMessages))));
+
+    var logOutput = SafeHtml.create('html', {}, SafeHtml.concat(head, body));
+
+    var outFileName = this.identifier + 'LoggingOutput_' + moment(goog.now()).utc().format('YYYYMMDD_Hmmss') + 'Z.html';
+    if (os.file.persist.saveFile(outFileName, goog.html.SafeHtml.unwrap(logOutput), 'text/html')) {
+      os.alert.AlertManager.getInstance().sendAlert('Created ' + outFileName, os.alert.AlertEventSeverity.SUCCESS);
+    } else {
+      os.alert.AlertManager.getInstance().sendAlert('Could not create ' + outFileName,
+          os.alert.AlertEventSeverity.ERROR);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  addLogRecord(logRecord) {
+    // If this window is not opened but enabled (the X button was clicked), then disable it
+    if (!this.hasActiveWindow() && this.isEnabled()) {
+      this.setEnabled(false);
+    }
+    super.addLogRecord(logRecord);
+  }
+}
+
+exports = FancierWindow;

--- a/src/os/defines.js
+++ b/src/os/defines.js
@@ -1,5 +1,5 @@
-goog.provide('os.defines');
-goog.provide('os.worker');
+goog.module('os.defines');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -36,17 +36,3 @@ goog.define('os.SETTINGS_DB_NAME', os.NAMESPACE + '.settings');
  * @define {string} The database name used to transfer between apps
  */
 goog.define('os.SHARED_FILE_DB_NAME', 'com.bitsys.db');
-
-
-/**
- * @define {string} The path to os workers.
- *
- * Override this in compiled mode using --define os.worker.DIR='something/else', or to override in uncompiled mode
- * use:
- * <pre>
- *   var CLOSURE_UNCOMPILED_DEFINES = {'os.worker.DIR': 'something/else'};
- * </pre>
- *
- * Note the above must be executed prior to loading base.js.
- */
-goog.define('os.worker.DIR', 'src/worker/');

--- a/src/os/ui/alert/alertpopup.js
+++ b/src/os/ui/alert/alertpopup.js
@@ -1,5 +1,6 @@
 goog.provide('os.ui.alert.AlertPopupCtrl');
 goog.provide('os.ui.alert.alertPopupDirective');
+
 goog.require('goog.async.Delay');
 goog.require('goog.events.Event');
 goog.require('goog.events.EventTarget');
@@ -82,11 +83,6 @@ os.ui.alert.AlertPopupCtrl = function($scope) {
    * @type {Array.<Object>}
    */
   this['alertPopups'] = [];
-
-  if (!os.alertManager) {
-    // has not been initialized yet
-    os.alertManager = os.alert.AlertManager.getInstance();
-  }
 
   this.alertClientId_ = 'alertpopups';
   os.alertManager.processMissedAlerts(this.alertClientId_, this.handleAlertEvent_, this);

--- a/src/os/ui/alerts.js
+++ b/src/os/ui/alerts.js
@@ -1,5 +1,7 @@
 goog.provide('os.ui.alert.AlertsCtrl');
 goog.provide('os.ui.alertsDirective');
+
+goog.require('os.alertManager');
 goog.require('os.defines');
 goog.require('os.ui.Module');
 
@@ -53,11 +55,6 @@ os.ui.alert.AlertsCtrl = function($scope, $timeout, $element) {
    * @type {boolean}
    */
   this['showAlertPopups'] = /** @type {string} */ (os.settings.get(['showAlertPopups'], true));
-
-  if (!os.alertManager) {
-    // has not been initialized yet
-    os.alertManager = os.alert.AlertManager.getInstance();
-  }
 
   os.alertManager.getAlerts().getValues().forEach(this.registerAlert_, this);
   os.alertManager.listen(os.alert.EventType.ALERT, this.registerAlert_, false, this);

--- a/src/os/ui/scaleline.js
+++ b/src/os/ui/scaleline.js
@@ -1,49 +1,50 @@
-goog.provide('os.ui.ScaleLineCtrl');
-goog.provide('os.ui.scaleLineDirective');
+goog.module('os.ui.scaleLineDirective');
+goog.module.declareLegacyNamespace();
 
 goog.require('os.ui.Module');
 goog.require('os.ui.menu.MenuButtonCtrl');
-goog.require('os.ui.menu.unit');
 
 
 /**
- * The scale line directive
+ * Controller for the scale line directive.
+ * @extends {os.ui.menu.MenuButtonCtrl}
+ */
+class ScaleLineCtrl extends os.ui.menu.MenuButtonCtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope The Angular scope.
+   * @param {!angular.JQLite} $element The root DOM element.
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    super($scope, $element);
+
+    this.menu = os.ui.menu.UNIT;
+    this.btnPosition = 'right top';
+    this.menuPosition = 'right bottom-4';
+  }
+}
+
+/**
+ * The scale line directive.
  *
  * @return {angular.Directive}
  */
-os.ui.scaleLineDirective = function() {
+const scaleLineDirective = function() {
   return {
     restrict: 'E',
     replace: true,
     scope: true,
     template: '<li class="pointer" id="scale-line" ng-click="ctrl.openMenu()" ng-right-click="ctrl.openMenu()">' +
         '<div class="unit-group"></div></li>',
-    controller: os.ui.ScaleLineCtrl,
+    controller: ScaleLineCtrl,
     controllerAs: 'ctrl'
   };
 };
 
-
 /**
  * Add the directive to the module.
  */
-os.ui.Module.directive('scaleLine', [os.ui.scaleLineDirective]);
+os.ui.Module.directive('scaleLine', [scaleLineDirective]);
 
-
-
-/**
- * Controller function for the scale line directive
- *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @extends {os.ui.menu.MenuButtonCtrl}
- * @constructor
- * @ngInject
- */
-os.ui.ScaleLineCtrl = function($scope, $element) {
-  os.ui.ScaleLineCtrl.base(this, 'constructor', $scope, $element);
-  this.menu = os.ui.menu.UNIT;
-  this.btnPosition = 'right top';
-  this.menuPosition = 'right bottom-4';
-};
-goog.inherits(os.ui.ScaleLineCtrl, os.ui.menu.MenuButtonCtrl);
+exports = scaleLineDirective;

--- a/src/os/worker.js
+++ b/src/os/worker.js
@@ -1,0 +1,15 @@
+goog.module('os.worker');
+goog.module.declareLegacyNamespace();
+
+/**
+ * @define {string} The path to os workers.
+ *
+ * Override this in compiled mode using --define os.worker.DIR='something/else', or to override in uncompiled mode
+ * use:
+ * <pre>
+ *   var CLOSURE_UNCOMPILED_DEFINES = {'os.worker.DIR': 'something/else'};
+ * </pre>
+ *
+ * Note the above must be executed prior to loading base.js.
+ */
+goog.define('os.worker.DIR', 'src/worker/');

--- a/src/plugin/heatmap/heatmap.js
+++ b/src/plugin/heatmap/heatmap.js
@@ -8,6 +8,7 @@ goog.require('os.events.LayerConfigEvent');
 goog.require('os.ex.ZipExporter');
 goog.require('os.file.File');
 goog.require('os.job.Job');
+goog.require('os.worker');
 
 
 /**


### PR DESCRIPTION
This branch is being used to work out any kinks with `goog.module` and determine the preferred approach to converting source files. The intent is to require minimal changes when converting from `goog.module` to ES6 modules, once all code has made the initial transition.

The first commit is required for tests to run with `goog.module`, so it can be separately merged if needed.

These PR's are required for the build to pass. They add `goog.module` handling to our ESLint config.
- https://github.com/ngageoint/eslint-config-opensphere/pull/10
- https://github.com/ngageoint/eslint-plugin-opensphere/pull/6