### PR TITLE
refactor(slickgrid): style change to header row for slickgrid

### DIFF
--- a/scss/os/_overrides_slickgrid.scss
+++ b/scss/os/_overrides_slickgrid.scss
@@ -40,12 +40,12 @@
   }
 
   .slick-header-column {
-    background: $body-bg;
+    background: $table-head-color;
     border-bottom: 1px solid $table-border-color;
     border-right-color: $table-border-color;
     border-top: 1px solid $table-border-color;
     box-sizing: content-box;
-    color: color-yiq($body-bg);
+    color: color-yiq($table-head-color);
     cursor: pointer;
 
     .ui-state-hover {


### PR DESCRIPTION
This is to make the header row visually consistent with the rest of the header 