### PR TITLE
fix(alert): use goog.provide for global instance to allow reassignment

### DIFF
--- a/src/os/alert/alertmanagerinstance.js
+++ b/src/os/alert/alertmanagerinstance.js
@@ -2,9 +2,12 @@
  * This is added for backward compatibility with files that goog.require('os.alertManager'). This can be removed if
  * those are replaced with `goog.require('os.alert.AlertManager')` and use `getInstance()`.
  */
-goog.module('os.alertManager');
-goog.module.declareLegacyNamespace();
+goog.provide('os.alertManager');
 
-const AlertManager = goog.require('os.alert.AlertManager');
+goog.require('os.alert.AlertManager');
 
-exports = AlertManager.getInstance();
+/**
+ * Global alert manager instance.
+ * @type {os.alert.AlertManager}
+ */
+os.alertManager = os.alert.AlertManager.getInstance();


### PR DESCRIPTION
This file will eventually be removed in favor of getInstance, and does not need to be a module.