### PR TITLE
fix(define): fix os.worker.DIR in the debug build

### DIFF
--- a/src/os/worker.js
+++ b/src/os/worker.js
@@ -12,4 +12,5 @@ goog.module.declareLegacyNamespace();
  *
  * Note the above must be executed prior to loading base.js.
  */
-goog.define('os.worker.DIR', 'src/worker/');
+const DIR = goog.define('os.worker.DIR', 'src/worker/');
+exports = {DIR};


### PR DESCRIPTION
`goog.define` was setting the value correctly, but the module loader then called `goog.module.declareLegacyNamespace` which recreated the `os.worker` namespace. Because that file doesn't have exports, `os.worker` was set to `undefined`. Solution is to export defines on the namespace.