### PR TITLE
docs(modules): add documentation on goog.module and es6 classes

### DIFF
--- a/docs/guides/angular_module_guide/index.rst
+++ b/docs/guides/angular_module_guide/index.rst
@@ -1,0 +1,45 @@
+Angular Directives in Modules
+=============================
+
+A primary use case of having multiple ``goog.provide`` statements per file is with Angular directives and their controller. OpenSphere prefers to pair the directive and controller within the same file given they are coupled to create the UI. This poses a problem for a backward-compatible transition to ``goog.module``, given only one module name is allowed per file.
+
+Our options were to split the original names into separate files, or change our approach to exposing the UI. We decided to use a shim to maintain compatibility with existing code. This seems to result in the best end product, and will be detailed in this guide.
+
+The following example shows how the ``map`` directive was transitioned to a module.
+
+Creating the UI Module
+----------------------
+
+- The module can use the original controller name, minus ``Ctrl``. The name can be adjusted if needed, for example if this convention results in a name conflict with another class.
+- Export the controller as ``Controller``, and the directive as ``directive``.
+
+.. literalinclude:: src/map.js
+  :language: javascript
+  :caption: ``src/os/ui/map.js``
+
+Using the Module
+----------------
+
+To reference the UI module in other files:
+
+.. code-block:: javascript
+
+    const MapUI = goog.require('os.ui.Map');
+    // reference the controller class as MapUI.Controller
+    // reference the directive function as MapUI.directive
+
+Backward Compatibility Shim
+---------------------------
+
+To avoid a breaking change with the new module, we'll create a shim to provide the old namespaces. The shim needs to accomplish a couple things:
+
+- Make the old namespaces available to ``goog.require`` statements.
+- Deprecate the old namespaces so developers are aware of the change.
+
+.. literalinclude:: src/map_shim.js
+  :language: javascript
+  :caption: ``src/os/ui/map_shim.js``
+
+The shim will be maintained until all code referencing the old namespaces has been transitioned to directly reference the new module. After a suitable (TBD) amount of time has passed for developers to respond to the deprecation warning, the shim will be deleted.
+
+.. warning:: The deprecation warning will not appear as a result of ``goog.require``. The Closure compiler will only issue a warning if the old directive/controller references are invoked in code.

--- a/docs/guides/angular_module_guide/src/map.js
+++ b/docs/guides/angular_module_guide/src/map.js
@@ -1,0 +1,12 @@
+goog.module('os.ui.Map');
+goog.module.declareLegacyNamespace();
+
+const Controller = class {
+  // Create the controller
+};
+
+const directive = () => {
+  // Create the directive
+};
+
+exports = {Controller, directive};

--- a/docs/guides/angular_module_guide/src/map_shim.js
+++ b/docs/guides/angular_module_guide/src/map_shim.js
@@ -1,0 +1,14 @@
+goog.provide('os.ui.MapCtrl');
+goog.provide('os.ui.mapDirective');
+
+goog.require('os.ui.Map');
+
+/**
+ * @deprecated Please use goog.require('os.ui.Map').Controller instead.
+ */
+os.ui.MapCtrl = os.ui.Map.Controller;
+
+/**
+ * @deprecated Please use goog.require('os.ui.Map').directive instead.
+ */
+os.ui.mapDirective = os.ui.Map.directive;

--- a/docs/guides/es6_class_guide/index.rst
+++ b/docs/guides/es6_class_guide/index.rst
@@ -38,7 +38,7 @@ ES6 Constructor
 
 - Defined using the ``class`` keyword.
 - Constructor is defined with the special ``constructor`` function. The ``@constructor`` annotation is not required.
-- If it extends another class, the ``extends`` keyword is used. This establishes prototypal inheritance, and cues the compiler so ``@extends`` is not required.
+- If it extends another class, the ``extends`` keyword is used. This establishes prototypal inheritance, and cues the compiler so ``@extends`` is not required. ``@extends`` is still used when providing generic types for a template (ie, ``@extends {MyParentClass<MyType>}``).
 - Parent constructor is invoked with ``super(<args>)``.
 - Class properties are added with ``this.<property>``.
 

--- a/docs/guides/es6_class_guide/index.rst
+++ b/docs/guides/es6_class_guide/index.rst
@@ -1,0 +1,130 @@
+Using ES6 Classes in OpenSphere
+===============================
+
+As part of the transition, OpenSphere is converting all Google Closure style classes to use the `ES6 class syntax`_. An ES6 ``class`` is fundamentally the same as a class in Closure, which means the two can be intermingled to a degree.
+
+.. _ES6 class syntax: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes
+
+External Documentation
+**********************
+
+The following are a few helpful guides/references for ES6 classes. It's recommended to start here if you do not already have an understanding of JavaScript classes.
+
+- `Introduction to ES6 classes <https://medium.com/beginners-guide-to-mobile-web-development/javascript-introduction-to-es6-classes-ecb2db9fe985>`_
+- `MDN reference <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes>`_
+- `Simple ES6 guide <https://flaviocopes.com/es6/#classes>`_
+
+ES6 vs Closure
+**************
+
+While ES6 classes and Closure classes are nearly the same under the hood, they are very different in syntax. This section outlines the key differences.
+
+Closure Constructor
+-------------------
+
+- Class name assigned to a constructor function.
+- Requires the ``@constructor`` JSDoc annotation to inform the compiler that it's a class constructor.
+- If it extends another class, the ``@extends`` annotation is also required.
+- Parent constructor is invoked with ``<class>.base(this, 'constructor', <args>)``.
+- Class properties are added with ``this.<property>``.
+- Prototypal inheritance is established by calling ``goog.inherits(<child>, <parent>)``.
+
+.. literalinclude:: src/closureclass.js
+  :lines: 5-22
+  :language: javascript
+
+ES6 Constructor
+---------------
+
+- Defined using the ``class`` keyword.
+- Constructor is defined with the special ``constructor`` function. The ``@constructor`` annotation is not required.
+- If it extends another class, the ``extends`` keyword is used. This establishes prototypal inheritance, and cues the compiler so ``@extends`` is not required.
+- Parent constructor is invoked with ``super(<args>)``.
+- Class properties are added with ``this.<property>``.
+
+.. literalinclude:: src/es6class.js
+  :lines: 6-32
+  :language: javascript
+
+.. warning:: An ES6 class can extend a Closure class, but not the reverse. Closure classes add properties under the hood for ``goog.base`` and ES6 classes will not have these. This means leaf classes must be refactored before their parents.
+
+Member Functions
+----------------
+
+With Closure classes, member functions are added to the prototype. They reference the parent function using ``<class>.base(this, '<function>', <args>)``.
+
+.. literalinclude:: src/closureclass.js
+  :lines: 24-30
+  :language: javascript
+
+In ES6, member functions are defined within the ``class``. They reference the parent function using ``super.<function>(<args>)``.
+
+.. literalinclude:: src/es6class.js
+  :lines: 25-31
+  :language: javascript
+
+.. note:: OpenSphere has historically used the ``<get/set>PropName`` pattern to get/set properties on a class. The `get`_ and `set`_ syntax has been around for awhile and works well with ES6 classes, but switching to it would be a breaking change.
+
+.. _get: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get
+.. _set: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set
+
+Properties
+----------
+
+Both class styles define their properties in the constructor in much the same manner.
+
+The key difference for ES6 classes is that they are `@struct`_ by default, which prevents using bracket notation or adding properties outside the constructor. If either of those are needed (ie, using bracket notation to avoid property renaming), the class must have `@unrestricted`_ in the JSDoc.
+
+.. _@struct: https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#struct
+.. _@unrestricted: https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#unrestricted
+
+.. code-block:: javascript
+
+    /**
+     * @unrestricted
+     */
+    class MyClass {
+      constructor() {
+        // bracket notation to avoid compilation
+        this['id'] = 1234;
+      }
+    }
+
+Singletons
+----------
+
+Class instance singletons have historically been created using ``goog.addSingletonGetter`` which creates an instance and adds a ``getInstance`` function to the class. With ES6 classes and the local scope provided by modules, this is easy to do natively by adding a ``static getInstance()`` call to the class.
+
+.. code-block:: javascript
+
+    class MyClass {
+      constructor() {}
+
+      static getInstance() {
+        return instance;
+      }
+    }
+
+    // instance can be externally referenced with MyClass.getInstance()
+    const instance = new MyClass();
+
+Constants
+---------
+
+Constants on a class can be represented using a combination of the `static`_ and `get`_ keywords. This is a convenient way to define the constant on the class without needing to export the constant.
+
+.. _static: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static
+.. _get: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get
+
+.. code-block:: javascript
+
+    class MyClass {
+      constructor() {}
+
+      static get MY_CONSTANT() {
+        return theConstant;
+      }
+    }
+
+    // constant can be externally referenced with MyClass.MY_CONSTANT
+    const theConstant = 42;

--- a/docs/guides/es6_class_guide/src/closureclass.js
+++ b/docs/guides/es6_class_guide/src/closureclass.js
@@ -1,0 +1,30 @@
+goog.provide('os.MyClass');
+
+goog.require('os.MyParentClass');
+
+/**
+ * Description of the class.
+ * @param {string} arg1 A string arg.
+ * @param {number} arg2 A number arg.
+ * @extends {os.MyParentClass}
+ * @constructor
+ */
+os.MyClass = function(arg1, arg2) {
+  os.MyClass.base(this, 'constructor', arg1);
+
+  /**
+   * Description of arg2.
+   * @type {number}
+   * @private
+   */
+  this.arg2_ = arg2;
+};
+goog.inherits(os.MyClass, os.MyParentClass);
+
+/**
+ * @inheritDoc
+ */
+os.MyClass.prototype.setArg1 = function(arg1) {
+  os.MyClass.base(this, 'setArg1', arg1);
+  console.log('Set arg1 in parent.');
+};

--- a/docs/guides/es6_class_guide/src/es6class.js
+++ b/docs/guides/es6_class_guide/src/es6class.js
@@ -1,0 +1,34 @@
+goog.module('os.MyClass');
+goog.module.declareLegacyNamespace();
+
+const MyParentClass = goog.require('os.MyParentClass');
+
+/**
+ * Description of the class.
+ */
+class MyClass extends MyParentClass {
+  /**
+   * @param {string} arg1 A string arg.
+   * @param {number} arg2 A number arg.
+   */
+  constructor(arg1, arg2) {
+    super(arg1);
+
+    /**
+     * Description of arg2.
+     * @type {number}
+     * @private
+     */
+    this.arg2_ = arg2;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setArg1(arg1) {
+    super.setArg1(arg1);
+    console.log('Set arg1 in parent.');
+  }
+}
+
+exports = MyClass;

--- a/docs/guides/es6_transition_guide.rst
+++ b/docs/guides/es6_transition_guide.rst
@@ -14,6 +14,7 @@ As a step toward modernizing our codebase, OpenSphere plans to migrate all code 
 
   goog_module_guide/index
   es6_class_guide/index
+  angular_module_guide/index
 
 External Documentation
 **********************

--- a/docs/guides/es6_transition_guide.rst
+++ b/docs/guides/es6_transition_guide.rst
@@ -1,0 +1,26 @@
+ES6 Transition Guide
+====================
+
+.. note:: Please provide any feedback on this guide in `#810`_. Thank you!
+.. _#810: https://github.com/ngageoint/opensphere/issues/810
+
+As a step toward modernizing our codebase, OpenSphere plans to migrate all code to use ES6 modules. The Closure Compiler does not allow an incremental transition directly to ES6 modules, given source using ``goog.provide`` cannot directly import them. Closure has however provided a stepping stone for this transition.
+
+``goog.module`` is a replacement for ``goog.provide`` that allows an incremental transition to ES6. Source files using ``goog.module`` may interoperate with both ``goog.provide`` and ES6 modules.
+
+.. toctree::
+  :maxdepth: 1
+  :caption: Guides
+
+  goog_module_guide/index
+  es6_class_guide/index
+
+External Documentation
+**********************
+
+Closure has several Wiki pages on ``goog.module`` and ES6/Closure that are all recommended reading to help understand this process.
+
+- `goog.module: an ES6 module like alternative to goog.provide <https://github.com/google/closure-library/wiki/goog.module:-an-ES6-module-like-alternative-to-goog.provide>`_
+- `Migrating from goog.module to ES6 modules <https://github.com/google/closure-compiler/wiki/Migrating-from-goog.modules-to-ES6-modules>`_
+- `Closure/ES6 interop <https://github.com/google/closure-library/wiki/ES6-modules-and-Closure-Library>`_
+- `ES6 and the Closure Library <https://github.com/google/closure-library/wiki/ES6-modules-and-Closure-Library>`_

--- a/docs/guides/goog_module_guide/index.rst
+++ b/docs/guides/goog_module_guide/index.rst
@@ -1,0 +1,92 @@
+Using goog.module in OpenSphere
+===============================
+
+Modules have a number of key differences from files using ``goog.provide`` that are important for developers to keep in mind.
+
+Module Scope
+************
+
+Every module has its own local scope. This prevents polluting the global ``window`` context because all variables defined in the module are local by default.
+
+Consider the following code at the root level of a JavaScript file:
+
+.. code-block:: javascript
+
+    const myString = 'Hello, World!';
+
+If this were loaded in a normal script, ``window.myString`` would be set to the string ``Hello, World!``. When loaded in a module, the variable is only accessible locally in the module. ``window.myString`` will still be ``undefined``.
+
+To provide functions, classes, etc to external files, a module may use the ``exports`` object to define what to expose from its local scope. To make the above string available externally, a module could do the following:
+
+.. code-block:: javascript
+
+    goog.module('my.ns');
+
+    const myString = 'Hello, World!';
+
+    exports = {myString};
+
+Then to reference that string in another file:
+
+.. code-block:: javascript
+
+    const {myString} = goog.require('my.ns');
+    console.log(myString);
+
+.. note:: Within a module, ``goog.require`` now has a return value. It returns the exports of the required module.
+
+.. note:: This example makes use of `destructuring assignment <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment>`_ both in the exports and the ``goog.require`` statement. This expression is particularly convenient with module imports/exports.
+
+Global Namespace
+****************
+
+The ``goog.module`` call does not add anything to the global context on its own. Consider the following code:
+
+.. code-block:: javascript
+
+    goog.provide('my.Class');
+
+This line defines ``window.my.Class`` on the global scope. ``goog.module('my.Class')`` does not do this. It simply makes a module by that name available to another module calling ``goog.require('my.Class')``.
+
+To allow legacy ``goog.provide`` files to reference a module by that namespace, a module must call ``goog.module.declareLegacyNamespace()`` after the ``goog.module`` call. Closure's module loader will process that call and set the global namespace to the module's exports.
+
+.. code-block:: javascript
+
+    goog.module('my.Class');
+    goog.module.declareLegacyNamespace();
+
+Multiple goog.provide's
+***********************
+
+A single ``goog.module`` statement is allowed per file. When converting a file with multiple ``goog.provide`` statements, they either need to be split out into separate files or consolidated to a single module. Splitting into separate files is useful to preserve existing namespaces and avoid breaking changes, but some cases may benefit from consolidating down to one namespace. Angular directive/controller pairs are a good example where consolidation and refactor might be preferred.
+
+Type Only Imports
+*****************
+
+If a ``goog.require`` is only needed to access types in a module, use ``goog.requireType``. This will only be used by the compiler for type checking and does not create a hard dependency on the required module. These calls will also be discarded from the compiled output.
+
+.. code-block:: javascript
+
+    // SomeEvent is a dependency and programmatically used in the file.
+    const SomeEvent = goog.require('os.SomeEvent');
+
+    // The SomeEvent type is referenced in JSDoc, and is not a dependency.
+    const SomeEvent = goog.requireType('os.SomeEvent');
+
+Typedefs
+********
+
+``@typedef`` declarations are only used by the compiler, but must be exported if they're used outside the file that declares them. Alternatively they can be moved to an extern to avoid the need for ``goog.requireType`` to use them.
+
+.. code-block:: javascript
+
+    /**
+     * @typedef {{
+     *   prop1: string,
+     *   prop2: number
+     * }}
+     */
+    const MyType;
+
+    // Required if MyType is referenced outside the file.
+    exports = {MyType};

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ The code is open source, and `available on GitHub`_.
    getting_started
    windows_development
    guides/app_guide
+   guides/es6_transition_guide
    guides/plugin_guide
    guides/settings_guide
    guides/deployment_guide


### PR DESCRIPTION
Describes our transition process to ES6 and explains new code practices with `goog.module` and ES6 `class`.

Live link: http://elite-cap.surge.sh/guides/es6_transition_guide.html