### PR TITLE
chore(button): updated outline button color to appear clickable

### DIFF
--- a/scss/overrides_slate/_bootswatch.scss
+++ b/scss/overrides_slate/_bootswatch.scss
@@ -28,7 +28,7 @@ $web-font-path: 'https://fonts.googleapis.com/css?family=Open+Sans:400,700' !def
 }
 
 .btn-outline-primary {
-  color: $white;
+  color: $link-color;
 }
 
 .form-control:disabled,


### PR DESCRIPTION
Make button text different than plain text.

"Ghost buttons" btn-outline-primary border-0 are often use to get an affordance of clicking, with hover effects and all, without having a full button style. This change updates the color for primary to remain blue, so it behaves like a clickable hyperlink and not plain text.