### PR TITLE
Update required version of node

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -11,7 +11,7 @@ Prerequisites
 
 - git
 - Java 1.7.0+
-- Node 6+ and npm
+- Node 8.16+ and npm
 - Yarn_
 - Python
 - Sphinx (optional, used to generate these docs)


### PR DESCRIPTION
Node 6 isn't enough.  The `@semantic-release/changelog` dependency wants at least 8.16.