### PR TITLE
feat(contextmenu): allow middle click to launch context menu

### DIFF
--- a/src/os/ol/events/condition.js
+++ b/src/os/ol/events/condition.js
@@ -14,3 +14,17 @@ os.ol.events.condition.rightClick = function(mapBrowserEvent) {
       mapBrowserEvent.type === ol.MapBrowserEventType.POINTERDOWN) &&
       !!mapBrowserEvent.pointerEvent && mapBrowserEvent.pointerEvent.button === 2;
 };
+
+
+/**
+ * If a map browser event is for a middle or right click.
+ *
+ * @param {ol.MapBrowserEvent} mapBrowserEvent The map browser event
+ * @return {boolean} If the event represents a right click
+ */
+os.ol.events.condition.middleOrRightClick = function(mapBrowserEvent) {
+  return !!mapBrowserEvent && (mapBrowserEvent.type === ol.MapBrowserEventType.POINTERUP ||
+      mapBrowserEvent.type === ol.MapBrowserEventType.POINTERDOWN) &&
+      !!mapBrowserEvent.pointerEvent && (mapBrowserEvent.pointerEvent.button === 2 ||
+        mapBrowserEvent.pointerEvent.button === 1);
+};

--- a/src/os/ui/ol/interaction/contextmenuinteraction.js
+++ b/src/os/ui/ol/interaction/contextmenuinteraction.js
@@ -38,7 +38,7 @@ os.ui.ol.interaction.ContextMenu = function(opt_options) {
    * @type {function(ol.MapBrowserEvent):boolean}
    * @protected
    */
-  this.condition = options.condition || os.ol.events.condition.rightClick;
+  this.condition = options.condition || os.ol.events.condition.middleOrRightClick;
 
   /**
    * Menu for hit detected features.

--- a/test/os/ol/events/condition.test.js
+++ b/test/os/ol/events/condition.test.js
@@ -29,4 +29,40 @@ describe('os.ol.events.condition', function() {
     expect(os.ol.events.condition.rightClick()).toBe(false);
     expect(os.ol.events.condition.rightClick(null)).toBe(false);
   });
+
+  it('detects middleOrRight click events', function() {
+    var mockEvent = {
+      type: ol.MapBrowserEventType.POINTERUP,
+      pointerEvent: {
+        button: 2
+      }
+    };
+
+    // happy path
+    expect(os.ol.events.condition.middleOrRightClick(mockEvent)).toBe(true);
+
+    // left doesn't work
+    mockEvent.pointerEvent.button = 0;
+    expect(os.ol.events.condition.middleOrRightClick(mockEvent)).toBe(false);
+
+    // middle button okay here
+    mockEvent.pointerEvent.button = 1;
+    expect(os.ol.events.condition.middleOrRightClick(mockEvent)).toBe(true);
+
+    // just checking
+    mockEvent.pointerEvent.button = 3;
+    expect(os.ol.events.condition.middleOrRightClick(mockEvent)).toBe(false);
+
+    // revert back to right as a sanity check
+    mockEvent.pointerEvent.button = 2;
+    expect(os.ol.events.condition.middleOrRightClick(mockEvent)).toBe(true);
+
+    // different event type
+    mockEvent.type = ol.MapBrowserEventType.SINGLECLICK;
+    expect(os.ol.events.condition.middleOrRightClick(mockEvent)).toBe(false);
+
+    // no event doesn't fail
+    expect(os.ol.events.condition.middleOrRightClick()).toBe(false);
+    expect(os.ol.events.condition.middleOrRightClick(null)).toBe(false);
+  });
 });


### PR DESCRIPTION
Some users with browser configurations set by their IT departments get an annoying browser context menu on top of our app one. This gives them another, similar option to launch that menu. 
I'm open to other suggestions if there are better ideas for things we can fix on our end.