### PR TITLE
Places persistence fixes

### DIFF
--- a/src/plugin/places/placesmanager.js
+++ b/src/plugin/places/placesmanager.js
@@ -4,6 +4,7 @@ goog.require('goog.async.Delay');
 goog.require('goog.events.Event');
 goog.require('goog.events.EventTarget');
 goog.require('goog.events.EventType');
+goog.require('os.alert.AlertManager');
 goog.require('os.im.Importer');
 goog.require('os.object');
 goog.require('os.ui.im.ImportEvent');
@@ -64,6 +65,13 @@ plugin.places.PlacesManager = function() {
    * @private
    */
   this.savedEmpty_ = false;
+
+  /**
+   * If the manager failed to export Places.
+   * @type {boolean}
+   * @private
+   */
+  this.exportFailed_ = false;
 
   /**
    * Delay to dedupe saving data.
@@ -411,6 +419,15 @@ plugin.places.PlacesManager.prototype.onExportComplete_ = function(event) {
     this.saveContent_(output);
   } else {
     this.handleError_('Failed exporting places to browser storage. Content was empty.');
+
+    if (!this.exportFailed_) {
+      this.exportFailed_ = true;
+      var target = new goog.events.EventTarget();
+      var msg = 'There was a problem saving your Places to browser storage. ' +
+          'Places will no longer save during the current session.' +
+          '<br><br><b>You should export your Places to a file to ensure that they are not lost on refresh.</b>';
+      os.alert.AlertManager.getInstance().sendAlert(msg, undefined, undefined, undefined, target);
+    }
   }
 };
 

--- a/src/plugin/places/placesmenu.js
+++ b/src/plugin/places/placesmenu.js
@@ -335,42 +335,54 @@ plugin.places.menu.mapDispose = function() {
  */
 plugin.places.menu.spatialSetup = function() {
   var menu = os.ui.menu.SPATIAL;
-  if (menu) {
+
+  if (menu && !menu.getRoot().find(plugin.places.menu.GROUP_LABEL)) {
     var root = menu.getRoot();
-    var group = root.find(os.ui.menu.spatial.Group.TOOLS);
-    goog.asserts.assert(group, 'Group "' + os.ui.menu.spatial.Group.TOOLS + '" should exist! Check spelling?');
-
-    if (!group.find(plugin.places.menu.EventType.SAVE_TO)) {
-      group.addChild({
-        label: 'Create Place...',
-        eventType: plugin.places.menu.EventType.SAVE_TO,
-        tooltip: 'Creates a new place from the feature',
-        icons: ['<i class="fa fa-fw ' + plugin.places.Icon.PLACEMARK + '"></i>'],
-        beforeRender: plugin.places.menu.visibleIfCanSaveSpatial,
-        handler: plugin.places.menu.saveSpatialToPlaces,
-        sort: 100
-      });
-
-      group.addChild({
-        label: 'Edit Place',
-        eventType: plugin.places.menu.EventType.EDIT_PLACEMARK,
-        tooltip: 'Edit the saved place',
-        icons: ['<i class="fa fa-fw fa-pencil"></i>'],
-        beforeRender: plugin.places.menu.visibleIfIsPlace,
-        handler: plugin.places.menu.onSpatialEdit_,
-        sort: 110
-      });
-
-      group.addChild({
-        label: 'Create Text Box...',
-        eventType: plugin.places.menu.EventType.SAVE_TO_ANNOTATION,
-        tooltip: 'Creates a new place with a text box',
-        icons: ['<i class="fa fa-fw ' + plugin.places.Icon.ANNOTATION + '"></i>'],
-        beforeRender: plugin.places.menu.visibleIfCanSaveSpatial,
-        handler: plugin.places.menu.saveSpatialToAnnotation,
-        sort: 120
-      });
-    }
+    root.addChild({
+      label: plugin.places.menu.GROUP_LABEL,
+      type: os.ui.menu.MenuItemType.GROUP,
+      sort: 50,
+      children: [
+        {
+          label: 'Create Place...',
+          eventType: plugin.places.menu.EventType.SAVE_TO,
+          tooltip: 'Creates a new place from the feature',
+          icons: ['<i class="fa fa-fw ' + plugin.places.Icon.PLACEMARK + '"></i>'],
+          beforeRender: plugin.places.menu.visibleIfCanSaveSpatial,
+          handler: plugin.places.menu.saveSpatialToPlaces,
+          metricKey: os.metrics.Places.ADD_PLACE,
+          sort: 100
+        }, {
+          label: 'Edit Place',
+          eventType: plugin.places.menu.EventType.EDIT_PLACEMARK,
+          tooltip: 'Edit the saved place',
+          icons: ['<i class="fa fa-fw fa-pencil"></i>'],
+          beforeRender: plugin.places.menu.visibleIfIsPlace,
+          handler: plugin.places.menu.onSpatialEdit_,
+          sort: 110
+        },
+        {
+          label: 'Create Text Box...',
+          eventType: plugin.places.menu.EventType.SAVE_TO_ANNOTATION,
+          tooltip: 'Creates a new place with a text box',
+          icons: ['<i class="fa fa-fw ' + plugin.places.Icon.ANNOTATION + '"></i>'],
+          beforeRender: plugin.places.menu.visibleIfCanSaveSpatial,
+          handler: plugin.places.menu.saveSpatialToAnnotation,
+          metricKey: os.metrics.Places.ADD_ANNOTATION,
+          sort: 120
+        },
+        {
+          label: 'Quick Add Places...',
+          eventType: plugin.places.menu.EventType.QUICK_ADD_PLACES,
+          tooltip: 'Quickly add places to the selected folder',
+          icons: ['<i class="fa fa-fw ' + plugin.places.Icon.QUICK_ADD + '"></i>'],
+          beforeRender: plugin.places.menu.visibleIfCanSaveSpatial,
+          handler: plugin.places.menu.quickAddFromSpatial,
+          metricKey: os.metrics.Places.QUICK_ADD_PLACES,
+          sort: 120
+        }
+      ]
+    });
   }
 };
 
@@ -684,6 +696,20 @@ plugin.places.menu.quickAddFromCoordinate = function(event) {
     event.stopPropagation();
 
     plugin.places.ui.QuickAddPlacesCtrl.launch(undefined, new ol.geom.Point(context));
+  }
+};
+
+
+/**
+ * Launch the quick add dialog with an initial seed point.
+ *
+ * @param {os.ui.menu.MenuEvent<Object>} event The menu event.
+ */
+plugin.places.menu.quickAddFromSpatial = function(event) {
+  var context = event.getContext();
+  if (context) {
+    var geom = /** @type {ol.geom.SimpleGeometry} */ (context['geometry']);
+    plugin.places.ui.QuickAddPlacesCtrl.launch(undefined, geom);
   }
 };
 


### PR DESCRIPTION
This adds checks for the sporadic null cases we've seen with saving/loading Places. It also adds another spot where it will loop back and re-initialize if there is an missing places root node.

I also noticed while working on this that the Spatial menu places were under a different menu header and that Quick Add Places was not an available option, so I changed that to be consistent with the Map menu.