### PR TITLE
feat(cesium): updates cesium version to 1.65

### DIFF
--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -3889,11 +3889,12 @@ Cesium.PerspectiveFrustum.prototype.computeCullingVolume = function(position, di
  * @param {!number} drawingBufferWidth
  * @param {!number} drawingBufferHeight
  * @param {!number} dist
+ * @param {!number} pixelRatio
  * @param {!Cesium.Cartesian2} result
  * @return {!Cesium.Cartesian2}
  */
 Cesium.PerspectiveFrustum.prototype.getPixelDimensions = function(drawingBufferWidth, drawingBufferHeight, dist,
-    result) {};
+  pixelRatio, result) {};
 
 
 

--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
     "blob-polyfill": "^2.0.20171115",
     "bootstrap": "4.3.1",
     "bootswatch": "4.3.1",
-    "cesium": "1.60",
+    "cesium": "1.65",
     "compass-mixins": "^0.12.10",
     "crossfilter2": "1.4.8",
     "css-element-queries": "=1.2.1",


### PR DESCRIPTION
Updates the Cesium version to 1.65. There was one breaking change that affected the method signature of an extern we have defined. We don't use it anywhere in Opensphere though.

https://github.com/AnalyticalGraphicsInc/cesium/blob/1.65/CHANGES.md references their breaking change.