### PR TITLE
fix(wmts): use params from the URI, ensure service is set

### DIFF
--- a/src/plugin/wmts/wmtsserver.js
+++ b/src/plugin/wmts/wmtsserver.js
@@ -242,24 +242,29 @@ plugin.wmts.Server.prototype.load = function(opt_ping) {
 
 
 /**
- * Builds query data from the WMTS params.
+ * Updates query data from the WMTS params.
  *
- * @return {goog.Uri.QueryData}
+ * @param {goog.Uri.QueryData} queryData The query data.
  * @private
  */
-plugin.wmts.Server.prototype.getQueryData_ = function() {
-  var queryData = this.params_ ? this.params_.clone() : new goog.Uri.QueryData();
+plugin.wmts.Server.prototype.updateQueryData_ = function(queryData) {
   queryData.setIgnoreCase(true);
 
-  queryData.set('request', 'GetCapabilities');
-
-  var version = plugin.wmts.Server.DEFAULT_VERSION;
-  if (queryData.containsKey('version')) {
-    version = queryData.get('version');
+  if (this.params_) {
+    queryData.extend(this.params_);
   }
 
-  queryData.set('version', version);
-  return queryData;
+  if (!queryData.containsKey('request')) {
+    queryData.set('request', 'GetCapabilities');
+  }
+
+  if (!queryData.containsKey('service')) {
+    queryData.set('service', 'WMTS');
+  }
+
+  if (!queryData.containsKey('version')) {
+    queryData.set('version', plugin.wmts.Server.DEFAULT_VERSION);
+  }
 };
 
 
@@ -289,8 +294,7 @@ plugin.wmts.Server.prototype.loadCapabilities = function() {
  */
 plugin.wmts.Server.prototype.testUrl = function(url, opt_success, opt_error) {
   var uri = new goog.Uri(url);
-  var queryData = this.getQueryData_();
-  uri.setQueryData(queryData);
+  this.updateQueryData_(uri.getQueryData());
 
   var onSuccess = opt_success || this.handleCapabilities;
   var onError = opt_error || this.onOGCError;


### PR DESCRIPTION
A user reported problems adding a WMTS server that required `service=WMTS` in the request. Even when providing that in the input URL, `plugin.wmts.Server.prototype.testUrl` was dropping the parameter. This makes a few changes to how WMTS params are formed for the test request:

- Params parsed from the URL are preserved by starting with the `goog.Uri`'s query data.
- Extend the parameters with any configured on the layer.
- Add the `service` parameter if it does not already exist.

I don't have a public WMTS server that replicates the issue, but at minimum please ensure the following server can still be manually added:

https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi?SERVICE=WMTS&request=GetCapabilities