### PR TITLE
Don't create alert manager instance until requested

### DIFF
--- a/docs/guides/es6_class_guide/index.rst
+++ b/docs/guides/es6_class_guide/index.rst
@@ -93,20 +93,26 @@ The key difference for ES6 classes is that they are `@struct`_ by default, which
 Singletons
 ----------
 
-Class instance singletons have historically been created using ``goog.addSingletonGetter`` which creates an instance and adds a ``getInstance`` function to the class. With ES6 classes and the local scope provided by modules, this is easy to do natively by adding a ``static getInstance()`` call to the class.
+Class instance singletons have historically been created using ``goog.addSingletonGetter`` which adds a ``getInstance`` function to the class. With ES6 classes and the local scope provided by modules, this is easy to do natively by adding a ``static getInstance()`` call to the class.
 
 .. code-block:: javascript
+
+    // store the instance in a module-scoped variable that can be externally referenced
+    // with MyClass.getInstance()
+    let instance;
 
     class MyClass {
       constructor() {}
 
       static getInstance() {
+        // do not create the instance until the first time this function is called
+        if (!instance) {
+          instance = new MyClass();
+        }
+
         return instance;
       }
     }
-
-    // instance can be externally referenced with MyClass.getInstance()
-    const instance = new MyClass();
 
 Constants
 ---------

--- a/src/os/alert/alertmanager.js
+++ b/src/os/alert/alertmanager.js
@@ -69,7 +69,11 @@ class AlertManager extends goog.events.EventTarget {
    * @return {AlertManager}
    */
   static getInstance() {
-    return instance_;
+    if (!instance) {
+      instance = new AlertManager();
+    }
+
+    return instance;
   }
 
   /**
@@ -167,6 +171,6 @@ class AlertManager extends goog.events.EventTarget {
  * Global alert manager instance.
  * @type {AlertManager}
  */
-const instance_ = new AlertManager();
+let instance;
 
 exports = AlertManager;


### PR DESCRIPTION
The new singleton instance format used in modules should not create the instance until `getInstance` is called. This more closely mimics the behavior of `goog.addSingletonGetter`.

Updated the example in the docs to reflect this, and the transform will also create `getInstance` calls in this manner.