### PR TITLE
fix(mixin): address ng isClass failures

### DIFF
--- a/src/os/mixin/fixinjectorinvoke.js
+++ b/src/os/mixin/fixinjectorinvoke.js
@@ -1,0 +1,34 @@
+goog.module('os.mixin.fixInjectorInvoke');
+goog.module.declareLegacyNamespace();
+
+/**
+ * The isClass function in angular does not properly check
+ * func.hasOwnProperty('$$ngIsClass'), resulting in incorrect
+ * values for classes which extend an older ES5 class.
+ *
+ * Example:
+ *
+ *    var OldClass = function() {};
+ *    OldClass.$$ngIsClass = false;
+ *    class NewClass extends OldClass {};
+ *    OldClass.$$ngIsClass // false! We need this to be true|undefined|null
+ *
+ * @param {Function|null|undefined} fn
+ */
+const fixNgIsClass = (fn) => {
+  if (fn && typeof fn === 'function' && !fn.hasOwnProperty('$$ngIsClass')) {
+    fn['$$ngIsClass'] = null;
+  }
+};
+
+/**
+ * @param {!angular.$injector} injector
+ */
+exports = (injector) => {
+  const oldInvoke = injector.invoke;
+  injector.invoke = (input, self, locals, serviceName) => {
+    const fn = Array.isArray(input) ? input[input.length - 1] : input;
+    fixNgIsClass(fn);
+    return oldInvoke(input, self, locals, serviceName);
+  };
+};

--- a/src/os/ui/abstractmainctrl.js
+++ b/src/os/ui/abstractmainctrl.js
@@ -13,6 +13,7 @@ goog.require('os.config');
 goog.require('os.config.Settings');
 goog.require('os.metrics');
 goog.require('os.metrics.Metrics');
+goog.require('os.mixin.fixInjectorInvoke');
 goog.require('os.net');
 goog.require('os.net.CertNazi');
 goog.require('os.net.ProxyHandler');
@@ -59,6 +60,7 @@ os.ui.AbstractMainCtrl = function($scope, $injector, rootPath, defaultAppName) {
    * @type {angular.$injector}
    */
   os.ui.injector = $injector;
+  os.mixin.fixInjectorInvoke($injector);
 
   /**
    * @type {?os.net.CertNazi}

--- a/test/os/mixin/fixinjectorinvoke.test.js
+++ b/test/os/mixin/fixinjectorinvoke.test.js
@@ -1,0 +1,51 @@
+goog.require('os.mixin.fixInjectorInvoke');
+
+describe('fixInjectorInvoke', () => {
+  const fixInjectorInvoke = goog.module.get('os.mixin.fixInjectorInvoke');
+
+  let injector;
+  beforeEach(() => {
+    injector = {
+      invoke: () => {}
+    };
+  });
+
+  it('should pass through arguments to the original invoke function', () => {
+    spyOn(injector, 'invoke').andCallThrough();
+    const originalInvoke = injector.invoke;
+
+    fixInjectorInvoke(injector);
+    injector.invoke(1, 2, 3, 4);
+
+    expect(originalInvoke).toHaveBeenCalledWith(1, 2, 3, 4);
+  });
+
+  it('should set $$ngIsClass as a null own property on the function arg', () => {
+    fixInjectorInvoke(injector);
+
+    const fn = () => {};
+    injector.invoke(fn);
+
+    expect(fn.hasOwnProperty('$$ngIsClass')).toBe(true);
+    expect(fn.$$ngIsClass).toBe(null);
+  });
+
+  it('should handle fn as the last array arg', () => {
+    fixInjectorInvoke(injector);
+
+    const fn = () => {};
+    injector.invoke(['something', fn]);
+
+    expect(fn.hasOwnProperty('$$ngIsClass')).toBe(true);
+    expect(fn.$$ngIsClass).toBe(null);
+  });
+
+  it('should not modify $$ngIsClass if already set as an own property', () => {
+    fixInjectorInvoke(injector);
+
+    const fn = () => {};
+    fn.$$ngIsClass = false;
+    injector.invoke(fn);
+    expect(fn.$$ngIsClass).toBe(false);
+  });
+});


### PR DESCRIPTION
Angular's `isClass()` used in `invoke()` is incorrect in that it does not check `func.hasOwnProperty('$$ngIsClass')`. If an ES6 class extends an older class structure, `isClass()` will report the parent's cached result, which is incorrect and will result in an error.

Example:
```javascript
  const OldClass = function() {};
  OldClass.$$ngIsClass = false;
  class NewClass extends OldClass;
  NewClass.$$ngIsClass // false!
```

Therefore, this mixes in a fix for that in `$injector.invoke` just after `os.ui.injector` is set in `AbstractMainCtrl`.