### PR TITLE
feat(bins): Added Empty Bin support

### DIFF
--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -542,3 +542,22 @@ osx.feature.RingDefinition;
  * }}
  */
 osx.feature.RingOptions;
+
+
+/**
+ * Namespace.
+ * @type {Object}
+ */
+osx.histo;
+
+
+/**
+ * @typedef {{
+  *   range: Array<number>,
+  *   step: number,
+  *   binCount: number,
+  *   binCountAll: number
+  * }}
+  */
+osx.histo.BinMethodStats;
+

--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -542,22 +542,3 @@ osx.feature.RingDefinition;
  * }}
  */
 osx.feature.RingOptions;
-
-
-/**
- * Namespace.
- * @type {Object}
- */
-osx.histo;
-
-
-/**
- * @typedef {{
-  *   range: Array<number>,
-  *   step: number,
-  *   binCount: number,
-  *   binCountAll: number
-  * }}
-  */
-osx.histo.BinMethodStats;
-

--- a/src/os/histo/datebinmethod.js
+++ b/src/os/histo/datebinmethod.js
@@ -490,7 +490,7 @@ os.histo.DateBinMethod.prototype.restore = function(config) {
 
   var show = config['showEmptyBins'];
   this.setShowEmptyBins(show == true); // loose truthy
- 
+
   var binTypes = /** @type {Array<string>|undefined} */ (config['binTypes']);
   if (binTypes) {
     this.setDateBinTypes(binTypes);

--- a/src/os/histo/datebinmethod.js
+++ b/src/os/histo/datebinmethod.js
@@ -68,6 +68,7 @@ os.histo.Labels = {
 os.histo.DateBinMethod = function() {
   os.histo.DateBinMethod.base(this, 'constructor');
   this.type = os.histo.DateBinMethod.TYPE;
+  this.showEmptyBins = false;
 
   /**
    * @type {os.histo.DateBinType}
@@ -470,6 +471,7 @@ os.histo.DateBinMethod.prototype.persist = function(opt_to) {
 
   opt_to['binType'] = this.getDateBinType();
   opt_to['binTypes'] = this.getDateBinTypes();
+  opt_to['showEmptyBins'] = this.getShowEmptyBins();
 
   return opt_to;
 };
@@ -486,6 +488,9 @@ os.histo.DateBinMethod.prototype.restore = function(config) {
     this.setDateBinType(binType);
   }
 
+  var show = config['showEmptyBins'];
+  this.setShowEmptyBins(show == true); // loose truthy
+ 
   var binTypes = /** @type {Array<string>|undefined} */ (config['binTypes']);
   if (binTypes) {
     this.setDateBinTypes(binTypes);

--- a/src/os/histo/datebinmethod.js
+++ b/src/os/histo/datebinmethod.js
@@ -169,7 +169,7 @@ os.histo.DateBinMethod.prototype.getTypeMax = function(opt_timestamp) {
       start.setUTCMonth(new Date(opt_timestamp).getUTCMonth(), 1);
       end.setUTCMonth(start.getUTCMonth() + 1, 1);
 
-      return Math.floor((end.getTime() - start.getTime()) / (60 * 60 * 1000));
+      return Math.floor((end.getTime() - start.getTime()) / (60 * 60 * 1000)) - 1; // goes from 0 to ((days * 24) - 1) hours
     case os.histo.DateBinType.HOUR_OF_YEAR:
       var start = new Date();
       var end = new Date();
@@ -180,6 +180,8 @@ os.histo.DateBinMethod.prototype.getTypeMax = function(opt_timestamp) {
       end.setUTCFullYear(start.getUTCFullYear() + 1, 0, 1);
 
       return Math.floor((end.getTime() - start.getTime()) / (60 * 60 * 1000));
+    case os.histo.DateBinType.MONTH_OF_YEAR:
+      return 11;
     default:
       return 0;
   }

--- a/src/os/histo/datebinmethod.js
+++ b/src/os/histo/datebinmethod.js
@@ -112,6 +112,26 @@ os.histo.DateBinMethod.MAGIC = moment.utc('0867-05-03T09:00:00Z').valueOf();
 
 
 /**
+ * "Unique" value used to detect when generating empty bins across month(s)
+ * WARNING: Over thousands of years, the stats.binCountAll estimate will get more and more off
+ *
+ * @type {number}
+ * @const
+ */
+os.histo.DateBinMethod.MAGIC_MONTH_MILLIS = 1000 * 60 * 60 * 2 * 365; // 2 = (24 / 12) i.e. days divided by 12 mo/yr
+
+
+/**
+ * "Unique" value used to detect when generating empty bins across year(s)
+ * WARNING: Over thousands of years, the stats.binCountAll estimate will get more and more off
+ *
+ * @type {number}
+ * @const
+ */
+os.histo.DateBinMethod.MAGIC_YEAR_MILLIS = (1000 * 60 * 60 * 24 * 365);
+
+
+/**
  * @return {os.histo.DateBinType}
  */
 os.histo.DateBinMethod.prototype.getDateBinType = function() {
@@ -490,9 +510,6 @@ os.histo.DateBinMethod.prototype.restore = function(config) {
     this.setDateBinType(binType);
   }
 
-  var show = config['showEmptyBins'];
-  this.setShowEmptyBins(show == true); // loose truthy
-
   var binTypes = /** @type {Array<string>|undefined} */ (config['binTypes']);
   if (binTypes) {
     this.setDateBinTypes(binTypes);
@@ -512,23 +529,23 @@ os.histo.DateBinMethod.prototype.exportAsFilter = function(bins) {
 /**
  * @inheritDoc
  */
-os.histo.DateBinMethod.prototype.getConfigForBin = function(bins) {
-  var result = os.histo.DateBinMethod.base(this, 'getConfigForBin', bins);
+os.histo.DateBinMethod.prototype.getStatsForBin = function(bins) {
+  var result = os.histo.DateBinMethod.base(this, 'getStatsForBin', bins);
   if (result == null) return result;
 
-  var max1 = this.getTypeMax(result['range'][0]);
-  var max2 = this.getTypeMax(result['range'][1]);
+  var max1 = this.getTypeMax(result.range[0]);
+  var max2 = this.getTypeMax(result.range[1]);
 
   if (max1 != 0 || max2 != 0) {
     // when the range is a logical time period, e.g. Day of Week, Hour of Day, etc
-    result['range'] = [0, (max2 > max1 ? max2 : max1)];
-    result['step'] = 1;
-    result['binCountAll'] = ((result['range'][1] - result['range'][0]) / result['step']) + 1;
+    result.range = [0, (max2 > max1 ? max2 : max1)];
+    result.step = 1;
+    result.binCountAll = ((result.range[1] - result.range[0]) / result.step) + 1;
   } else {
     // when the range is a specific time period, e.g. Jan 3rd thru Jan 17th
     var type = this.getDateBinType();
-    var min = new Date(result['range'][0]);
-    var max = new Date(result['range'][1]);
+    var min = new Date(result.range[0]);
+    var max = new Date(result.range[1]);
     var floor = 'sec';
     var step = 1000; // 1K milliseconds = 1 second
     switch (type) {
@@ -550,18 +567,19 @@ os.histo.DateBinMethod.prototype.getConfigForBin = function(bins) {
         break;
       case os.histo.DateBinType.MONTH:
         floor = 'month';
-        step = step * 60 * 60 * 24 * 31; // approximate... TODO
+        step = os.histo.DateBinMethod.MAGIC_MONTH_MILLIS; // approximate... you must detect this and then calculate the next step
         break;
       case os.histo.DateBinType.YEAR:
         floor = 'year';
-        step = step * 60 * 60 * 24 * 365; // approximate... only called if the bin doesn't exist
+        step = os.histo.DateBinMethod.MAGIC_YEAR_MILLIS; // approximate... you must detect this and then calculate the next step
         break;
       default:
         break;
     }
-    result['range'] = [os.time.floor(min, floor).getTime(), os.time.floor(max, floor).getTime()];
-    result['step'] = step;
-    result['binCountAll'] = ((result['range'][1] - result['range'][0]) / result['step']) + 1;
+    result.range = [os.time.floor(min, floor).getTime(), os.time.floor(max, floor).getTime()];
+    result.step = step;
+    // For MONTH and YEAR, err on the side of too many bins, e.g. for years with 366 days, still give a bin when dividing by 365 days
+    result.binCountAll = Math.round(((result.range[1] - result.range[0]) / result.step) + 1.0);
   }
   return result;
 };

--- a/src/os/histo/datebinmethod.js
+++ b/src/os/histo/datebinmethod.js
@@ -68,7 +68,6 @@ os.histo.Labels = {
 os.histo.DateBinMethod = function() {
   os.histo.DateBinMethod.base(this, 'constructor');
   this.type = os.histo.DateBinMethod.TYPE;
-  this.showEmptyBins = false;
 
   /**
    * @type {os.histo.DateBinType}
@@ -199,7 +198,7 @@ os.histo.DateBinMethod.prototype.getTypeMax = function(opt_timestamp) {
       start.setUTCFullYear(new Date(opt_timestamp).getUTCFullYear(), 0, 1);
       end.setUTCFullYear(start.getUTCFullYear() + 1, 0, 1);
 
-      return Math.floor((end.getTime() - start.getTime()) / (60 * 60 * 1000));
+      return Math.floor((end.getTime() - start.getTime()) / (60 * 60 * 1000)) - 1; // goes from 0 to ((days * 24) - 1) hours
     case os.histo.DateBinType.MONTH_OF_YEAR:
       return 11;
     default:
@@ -493,7 +492,6 @@ os.histo.DateBinMethod.prototype.persist = function(opt_to) {
 
   opt_to['binType'] = this.getDateBinType();
   opt_to['binTypes'] = this.getDateBinTypes();
-  opt_to['showEmptyBins'] = this.getShowEmptyBins();
 
   return opt_to;
 };

--- a/src/os/histo/numericbinmethod.js
+++ b/src/os/histo/numericbinmethod.js
@@ -328,7 +328,6 @@ os.histo.NumericBinMethod.prototype.persist = function(opt_to) {
   opt_to['offset'] = this.offset;
   opt_to['min'] = this.min;
   opt_to['max'] = this.max;
-  opt_to['showEmptyBins'] = this.showEmptyBins;
 
   return opt_to;
 };
@@ -358,11 +357,6 @@ os.histo.NumericBinMethod.prototype.restore = function(config) {
   var max = /** @type {string|number|undefined} */ (config['max']);
   if (max != null && !isNaN(max)) {
     this.setMax(Number(max));
-  }
-
-  var show = /** @type {string|boolean|undefined} */ (config['showEmptyBins']);
-  if (show != null) {
-    this.setShowEmptyBins(show == true); // loose comparison rather than ===
   }
 };
 
@@ -459,11 +453,11 @@ os.histo.NumericBinMethod.prototype.getFilterForRange_ = function(range) {
 /**
  * @inheritDoc
  */
-os.histo.NumericBinMethod.prototype.getConfigForBin = function(bins) {
-  var result = os.histo.NumericBinMethod.base(this, 'getConfigForBin', bins);
+os.histo.NumericBinMethod.prototype.getStatsForBin = function(bins) {
+  var result = os.histo.NumericBinMethod.base(this, 'getStatsForBin', bins);
   if (result != null) {
-    result['step'] = this.getWidth() || 1; // don't allow divide by 0 errors
-    result['binCountAll'] = ((result['range'][1] - result['range'][0]) / result['step']) + 1;
+    result.step = this.getWidth() || 1; // don't allow divide by 0 errors
+    result.binCountAll = ((result.range[1] - result.range[0]) / result.step) + 1;
   }
   return result;
 };

--- a/src/os/histo/numericbinmethod.js
+++ b/src/os/histo/numericbinmethod.js
@@ -328,6 +328,7 @@ os.histo.NumericBinMethod.prototype.persist = function(opt_to) {
   opt_to['offset'] = this.offset;
   opt_to['min'] = this.min;
   opt_to['max'] = this.max;
+  opt_to['showEmptyBins'] = this.showEmptyBins;
 
   return opt_to;
 };
@@ -357,6 +358,11 @@ os.histo.NumericBinMethod.prototype.restore = function(config) {
   var max = /** @type {string|number|undefined} */ (config['max']);
   if (max != null && !isNaN(max)) {
     this.setMax(Number(max));
+  }
+
+  var show = /** @type {string|boolean|undefined} */ (config['showEmptyBins']);
+  if (show != null) {
+    this.setShowEmptyBins(show == true); // loose comparison rather than ===
   }
 };
 

--- a/src/os/histo/numericbinmethod.js
+++ b/src/os/histo/numericbinmethod.js
@@ -457,6 +457,19 @@ os.histo.NumericBinMethod.prototype.getFilterForRange_ = function(range) {
 
 
 /**
+ * @inheritDoc
+ */
+os.histo.NumericBinMethod.prototype.getConfigForBin = function(bins) {
+  var result = os.histo.NumericBinMethod.base(this, 'getConfigForBin', bins);
+  if (result != null) {
+    result['step'] = this.getWidth() || 1; // don't allow divide by 0 errors
+    result['binCountAll'] = ((result['range'][1] - result['range'][0]) / result['step']) + 1;
+  }
+  return result;
+};
+
+
+/**
  * Test if a value is between or equal to the bin method's range for a set of minimum values.
  *
  * @param {!Array<number>} values The values to check

--- a/src/os/histo/uniquebinmethod.js
+++ b/src/os/histo/uniquebinmethod.js
@@ -1,3 +1,4 @@
+goog.provide('os.histo.BinMethodStats');
 goog.provide('os.histo.UniqueBinMethod');
 
 goog.require('os.IPersistable');
@@ -6,6 +7,18 @@ goog.require('os.histo.IBinMethod');
 goog.require('os.histo.bin');
 goog.require('os.object');
 
+
+
+/**
+ * A function used to sort features.
+ * @typedef {{
+  *   range: Array<number>,
+  *   step: number,
+  *   binCount: number,
+  *   binCountAll: number
+  * }}
+ */
+os.histo.BinMethodStats;
 
 
 /**
@@ -52,6 +65,13 @@ os.histo.UniqueBinMethod = function() {
    * @protected
    */
   this.showEmptyBins = false;
+
+  /**
+   * Cap the amount of resources used by the crossfilter
+   * @type {number}
+   * @protected
+   */
+  this.maxBins = 1000000;
 };
 
 
@@ -224,6 +244,11 @@ os.histo.UniqueBinMethod.prototype.restore = function(config) {
   if (show != null) {
     this.setShowEmptyBins(show == true); // loose comparison rather than ===
   }
+
+  var maxBins = /** @type {number|undefined} */ (config['maxBins']);
+  if (maxBins) {
+    this.setMaxBins(maxBins); // only set if non-zero and non-null
+  }
 };
 
 
@@ -362,6 +387,24 @@ os.histo.UniqueBinMethod.prototype.setShowEmptyBins = function(value) {
 
 
 /**
+ * Gets the maxBins property
+ * @return {number}
+ */
+os.histo.UniqueBinMethod.prototype.getMaxBins = function() {
+  return this.maxBins;
+};
+
+
+/**
+ * Sets the maxBins property
+ * @param {number} value
+ */
+os.histo.UniqueBinMethod.prototype.setMaxBins = function(value) {
+  this.maxBins = value;
+};
+
+
+/**
  * Get the filter for an individual bin.
  *
  * @param {!os.histo.Bin} bin The bin
@@ -383,14 +426,13 @@ os.histo.UniqueBinMethod.prototype.getFilterForBin = function(bin) {
  * Get the range, step size, etc for the bins made by this method.
  *
  * @param {!Array<os.histo.Bin>} bins The bins made using this bin method
- * @return {osx.histo.BinMethodStats|null} The config
- * @public
+ * @return {os.histo.BinMethodStats|null} The config
  */
 os.histo.UniqueBinMethod.prototype.getStatsForBin = function(bins) {
   if (!bins || bins.length == 0) return null;
   var range = [bins[0]['key'], bins[bins.length - 1]['key']];
   var step = 1; // don't allow divide by 0 errors
-  return /** @type {osx.histo.BinMethodStats} */ ({
+  return /** @type {os.histo.BinMethodStats} */ ({
     range: range,
     step: step,
     binCount: bins.length,

--- a/src/os/histo/uniquebinmethod.js
+++ b/src/os/histo/uniquebinmethod.js
@@ -198,6 +198,7 @@ os.histo.UniqueBinMethod.prototype.persist = function(opt_to) {
   opt_to['field'] = this.getField();
   opt_to['isDate'] = this.getIsDate();
   opt_to['arrayKeys'] = this.getArrayKeys();
+  opt_to['showEmptyBins'] = this.getShowEmptyBins();
 
   return opt_to;
 };
@@ -217,6 +218,11 @@ os.histo.UniqueBinMethod.prototype.restore = function(config) {
   var arrayKeys = /** @type {boolean|string|undefined} */ (config['arrayKeys']);
   if (typeof arrayKeys === 'boolean' || typeof arrayKeys === 'string') {
     this.setArrayKeys(arrayKeys);
+  }
+
+  var show = /** @type {string|boolean|undefined} */ (config['showEmptyBins']);
+  if (show != null) {
+    this.setShowEmptyBins(show == true); // loose comparison rather than ===
   }
 };
 
@@ -377,19 +383,19 @@ os.histo.UniqueBinMethod.prototype.getFilterForBin = function(bin) {
  * Get the range, step size, etc for the bins made by this method.
  *
  * @param {!Array<os.histo.Bin>} bins The bins made using this bin method
- * @return {any|null} The config
+ * @return {osx.histo.BinMethodStats|null} The config
  * @public
  */
-os.histo.UniqueBinMethod.prototype.getConfigForBin = function(bins) {
+os.histo.UniqueBinMethod.prototype.getStatsForBin = function(bins) {
   if (!bins || bins.length == 0) return null;
   var range = [bins[0]['key'], bins[bins.length - 1]['key']];
   var step = 1; // don't allow divide by 0 errors
-  return {
-    'range': range,
-    'step': step,
-    'binCount': bins.length,
-    'binCountAll': ((range[1] - range[0]) / step) + 1 // +1 since it needs a bin for the top and bottom entry
-  };
+  return /** @type {osx.histo.BinMethodStats} */ ({
+    range: range,
+    step: step,
+    binCount: bins.length,
+    binCountAll: ((range[1] - range[0]) / step) + 1 // +1 since it needs a bin for the top and bottom entry
+  });
 };
 
 /**

--- a/src/os/histo/uniquebinmethod.js
+++ b/src/os/histo/uniquebinmethod.js
@@ -45,6 +45,13 @@ os.histo.UniqueBinMethod = function() {
    * @protected
    */
   this.isDate = false;
+
+  /**
+   * The graph(s) using this BinMethod instance should show the bins with count = 0
+   * @type {boolean}
+   * @protected
+   */
+  this.showEmptyBins = false;
 };
 
 
@@ -327,6 +334,24 @@ os.histo.UniqueBinMethod.prototype.getIsDate = function() {
  */
 os.histo.UniqueBinMethod.prototype.setIsDate = function(value) {
   this.isDate = value;
+};
+
+
+/**
+ * Gets the showEmptyBins property
+ * @return {boolean} true if the empty bins should be displayed by the graphing system
+ */
+os.histo.UniqueBinMethod.prototype.getShowEmptyBins = function() {
+  return this.showEmptyBins;
+};
+
+
+/**
+ * Sets the showEmptyBins property
+ * @param {boolean} value toggle to show/hide the empty bins
+ */
+os.histo.UniqueBinMethod.prototype.setShowEmptyBins = function(value) {
+  this.showEmptyBins = value;
 };
 
 

--- a/src/os/histo/uniquebinmethod.js
+++ b/src/os/histo/uniquebinmethod.js
@@ -71,7 +71,7 @@ os.histo.UniqueBinMethod = function() {
    * @type {number}
    * @protected
    */
-  this.maxBins = 1000000;
+  this.maxBins = Infinity;
 };
 
 
@@ -219,6 +219,7 @@ os.histo.UniqueBinMethod.prototype.persist = function(opt_to) {
   opt_to['isDate'] = this.getIsDate();
   opt_to['arrayKeys'] = this.getArrayKeys();
   opt_to['showEmptyBins'] = this.getShowEmptyBins();
+  opt_to['maxBins'] = this.getMaxBins();
 
   return opt_to;
 };
@@ -245,9 +246,9 @@ os.histo.UniqueBinMethod.prototype.restore = function(config) {
     this.setShowEmptyBins(show == true); // loose comparison rather than ===
   }
 
-  var maxBins = /** @type {number|undefined} */ (config['maxBins']);
-  if (maxBins) {
-    this.setMaxBins(maxBins); // only set if non-zero and non-null
+  var maxBins = /** @type {string|number|undefined} */ (config['maxBins']);
+  if (maxBins != null && !isNaN(maxBins)) {
+    this.setMaxBins(Number(maxBins));
   }
 };
 

--- a/src/os/histo/uniquebinmethod.js
+++ b/src/os/histo/uniquebinmethod.js
@@ -374,6 +374,25 @@ os.histo.UniqueBinMethod.prototype.getFilterForBin = function(bin) {
 
 
 /**
+ * Get the range, step size, etc for the bins made by this method.
+ *
+ * @param {!Array<os.histo.Bin>} bins The bins made using this bin method
+ * @return {any|null} The config
+ * @public
+ */
+os.histo.UniqueBinMethod.prototype.getConfigForBin = function(bins) {
+  if (!bins || bins.length == 0) return null;
+  var range = [bins[0]['key'], bins[bins.length - 1]['key']];
+  var step = 1; // don't allow divide by 0 errors
+  return {
+    'range': range,
+    'step': step,
+    'binCount': bins.length,
+    'binCountAll': ((range[1] - range[0]) / step) + 1 // +1 since it needs a bin for the top and bottom entry
+  };
+};
+
+/**
  * Test if a value is contained within a set of values. Avoided ol.array.includes to prevent an extra function call.
  *
  * @param {!Array<string>} values

--- a/src/os/time/time.js
+++ b/src/os/time/time.js
@@ -867,3 +867,18 @@ os.time.replaceNow_ = function(match, p1, offset, str) {
   return os.time.momentFormat(date, parts[1] || os.time.DEFAULT_TIME_FORMAT, true);
 };
 os.net.VariableReplacer.add('now', os.time.replaceNow_);
+
+
+/**
+ * Gets the difference in millis between the original date and the offset one.
+ *
+ * @param {Date} date The date to offset
+ * @param {string} duration The duration of the offset
+ * @param {number} offset Multiplier for the duration
+ * @param {boolean=} opt_local Whether the incoming and outgoing dates are local or UTC
+ * @return {number} The new date
+ */
+os.time.step = function(date, duration, offset, opt_local) {
+  var next = os.time.offset(date, duration, offset, opt_local);
+  return (next.getTime() - date.getTime());
+};

--- a/src/os/ui/uiswitch.js
+++ b/src/os/ui/uiswitch.js
@@ -38,6 +38,7 @@ os.ui.uiSwitchDirective = function() {
     scope: {
       'items': '=',
       'directiveFunction': '=',
+      'options': '=?',
       'generic': '@',
       'alwaysSwitch': '@'
     },

--- a/test/os/histo/datebinmethod.test.js
+++ b/test/os/histo/datebinmethod.test.js
@@ -354,4 +354,78 @@ describe('os.histo.DateBinMethod', function() {
     result = method.getBinKey('123abc');
     expect(result).toEqual('123abc');
   });
+
+
+  it('should provide bins statistics', function() {
+    var method = new os.histo.DateBinMethod();
+    method.setField('field');
+    method.setDateBinType(os.histo.DateBinType.MONTH);
+
+    var minDate = new Date(2020, 0, 3); // Jan 3, 2020 >> Jan 2020
+    var maxDate = new Date(2030, 0, 15); // Jan 15, 2030 >> Jan 2030
+    var min = os.time.floor(minDate, 'month').getTime();
+    var max = os.time.floor(maxDate, 'month').getTime();
+    var bins = [];
+    var bin;
+
+    bin = new os.data.histo.ColorBin('#000');
+    bin['key'] = min;
+    bin['label'] = method.getLabelForKey(min);
+    bin['id'] = bin['label'];
+    bin['series'] = '';
+    bin['count'] = 0;
+    bin['sel'] = false;
+    bin['highlight'] = false;
+    bins.push(bin);
+
+    bin = new os.data.histo.ColorBin('#000');
+    bin['key'] = max;
+    bin['label'] = method.getLabelForKey(max);
+    bin['id'] = bin['label'];
+    bin['series'] = '';
+    bin['count'] = 0;
+    bin['sel'] = false;
+    bin['highlight'] = false;
+    bins.push(bin);
+
+    var stats = method.getStatsForBin(bins);
+    expect(stats.range[0]).toBe(min);
+    expect(stats.range[1]).toBe(max);
+    expect(stats.binCount).toBe(2);
+    // Note: see sourcemodel.js > generateEmptyBins_() for example of how to use MAGIC_MONTH_MILLIS and os.time.step()
+    expect(stats.binCountAll).toBe(121);
+
+    minDate = new Date(2019, 1, 12); // Feb 12 >> Feb
+    maxDate = new Date(2019, 2, 1); // Mar 1 >> Mar
+    min = os.time.floor(minDate, 'month').getTime();
+    max = os.time.floor(maxDate, 'month').getTime();
+    bins = [];
+
+    bin = new os.data.histo.ColorBin('#000');
+    bin['key'] = min;
+    bin['label'] = method.getLabelForKey(min);
+    bin['id'] = bin['label'];
+    bin['series'] = '';
+    bin['count'] = 0;
+    bin['sel'] = false;
+    bin['highlight'] = false;
+    bins.push(bin);
+
+    bin = new os.data.histo.ColorBin('#000');
+    bin['key'] = max;
+    bin['label'] = method.getLabelForKey(max);
+    bin['id'] = bin['label'];
+    bin['series'] = '';
+    bin['count'] = 0;
+    bin['sel'] = false;
+    bin['highlight'] = false;
+    bins.push(bin);
+
+    var stats = method.getStatsForBin(bins);
+    expect(stats.range[0]).toBe(min);
+    expect(stats.range[1]).toBe(max);
+    expect(stats.binCount).toBe(2);
+    // Note: see sourcemodel.js > generateEmptyBins_() for example of how to use MAGIC_MONTH_MILLIS and os.time.step()
+    expect(stats.binCountAll).toBe(2);
+  });
 });

--- a/test/os/histo/numericbinmethod.test.js
+++ b/test/os/histo/numericbinmethod.test.js
@@ -229,12 +229,14 @@ describe('os.histo.NumericBinMethod', function() {
     method.setValueFunction(fn);
     method.setWidth(55);
     method.setOffset(14);
+    method.setShowEmptyBins(true);
 
     var clone = method.clone();
     expect(clone.getField()).toBe('field');
     expect(clone.valueFunction).toBe(fn);
     expect(clone.getWidth()).toBe(55);
     expect(clone.getOffset()).toBe(14);
+    expect(clone.getShowEmptyBins()).toBe(true);
   });
 
   it('should restore correctly', function() {
@@ -243,10 +245,12 @@ describe('os.histo.NumericBinMethod', function() {
     // doesn't change width/offset if they aren't set on the restore object
     var oldWidth = method.getWidth();
     var oldOffset = method.getOffset();
+    var oldShowEmptyBins = method.getShowEmptyBins();
     method.restore({});
 
     expect(method.getWidth()).toBe(oldWidth);
     expect(method.getOffset()).toBe(oldOffset);
+    expect(method.getShowEmptyBins()).toBe(oldShowEmptyBins);
 
     // or if the values are non-numeric
     method.restore({
@@ -256,6 +260,7 @@ describe('os.histo.NumericBinMethod', function() {
 
     expect(method.getWidth()).toBe(oldWidth);
     expect(method.getOffset()).toBe(oldOffset);
+    expect(method.getShowEmptyBins()).toBe(oldShowEmptyBins);
 
     method.restore({
       'width': 'not numeric',
@@ -264,23 +269,65 @@ describe('os.histo.NumericBinMethod', function() {
 
     expect(method.getWidth()).toBe(oldWidth);
     expect(method.getOffset()).toBe(oldOffset);
+    expect(method.getShowEmptyBins()).toBe(oldShowEmptyBins);
 
     // does change them if they are set
     method.restore({
       'width': 12,
-      'offset': 34
+      'offset': 34,
+      'showEmptyBins': true
     });
 
     expect(method.getWidth()).toBe(12);
     expect(method.getOffset()).toBe(34);
+    expect(method.getShowEmptyBins()).toBe(true);
 
     // converts numeric strings to numbers
     method.restore({
       'width': '56',
-      'offset': '78'
+      'offset': '78',
+      'showEmptyBins': false
     });
 
     expect(method.getWidth()).toBe(56);
     expect(method.getOffset()).toBe(78);
+    expect(method.getShowEmptyBins()).toBe(false);
+  });
+
+  it('should provide bins statistics', function() {
+    var method = new os.histo.NumericBinMethod();
+    method.setField('field');
+    method.setWidth(5);
+
+    var min = 0;
+    var max = 40;
+    var bins = [];
+    var bin;
+
+    bin = new os.data.histo.ColorBin('#000');
+    bin['key'] = min;
+    bin['label'] = method.getLabelForKey(min);
+    bin['id'] = bin['label'];
+    bin['series'] = '';
+    bin['count'] = 0;
+    bin['sel'] = false;
+    bin['highlight'] = false;
+    bins.push(bin);
+
+    bin = new os.data.histo.ColorBin('#000');
+    bin['key'] = max;
+    bin['label'] = method.getLabelForKey(max);
+    bin['id'] = bin['label'];
+    bin['series'] = '';
+    bin['count'] = 0;
+    bin['sel'] = false;
+    bin['highlight'] = false;
+    bins.push(bin);
+
+    var stats = method.getStatsForBin(bins);
+    expect(stats.range[0]).toBe(min);
+    expect(stats.range[1]).toBe(max);
+    expect(stats.binCount).toBe(2);
+    expect(stats.binCountAll).toBe(9);
   });
 });

--- a/test/os/histo/uniquebinmethod.test.js
+++ b/test/os/histo/uniquebinmethod.test.js
@@ -104,10 +104,12 @@ describe('os.histo.UniqueBinMethod', function() {
     };
     method.setValueFunction(fn);
     method.setShowEmptyBins(true);
+    method.setMaxBins(1);
 
     var clone = method.clone();
     expect(clone.getField()).toBe('field');
     expect(clone.getShowEmptyBins()).toBe(true);
+    expect(clone.getMaxBins()).toBe(1);
     expect(clone.valueFunction).toBe(fn);
   });
 
@@ -119,27 +121,33 @@ describe('os.histo.UniqueBinMethod', function() {
     method.restore({});
     expect(method.getField()).toBe('field');
     expect(method.getShowEmptyBins()).toBe(false);
+    expect(method.getMaxBins()).toBe(Infinity);
 
     method.restore({
       field: null
     });
     expect(method.getField()).toBe('field');
     expect(method.getShowEmptyBins()).toBe(false);
+    expect(method.getMaxBins()).toBe(Infinity);
 
     // sets the field if the value is a string
     method.restore({
       field: '',
-      showEmptyBins: true
+      showEmptyBins: true,
+      maxBins: '1'
     });
     expect(method.getField()).toBe('');
     expect(method.getShowEmptyBins()).toBe(true);
+    expect(method.getMaxBins()).toBe(1);
 
     method.restore({
       field: 'otherField',
-      showEmptyBins: false
+      showEmptyBins: false,
+      maxBins: 'not a number' // does not override the '1' provided before
     });
     expect(method.getField()).toBe('otherField');
     expect(method.getShowEmptyBins()).toBe(false);
+    expect(method.getMaxBins()).toBe(1);
   });
 
   it('should provide bins statistics', function() {

--- a/test/os/histo/uniquebinmethod.test.js
+++ b/test/os/histo/uniquebinmethod.test.js
@@ -103,9 +103,11 @@ describe('os.histo.UniqueBinMethod', function() {
       return 'hi';
     };
     method.setValueFunction(fn);
+    method.setShowEmptyBins(true);
 
     var clone = method.clone();
     expect(clone.getField()).toBe('field');
+    expect(clone.getShowEmptyBins()).toBe(true);
     expect(clone.valueFunction).toBe(fn);
   });
 
@@ -116,21 +118,63 @@ describe('os.histo.UniqueBinMethod', function() {
     // if the field isn't set, don't change it
     method.restore({});
     expect(method.getField()).toBe('field');
+    expect(method.getShowEmptyBins()).toBe(false);
 
     method.restore({
       field: null
     });
     expect(method.getField()).toBe('field');
+    expect(method.getShowEmptyBins()).toBe(false);
 
     // sets the field if the value is a string
     method.restore({
-      field: ''
+      field: '',
+      showEmptyBins: true
     });
     expect(method.getField()).toBe('');
+    expect(method.getShowEmptyBins()).toBe(true);
 
     method.restore({
-      field: 'otherField'
+      field: 'otherField',
+      showEmptyBins: false
     });
     expect(method.getField()).toBe('otherField');
+    expect(method.getShowEmptyBins()).toBe(false);
+  });
+
+  it('should provide bins statistics', function() {
+    var method = new os.histo.UniqueBinMethod();
+    method.setField('field');
+
+    var min = 0;
+    var max = 4;
+    var bins = [];
+    var bin;
+
+    bin = new os.data.histo.ColorBin('#000');
+    bin['key'] = min;
+    bin['label'] = method.getLabelForKey(min);
+    bin['id'] = bin['label'];
+    bin['series'] = '';
+    bin['count'] = 0;
+    bin['sel'] = false;
+    bin['highlight'] = false;
+    bins.push(bin);
+
+    bin = new os.data.histo.ColorBin('#000');
+    bin['key'] = max;
+    bin['label'] = method.getLabelForKey(max);
+    bin['id'] = bin['label'];
+    bin['series'] = '';
+    bin['count'] = 0;
+    bin['sel'] = false;
+    bin['highlight'] = false;
+    bins.push(bin);
+
+    var stats = method.getStatsForBin(bins);
+    expect(stats.range[0]).toBe(min);
+    expect(stats.range[1]).toBe(max);
+    expect(stats.binCount).toBe(2);
+    expect(stats.binCountAll).toBe(5);
   });
 });

--- a/test/os/time/time.test.js
+++ b/test/os/time/time.test.js
@@ -237,4 +237,44 @@ describe('os.time', function() {
     expect(os.time.humanize(moment.duration(50, 'hours'))).toBe('2 days, 2 hours');
     expect(os.time.humanize(moment.duration(2883, 'minutes'))).toBe('2 days, 3 minutes');
   });
+
+  it('should get the step between two dates properly', function() {
+    const hour_ = (1000 * 60 * 60);
+    const day_ = (1000 * 60 * 60 * 24);
+    const week_ = (1000 * 60 * 60 * 24 * 7);
+
+    var d1 = new Date(2000, 1, 1, 23, 30, 0, 99); // leap year
+    var d2 = new Date(2001, 1, 1, 23, 30, 0, 99);
+    var d3 = new Date(2004, 1, 1, 23, 30, 0, 99); // leap year
+    var d4 = new Date(2005, 1, 1, 23, 30, 0, 99);
+    var d5 = new Date(2100, 1, 1, 23, 30, 0, 99); // special-case non-leap year
+    var d6 = new Date(2016, 11, 31, 0, 0, 0, 0); // leap second
+
+    // inconsistent number of milliseconds per month / year
+    expect(os.time.step(d1, os.time.Duration.YEAR, 1)).toBe(366 * day_);
+    expect(os.time.step(d2, os.time.Duration.YEAR, 1)).toBe(365 * day_);
+    expect(os.time.step(d1, os.time.Duration.YEAR, 1)).toBe(d2.getTime() - d1.getTime());
+    expect(os.time.step(d1, os.time.Duration.YEAR, 4)).toBe(d3.getTime() - d1.getTime());
+    expect(os.time.step(d1, os.time.Duration.YEAR, 5)).toBe(d4.getTime() - d1.getTime());
+    expect(os.time.step(d2, os.time.Duration.YEAR, 3)).toBe(d3.getTime() - d2.getTime());
+    expect(os.time.step(d3, os.time.Duration.YEAR, 1)).toBe(d4.getTime() - d3.getTime());
+    expect(os.time.step(d3, os.time.Duration.MONTH, 1)).toBe(29 * day_);
+    expect(os.time.step(d3, os.time.Duration.MONTH, 2)).toBe(60 * day_); // 29 + 31
+    expect(os.time.step(d3, os.time.Duration.MONTH, 3)).toBe(90 * day_); // 29 + 31 + 30
+    expect(os.time.step(d4, os.time.Duration.MONTH, 1)).toBe(28 * day_);
+    expect(os.time.step(d5, os.time.Duration.MONTH, 1)).toBe(28 * day_);
+
+    // inconsistent number of milliseconds per day... not supported by JavaScript Date
+    expect(os.time.step(d6, os.time.Duration.DAY, 1)).toBe(day_); // + 1000);
+
+    // consistent number of milliseconds per hour, day, week
+    expect(os.time.step(d1, os.time.Duration.HOURS, 1)).toBe(hour_);
+    expect(os.time.step(d1, os.time.Duration.DAY, 1)).toBe(day_);
+    expect(os.time.step(d1, os.time.Duration.WEEK, 1)).toBe(week_);
+
+    var scale = 3;
+    expect(os.time.step(d1, os.time.Duration.HOURS, scale)).toBe(scale * hour_);
+    expect(os.time.step(d1, os.time.Duration.DAY, scale)).toBe(scale * day_);
+    expect(os.time.step(d1, os.time.Duration.WEEK, scale)).toBe(scale * week_);
+  });
 });


### PR DESCRIPTION
Updated OS backend to support graph views of binned Feature data where there are numerical gaps in the data.

NOTE: Histogram and Bins unused by OpenSphere.  

**Unit Tests**
- time.test.js - Tests the use of a new "step" function, which gets the millisecond difference between a given date and the next Month or Year

- uniquebinmethod.test.js - Now includes "getStatsForBin" function to calculate range and step size based on a config.  Also stores the configuration showing/hiding empty bins after crossfiltering calculations
- numericbinmethod.test.js - Updating accordingly
- datebinmethod.test.js - Updating accordingly

See GEOVIZ-33