### PR TITLE
fix(cesium): better goto support for primitive layers

### DIFF
--- a/src/plugin/cesium/primitivelayer.js
+++ b/src/plugin/cesium/primitivelayer.js
@@ -97,3 +97,26 @@ plugin.cesium.PrimitiveLayer.prototype.removePrimitive = function() {
 
   os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
 };
+
+
+/**
+ * @inheritDoc
+ */
+plugin.cesium.PrimitiveLayer.prototype.getExtent = function() {
+  var primitive = this.getPrimitive();
+
+  if (primitive.ready && primitive.boundingSphere) {
+    var sphere = primitive.boundingSphere;
+    var angle = Math.atan2(sphere.radius, Cesium.Cartesian3.magnitude(sphere.center));
+    var cartographicCenter = Cesium.Cartographic.fromCartesian(sphere.center);
+    var extent = [
+      os.geo.R2D * (cartographicCenter.longitude - angle),
+      os.geo.R2D * (cartographicCenter.latitude - angle),
+      os.geo.R2D * (cartographicCenter.longitude + angle),
+      os.geo.R2D * (cartographicCenter.latitude + angle)];
+
+    return ol.proj.transformExtent(extent, os.proj.EPSG4326, os.map.PROJECTION);
+  }
+
+  return undefined;
+};

--- a/src/plugin/cesium/primitivelayer.js
+++ b/src/plugin/cesium/primitivelayer.js
@@ -105,7 +105,7 @@ plugin.cesium.PrimitiveLayer.prototype.removePrimitive = function() {
 plugin.cesium.PrimitiveLayer.prototype.getExtent = function() {
   var primitive = this.getPrimitive();
 
-  if (primitive.ready && primitive.boundingSphere) {
+  if (primitive && primitive.ready && primitive.boundingSphere) {
     var sphere = primitive.boundingSphere;
     var angle = Math.atan2(sphere.radius, Cesium.Cartesian3.magnitude(sphere.center));
     var cartographicCenter = Cesium.Cartographic.fromCartesian(sphere.center);

--- a/src/plugin/cesium/tiles/cesium3dtileslayer.js
+++ b/src/plugin/cesium/tiles/cesium3dtileslayer.js
@@ -179,7 +179,7 @@ plugin.cesium.tiles.Layer.prototype.getExtent = function() {
     }
   }
 
-  return undefined;
+  return plugin.cesium.tiles.Layer.base(this, 'getExtent');
 };
 
 


### PR DESCRIPTION
Adds a general `getExtent` implementation for primitive layers.

This is not comprehensive because the application should really be operating on aggregated bounding volumes specified and implemented by the renderer (extents for OpenLayers and BoundingSpheres for Cesium) rather than always relying on the OL `getExtent()` function.

However, this will at least get the user in the correct vicinity even if it is not precise regarding altitude.

### Testing
1. Clone https://github.com/AnalyticalGraphicsInc/3d-tiles-samples into your workspace
1. Add `<yourWorkspaceUrl>/3d-tiles-samples/tilesets/TilesetWithDiscreteLOD/tileset.json` to OpenSphere
1. Right-click the new layer
    * Verify that "Go To" is an option
1. Select "Go To"
    * Verify that it goes to the big 3D dragon