### PR TITLE
fix(kml): fix missing google maps icons

### DIFF
--- a/src/os/ui/file/kml/kml.js
+++ b/src/os/ui/file/kml/kml.js
@@ -299,7 +299,7 @@ os.ui.file.kml.DEFAULT_ICON = {
  * @type {RegExp}
  * @const
  */
-os.ui.file.kml.GMAPS_SEARCH = /https?:\/\/maps\.google\.com\/mapfiles\/kml\//i;
+os.ui.file.kml.GMAPS_SEARCH = /^https?:\/\/maps\.google\.com\/mapfiles\/kml\//i;
 
 
 /**
@@ -317,13 +317,28 @@ os.ui.file.kml.getDefaultIcon = function() {
 
 
 /**
+ * @type {boolean}
+ */
+os.ui.file.kml.isGoogleMapsAccessible = true;
+
+
+/**
  * Replace the Google icon URI with the application image path.
  *
  * @param {string|null|undefined} src The image source URL.
- * @return {string} The icon src.
+ * @return {!string} The icon src.
  */
 os.ui.file.kml.replaceGoogleUri = function(src) {
-  return src ? src.replace(os.ui.file.kml.GMAPS_SEARCH, os.ui.file.kml.ICON_PATH) : '';
+  if (os.ui.file.kml.GMAPS_SEARCH.test(src)) {
+    const icon = os.ui.file.kml.GOOGLE_EARTH_ICON_SET.find((icon) => icon.path === src);
+    if (icon) {
+      return icon.path.replace(os.ui.file.kml.GMAPS_SEARCH, os.ui.file.kml.ICON_PATH);
+    } else if (!os.ui.file.kml.isGoogleMapsAccessible) {
+      return os.ui.file.kml.DEFAULT_ICON_PATH;
+    }
+  }
+
+  return src || '';
 };
 
 

--- a/src/plugin/file/kml/kmlplugin.js
+++ b/src/plugin/file/kml/kmlplugin.js
@@ -3,6 +3,7 @@ goog.provide('plugin.file.kml.KMLPlugin');
 goog.require('os.data.DataManager');
 goog.require('os.data.ProviderEntry');
 goog.require('os.layer.config.LayerConfigManager');
+goog.require('os.net.Request');
 goog.require('os.plugin.AbstractPlugin');
 goog.require('os.ui.im.ImportManager');
 goog.require('plugin.file.kml.KMLDescriptor');
@@ -77,4 +78,9 @@ plugin.file.kml.KMLPlugin.prototype.init = function() {
 
   // set up actions
   plugin.file.kml.menu.treeSetup();
+
+  return new os.net.Request(os.ui.file.kml.GOOGLE_EARTH_ICON_SET[0].path).getPromise()
+      .then(goog.nullFunction, () => {
+        os.ui.file.kml.isGoogleMapsAccessible = false;
+      });
 };

--- a/test/os/style/iconreader.test.js
+++ b/test/os/style/iconreader.test.js
@@ -80,11 +80,11 @@ describe('os.style.IconReader', function() {
   });
 
   it('should replace Google maps/earth icons with local copies', function() {
-    config.src = 'http://maps.google.com/mapfiles/kml/pal4/icon28.png';
+    config.src = 'http://maps.google.com/mapfiles/kml/pushpin/wht-pushpin.png';
 
     var icon = reader.getOrCreateStyle(config);
 
     // this should point back a directory to where we keep all of the KML icons
-    expect(icon.getSrc()).toBe(os.ROOT + 'images/icons/kml/pal4/icon28.png');
+    expect(icon.getSrc()).toBe(os.ROOT + 'images/icons/kml/pushpin/wht-pushpin.png');
   });
 });

--- a/test/os/ui/file/kml.test.js
+++ b/test/os/ui/file/kml.test.js
@@ -2,6 +2,11 @@ goog.require('os.ui.file.kml');
 
 
 describe('os.ui.file.kml', function() {
+  afterEach(() => {
+    // return this value to the default
+    os.ui.file.kml.isGoogleMapsAccessible = true;
+  });
+
   it('converts Google icon URLs', function() {
     expect(os.ui.file.kml.replaceGoogleUri(null)).toBe('');
     expect(os.ui.file.kml.replaceGoogleUri(undefined)).toBe('');
@@ -12,6 +17,17 @@ describe('os.ui.file.kml', function() {
     var original = os.ui.file.kml.GOOGLE_EARTH_URL + os.ui.file.kml.GoogleEarthIcons.PLACEMARK_CIRCLE;
     var expected = os.ui.file.kml.ICON_PATH + os.ui.file.kml.GoogleEarthIcons.PLACEMARK_CIRCLE;
     expect(os.ui.file.kml.replaceGoogleUri(original)).toBe(expected);
+  });
+
+  it('should not convert Google icon URLs which we do not have replacements for', () => {
+    const icon = os.ui.file.kml.GOOGLE_EARTH_URL + '/some_unknown_image.png';
+    expect(os.ui.file.kml.replaceGoogleUri(icon)).toBe(icon);
+  });
+
+  it('it should use the default icon for icons lacking replacements when maps.google.com is not available', () => {
+    os.ui.file.kml.isGoogleMapsAccessible = false;
+    const icon = os.ui.file.kml.GOOGLE_EARTH_URL + '/some_unknown_image.png';
+    expect(os.ui.file.kml.replaceGoogleUri(icon)).toBe(os.ui.file.kml.DEFAULT_ICON_PATH);
   });
 
   it('provides a default icon', function() {


### PR DESCRIPTION
There are some google maps icons which are not available for closed network usage by duplicating them in `images/icons/kml`. Previously, any file referencing those icons failed with a message in the console and did not show the point. This addresses that issue by checking to see if the icon is one of the ones that we enumerate for the Google icon set.

Additionally, the KML plugin now checks if maps.google.com is accessible and sets a flag that informs whether to use the default icon for missing URLs or just use the URL directly.

You can test all of the items in the "Placemarks" folder of https://developers.google.com/kml/documentation/KML_Samples.kml to ensure that they show up.