### PR TITLE
fix(icon): preserve icon aspect ratio in picker

### DIFF
--- a/scss/os/_iconpicker.scss
+++ b/scss/os/_iconpicker.scss
@@ -3,6 +3,11 @@
   width: 1.5rem;
 }
 
+.c-icon-picker__med-icon {
+  height: 2rem;
+  width: 2rem;
+}
+
 .c-icon-picker__large-icon {
   height: 3rem;
   width: 3rem;

--- a/views/icon/iconpalette.html
+++ b/views/icon/iconpalette.html
@@ -1,5 +1,7 @@
 <div class="d-flex flex-wrap u-overflow-y-auto">
-  <div ng-repeat="icon in iconSet" title="{{icon.title}}" class="c-icon-picker__large-icon p-1">
-    <button class="btn btn-secondary h-100 w-100" ng-click="palette.pick(icon.path, icon.title)"><img class="h-100 w-100" ng-src="{{palette.getIconSrc(icon.path)}}" /></button>
+  <div ng-repeat="icon in iconSet" title="{{icon.title}}" class="c-icon-picker__large-icon d-flex p-1">
+    <button class="btn btn-secondary" ng-click="palette.pick(icon.path, icon.title)">
+      <img class="img-fluid" ng-src="{{palette.getIconSrc(icon.path)}}" />
+    </button>
   </div>
 </div>

--- a/views/icon/iconselector.html
+++ b/views/icon/iconselector.html
@@ -13,8 +13,8 @@
   </div>
   <div class="modal-footer flex-shrink-0 d-flex justify-content-between">
     <div ng-if="selector.isValid()" class="d-flex align-items-center justify-content-center">
-      <img class="img-fluid c-icon-picker__large-icon c-icon-picker__background rounded" ng-src="{{selector.getPath(selected.path)}}" />
-      <button class="btn btn-outline-danger border-0 mx-2" ng-click="selector.reset()" ng-if="tabMap[activeTab].showResetButton" title="Reset the icon to default">  
+      <img class="img-fluid c-icon-picker__med-icon c-icon-picker__background rounded" ng-src="{{selector.getPath(selected.path)}}" />
+      <button class="btn btn-outline-danger border-0 mx-2" ng-click="selector.reset()" ng-if="tabMap[activeTab].showResetButton" title="Reset the icon to default">
         <i class="fa fa-refresh"></i>
         Reset
       </button>


### PR DESCRIPTION
The icon picker was using `h-100 w-100` to size icons in the grid. This was causing icons to be stretched vertically because the aspect ratio of the container (button) did not match the aspect ratio of the image. See before and after:
![Before](https://user-images.githubusercontent.com/5685437/73665546-84605f80-465e-11ea-821b-6d8e85f00b64.png)
![After](https://user-images.githubusercontent.com/5685437/73665550-862a2300-465e-11ea-8807-95b230f5c233.png)

I also reduced the size of the preview icon in the footer because it seemed larger than necessary. I believe this changed with the BS4 upgrade.