### PR TITLE
fix(menu): fix reopen behavior

### DIFF
--- a/src/os/ui/menu/menu.js
+++ b/src/os/ui/menu/menu.js
@@ -213,7 +213,9 @@ os.ui.menu.Menu.prototype.open = function(context, position, opt_target, opt_dis
  * Reopen the menu to update it. If the menu isn't already open, nothing will happen.
  */
 os.ui.menu.Menu.prototype.reopen = function() {
-  if (this.target_) {
+  if (this.target_ && this.isOpen_) {
+    // prevent open from closing the menu and returning early
+    this.isOpen_ = false;
     this.open(this.context_, this.position_, this.target_, false);
   }
 };


### PR DESCRIPTION
The `open` call will close the menu and return immediately if `isOpen_` is true. This prevents `reopen` from working properly, so `reopen` will now set that flag to false.