### PR TITLE
fix(alert-manager): adds instance setter for the alert manager

### DIFF
--- a/src/os/alert/alertmanager.js
+++ b/src/os/alert/alertmanager.js
@@ -65,7 +65,7 @@ class AlertManager extends goog.events.EventTarget {
   }
 
   /**
-   * Global alert manager instance.
+   * Get the global alert manager instance.
    * @return {AlertManager}
    */
   static getInstance() {
@@ -74,6 +74,14 @@ class AlertManager extends goog.events.EventTarget {
     }
 
     return instance;
+  }
+
+  /**
+   * Set the global alert manager instance.
+   * @param {!AlertManager} value The AlertManager instance to set.
+   */
+  static setInstance(value) {
+    instance = value;
   }
 
   /**


### PR DESCRIPTION
There are cases under the module refactor where the singleton getter
implementation wasn't working quite properly. This allows for setting
a specific instance in those cases.