### PR TITLE
fix(preset): enable animation/visibility in default preset

### DIFF
--- a/src/os/layer/preset/preset.js
+++ b/src/os/layer/preset/preset.js
@@ -50,7 +50,9 @@ os.layer.preset.addDefault = function(presets) {
       // create a temporary vector layer to produce a default layer config
       var layer = os.layer.createFromOptions({
         'id': os.layer.preset.DEFAULT_PRESET_ID,
-        'type': os.layer.config.StaticLayerConfig.ID
+        'type': os.layer.config.StaticLayerConfig.ID,
+        'animate': true,
+        'visible': true
       });
 
       if (layer) {
@@ -83,15 +85,11 @@ os.layer.preset.updateDefault = function(layer, preset) {
   if (layer && preset && preset.layerConfig) {
     var config = preset.layerConfig;
     var layerOptions = layer.getLayerOptions();
-    if (layerOptions) {
+    if (layerOptions && layerOptions['baseColor']) {
       // update the default color
-      if (layerOptions['baseColor']) {
-        var color = os.style.toRgbaString(/** @type {string} */ (layerOptions['baseColor']));
-        config['color'] = color;
-        config['fillColor'] = color;
-      }
-
-      config['animate'] = !!layerOptions['animate'];
+      var color = os.style.toRgbaString(/** @type {string} */ (layerOptions['baseColor']));
+      config['color'] = color;
+      config['fillColor'] = color;
     }
   }
 };


### PR DESCRIPTION
Creating a true "default" set of options for a layer is unfortunately tricky, because the original options may be modified when changes are made to the layer. This provides a minimal fix to a bug where applying the Default preset would remove a layer from the timeline.