### PR TITLE
refactor(slickgrid): extract function for sort prep

### DIFF
--- a/externs/slick.grid.externs.js
+++ b/externs/slick.grid.externs.js
@@ -940,20 +940,29 @@ Slick.Grid.prototype.setColumns = function(columnDefinitions) {};
 
 
 /**
- * @return {!Array<string>}
+ * @typedef {{columnId: (string|number), sortAsc: boolean, column: Object}} Slick.Grid.SortColumn
+ * @property {string|number} columnId The id of the sort column
+ * @property {boolean} sortAsc If true sort in ascending order
+ * @property {?Object} column Column definition object, added by us
+ */
+Slick.Grid.SortColumn;
+
+
+/**
+ * @return {!Array<Slick.Grid.SortColumn>}
  */
 Slick.Grid.prototype.getSortColumns = function() {};
 
 
 /**
- * @param {Array} columnDefinitions
+ * @param {Array<Slick.Grid.SortColumn>} columnDefinitions
  */
 Slick.Grid.prototype.setSortColumns = function(columnDefinitions) {};
 
 
 /**
- * @param {*} id
- * @return {*}
+ * @param {string|number} id
+ * @return {number|undefined}
  */
 Slick.Grid.prototype.getColumnIndex = function(id) {};
 


### PR DESCRIPTION
There was duplicate code that was copy-pasted, including explaining
comments. The code adds the real column definitions to the sort columns
returned by `slick.grid.getSortColumns()` to speed up the sorting
functions. That's been extracted to a function, preserving the
explaining comments.

Also defined a typedef to accurately define the type of the elements in
the sort column array returned by `slick.grid.getSortColumns()` and
given to the sorting functions. This definition includes the column
definitions added by the extracted function described above.