### PR TITLE
fix(kml): use scheme-relative URL for Google Maps

### DIFF
--- a/src/os/ui/file/kml/kml.js
+++ b/src/os/ui/file/kml/kml.js
@@ -76,7 +76,7 @@ os.ui.file.kml.Icon;
  * @type {string}
  * @const
  */
-os.ui.file.kml.GOOGLE_EARTH_URL = '//maps.google.com/mapfiles/kml/';
+os.ui.file.kml.GOOGLE_EARTH_URL = 'https://maps.google.com/mapfiles/kml/';
 
 
 /**
@@ -330,7 +330,8 @@ os.ui.file.kml.isGoogleMapsAccessible = true;
  */
 os.ui.file.kml.replaceGoogleUri = function(src) {
   if (os.ui.file.kml.GMAPS_SEARCH.test(src)) {
-    const icon = os.ui.file.kml.GOOGLE_EARTH_ICON_SET.find((icon) => src.endsWith(icon.path));
+    const secureSource = src.replace(/^http:/, 'https:');
+    const icon = os.ui.file.kml.GOOGLE_EARTH_ICON_SET.find((icon) => secureSource === icon.path);
     if (icon) {
       return icon.path.replace(os.ui.file.kml.GMAPS_SEARCH, os.ui.file.kml.ICON_PATH);
     } else if (!os.ui.file.kml.isGoogleMapsAccessible) {

--- a/src/os/ui/file/kml/kml.js
+++ b/src/os/ui/file/kml/kml.js
@@ -330,7 +330,7 @@ os.ui.file.kml.isGoogleMapsAccessible = true;
  */
 os.ui.file.kml.replaceGoogleUri = function(src) {
   if (os.ui.file.kml.GMAPS_SEARCH.test(src)) {
-    const secureSource = src.replace(/^http:/, 'https:');
+    const secureSource = 'https:' + src.replace(/^[a-z]*:\/\//, '//');
     const icon = os.ui.file.kml.GOOGLE_EARTH_ICON_SET.find((icon) => secureSource === icon.path);
     if (icon) {
       return icon.path.replace(os.ui.file.kml.GMAPS_SEARCH, os.ui.file.kml.ICON_PATH);

--- a/src/os/ui/file/kml/kml.js
+++ b/src/os/ui/file/kml/kml.js
@@ -76,7 +76,7 @@ os.ui.file.kml.Icon;
  * @type {string}
  * @const
  */
-os.ui.file.kml.GOOGLE_EARTH_URL = 'http://maps.google.com/mapfiles/kml/';
+os.ui.file.kml.GOOGLE_EARTH_URL = '//maps.google.com/mapfiles/kml/';
 
 
 /**
@@ -299,7 +299,7 @@ os.ui.file.kml.DEFAULT_ICON = {
  * @type {RegExp}
  * @const
  */
-os.ui.file.kml.GMAPS_SEARCH = /^https?:\/\/maps\.google\.com\/mapfiles\/kml\//i;
+os.ui.file.kml.GMAPS_SEARCH = /^(https?:)?\/\/maps\.google\.com\/mapfiles\/kml\//i;
 
 
 /**
@@ -330,7 +330,7 @@ os.ui.file.kml.isGoogleMapsAccessible = true;
  */
 os.ui.file.kml.replaceGoogleUri = function(src) {
   if (os.ui.file.kml.GMAPS_SEARCH.test(src)) {
-    const icon = os.ui.file.kml.GOOGLE_EARTH_ICON_SET.find((icon) => icon.path === src);
+    const icon = os.ui.file.kml.GOOGLE_EARTH_ICON_SET.find((icon) => src.endsWith(icon.path));
     if (icon) {
       return icon.path.replace(os.ui.file.kml.GMAPS_SEARCH, os.ui.file.kml.ICON_PATH);
     } else if (!os.ui.file.kml.isGoogleMapsAccessible) {

--- a/test/os/ui/file/kml.test.js
+++ b/test/os/ui/file/kml.test.js
@@ -14,9 +14,11 @@ describe('os.ui.file.kml', function() {
     expect(os.ui.file.kml.replaceGoogleUri('http://not.google.com/icon.png'))
         .toBe('http://not.google.com/icon.png');
 
-    var original = os.ui.file.kml.GOOGLE_EARTH_URL + os.ui.file.kml.GoogleEarthIcons.PLACEMARK_CIRCLE;
-    var expected = os.ui.file.kml.ICON_PATH + os.ui.file.kml.GoogleEarthIcons.PLACEMARK_CIRCLE;
+    const original = os.ui.file.kml.GOOGLE_EARTH_URL + os.ui.file.kml.GoogleEarthIcons.PLACEMARK_CIRCLE;
+    const expected = os.ui.file.kml.ICON_PATH + os.ui.file.kml.GoogleEarthIcons.PLACEMARK_CIRCLE;
     expect(os.ui.file.kml.replaceGoogleUri(original)).toBe(expected);
+    const schemeRelative = original.replace(/https?:/, '');
+    expect(os.ui.file.kml.replaceGoogleUri(schemeRelative)).toBe(expected);
   });
 
   it('should not convert Google icon URLs which we do not have replacements for', () => {


### PR DESCRIPTION
This should prevent the test URL for Google Maps from unnecessarily going through the proxy, in addition to supporting Google Maps icon URLs with both `http` and `https` schemes.