### PR TITLE
Add function to async apply an Angular scope

### DIFF
--- a/src/os/ui/ui.js
+++ b/src/os/ui/ui.js
@@ -190,9 +190,9 @@ os.ui.measureText = function(text, opt_classes, opt_font) {
 
 
 /**
- * Applies the scope
+ * Applies the scope with angular.Scope#apply.
  *
- * @param {?angular.Scope} scope
+ * @param {?angular.Scope} scope The Angular scope.
  * @param {number=} opt_delay Timeout interval to wait before applying the scope, in milliseconds
  */
 os.ui.apply = function(scope, opt_delay) {
@@ -207,6 +207,18 @@ os.ui.apply = function(scope, opt_delay) {
       }
     } catch (e) {
     }
+  }
+};
+
+
+/**
+ * Asynchronously applies the scope with angular.Scope#applyAsync.
+ *
+ * @param {?angular.Scope} scope The Angular scope.
+ */
+os.ui.applyAsync = function(scope) {
+  if (scope) {
+    scope.$applyAsync();
   }
 };
 

--- a/src/os/ui/ui.js
+++ b/src/os/ui/ui.js
@@ -203,7 +203,7 @@ os.ui.apply = function(scope, opt_delay) {
   } else {
     try {
       if (scope && (!scope.$root || !scope.$root.$$phase)) {
-        scope.$applyAsync();
+        scope.$apply();
       }
     } catch (e) {
     }


### PR DESCRIPTION
#877 caused unwanted side effects and doesn't seem to be a safe replacement for `$apply`. Code that needs to asynchronously apply an Angular scope should use `os.ui.applyAsync`.