### PR TITLE
chore(http-server): defaults address to localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "package:update": "if git diff --name-only ORIG_HEAD HEAD | grep --quiet package.json; then echo 'UPDATE: package.json was updated, consider running yarn in your workspace root'; fi",
     "perms": "chmod -R u+rwX,go+rX,go-w .",
     "semantic-release": "semantic-release --dry-run",
-    "start-server": "http-server ../../ -p 8282 -c-1 -o -U -s &",
+    "start-server": "http-server ../../ -a localhost -p 8282 -c-1 -o -U -s &",
     "stop-server": "run-script-os",
     "stop-server:darwin:linux": "pkill -f http-server",
     "stop-server:windows": "taskkill -F -PID $(netstat -ano | findstr 0.0.0.0:8282 | awk '{print $5}')"


### PR DESCRIPTION
This adds the `-a localhost` to http-server. This will default the link to localhost:8282 on server start