### PR TITLE
refactor(vendor-min): resolve tui-code-snippet relative to tui-editor

### DIFF
--- a/vendor-min.js
+++ b/vendor-min.js
@@ -2,8 +2,16 @@
 
 'use strict';
 
-const resolver = require('opensphere-build-resolver/utils');
-const Compiler = require('google-closure-compiler').compiler;
+const path = require('path');
+const {compile} = require('opensphere-build-closure-helper');
+const {resolveModulePath} = require('opensphere-build-resolver/utils');
+
+
+/**
+ * Path to the tui-editor module.
+ * @type {string}
+ */
+const tuiPath = resolveModulePath('tui-editor', __dirname);
 
 
 /**
@@ -12,27 +20,28 @@ const Compiler = require('google-closure-compiler').compiler;
  */
 const tuiEditorResources = [
   {
-    source: resolver.resolveModulePath('to-mark/dist', __dirname),
+    source: resolveModulePath('to-mark/dist', __dirname),
     scripts: ['to-mark.min.js']
   },
   {
-    source: resolver.resolveModulePath('highlight.js/lib', __dirname),
+    source: resolveModulePath('highlight.js/lib', __dirname),
     scripts: ['highlight.js']
   },
   {
-    source: resolver.resolveModulePath('squire-rte/build', __dirname),
+    source: resolveModulePath('squire-rte/build', __dirname),
     scripts: ['squire.js']
   },
   {
-    source: resolver.resolveModulePath('codemirror/lib', __dirname),
+    source: resolveModulePath('codemirror/lib', __dirname),
     scripts: ['codemirror.js']
   },
   {
-    source: resolver.resolveModulePath('tui-code-snippet/dist', __dirname),
+    // Resolve the dependency from tui-editor. This prevents resolving a different version hoisted from other deps.
+    source: resolveModulePath('tui-code-snippet/dist', tuiPath),
     scripts: ['tui-code-snippet.min.js']
   },
   {
-    source: resolver.resolveModulePath('tui-editor/dist', __dirname),
+    source: path.join(tuiPath, 'dist'),
     scripts: [
       'tui-editor-Editor.min.js',
       'tui-editor-extTable.min.js'
@@ -42,31 +51,20 @@ const tuiEditorResources = [
 
 
 /**
- * @param {Array<Object>} resources
- * @param {string} output
- * @param {string=} opt_optimzationLevel
+ * Minify a set of vendor scripts.
+ * @param {Array<Object>} resources List of scripts to minify.
+ * @param {string} output The output file.
+ * @param {string=} opt_optimizationLevel The optimization level.
  */
-var vendorMinify = function(resources, output, opt_optimzationLevel) {
-  var fileList = [];
-  resources.forEach(function(lib) {
-    lib.scripts.forEach(function(script) {
-      fileList = fileList.concat(lib.source + '/' + script);
-    });
-  });
+const vendorMinify = function(resources, output, opt_optimizationLevel = 'SIMPLE_OPTIMIZATIONS') {
+  const fileList = resources.map((lib) => lib.scripts.map((script) => path.join(lib.source, script))).flat();
 
-  var compiler = new Compiler({
-    js: fileList,
-    compilation_level: opt_optimzationLevel || 'SIMPLE_OPTIMIZATIONS',
-    js_output_file: output
+  compile({
+    'js': fileList,
+    'compilation_level': opt_optimizationLevel,
+    'hide_warnings_for': ['/node_modules/'],
+    'js_output_file': output
   });
-
-  compiler.run((exit, out, err) => {
-    if (exit) {
-      process.stderr.write(err, () => process.exit(1))
-    } else {
-      process.stdout.write('Yay it worked\n');
-    }
-  })
 };
 
 vendorMinify(tuiEditorResources, 'vendor/os-minified/os-tui-editor.min.js');


### PR DESCRIPTION
Dependencies of `tui-editor` updated their dependency on `tui-code-snippet`. This broke our vendor minification because `tui-code-snippet.min.js` does not exist in the new version. This PR resolves that module relative to `tui-editor`, so the direct dependency version will be found.

I also switched to using `opensphere-build-closure-helper` for the build to simplify the script a bit.