### PR TITLE
refactor(kml): provide KML model defaults from spec

### DIFF
--- a/src/plugin/file/kml/kmlparser.js
+++ b/src/plugin/file/kml/kmlparser.js
@@ -31,7 +31,7 @@ goog.require('os.ui.file.kml');
 goog.require('os.xml');
 goog.require('plugin.file.kml');
 goog.require('plugin.file.kml.KMLField');
-goog.require('plugin.file.kml.KMLModelParser');
+goog.require('plugin.file.kml.model');
 goog.require('plugin.file.kml.tour.FlyTo');
 goog.require('plugin.file.kml.tour.Tour');
 goog.require('plugin.file.kml.tour.TourControl');
@@ -1159,7 +1159,7 @@ plugin.file.kml.KMLParser.prototype.readPlacemark_ = function(el) {
   }
 
   if (this.hasModel_) {
-    new plugin.file.kml.KMLModelParser().parseModel(el, object);
+    plugin.file.kml.model.parseModel(el, object);
   }
 
   // set geometry fields on the object


### PR DESCRIPTION
- Provide model defaults from the KML spec (0 for heading/tilt/roll, 1 for scale values).
- Create `KMLModel` typedef so dot notation can be used and enforce compiler type checks.
- Replace `KMLModelParser` class with direct `parseModel` function.