### PR TITLE
fix(settings): indexeddb register method was depending on an async mo…

### DIFF
--- a/src/os/config/abstractsettingsinitializer.js
+++ b/src/os/config/abstractsettingsinitializer.js
@@ -36,9 +36,12 @@ os.config.AbstractSettingsInitializer = function() {
  * Kick off initialization of settings and bootstrap the application.
  */
 os.config.AbstractSettingsInitializer.prototype.init = function() {
-  this.registerStorages();
-  os.settings.listenOnce(os.config.EventType.INITIALIZED, this.onInitialized, false, this);
-  os.settings.init();
+  // IndexedDb is an async call
+  Modernizr.on('indexeddb', (result) => {
+    this.registerStorages();
+    os.settings.listenOnce(os.config.EventType.INITIALIZED, this.onInitialized, false, this);
+    os.settings.init();
+  });
 };
 
 


### PR DESCRIPTION
…derizer check

I didnt see a check for all async tests. IndexedDB is what we use for the browserCheck, however that check doesnt block the app from loading. So the app can load fast enough that the call to Modernizr.indexeddb is not accurate.