### PR TITLE
position a window by 'bottom'

### DIFF
--- a/src/os/ui/window.js
+++ b/src/os/ui/window.js
@@ -135,7 +135,8 @@ os.ui.windowDirective = function() {
       'windowContainer': '@',
       /* Array.<os.ui.window.HeaderBtnConfig> */
       'headerBtns': '=?',
-      'border': '='
+      'border': '=',
+      'bottom': '=?'
     },
     templateUrl: os.ROOT + 'views/window/window.html',
     controller: os.ui.WindowCtrl,
@@ -660,7 +661,10 @@ os.ui.WindowCtrl = function($scope, $element, $timeout) {
     $scope['x'] = (container.width() - $scope['width']) / 2;
   }
 
-  if ($scope['y'] == 'center') {
+  if ($scope['bottom'] != null && $scope['bottom'] != 'auto') {
+    $element.css('top', 'auto');
+    $element.css('bottom', $scope['bottom'] + 'px');
+  } else if ($scope['y'] == 'center') {
     var maxHeight = Math.min($(window).height(), container.height());
     if ($scope['height'] == 'auto') {
       // Put the element off the screen at the top
@@ -757,7 +761,9 @@ os.ui.WindowCtrl = function($scope, $element, $timeout) {
 
   var height = $scope['height'];
   if ($scope['height'] == 'auto') {
-    $element.css('bottom', 'auto');
+    if ($scope['bottom'] == null || $scope['bottom'] == 'auto') {
+      $element.css('bottom', 'auto');
+    }
   } else {
     height += 'px';
   }
@@ -767,7 +773,8 @@ os.ui.WindowCtrl = function($scope, $element, $timeout) {
     // if the window wasn't cascaded, position it based off the config
     $element.css('left', $scope['x'] + 'px');
 
-    if (!($scope['y'] == 'center' && $scope['height'] == 'auto')) {
+    if (!($scope['y'] == 'center' && $scope['height'] == 'auto') && ($scope['bottom'] == null ||
+        $scope['bottom'] == 'auto')) {
       $element.css('top', $scope['y'] + 'px');
     }
   }
@@ -1140,6 +1147,9 @@ os.ui.WindowCtrl.prototype.onChange = function(event, ui) {
 os.ui.WindowCtrl.prototype.onDragStart_ = function(event, ui) {
   this.scope.$emit(os.ui.WindowEventType.DRAGSTART);
 
+  this.scope['bottom'] = 'auto';
+  this.element.css('bottom', 'auto');
+
   // iframes kill mouse events if you roll over them while dragging, so we'll nip that in the bud
   angular.element('iframe').addClass('u-pointer-events-none');
 };
@@ -1294,11 +1304,13 @@ os.ui.WindowCtrl.prototype.constrainWindow_ = function() {
     this.element.css('left', x + 'px');
   }
 
-  if (y < winContainerTop) {
-    this.element.css('top', winContainerTop + 'px');
-  } else if ((y + h) > size.height) {
-    y = Math.max(size.height - h, winContainerTop);
-    this.element.css('top', y + 'px');
+  if (this.scope['bottom'] == null || this.scope['bottom'] == 'auto') {
+    if (y < winContainerTop) {
+      this.element.css('top', winContainerTop + 'px');
+    } else if ((y + h) > size.height) {
+      y = Math.max(size.height - h, winContainerTop);
+      this.element.css('top', y + 'px');
+    }
   }
 
   // If window is height auto, force max-height on the modal-content

--- a/src/os/ui/window.js
+++ b/src/os/ui/window.js
@@ -726,6 +726,12 @@ os.ui.WindowCtrl = function($scope, $element, $timeout) {
     $element.draggable(dragConfig);
   }
 
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.resizable_ = false;
+
   if (($scope['minWidth'] && $scope['maxWidth'] && $scope['minWidth'] != $scope['maxWidth']) ||
       ($scope['minHeight'] && $scope['maxHeight'] && $scope['minHeight'] != $scope['maxHeight'])) {
     // make the element resizable. the height/width values must be numbers, or jquery calculations won't work
@@ -742,6 +748,9 @@ os.ui.WindowCtrl = function($scope, $element, $timeout) {
     };
     Object.assign(resizeConfig, $scope['resizeOptions'] || {});
     $element.resizable(resizeConfig);
+    this.resizable_ = true;
+  } else {
+    $element.resizable({disabled: true});
   }
 
   $element.css('width', $scope['width'] + 'px');
@@ -1078,7 +1087,7 @@ os.ui.WindowCtrl.prototype.toggle = function() {
       this.element.height(this.lastHeight_);
       this.lastHeight_ = NaN;
       content.toggle();
-      this.element.resizable('option', 'disabled', false);
+      this.element.resizable('option', 'disabled', !this.resizable_);
       this.constrainWindow_();
       this.scope['collapsed'] = false;
       this.element.find('.js-window__header').removeClass('collapsed');


### PR DESCRIPTION
This ticket does two things:

1. Fix a bug where if the window was not resizable, the double-click action on the header would not work...and generate a console error
2.  Add ability to position a window by the bottom of the window. It now allows the 'bottom' scope variable. This will ignore the 'y' scope variable if both are passed in.

There is currently no way to test the bottom positioning in opensphere itself since no components use it to launch. You can test that it doesn't break any existing windows, however, by launching windows and verifying they behave as they did before.