### PR TITLE
fix(selection): cleanup related to feature selection

### DIFF
--- a/src/os/ui/menu/listmenu.js
+++ b/src/os/ui/menu/listmenu.js
@@ -1,9 +1,6 @@
 goog.provide('os.ui.menu.list');
 
 goog.require('os.command.FeaturesVisibility');
-goog.require('os.command.InvertSelect');
-goog.require('os.command.SelectAll');
-goog.require('os.command.SelectNone');
 goog.require('os.feature');
 goog.require('os.fn');
 goog.require('os.instanceOf');

--- a/src/os/ui/menu/listmenu.js
+++ b/src/os/ui/menu/listmenu.js
@@ -127,18 +127,18 @@ os.ui.menu.list.handleListEvent = function(event) {
     var eventType = event.type.replace(os.ui.menu.list.PREFIX_REGEXP, '');
     switch (eventType) {
       case os.action.EventType.SELECT:
-        // omit selection events from the stack to reduce clutter
-        new os.command.SelectAll(source.getId()).execute();
+        // don't create and execute a command if it's simple and we don't want it on the stack
+        source.selectAll();
         os.metrics.Metrics.getInstance().updateMetric(os.metrics.FeatureList.SELECT_ALL, 1);
         break;
       case os.action.EventType.DESELECT:
-        // omit selection events from the stack to reduce clutter
-        new os.command.SelectNone(source.getId()).execute();
+        // don't create and execute a command if it's simple and we don't want it on the stack
+        source.selectNone();
         os.metrics.Metrics.getInstance().updateMetric(os.metrics.FeatureList.DESELECT_ALL, 1);
         break;
       case os.action.EventType.INVERT:
-        // omit selection events from the stack to reduce clutter
-        new os.command.InvertSelect(source.getId()).execute();
+        // don't create and execute a command if it's simple and we don't want it on the stack
+        source.invertSelection();
         os.metrics.Metrics.getInstance().updateMetric(os.metrics.FeatureList.INVERT_SELECTION, 1);
         break;
       case os.action.EventType.HIDE_SELECTED:


### PR DESCRIPTION
Added some null checks and utilized more streamlined methods of selection in some menus.  Part of a cleanup effort.

Test Steps:
1. [opensphere](http://glorious-soccerball.surge.sh/opensphere/)
2. Load some data, Click on a few dots to select them
3. Right click on the Features layer in the Layers modal > Click "Clear Selection" > Verify all selected dots become unselected
4. Shift+Click and drag a box over some loaded dots > Click "Select" in the popup menu > Verify the appropriate dots become selected
5. Right click on the Map > Click "Clear Selection" > Verify all selected dots become unselected
