### PR TITLE
refactor: updated goog provides in slickgrid

### DIFF
--- a/src/os/ui/slick/slickgrid.js
+++ b/src/os/ui/slick/slickgrid.js
@@ -2,6 +2,7 @@ goog.provide('os.ui.slick.SlickGridCtrl');
 goog.provide('os.ui.slick.SlickGridEvent');
 goog.provide('os.ui.slick.SlickGridUtils');
 goog.provide('os.ui.slick.slickGridDirective');
+goog.provide('os.ui.slickGridDirective');
 
 goog.require('goog.Disposable');
 goog.require('goog.Timer');


### PR DESCRIPTION
Provide  os.ui.slickGridDirective  to match the exact name of the directive function. Leaving the old provide alone, since that will be addressed with the goog modules -> ES6 transition.