### PR TITLE
feat(electron): notify main process on cert handler registration

### DIFF
--- a/scripts/electron/preload.js
+++ b/scripts/electron/preload.js
@@ -14,6 +14,9 @@ let certHandler;
  */
 const registerCertificateHandler = (handler) => {
   certHandler = handler;
+
+  // Notify the main process that the handler has been registered.
+  ipcRenderer.send('client-certificate-handler-registered');
 };
 
 


### PR DESCRIPTION
Notify the main process when the client cert handler has been registered. This is used by https://github.com/ngageoint/opensphere-electron/pull/20 to select a client cert on auto update.