### PR TITLE
fix(filter): support multi-line strings for local is like (list) ops

### DIFF
--- a/src/os/ui/filter/op/islikeop.js
+++ b/src/os/ui/filter/op/islikeop.js
@@ -30,7 +30,7 @@ os.ui.filter.op.IsLike.prototype.getEvalExpression = function(varName, literal) 
     var reStr = os.ui.filter.string.escapeRegExp(literal);
 
     // test the expression, case insensitive
-    return '/^' + reStr + '$/i.test(' + varName + ')';
+    return '/^' + reStr + '$/im.test(' + varName + ')';
   }
 
   // null/empty string is not supported, so don't return an expression

--- a/src/os/ui/filter/op/likelistop.js
+++ b/src/os/ui/filter/op/likelistop.js
@@ -28,7 +28,7 @@ os.ui.filter.op.LikeList.prototype.getEvalExpression = function(varName, literal
       return os.ui.filter.string.escapeRegExp(str);
     });
 
-    return '/^(' + list.join('|') + ')$/i.test(' + varName + ')';
+    return '/^(' + list.join('|') + ')$/im.test(' + varName + ')';
   }
 
   // null/empty string is not supported, so don't return an expression

--- a/test/os/ui/filter/op/islikeop.test.js
+++ b/test/os/ui/filter/op/islikeop.test.js
@@ -18,12 +18,9 @@ describe('os.ui.filter.op.IsLike', function() {
   it('should generate the proper filter function expression', function() {
     // one wildcard
     var expr = op.getEvalExpression('testVar', 'testV*');
-    expect(expr).toBe('/^testV.*$/i.test(testVar)');
+    expect(expr).toBe('/^testV.*$/im.test(testVar)');
 
-    var testVar = 'testVal';
-
-    // prevent eslint no-unused-vars
-    expect(testVar).toBeDefined();
+    var testVar = 'testVal'; // eslint-disable-line
 
     expect(eval(expr)).toBe(true);
 
@@ -35,7 +32,7 @@ describe('os.ui.filter.op.IsLike', function() {
 
     // multiple wildcards
     expr = op.getEvalExpression('testVar', '*V*');
-    expect(expr).toBe('/^.*V.*$/i.test(testVar)');
+    expect(expr).toBe('/^.*V.*$/im.test(testVar)');
 
     testVar = 'testVal';
     expect(eval(expr)).toBe(true);
@@ -51,7 +48,7 @@ describe('os.ui.filter.op.IsLike', function() {
 
     // single character wildcards
     expr = op.getEvalExpression('testVar', 'f.....uck');
-    expect(expr).toBe('/^f.....uck$/i.test(testVar)');
+    expect(expr).toBe('/^f.....uck$/im.test(testVar)');
 
     testVar = 'firetruck';
     expect(eval(expr)).toBe(true);
@@ -70,7 +67,7 @@ describe('os.ui.filter.op.IsLike', function() {
 
     // special RegExp characters
     expr = op.getEvalExpression('testVar', 'ABCD-1234');
-    expect(expr).toBe('/^ABCD\\-1234$/i.test(testVar)');
+    expect(expr).toBe('/^ABCD\\-1234$/im.test(testVar)');
 
     testVar = 'ABCD-1234';
     expect(eval(expr)).toBe(true);
@@ -80,7 +77,7 @@ describe('os.ui.filter.op.IsLike', function() {
 
     // special RegExp characters with wildcards
     expr = op.getEvalExpression('testVar', 'ABCD-12*');
-    expect(expr).toBe('/^ABCD\\-12.*$/i.test(testVar)');
+    expect(expr).toBe('/^ABCD\\-12.*$/im.test(testVar)');
 
     testVar = 'ABCD-1234';
     expect(eval(expr)).toBe(true);
@@ -97,5 +94,14 @@ describe('os.ui.filter.op.IsLike', function() {
     expect(op.getEvalExpression('testVar', null)).toBe('');
     expect(op.getEvalExpression('testVar', '')).toBe('');
     expect(op.getEvalExpression('testVar', '   ')).toBe('');
+  });
+
+  it('should match multi-line strings', function() {
+    var expr = op.getEvalExpression('testVar', '*testV*');
+    expect(expr).toBe('/^.*testV.*$/im.test(testVar)');
+
+    var testVar = 'this text does not match\nbut this does match testVal'; // eslint-disable-line
+
+    expect(eval(expr)).toBe(true);
   });
 });

--- a/test/os/ui/filter/op/likelistop.test.js
+++ b/test/os/ui/filter/op/likelistop.test.js
@@ -39,12 +39,9 @@ describe('os.ui.filter.op.LikeList', function() {
   it('should generate the proper filter function expression', function() {
     // starts with 'a', ends with 'b', contains 'c', d plus two more characters
     var expr = op.getEvalExpression('testVar', 'a*, *b,   *c-*   ,   d..');
-    expect(expr).toBe('/^(a.*|.*b|.*c\\-.*|d..)$/i.test(testVar)');
+    expect(expr).toBe('/^(a.*|.*b|.*c\\-.*|d..)$/im.test(testVar)');
 
-    var testVar = 'aTest';
-
-    // prevent eslint no-unused-vars
-    expect(testVar).toBeDefined();
+    var testVar = 'aTest'; // eslint-disable-line
 
     expect(eval(expr)).toBe(true);
 
@@ -82,5 +79,14 @@ describe('os.ui.filter.op.LikeList', function() {
     expect(op.getEvalExpression('testVar', '   ')).toBe('');
     expect(op.getEvalExpression('testVar', ',,,')).toBe('');
     expect(op.getEvalExpression('testVar', ' ,  ,  ')).toBe('');
+  });
+
+  it('should match multi-line strings', function() {
+    var expr = op.getEvalExpression('testVar', 'test*, woo*');
+    expect(expr).toBe('/^(test.*|woo.*)$/im.test(testVar)');
+
+    var testVar = 'this text does not match\ntest but this does match'; // eslint-disable-line
+
+    expect(eval(expr)).toBe(true);
   });
 });

--- a/test/os/ui/filter/op/notlikeop.test.js
+++ b/test/os/ui/filter/op/notlikeop.test.js
@@ -1,6 +1,6 @@
 goog.require('os.ui.filter.op.NotLike');
 
-ddescribe('os.ui.filter.op.NotLike', function() {
+describe('os.ui.filter.op.NotLike', function() {
   var op = new os.ui.filter.op.NotLike();
   var innerOp = op.op;
 

--- a/test/os/ui/filter/op/notlikeop.test.js
+++ b/test/os/ui/filter/op/notlikeop.test.js
@@ -1,6 +1,6 @@
 goog.require('os.ui.filter.op.NotLike');
 
-describe('os.ui.filter.op.NotLike', function() {
+ddescribe('os.ui.filter.op.NotLike', function() {
   var op = new os.ui.filter.op.NotLike();
   var innerOp = op.op;
 
@@ -14,12 +14,9 @@ describe('os.ui.filter.op.NotLike', function() {
   it('should generate the proper filter function expression', function() {
     // one wildcard
     var expr = op.getEvalExpression('testVar', 'testV*');
-    expect(expr).toBe('!(/^testV.*$/i.test(testVar))');
+    expect(expr).toBe('!(/^testV.*$/im.test(testVar))');
 
-    var testVar = 'testVal';
-
-    // prevent eslint no-unused-vars
-    expect(testVar).toBeDefined();
+    var testVar = 'testVal'; // eslint-disable-line
 
     expect(eval(expr)).toBe(false);
 
@@ -31,7 +28,7 @@ describe('os.ui.filter.op.NotLike', function() {
 
     // multiple wildcards
     expr = op.getEvalExpression('testVar', '*V*');
-    expect(expr).toBe('!(/^.*V.*$/i.test(testVar))');
+    expect(expr).toBe('!(/^.*V.*$/im.test(testVar))');
 
     testVar = 'testVal';
     expect(eval(expr)).toBe(false);
@@ -47,7 +44,7 @@ describe('os.ui.filter.op.NotLike', function() {
 
     // single character wildcards
     expr = op.getEvalExpression('testVar', 'f.....uck');
-    expect(expr).toBe('!(/^f.....uck$/i.test(testVar))');
+    expect(expr).toBe('!(/^f.....uck$/im.test(testVar))');
 
     testVar = 'firetruck';
     expect(eval(expr)).toBe(false);
@@ -70,5 +67,19 @@ describe('os.ui.filter.op.NotLike', function() {
     expect(op.getEvalExpression('testVar', null)).toBe('');
     expect(op.getEvalExpression('testVar', '')).toBe('');
     expect(op.getEvalExpression('testVar', '   ')).toBe('');
+  });
+
+  it('should match multi-line strings', function() {
+    var expr = op.getEvalExpression('testVar', 'testV*');
+    expect(expr).toBe('!(/^testV.*$/im.test(testVar))');
+
+    var testVar = 'testVal'; // eslint-disable-line
+    expect(eval(expr)).toBe(false);
+
+    testVar = 'otherVal\ntestVal';
+    expect(eval(expr)).toBe(false);
+
+    testVar = 'otherVal\nline doesnt start with testVal';
+    expect(eval(expr)).toBe(true);
   });
 });


### PR DESCRIPTION
The `is like` and `is like list` operations only worked on single line strings. Added the `m` flag to also match the pattern in multi-line strings.