### PR TITLE
fix(menu): added CSS to handle too-large menus

### DIFF
--- a/scss/opensphere.scss
+++ b/scss/opensphere.scss
@@ -29,6 +29,7 @@
 @import 'os/link';
 @import 'os/loading';
 @import 'os/loboptions';
+@import 'os/menu';
 @import 'os/navtop';
 @import 'os/nganimate';
 @import 'os/ngonboarding';

--- a/scss/os/_menu.scss
+++ b/scss/os/_menu.scss
@@ -1,0 +1,4 @@
+.c-menu {
+  max-height: 100%;
+  overflow-y: auto;
+}


### PR DESCRIPTION
Using CSS overflow to handle when right-click menus are too large for the page; which addresses the immediate concern so all menu options are available, even in very small browser windows.
Test Steps:
1. Opensphere|http://terrific-parent.surge.sh/opensphere/
2. Shrink the window to an unreasonably small size
3. Right click the map or a Feature layer
4. Verify you can scroll all the way to the top and bottom of the menu