### PR TITLE
feat(cookie): override document.cookie in Electron

### DIFF
--- a/externs/electron.externs.js
+++ b/externs/electron.externs.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-returns-check */
 /**
  * @fileoverview Externs for OpenSphere integration with Electron.
  * @externs
@@ -58,3 +59,23 @@ let ElectronOS;
  * @param {Electron.CertificateRequestFn|undefined} handler The handler.
  */
 ElectronOS.registerCertificateHandler = function(handler) {};
+
+
+/**
+ * Get cookies for the current session.
+ * @return {string} The semi-colon delimited list of cookies.
+ */
+ElectronOS.getCookies = function() {};
+
+
+/**
+ * Set a cookie in the current session.
+ * @param {string} value The cookie value.
+ */
+ElectronOS.setCookie = function(value) {};
+
+
+/**
+ * Request cookie update from the main process.
+ */
+ElectronOS.updateCookies = function() {};

--- a/scripts/electron/preload.js
+++ b/scripts/electron/preload.js
@@ -9,6 +9,34 @@ let certHandler;
 
 
 /**
+ * Cookies set in the current session.
+ * @type {string}
+ */
+let cookies = '';
+
+
+/**
+ * User certificate event types.
+ * @enum {string}
+ */
+const CertEventType = {
+  HANDLER_REGISTERED: 'client-certificate-handler-registered',
+  SELECT: 'select-client-certificate',
+  SELECTED: 'client-certificate-selected'
+};
+
+
+/**
+ * Cookie event types.
+ * @enum {string}
+ */
+const CookieEventType = {
+  SET: 'set-cookie',
+  UPDATE: 'update-cookies'
+};
+
+
+/**
  * Register a certificate handler for Electron.
  * @param {Electron.CertificateRequestFn|undefined} handler The handler.
  */
@@ -16,7 +44,7 @@ const registerCertificateHandler = (handler) => {
   certHandler = handler;
 
   // Notify the main process that the handler has been registered.
-  ipcRenderer.send('client-certificate-handler-registered');
+  ipcRenderer.send(CertEventType.HANDLER_REGISTERED);
 };
 
 
@@ -30,22 +58,54 @@ const selectClientCertificate = (event, url, list) => {
   if (certHandler) {
     certHandler(url, list).then((cert) => {
       // Sent the selected certificate to the main process.
-      ipcRenderer.send('client-certificate-selected', url, cert);
+      ipcRenderer.send(CertEventType.SELECTED, url, cert);
     }, (reason) => {
       // The Electron handler will delete the promise if undefined is returned, as the user did not make a choice. A
       // null value indicates the user cancelled the request and a cert should not be used.
       const value = reason === 'unload' ? undefined : null;
-      ipcRenderer.send('client-certificate-selected', url, value);
+      ipcRenderer.send(CertEventType.SELECTED, url, value);
     });
   } else {
     // No handler regisered, use Electron's default behavior.
-    ipcRenderer.send('client-certificate-selected', url, list[0]);
+    ipcRenderer.send(CertEventType.SELECTED, url, list[0]);
   }
 };
 
 
+/**
+ * Get cookies for the current session.
+ * @return {string} The semi-colon delimited list of cookies.
+ */
+const getCookies = () => {
+  return cookies;
+};
+
+
+/**
+ * Set a cookie in the current session.
+ * @param {string} value The cookie value.
+ */
+const setCookie = (value) => {
+  ipcRenderer.send(CookieEventType.SET, value);
+};
+
+
+/**
+ * Request cookie update from the main process.
+ */
+const updateCookies = () => {
+  ipcRenderer.send(CookieEventType.UPDATE);
+};
+
+
 // Handle certificate select event from the main process.
-ipcRenderer.on('select-client-certificate', selectClientCertificate);
+ipcRenderer.on(CertEventType.SELECT, selectClientCertificate);
+
+
+// Handle cookie initialization from the main process.
+ipcRenderer.on(CookieEventType.UPDATE, (event, value) => {
+  cookies = value;
+});
 
 
 //
@@ -58,5 +118,8 @@ ipcRenderer.on('select-client-certificate', selectClientCertificate);
 // https://www.electronjs.org/docs/tutorial/security#3-enable-context-isolation-for-remote-content
 //
 contextBridge.exposeInMainWorld('ElectronOS', {
+  getCookies,
+  setCookie,
+  updateCookies,
   registerCertificateHandler
 });

--- a/src/plugin/electron/electronplugin.js
+++ b/src/plugin/electron/electronplugin.js
@@ -46,4 +46,25 @@ class ElectronPlugin extends AbstractPlugin {
 }
 
 
+//
+// Electron does not natively support document.cookie, which both OpenSphere and Closure use internally. Override the
+// native API with functions exposed in the preload script.
+//
+if (electron.isElectron()) {
+  Object.defineProperty(document, 'cookie', {
+    enumerable: true,
+    configurable: true,
+    get() {
+      return ElectronOS.getCookies();
+    },
+    set(value) {
+      ElectronOS.setCookie(value);
+    }
+  });
+
+  // Request an updated cookie list from the main process.
+  ElectronOS.updateCookies();
+}
+
+
 exports = ElectronPlugin;


### PR DESCRIPTION
Electron does not natively support `document.cookie`. It has its own [Cookies API](https://www.electronjs.org/docs/api/cookies) to store cookies on a Session object. Closure's `goog.net.Cookies` class and the debug loader both use `document.cookie`, so it would be ideal to override that to interface with Electron's API.

https://github.com/ngageoint/opensphere-electron/pull/22