### PR TITLE
feat(dragdrop): allow disabling dragDrop directive with ng-attr

### DIFF
--- a/src/os/ui/dragdrop/dragdrop.js
+++ b/src/os/ui/dragdrop/dragdrop.js
@@ -77,10 +77,21 @@ os.ui.DragDropStyle = {
  *
  * @param {!angular.Scope} $scope angular scope
  * @param {!angular.JQLite} $element to which this directive is applied
+ * @param {!Object.<string, string>} $attrs Directive attributes
  */
-os.ui.dragDropLink = function($scope, $element) {
-  var dragDrop = new os.ui.DragDrop($scope, $element);
-  $scope.$on('$destroy', dragDrop.destroy.bind(dragDrop));
+os.ui.dragDropLink = function($scope, $element, $attrs) {
+  let dragDrop = null;
+  $attrs.$observe('dragDrop', function(attr) {
+    if ($attrs['dragDrop'] !== undefined) {
+      if (!dragDrop) {
+        dragDrop = new os.ui.DragDrop($scope, $element);
+        $scope.$on('$destroy', dragDrop.destroy.bind(dragDrop));
+      }
+    } else if (dragDrop) {
+      dragDrop.destroy();
+      dragDrop = null;
+    }
+  });
 };
 
 
@@ -160,11 +171,13 @@ os.ui.DragDrop = function($scope, $element) {
  * Clear references to Angular/DOM elements.
  */
 os.ui.DragDrop.prototype.destroy = function() {
-  this.source_.dispose();
-  this.target_.dispose();
-  this.source_ = null;
-  this.target_ = null;
-  this.scope_ = null;
+  if (this.scope_) {
+    this.source_.dispose();
+    this.target_.dispose();
+    this.source_ = null;
+    this.target_ = null;
+    this.scope_ = null;
+  }
 };
 
 


### PR DESCRIPTION
Using ng-attr-drag-drop="{{someCondition || undefined}}" does prevent the dragDrop directive from being rendered

It would be nice to be able to dynamically disable dragdrop without having to duplicate all of the content.

For example, instead of
```
<div ng-if="ctrl.canRead" drag-drop ...>
  ....
</div>
<div ng-if="!ctrl.canRead">
  ....
</div>
```
you could use
```
<div ng-attr-drag-drop="{{ctrl.canRead ? '' : undefined}}" ...>
  ....
</div>
```
if you check the dragDrop attr in the directive link function.

The drag-drop attribute without a value will be an empty string. Anything not undefined will be rendered.

UUOM-787