### PR TITLE
feat(goto): use newer flyto for feature layers

### DIFF
--- a/src/os/ui/menu/layermenu.js
+++ b/src/os/ui/menu/layermenu.js
@@ -367,11 +367,27 @@ os.ui.menu.layer.onFeatureList_ = function(event) {
  * @private
  */
 os.ui.menu.layer.onGoTo_ = function(event) {
-  var extent = os.ui.menu.layer.getLayersFromContext(event.getContext())
-      .reduce(os.fn.reduceExtentFromLayers, ol.extent.createEmpty());
+  // aggregate the features and execute os.feature.flyTo, in case they have altitude and pure extent wont cut it
+  const layers = os.ui.menu.layer.getLayersFromContext(event.getContext());
+  const features = layers.reduce((feats, layer) => {
+    let source = layer.getSource();
+    if (source instanceof ol.source.Vector) {
+      source = /** @type {ol.source.Vector} */ (source);
+      const newFeats = source.getFeatures();
+      return newFeats.length > 0 ? feats.concat(newFeats) : feats;
+    }
+    return feats;
+  }, []);
 
-  if (!ol.extent.isEmpty(extent)) {
-    os.commandStack.addCommand(new os.command.FlyToExtent(extent));
+  if (features && features.length) {
+    os.feature.flyTo(features);
+  } else {
+    var extent = os.ui.menu.layer.getLayersFromContext(event.getContext())
+        .reduce(os.fn.reduceExtentFromLayers, ol.extent.createEmpty());
+
+    if (!ol.extent.isEmpty(extent)) {
+      os.commandStack.addCommand(new os.command.FlyToExtent(extent));
+    }
   }
 };
 


### PR DESCRIPTION
WIP!

Found this issue when importing a csv that had an ellipse at altitude. When the ellipse was styled as such, go to seemed to work fine. When it was just the center point it went straight to the ground below based on the xy extent.

Test Steps:
Load several layers of different types
Ensure that "Go To" from the context menu works on all of them and any combination of them