### PR TITLE
fix(layerpicker): fixed select2 val not updating with scope layer(s)

### DIFF
--- a/src/os/ui/layer/layerpicker.js
+++ b/src/os/ui/layer/layerpicker.js
@@ -131,6 +131,9 @@ os.ui.layer.LayerPickerCtrl = function($scope, $element, $timeout) {
     this.multiple() ? this.initLayers_() : this.initLayer_();
   }.bind(this));
 
+  this.scope_.$watch('layer', this.initLayer_.bind(this));
+  this.scope_.$watch('layers', this.initLayers_.bind(this));
+
   this.scope_.$on('updateLayers', this.updateLayers.bind(this));
   this.scope_.$on('$destroy', this.destroy_.bind(this));
 };


### PR DESCRIPTION
Having issues with LayerPicker updating whenever a higher-level directive modifies the two-way binding scope of "layer(s)". AngularJS needs to watch for changes to it's layer(s) on scope and update the Select2 component to reflect the new scope.