### PR TITLE
feat(noop): added an empty function for common use

### DIFF
--- a/src/os/fn/fn.js
+++ b/src/os/fn/fn.js
@@ -148,3 +148,11 @@ os.fn.nodesToLayers = function(nodes) {
 };
 
 
+/**
+ * An empty function that accepts no arguments.
+ * Useful for features that offer optional callbacks.
+ * @return {undefined}
+ */
+os.fn.noop = function() {
+  // No Operation
+};


### PR DESCRIPTION
Added an empty function to the `os.fn` namespace for common use.