### PR TITLE
chore(package): remove superfluous script call

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "precompile:resolve": "cp addlayer.js .build",
     "compile:resolve": "os-resolve --outputDir .build --defineRoots $(cat .build/version)",
     "postcompile:resolve": "node scripts/addlayer-replace.js",
-    "compile:debugcss": "for i in $(ls -1 .build/themes | grep node-sass-args); do node-sass --source-map true -o .build/themes --output-style expanded $(cat .build/themes/$i) & pids=\"$pids $!\"; done; wait $pids; npm run postcompile:debugcss",
+    "compile:debugcss": "for i in $(ls -1 .build/themes | grep node-sass-args); do node-sass --source-map true -o .build/themes --output-style expanded $(cat .build/themes/$i) & pids=\"$pids $!\"; done; wait $pids;",
     "postcompile:debugcss": "for i in $(ls -1 .build/themes | grep combined.css | grep -v combined.css.map); do postcss .build/themes/$i --no-map -u autoprefixer -r & pids=\"$pids $!\"; done; wait $pids",
     "minify:css": "for i in $(ls -1 .build/themes | grep combined.css | grep -v combined.css.map); do cleancss --output .build/themes/$(echo $i | sed 's/combined/min/') .build/themes/$i & pids=\"$pids $!\"; done; wait $pids",
     "compile:css": "npm run compile:debugcss; npm run minify:css;",


### PR DESCRIPTION
npm/yarn automatically calls `preX` and `postX` for every call to `npm run X`