### PR TITLE
fix(select2): fixed full width for select2 search fields

### DIFF
--- a/scss/os/_overrides_select2.scss
+++ b/scss/os/_overrides_select2.scss
@@ -45,6 +45,8 @@
       }
 
       .select2-search-field {
+        width: 100%;
+
         input.select2-input {
           background: transparent;
           border: 0;


### PR DESCRIPTION
There's an issue with the Select2 component's input field not filling its container when inside a hidden element... and later shows itself. Needed to put `width: 100%` in the override styling of the Select2 CSS class `select2-search-field` to fix the bug.