### PR TITLE
WIP fix(source): improved visibility toggle in source

### DIFF
--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -3490,12 +3490,23 @@ os.source.Vector.prototype.setVisibleFeatures = function(features) {
     }.bind(this));
   }
 
-  this.updateFeaturesVisibility(this.getFeatures(), false);
-  this.updateFeaturesVisibility(features, true);
-
-  if (selected.length) {
-    this.setSelectedItems(selected);
-  }
+  // add a debounce as well as bit of time between large changes to the source visibility
+  os.sequence(
+      this,
+      'source.setVisibleFeatures',
+      35,
+      function() {
+        this.updateFeaturesVisibility(this.getFeatures(), false);
+      },
+      function() {
+        this.updateFeaturesVisibility(features, true);
+      },
+      function() {
+        if (selected.length) {
+          this.setSelectedItems(selected);
+        }
+      }
+  );
 };
 
 

--- a/test/os/os.test.js
+++ b/test/os/os.test.js
@@ -28,3 +28,68 @@ describe('ol.Feature mixins', function() {
   });
 });
 
+describe('os.sequence', function() {
+  it('should call functions 1) in order and 2) with a specified wait in between', function() {
+    var count = {
+      'f1': 0,
+      'f2': 0,
+      'f3': 0
+    };
+    var f1 = function() {
+      count['f1']++;
+    };
+    var f2 = function() {
+      count['f2']++;
+    };
+    var f3 = function() {
+      count['f3']++;
+    };
+
+    var start = new Date().getTime();
+    var step = 10;
+
+    // the call being tested
+    os.sequence(null, 'test', step, f1, f2, f3);
+
+    expect(count['f1']).toBe(0);
+    expect(count['f2']).toBe(0);
+    expect(count['f3']).toBe(0);
+
+    waitsFor('first step to finish', function() {
+      if (count['f1']) {
+        expect((new Date().getTime()) - start >= (1 * step)).toBe(true);
+        expect((new Date().getTime()) - start <= (2 * step)).toBe(true);
+        expect(count['f1']).toBe(1);
+        expect(count['f2']).toBe(0);
+        expect(count['f3']).toBe(0);
+        return true;
+      }
+      return false;
+    }, 100);
+
+    waitsFor('second step to finish', function() {
+      if (count['f2']) {
+        expect((new Date().getTime()) - start >= (2 * step)).toBe(true);
+        expect((new Date().getTime()) - start <= (3 * step)).toBe(true);
+        expect(count['f1']).toBe(1);
+        expect(count['f2']).toBe(1);
+        expect(count['f3']).toBe(0);
+        return true;
+      }
+      return false;
+    }, 100);
+
+    waitsFor('third step to finish', function() {
+      if (count['f3']) {
+        expect((new Date().getTime()) - start >= (3 * step)).toBe(true);
+        expect((new Date().getTime()) - start <= (4 * step)).toBe(true);
+        expect(count['f1']).toBe(1);
+        expect(count['f2']).toBe(1);
+        expect(count['f3']).toBe(1);
+        return true;
+      }
+      return false;
+    }, 100);
+  });
+});
+


### PR DESCRIPTION
Added a new os.sequence() utility function to provide an interrupt-capable, multi-step process debouncer.  Used it to resolve timing issue with rapidly changing Feature visibility.

Testing Steps

1. [OS](faithful-cause.surge.sh/opensphere)
2. Add a Layer and load some data
3. Click the "Eye" icon next to the Feature Layer checkbox
4. Verify the feature(s) disappear
5. Click the "Slash-Eye" icon
6. Verify the feature(s) reappear

