### PR TITLE
docs(server guide): fix configuration

### DIFF
--- a/docs/guides/plugin_server_guide/src/plugin/tileserver/tileserver.js-parsing
+++ b/docs/guides/plugin_server_guide/src/plugin/tileserver/tileserver.js-parsing
@@ -95,7 +95,7 @@ plugin.tileserver.Tileserver.prototype.toChildNode = function(layer) {
     'urls': layer['tiles'],
     'extent': layer['bounds'],
     'extentProjection': os.proj.EPSG4326,
-    'icons': os.ui.createIconSet(fullId, [os.ui.IconsSVG.TILES], [], [255, 255, 255, 1]),
+    'icons': os.ui.createIconSet(id, [os.ui.IconsSVG.TILES], [], [255, 255, 255, 1]),
     'projection': os.proj.EPSG3857,
     'minZoom': Math.max(os.map.MIN_ZOOM, layer['minzoom']),
     'maxZoom': Math.min(os.map.MAX_ZOOM, layer['maxzoom']),


### PR DESCRIPTION
The current server guide code doesn't compile.

This is a bit speculative as a fix though. The `fullId` is what its called in the OGC and WMTS plugins, but the same concept appears to be called `id` here.