### PR TITLE
improvement(slickgrid): context menu position not rely on external ids

### DIFF
--- a/src/os/ui/slick/slickgrid.js
+++ b/src/os/ui/slick/slickgrid.js
@@ -1107,10 +1107,15 @@ os.ui.slick.SlickGridCtrl.prototype.onContextMenu_ = function(event, opt_positio
         os.ui.openMenu(menu, {x: menuX, y: menuY});
       }
     } else if (menu instanceof os.ui.menu.Menu) {
+      const rect = this.element[0].getBoundingClientRect();
+
+      menuX -= rect['left'];
+      menuY -= rect['top'];
+
       menu.open(contextArgs, {
         my: 'left top',
         at: 'left+' + menuX + ' top+' + menuY,
-        of: os.ui.windowSelector.CONTAINER
+        of: this.element[0]
       }, this);
     }
   }

--- a/src/os/ui/slick/slickgrid.js
+++ b/src/os/ui/slick/slickgrid.js
@@ -1109,8 +1109,8 @@ os.ui.slick.SlickGridCtrl.prototype.onContextMenu_ = function(event, opt_positio
     } else if (menu instanceof os.ui.menu.Menu) {
       const rect = this.element[0].getBoundingClientRect();
 
-      menuX -= rect['left'];
-      menuY -= rect['top'];
+      menuX -= rect.left;
+      menuY -= rect.top;
 
       menu.open(contextArgs, {
         my: 'left top',


### PR DESCRIPTION
There was an issue discovered where the wrapper for SlickGrid was using an external HTML ID for the positioning of context menus. That works fine as long as that ID starts at the top left corner of the view port.