### PR TITLE
feat(error_class): update use of error class to bootstrap 4 equivalent

### DIFF
--- a/addlayer.js
+++ b/addlayer.js
@@ -11,12 +11,12 @@
   };
 
   if (!window.localStorage) {
-    status.append('<div class="error">Error: localStorage not present</div>');
+    status.append('<div class="alert alert-danger">Error: localStorage not present</div>');
     return;
   }
 
   if (!str) {
-    status.html('<div class="error">Error: No URI-encoded file path or ' +
+    status.html('<div class="alert alert-danger">Error: No URI-encoded file path or ' +
         'JSON string was found in the location fragment</div>');
     return;
   }
@@ -34,18 +34,18 @@
       data = JSON.parse(str);
       type = 'addLayer';
     } catch (e) {
-      status.append('<div class="error">Error: malformed JSON in fragment.</div>');
+      status.append('<div class="alert alert-danger">Error: malformed JSON in fragment.</div>');
     }
   }
 
   if (!data) {
-    status.html('<div class="error">Error: No URI-encoded file path or ' +
+    status.html('<div class="alert alert-danger">Error: No URI-encoded file path or ' +
         'JSON string was found in the location fragment</div>');
     return;
   }
 
   if (!type) {
-    status.html('<div class="error">Error: No message type was found</div>');
+    status.html('<div class="alert alert-danger">Error: No message type was found</div>');
     return;
   }
 

--- a/views/forms/multiurl.html
+++ b/views/forms/multiurl.html
@@ -38,7 +38,7 @@
 
       <input type="submit" hidden />
     </form>
-    <div class="error" ng-if="error">
+    <div class="alert alert-danger" ng-if="error">
       <h5>Error!</h5>
       <p ng-bind-html="error"></p>
     </div>

--- a/views/forms/singleurl.html
+++ b/views/forms/singleurl.html
@@ -26,7 +26,7 @@
 
       <input type="submit" hidden>
     </form>
-    <div class="error" ng-if="error">
+    <div class="alert alert-danger" ng-if="error">
       <h5>Error!</h5>
       <p ng-bind-html="error"></p>
     </div>

--- a/views/plugin/ogc/ui/ogcserverimport.html
+++ b/views/plugin/ogc/ui/ogcserverimport.html
@@ -29,7 +29,7 @@
       </div>
       <input type="submit" hidden>
     </form>
-    <div class="error" ng-if="error">
+    <div class="alert alert-danger" ng-if="error">
       <h5>Error!</h5>
       <p ng-bind-html="error"></p>
     </div>


### PR DESCRIPTION
Cleans up some places that were using outdated css for error messages

Here's some before/after examples:
![ProviderError](https://user-images.githubusercontent.com/35077650/81698972-f695cc80-9423-11ea-86b9-9de4028c650e.png)
![AddLayerError](https://user-images.githubusercontent.com/35077650/81700686-3eb5ee80-9426-11ea-9bca-dc261585c635.png)
