### PR TITLE
fix(source): fix remove when not using spatial

### DIFF
--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -1979,6 +1979,9 @@ os.source.Vector.prototype.removeFeatureInternal = function(feature, opt_isBulk)
       delete this.nullGeometryFeatures_[featureKey];
     } else if (!opt_isBulk && this.featuresRtree_) {
       this.featuresRtree_.remove(feature);
+    } else if (!this.featuresRtree_) {
+      this.dispatchEvent(new ol.source.Vector.Event(
+          ol.source.VectorEventType.REMOVEFEATURE, feature));
     }
 
     this.featureCount_ = Math.max(this.featureCount_ - 1, 0);

--- a/test/os/source/vectorsource.test.js
+++ b/test/os/source/vectorsource.test.js
@@ -146,13 +146,20 @@ describe('os.source.Vector', function() {
 
   it('should remove features from the source', () => {
     const feature = new ol.Feature(new ol.geom.Point([0, 0]));
-    const source = new os.source.Vector(undefined);
-    source.addFeature(feature);
-    source.processNow();
-    source.removeFeature(feature);
-    source.unprocessNow();
-    expect(source.getFeatures().length).toBe(0);
-    expect(source.getFeatureById(feature.getId())).toBe(null);
+    const sources = [
+      new os.source.Vector(undefined),
+      new os.source.Vector({
+        useSpatialIndex: false
+      })];
+
+    sources.forEach((source) => {
+      source.addFeature(feature);
+      source.processNow();
+      source.removeFeature(feature);
+      source.unprocessNow();
+      expect(source.getFeatures().length).toBe(0);
+      expect(source.getFeatureById(feature.getId())).toBe(null);
+    });
   });
 
   it('should not error on attempting multiple removes of a feature', () => {


### PR DESCRIPTION
The option useSpatialIndex=false uses a feature collection rather than an r-tree. Feature removal needs to support that case.