### PR TITLE
feat(renderer): add display settings hook up for multiple renderers

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -226,6 +226,7 @@
     }
   },
   "user": {
+    "activeWebGLRenderer": "cesium",
     "dataManager": {
       "filterTime": true
     },

--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -110,6 +110,13 @@ os.MapContainer = function() {
   this.webGLRenderer_ = undefined;
 
   /**
+   * The available WebGL map/globe renderers.
+   * @type {Object<string, os.webgl.IWebGLRenderer>}
+   * @private
+   */
+  this.webGLRenderers_ = {};
+
+  /**
    * If the WebGL renderer is initializing. Disables toggling the view.
    * @type {boolean}
    * @private
@@ -275,7 +282,7 @@ os.MapContainer.prototype.disposeInternal = function() {
 
 
 /**
- * Get the WebGL renderer.
+ * Get the active WebGL renderer.
  *
  * @return {os.webgl.IWebGLRenderer|undefined}
  */
@@ -285,11 +292,35 @@ os.MapContainer.prototype.getWebGLRenderer = function() {
 
 
 /**
- * Set the WebGL renderer.
+ * Get the available WebGL renderers.
+ *
+ * @return {Object<string, os.webgl.IWebGLRenderer>}
+ */
+os.MapContainer.prototype.getWebGLRenderers = function() {
+  return this.webGLRenderers_;
+};
+
+
+/**
+ * Add a WebGL renderer
+ *
+ * @param {os.webgl.IWebGLRenderer|undefined} renderer
+ */
+os.MapContainer.prototype.addWebGLRenderer = function(renderer) {
+  if (renderer) {
+    this.webGLRenderers_[renderer.getId() || os.string.randomString()] = renderer;
+  }
+};
+
+
+/**
+ * Set the active WebGL renderer.
  *
  * @param {os.webgl.IWebGLRenderer|undefined} value The new renderer.
  */
 os.MapContainer.prototype.setWebGLRenderer = function(value) {
+  this.addWebGLRenderer(value);
+
   if (this.webGLRenderer_) {
     if (this.webGLRenderer_.isInitialized()) {
       // do not allow replacing the WebGL renderer once it has been initialized, because it may make changes to
@@ -302,6 +333,9 @@ os.MapContainer.prototype.setWebGLRenderer = function(value) {
   }
 
   this.webGLRenderer_ = value;
+  if (value && value.id) {
+    os.settings.set(os.webgl.AbstractWebGLRenderer.ACTIVE_SETTINGS_KEY, value.id);
+  }
 
   if (this.webGLRenderer_) {
     this.webGLRenderer_.setMap(this.map_);

--- a/src/os/webgl/abstractwebglrenderer.js
+++ b/src/os/webgl/abstractwebglrenderer.js
@@ -19,6 +19,27 @@ os.webgl.AbstractWebGLRenderer = function() {
   os.webgl.AbstractWebGLRenderer.base(this, 'constructor');
 
   /**
+   * The renderer id
+   * @type {string}
+   * @protected
+   */
+  this.id = '';
+
+  /**
+   * The renderer label
+   * @type {string}
+   * @protected
+   */
+  this.label = '';
+
+  /**
+   * The renderer description
+   * @type {string}
+   * @protected
+   */
+  this.description = '';
+
+  /**
    * If the renderer has been initialized.
    * @type {boolean}
    * @protected
@@ -95,6 +116,14 @@ os.webgl.AbstractWebGLRenderer.LOGGER_ = goog.log.getLogger('os.webgl.AbstractWe
 
 
 /**
+ * The settings key for tracking the active renderer
+ * @type {string}
+ * @const
+ */
+os.webgl.AbstractWebGLRenderer.ACTIVE_SETTINGS_KEY = 'activeWebGLRenderer';
+
+
+/**
  * @inheritDoc
  */
 os.webgl.AbstractWebGLRenderer.prototype.disposeInternal = function() {
@@ -104,6 +133,30 @@ os.webgl.AbstractWebGLRenderer.prototype.disposeInternal = function() {
   this.watchedSettings.forEach(function(key) {
     os.settings.unlisten(key, this.onSettingChange, false, this);
   }, this);
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.webgl.AbstractWebGLRenderer.prototype.getId = function() {
+  return this.id || '';
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.webgl.AbstractWebGLRenderer.prototype.getLabel = function() {
+  return this.label || '';
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.webgl.AbstractWebGLRenderer.prototype.getDescription = function() {
+  return this.description || '';
 };
 
 

--- a/src/os/webgl/iwebglrenderer.js
+++ b/src/os/webgl/iwebglrenderer.js
@@ -14,6 +14,27 @@ os.webgl.IWebGLRenderer = function() {};
 
 
 /**
+ * The text id for the renderer
+ * @return {string}
+ */
+os.webgl.IWebGLRenderer.prototype.getId;
+
+
+/**
+ * A user facing label for the renderer
+ * @return {string}
+ */
+os.webgl.IWebGLRenderer.prototype.getLabel;
+
+
+/**
+ * A user facing description for the renderer
+ * @return {string}
+ */
+os.webgl.IWebGLRenderer.prototype.getDescription;
+
+
+/**
  * If the renderer is initialized.
  * @return {boolean}
  */

--- a/src/plugin/cesium/cesiumplugin.js
+++ b/src/plugin/cesium/cesiumplugin.js
@@ -1,23 +1,8 @@
 goog.provide('plugin.cesium.Plugin');
 
-goog.require('os.data.ProviderEntry');
-goog.require('os.layer.Group');
 goog.require('os.plugin.AbstractPlugin');
-goog.require('os.webgl.SynchronizerManager');
 goog.require('plugin.cesium.CesiumRenderer');
-goog.require('plugin.cesium.menu');
-goog.require('plugin.cesium.mixin.olcs');
-goog.require('plugin.cesium.mixin.renderloop');
-goog.require('plugin.cesium.sync.ImageStaticSynchronizer');
-goog.require('plugin.cesium.sync.ImageSynchronizer');
-goog.require('plugin.cesium.sync.TileSynchronizer');
-goog.require('plugin.cesium.sync.VectorSynchronizer');
-goog.require('plugin.cesium.tiles');
-goog.require('plugin.cesium.tiles.Descriptor');
-goog.require('plugin.cesium.tiles.LayerConfig');
-goog.require('plugin.cesium.tiles.Provider');
-goog.require('plugin.cesium.tiles.TilesetImportUI');
-goog.require('plugin.cesium.tiles.mime');
+
 
 
 /**
@@ -50,46 +35,10 @@ plugin.cesium.Plugin.prototype.init = function() {
   plugin.cesium.ionUrl = /** @type {string} */ (os.settings.get(plugin.cesium.SettingsKey.ION_URL,
       plugin.cesium.DEFAULT_ION_URL));
 
-  // set the WebGL renderer to use Cesium
-  os.MapContainer.getInstance().setWebGLRenderer(new plugin.cesium.CesiumRenderer());
-
-  // register the default set of synchronizers
-  var sm = os.webgl.SynchronizerManager.getInstance();
-  sm.registerSynchronizer(os.layer.SynchronizerType.VECTOR, plugin.cesium.sync.VectorSynchronizer);
-  sm.registerSynchronizer(os.layer.SynchronizerType.TILE, plugin.cesium.sync.TileSynchronizer);
-  sm.registerSynchronizer(os.layer.SynchronizerType.IMAGE, plugin.cesium.sync.ImageSynchronizer);
-  sm.registerSynchronizer(os.layer.SynchronizerType.DRAW, plugin.cesium.sync.VectorSynchronizer);
-  sm.registerSynchronizer(os.layer.SynchronizerType.IMAGE_STATIC, plugin.cesium.sync.ImageStaticSynchronizer);
-
-  // add 3D layer group
-  var group = new os.layer.Group();
-  group.setPriority(3);
-  group.setOSType(plugin.cesium.CESIUM_ONLY_LAYER);
-  group.setCheckFunc(function(layer) {
-    if (os.implements(layer, os.layer.ILayer.ID)) {
-      return /** @type {os.layer.ILayer} */ (layer).getOSType() === plugin.cesium.CESIUM_ONLY_LAYER;
-    }
-    return false;
-  });
-
-  os.map.mapContainer.addGroup(group);
-
-  // set up menus
-  plugin.cesium.menu.importSetup();
-
-  // register 3D tiles layers
-  var lcm = os.layer.config.LayerConfigManager.getInstance();
-  lcm.registerLayerConfig(plugin.cesium.tiles.ID, plugin.cesium.tiles.LayerConfig);
-
-  var dm = os.dataManager;
-  dm.registerProviderType(new os.data.ProviderEntry(
-      plugin.cesium.tiles.ID,
-      plugin.cesium.tiles.Provider,
-      plugin.cesium.tiles.TYPE,
-      plugin.cesium.tiles.TYPE));
-  dm.registerDescriptorType(plugin.cesium.tiles.ID, plugin.cesium.tiles.Descriptor);
-
-  var im = os.ui.im.ImportManager.getInstance();
-  im.registerImportDetails(plugin.cesium.tiles.TYPE, true);
-  im.registerImportUI(plugin.cesium.tiles.mime.TYPE, new plugin.cesium.tiles.TilesetImportUI());
+  // check if cesium is the active renderer
+  if (os.settings.get(os.webgl.AbstractWebGLRenderer.ACTIVE_SETTINGS_KEY) == plugin.cesium.Plugin.ID) {
+    os.MapContainer.getInstance().setWebGLRenderer(new plugin.cesium.CesiumRenderer());
+  } else {
+    os.MapContainer.getInstance().addWebGLRenderer(new plugin.cesium.CesiumRenderer());
+  }
 };

--- a/src/plugin/cesium/cesiumrenderer.js
+++ b/src/plugin/cesium/cesiumrenderer.js
@@ -5,15 +5,32 @@ goog.require('goog.log');
 goog.require('olcs.OLCesium');
 goog.require('olcs.core');
 goog.require('os.MapEvent');
+goog.require('os.data.ProviderEntry');
+goog.require('os.layer.Group');
 goog.require('os.webgl.AbstractWebGLRenderer');
+goog.require('os.webgl.SynchronizerManager');
 goog.require('plugin.cesium');
 goog.require('plugin.cesium.Camera');
 goog.require('plugin.cesium.TerrainLayer');
 goog.require('plugin.cesium.TileGridTilingScheme');
 goog.require('plugin.cesium.command.FlyToSphere');
 goog.require('plugin.cesium.interaction');
+goog.require('plugin.cesium.menu');
 goog.require('plugin.cesium.mixin');
+goog.require('plugin.cesium.mixin.olcs');
+goog.require('plugin.cesium.mixin.renderloop');
+goog.require('plugin.cesium.sync.ImageStaticSynchronizer');
+goog.require('plugin.cesium.sync.ImageSynchronizer');
 goog.require('plugin.cesium.sync.RootSynchronizer');
+goog.require('plugin.cesium.sync.TileSynchronizer');
+goog.require('plugin.cesium.sync.VectorSynchronizer');
+goog.require('plugin.cesium.tiles');
+goog.require('plugin.cesium.tiles.Descriptor');
+goog.require('plugin.cesium.tiles.LayerConfig');
+goog.require('plugin.cesium.tiles.Provider');
+goog.require('plugin.cesium.tiles.TilesetImportUI');
+goog.require('plugin.cesium.tiles.mime');
+
 
 
 /**
@@ -26,6 +43,10 @@ plugin.cesium.CesiumRenderer = function() {
   plugin.cesium.CesiumRenderer.base(this, 'constructor');
   this.log = plugin.cesium.CesiumRenderer.LOGGER_;
   this.maxFeaturesKey = 'maxFeatures.cesium';
+
+  this.id = plugin.cesium.Plugin.ID;
+  this.label = 'Cesium';
+  this.description = 'Cesium is a 3D globe renderer for general use.';
 
   /**
    * The Openlayers/Cesium synchronizer.
@@ -108,6 +129,46 @@ plugin.cesium.CesiumRenderer.prototype.initialize = function() {
     return new goog.Promise(function(resolve, reject) {
       plugin.cesium.loadCesium().then(function() {
         try {
+          // register the default set of synchronizers
+          var sm = os.webgl.SynchronizerManager.getInstance();
+          sm.registerSynchronizer(os.layer.SynchronizerType.VECTOR, plugin.cesium.sync.VectorSynchronizer);
+          sm.registerSynchronizer(os.layer.SynchronizerType.TILE, plugin.cesium.sync.TileSynchronizer);
+          sm.registerSynchronizer(os.layer.SynchronizerType.IMAGE, plugin.cesium.sync.ImageSynchronizer);
+          sm.registerSynchronizer(os.layer.SynchronizerType.DRAW, plugin.cesium.sync.VectorSynchronizer);
+          sm.registerSynchronizer(os.layer.SynchronizerType.IMAGE_STATIC, plugin.cesium.sync.ImageStaticSynchronizer);
+
+          // add 3D layer group
+          var group = new os.layer.Group();
+          group.setPriority(3);
+          group.setOSType(plugin.cesium.CESIUM_ONLY_LAYER);
+          group.setCheckFunc(function(layer) {
+            if (os.implements(layer, os.layer.ILayer.ID)) {
+              return /** @type {os.layer.ILayer} */ (layer).getOSType() === plugin.cesium.CESIUM_ONLY_LAYER;
+            }
+            return false;
+          });
+
+          os.map.mapContainer.addGroup(group);
+
+          // set up menus
+          plugin.cesium.menu.importSetup();
+
+          // register 3D tiles layers
+          var lcm = os.layer.config.LayerConfigManager.getInstance();
+          lcm.registerLayerConfig(plugin.cesium.tiles.ID, plugin.cesium.tiles.LayerConfig);
+
+          var dm = os.dataManager;
+          dm.registerProviderType(new os.data.ProviderEntry(
+              plugin.cesium.tiles.ID,
+              plugin.cesium.tiles.Provider,
+              plugin.cesium.tiles.TYPE,
+              plugin.cesium.tiles.TYPE));
+          dm.registerDescriptorType(plugin.cesium.tiles.ID, plugin.cesium.tiles.Descriptor);
+
+          var im = os.ui.im.ImportManager.getInstance();
+          im.registerImportDetails(plugin.cesium.tiles.TYPE, true);
+          im.registerImportUI(plugin.cesium.tiles.mime.TYPE, new plugin.cesium.tiles.TilesetImportUI());
+
           plugin.cesium.mixin.loadCesiumMixins();
           plugin.cesium.TileGridTilingScheme.init();
 

--- a/views/config/displaysettings.html
+++ b/views/config/displaysettings.html
@@ -62,6 +62,20 @@
   </div>
 
   <div class="mb-2" ng-if="display.show3DSettings">
+    <h5 ng-if="display.renderers3D.length > 1">3D Renderer</h5>
+    <div ng-if="display.renderers3D.length > 1" class="form-group mb-2">
+      <div ng-repeat="renderer in display.renderers3D" class="form-check form-check-inline" title="{{renderer.desc}}">
+        <input class="form-check-input" id="{{renderer.id}}" type="radio" ng-value="renderer.id" ng-model="display.renderer">
+        <label class="form-check-label" for="{{renderer.id}}">{{renderer.label}}</label>
+      </div>
+      <div class="form-check-inline">
+        <button class="btn btn-primary float-right" ng-click="display.refreshApply()" ng-disabled="!display.resetButtonActive"
+            title="Refresh the application to apply renderer">
+          <i class="fa fa-refresh"></i>
+          Refresh and Apply
+        </button>
+      </div>
+    </div>
     <h5>3D Globe Options</h5>
     <div class="form-group">
       <div class="form-check" title="{{display.help.sky}}">
@@ -111,7 +125,7 @@
     </div>
     <div class="form-group row flex-shrink-0" ng-if="display.show3DSettings" title="{{display.help.help3D}}">
       <label class="col-form-label col-2">3D Globe</label>
-      <input class="form-control col-2" id="maxFeatures3D" type="number" min="100" max="2000000" step="1"
+      <input class="form-control col-2" id="maxFeatures3D" type="number" min="100" max="10000000" step="1"
           ng-model="display.maxFeatures3D" ng-change="display.updateMaxFeatures(true)" required >
     </div>
   </div>


### PR DESCRIPTION
In the event that more than one webgl renderer is present: 
allow the associated plugin to register it with the mapContainer
allow users to choose one from the display settings