### PR TITLE
fix(alert): fix alert badge not displaying

### DIFF
--- a/views/badge.html
+++ b/views/badge.html
@@ -1,3 +1,5 @@
-<span class="badge" ng-if="badge.count > 0" ng-class="badge.getClass()">
-  {{badge.count > 9 ? '9+' : badge.count}}
+<span>
+  <span class="badge" ng-class="badge.getClass()" ng-if="badge.count > 0">
+    {{badge.count > 9 ? '9+' : badge.count}}
+  </span>
 </span>


### PR DESCRIPTION
Putting ng-if on the root element prevents it from linking to the controller. This was changed when fixing `html-validate` errors because we previously had a `div` inside a `span`, which is not allowed.