### PR TITLE
feat(featureinfo): toggle hide empty columns in feature info properties

### DIFF
--- a/scss/opensphere.scss
+++ b/scss/opensphere.scss
@@ -40,6 +40,7 @@
 @import 'os/overrides_select2';
 @import 'os/overrides_slickgrid';
 @import 'os/overrides_tuieditor';
+@import 'os/propertiestab';
 @import 'os/searchresults';
 @import 'os/singlepage';
 @import 'os/slicktree';

--- a/scss/os/_propertiestab.scss
+++ b/scss/os/_propertiestab.scss
@@ -1,8 +1,22 @@
-.c-properties-table {
+$header-bg-color: yiq-contrast-color($body-bg, $gray-200, $gray-800);
+
+.c-properties-tab__table {
   table-layout: fixed;
+
+  thead {
+    background: $header-bg-color;
+  }
 
   th:first-child,
   td:first-child {
     width: 40%;
   }
+}
+
+.c-properties-tab__toggle-empty.active {
+  color: $primary;
+}
+
+.c-properties-tab__footer {
+  background: $header-bg-color;
 }

--- a/scss/os/_propertiestab.scss
+++ b/scss/os/_propertiestab.scss
@@ -1,0 +1,8 @@
+.c-properties-table {
+  table-layout: fixed;
+
+  th:first-child,
+  td:first-child {
+    width: 40%;
+  }
+}

--- a/src/os/ui/feature/tab/propertiestab.js
+++ b/src/os/ui/feature/tab/propertiestab.js
@@ -136,7 +136,8 @@ os.ui.feature.tab.PropertiesTabCtrl.prototype.toggleEmpty = function() {
  */
 os.ui.feature.tab.PropertiesTabCtrl.prototype.updateStatus_ = function() {
   if (this['properties']) {
-    const fieldsText = `${this['properties'].length} fields`;
+    const numProps = this['properties'].length;
+    const fieldsText = `${numProps} field${numProps > 1 ? 's' : ''}`;
     const hiddenText = this.hiddenProperties_ > 0 ? `(${this.hiddenProperties_} hidden)` : '';
     this['status'] = `${fieldsText} ${hiddenText}`;
   } else {

--- a/src/os/ui/feature/tab/propertiestab.js
+++ b/src/os/ui/feature/tab/propertiestab.js
@@ -61,16 +61,29 @@ os.ui.feature.tab.PropertiesTabCtrl = function($scope, $element) {
   this.source = null;
 
   /**
-   * If empty properties should be shown.
-   * @type {boolean}
+   * Number of properties hidden from view.
+   * @type {number}
+   * @private
    */
-  this['showEmpty'] = os.settings.get(os.ui.feature.tab.PropertiesTabCtrl.SHOW_EMPTY_KEY, true);
+  this.hiddenProperties_ = 0;
 
   /**
    * Array of feature property model objects.
    * @type {Array<Object<string, *>>}
    */
   this['properties'] = null;
+
+  /**
+   * If empty properties should be shown.
+   * @type {boolean}
+   */
+  this['showEmpty'] = os.settings.get(os.ui.feature.tab.PropertiesTabCtrl.SHOW_EMPTY_KEY, true);
+
+  /**
+   * Status message to display below the table.
+   * @type {string}
+   */
+  this['status'] = '';
 
   os.ui.feature.tab.PropertiesTabCtrl.base(this, 'constructor', $scope, $element);
 };
@@ -118,10 +131,27 @@ os.ui.feature.tab.PropertiesTabCtrl.prototype.toggleEmpty = function() {
 
 
 /**
+ * Update the status message.
+ * @private
+ */
+os.ui.feature.tab.PropertiesTabCtrl.prototype.updateStatus_ = function() {
+  if (this['properties']) {
+    const fieldsText = `${this['properties'].length} fields`;
+    const hiddenText = this.hiddenProperties_ > 0 ? `(${this.hiddenProperties_} hidden)` : '';
+    this['status'] = `${fieldsText} ${hiddenText}`;
+  } else {
+    this['status'] = '';
+  }
+};
+
+
+/**
  * Updates the properties table from the current source columns.
  */
 os.ui.feature.tab.PropertiesTabCtrl.prototype.updateProperties = function() {
   this['properties'] = [];
+  this.hiddenProperties_ = 0;
+
   if (this.feature) {
     var source = os.feature.getSource(this.feature);
 
@@ -147,6 +177,7 @@ os.ui.feature.tab.PropertiesTabCtrl.prototype.updateProperties = function() {
   }
 
   this.sortProperties_();
+  this.updateStatus_();
 
   os.ui.apply(this.scope);
 };
@@ -174,6 +205,8 @@ os.ui.feature.tab.PropertiesTabCtrl.prototype.addProperty = function(field, valu
         'value': value
       });
     }
+  } else {
+    this.hiddenProperties_++;
   }
 };
 

--- a/views/feature/tab/propertiestab.html
+++ b/views/feature/tab/propertiestab.html
@@ -1,25 +1,39 @@
-<div class="d-flex flex-fill u-overflow-y-auto">
-  <table class="table table-striped table-hover m-0">
+<div class="d-flex flex-column flex-fill">
+  <table class="c-properties-table table table-borderless border-bottom m-0">
     <thead>
       <tr>
-        <th ng-click="propctrl.order('field')">Field
+        <th ng-click="propctrl.setOrderColumn('field')">
+          Field
           <i ng-show="columnToOrder == 'field'" class="slick-sort-indicator"
             ng-class="{'slick-sort-indicator-desc': !reverse, 'slick-sort-indicator-asc': reverse}">
           </i>
         </th>
-        <th ng-click="propctrl.order('value')">Value
-          <i ng-show="columnToOrder == 'value'" class="slick-sort-indicator"
-            ng-class="{'slick-sort-indicator-desc': !reverse, 'slick-sort-indicator-asc': reverse}">
-          </i>
+        <th>
+          <div class="d-flex align-items-center">
+            <div class="flex-fill" ng-click="propctrl.setOrderColumn('value')">
+              Value
+              <i ng-show="columnToOrder == 'value'" class="slick-sort-indicator"
+                ng-class="{'slick-sort-indicator-desc': !reverse, 'slick-sort-indicator-asc': reverse}">
+              </i>
+            </div>
+            <i class="fa c-glyph" ng-class="propctrl.showEmpty && 'fa-compress' || 'fa-expand'"
+              ng-click="propctrl.toggleEmpty()"
+              title="{{propctrl.showEmpty ? 'Hide empty values' : 'Show empty values'}}">
+            </i>
+          </div>
         </th>
       </tr>
     </thead>
-    <tbody>
-      <tr ng-repeat="property in propctrl.properties" ng-click="propctrl.select($event, property)" ng-class="{'selected': selected==property}">
-        <td class="text-truncate">{{property.field}}</td>
-        <td><featureinfocell property="property"></featureinfocell></td>
-      </tr>
-    </tbody>
   </table>
+  <div class="u-overflow-y-auto">
+    <table class="c-properties-table table table-striped table-hover m-0">
+      <tbody>
+        <tr ng-repeat="property in propctrl.properties" ng-click="propctrl.select($event, property)" ng-class="{'selected': selected==property}">
+          <td class="text-truncate" title="{{property.field}}">{{property.field}}</td>
+          <td><featureinfocell property="property"></featureinfocell></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>
 

--- a/views/feature/tab/propertiestab.html
+++ b/views/feature/tab/propertiestab.html
@@ -1,5 +1,5 @@
 <div class="d-flex flex-column flex-fill">
-  <table class="c-properties-table table table-borderless border-bottom m-0">
+  <table class="c-properties-tab__table table table-borderless border-bottom m-0">
     <thead>
       <tr>
         <th ng-click="propctrl.setOrderColumn('field')">
@@ -16,17 +16,18 @@
                 ng-class="{'slick-sort-indicator-desc': !reverse, 'slick-sort-indicator-asc': reverse}">
               </i>
             </div>
-            <i class="fa c-glyph" ng-class="propctrl.showEmpty && 'fa-compress' || 'fa-expand'"
+            <i class="fa fa-compress c-glyph c-properties-tab__toggle-empty"
+              ng-class="!propctrl.showEmpty && 'active'"
               ng-click="propctrl.toggleEmpty()"
-              title="{{propctrl.showEmpty ? 'Hide empty values' : 'Show empty values'}}">
+              title="{{propctrl.showEmpty ? 'Hide empty fields' : 'Show empty fields'}}">
             </i>
           </div>
         </th>
       </tr>
     </thead>
   </table>
-  <div class="u-overflow-y-auto">
-    <table class="c-properties-table table table-striped table-hover m-0">
+  <div class="u-overflow-y-auto flex-fill">
+    <table class="c-properties-tab__table table table-striped table-hover m-0">
       <tbody>
         <tr ng-repeat="property in propctrl.properties" ng-click="propctrl.select($event, property)" ng-class="{'selected': selected==property}">
           <td class="text-truncate" title="{{property.field}}">{{property.field}}</td>
@@ -34,6 +35,9 @@
         </tr>
       </tbody>
     </table>
+  </div>
+  <div class="c-properties-tab__footer border-top p-1" ng-if="propctrl.status">
+    {{propctrl.status}}
   </div>
 </div>
 


### PR DESCRIPTION
Features with sparsely populated columns do not present well in the Feature Info dialog, if the user does not care about the empty columns. This is common with layers whose metadata fields vary by feature type, like OSM.

This PR adds a toggle button to show/hide empty columns in Feature Info. This preference defaults to showing empty (current behavior) and is saved to settings so the value persists through app refresh.

I also did some cleanup/rework on the Feature Info properties tab:

- Table header is now fixed so scrolling only impacts data rows. This makes it easy to toggle sort and the new show/hide even when scrolled.
- Changing the displayed properties for any reason (new feature, toggling show/hide empty, etc) will now apply the sort so properties are still displayed in the order indicated by the headers.
- Fixed the first column width to 40% for a consistent layout. Previously width was determined by the browser using column values.
- The Field column now truncates text exceeding the column width, and displays the full value on hover. The Value column continues to wrap so the full value can be seen.

Demo: https://unwieldy-sink.surge.sh/
Test CSV: [Empty Columns.txt](https://github.com/ngageoint/opensphere/files/4891800/Empty.Columns.txt)
