### PR TITLE
fix(kml): fixes resolution of URIs to relative ZIP assets

### DIFF
--- a/src/os/ui/screenoverlay.js
+++ b/src/os/ui/screenoverlay.js
@@ -43,7 +43,7 @@ os.ui.launchScreenOverlay = function(options) {
 
   var size = options.size || [250, 75];
   var width = Math.max(size[0], 250);
-  var height = Math.max(size[1], 75);
+  var height = size[1] === 0 ? 'auto' : Math.max(size[1], 75);
 
   var xLoc = options.xy ? options.xy[0] : 25;
   var yLoc = options.xy ? options.xy[1] : 50;

--- a/src/plugin/file/kml/kml.js
+++ b/src/plugin/file/kml/kml.js
@@ -763,6 +763,14 @@ plugin.file.kml.readURI = function(node) {
   }
 
   if (node.baseURI && (!assetMap || !(s in assetMap))) {
+    // According to the KML spec, relative paths to assets should use forward slashes. However, since this is KML
+    // and KML is the worst, we have encountered numerous files that use backslashes. The workaround here is when
+    // we fail to find an asset in the map, to check it with forward slashes, and use that URI if we find it.
+    const replaced = s.replace(/\\/gi, '/');
+    if (assetMap && replaced in assetMap) {
+      return replaced;
+    }
+
     return goog.Uri.resolve(node.baseURI, s).toString();
   }
 

--- a/src/plugin/file/kml/kmlparser.js
+++ b/src/plugin/file/kml/kmlparser.js
@@ -605,13 +605,11 @@ plugin.file.kml.KMLParser.prototype.handleZipEntries = function(entries) {
 
       this.kmzImagesRemaining_++;
 
-      entry.getData(new zip.Data64URIWriter('image/' + result[1]),
-          this.processZipImage_.bind(this, entry.filename));
+      entry.getData(new zip.Data64URIWriter('image/' + result[1]), this.processZipAsset_.bind(this, entry.filename));
     } else if (collada.test(entry.filename)) {
       this.hasModel_ = true;
       this.kmzImagesRemaining_++;
-      entry.getData(new zip.TextWriter(),
-          this.processZipCollada_.bind(this, entry.filename));
+      entry.getData(new zip.TextWriter(), this.processZipAsset_.bind(this, entry.filename));
     }
   }
 
@@ -660,11 +658,12 @@ plugin.file.kml.KMLParser.prototype.imagesRemaining_ = function() {
 
 
 /**
+ * Handler for processing assets within the ZIP file. This includes images and collada model files.
  * @param {*} filename
  * @param {*} uri
  * @private
  */
-plugin.file.kml.KMLParser.prototype.processZipImage_ = function(filename, uri) {
+plugin.file.kml.KMLParser.prototype.processZipAsset_ = function(filename, uri) {
   if (typeof filename === 'string' && typeof uri === 'string') {
     this.assetMap_[filename] = uri;
     this.kmzImagesRemaining_--;
@@ -674,20 +673,6 @@ plugin.file.kml.KMLParser.prototype.processZipImage_ = function(filename, uri) {
   }
 };
 
-/**
- * @param {*} filename
- * @param {*} content
- * @private
- */
-plugin.file.kml.KMLParser.prototype.processZipCollada_ = function(filename, content) {
-  if (typeof filename === 'string' && typeof content === 'string') {
-    this.assetMap_[filename] = content;
-    this.kmzImagesRemaining_--;
-  } else {
-    goog.log.error(this.log_, 'There was a problem unzipping the KMZ!');
-    this.onError();
-  }
-};
 
 /**
  * @param {string} filename

--- a/test/plugin/file/kml/kml.test.js
+++ b/test/plugin/file/kml/kml.test.js
@@ -64,6 +64,38 @@ describe('plugin.file.kml', function() {
     expect(link['viewRefreshTime']).toBe(viewRefreshTime);
   });
 
+  it('reads a relative-URI kml:Link element with incorrect (but still supported) backslashes', function() {
+    // this covers a case of reading relative-URI assets from a KMZ file with backslash-delimited paths
+    var href = 'images\\relative\\url\\image.png';
+    var forwardSlashHref = 'images/relative/url/image.png';
+    var refreshMode = 'onInterval';
+    var refreshInterval = 10;
+    var viewRefreshMode = 'onStop';
+    var viewRefreshTime = 15;
+
+    var linkXml =
+        '<Link>' +
+        '<href>' + href + '</href>' +
+        '<refreshMode>' + refreshMode + '</refreshMode>' +
+        '<refreshInterval>' + refreshInterval + '</refreshInterval>' +
+        '<viewRefreshMode>' + viewRefreshMode + '</viewRefreshMode>' +
+        '<viewRefreshTime>' + viewRefreshTime + '</viewRefreshTime>' +
+        '</Link>';
+    var doc = goog.dom.xml.loadXml(linkXml);
+    var linkEl = goog.dom.getFirstElementChild(doc);
+
+    linkEl.assetMap = {
+      [forwardSlashHref]: 'data://fakeimagedatauri'
+    };
+
+    var link = ol.xml.pushParseAndPop({}, plugin.file.kml.OL_LINK_PARSERS(), linkEl, []);
+    expect(link['href']).toBe(forwardSlashHref);
+    expect(link['refreshMode']).toBe(refreshMode);
+    expect(link['refreshInterval']).toBe(refreshInterval);
+    expect(link['viewRefreshMode']).toBe(viewRefreshMode);
+    expect(link['viewRefreshTime']).toBe(viewRefreshTime);
+  });
+
   describe('Track and MultiTrack Support', function() {
     /**
      * Generate coord/when XML pairs to define a Track.

--- a/test/plugin/file/kml/kmlparser.test.js
+++ b/test/plugin/file/kml/kmlparser.test.js
@@ -351,4 +351,30 @@ describe('plugin.file.kml.KMLParser', function() {
       expect(geom.getGeometries().length).toBe(1);
     });
   });
+
+  it('should add parsed assets to the assetMap', function() {
+    // start fresh
+    parser.cleanup();
+    parser.clearAssets();
+
+    parser.processZipAsset_('images/fake-image.png', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8');
+    parser.processZipAsset_('models/fake-collada.png', 'fakecolladacontent');
+
+
+    expect(parser.assetMap_['models/fake-collada.png']).toBe('fakecolladacontent');
+  });
+
+  it('should error when asked to parse an improper asset', function() {
+    // start fresh
+    parser.cleanup();
+    parser.clearAssets();
+
+    const fn = () => {};
+    spyOn(parser, 'onError').andCallFake(fn);
+
+    parser.processZipAsset_('models/fake-collada.png', null);
+    parser.processZipAsset_('models/fake-collada2.png', {});
+
+    expect(parser.onError.calls.length).toBe(2);
+  });
 });


### PR DESCRIPTION
This PR covers a case where KMZs sometimes contain URIs to relative assets with backslashes instead of forward slashes. This is technically invalid according to the KML spec, but happens often enough in our experience that it's worth having a low-risk workaround to cover it.