### PR TITLE
fix(image): order image layers between tile/feature layers in 2D

### DIFF
--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -940,17 +940,18 @@ os.MapContainer.prototype.init = function() {
   tileGroup.setCheckFunc(os.MapContainer.isTileLayer);
   tileGroup.setOSType(os.layer.LayerType.TILES);
 
+  var imageGroup = new os.layer.Group({
+    hidden: true
+  });
+  imageGroup.setPriority(-1);
+  imageGroup.setCheckFunc(os.MapContainer.isImageLayer);
+  imageGroup.setOSType(os.layer.LayerType.IMAGE);
+
   var vectorGroup = new os.layer.Group({
     layers: [this.drawingLayer_]
   });
   vectorGroup.setCheckFunc(os.MapContainer.isVectorLayer);
   vectorGroup.setOSType(os.layer.LayerType.FEATURES);
-
-  var imageGroup = new os.layer.Group({
-    hidden: true
-  });
-  imageGroup.setCheckFunc(os.MapContainer.isImageLayer);
-  imageGroup.setOSType(os.layer.LayerType.IMAGE);
 
   var referenceGroup = new os.layer.Group();
   referenceGroup.setPriority(100);
@@ -982,9 +983,9 @@ os.MapContainer.prototype.init = function() {
     interactions: this.interactionFunction_ ? this.interactionFunction_() : undefined,
     layers: new ol.Collection([
       tileGroup,
+      imageGroup,
       vectorGroup,
-      referenceGroup,
-      imageGroup
+      referenceGroup
     ]),
     // prevents a blank map while flyTo animates
     loadTilesWhileAnimating: true,


### PR DESCRIPTION
The image layer group was being added last in the list of default layer groups. This causes OpenLayers to render it on top of the feature/reference group, so features are hidden beneath KML Ground Overlays or other image layers.

This PR adds the image group immediately after the tile group in the default group list, and sets the priority to -1 so it's considered between the tile/feature groups when new groups are added.

Note: This does not impact the Cesium renderer because Cesium renders all tile/image layers first, then Billboards (features) on top of that.