### PR TITLE
fix(settings): add delay to descriptor persistence

### DIFF
--- a/src/os/data/datamanager.js
+++ b/src/os/data/datamanager.js
@@ -65,7 +65,7 @@ os.data.DataManager = function() {
    * @type {goog.async.Delay}
    * @private
    */
-  this.persistDelay_ = new goog.async.Delay(this.persistDescriptors, 50, this);
+  this.persistDelay_ = new goog.async.Delay(this.persistDescriptors_, 50, this);
 
   this.migrateDescriptors_();
 };
@@ -217,7 +217,7 @@ os.data.DataManager.prototype.addDescriptor = function(descriptor) {
     }
 
     this.dispatchEvent(new os.data.DescriptorEvent(os.data.DescriptorEventType.ADD_DESCRIPTOR, descriptor));
-    this.persistDelay_.start();
+    this.persistDescriptors();
   } else {
     goog.log.error(this.log, 'Could not add the descriptor because its ID was empty or null');
   }
@@ -236,7 +236,7 @@ os.data.DataManager.prototype.removeDescriptor = function(descriptor) {
     }
 
     this.dispatchEvent(new os.data.DescriptorEvent(os.data.DescriptorEventType.REMOVE_DESCRIPTOR, descriptor));
-    this.persistDelay_.start();
+    this.persistDescriptors();
   } else {
     goog.log.error(this.log, 'Could not remove the descriptor because its ID was empty or null');
   }
@@ -491,6 +491,14 @@ os.data.DataManager.prototype.hasError = function() {
  * @inheritDoc
  */
 os.data.DataManager.prototype.persistDescriptors = function() {
+  this.persistDelay_.start();
+};
+
+
+/**
+ * Private persist descriptors call - no delay
+ */
+os.data.DataManager.prototype.persistDescriptors_ = function() {
   var list = [];
   var aliasesSeen = {};
   var now = Date.now();

--- a/test/os/data/datamanager.test.js
+++ b/test/os/data/datamanager.test.js
@@ -23,8 +23,7 @@ describe('os.data.DataManager', function() {
 
   it('should only persist recently active descriptors', function() {
     dm.getDescriptor('1').setActive(true);
-    dm.persistDescriptors();
-
+    dm.persistDescriptors_();
     var arr = os.settings.get(dm.getDescriptorKey());
     expect(arr.length).toBe(1);
   });

--- a/test/os/data/osdatamanager.test.js
+++ b/test/os/data/osdatamanager.test.js
@@ -158,7 +158,7 @@ describe('os.data.OSDataManager', function() {
 
     var d = dm.descriptors_['testy'];
     delete dm.descriptors_['testy2'];
-    dm.persistDescriptors();
+    dm.persistDescriptors_();
 
     delete dm.descriptors_['testy'];
     delete dm.descriptors_['other'];


### PR DESCRIPTION
I was seeing a case where the style of incoming features was causing rapid saves to settings. Specifically:

`os.data.LayerSyncDescriptor.prototype.onLayerChange` would call `this.onStyleChange()` and that event would trigger persisting the descriptors hundreds of times as data streamed in. Hopefully this check will tone down the number of settings calls.

This was causing problems with our custom setting storage option.