### PR TITLE
fix(geo): lat lon parse direction with opt_format

### DIFF
--- a/src/os/geo/geo.js
+++ b/src/os/geo/geo.js
@@ -899,7 +899,7 @@ os.geo.parseLon = function(str, opt_format) {
         break;
       case 'DDM':
         confs.push({
-          regex: new RegExp(os.geo.START_ + os.geo.DDM_DELIMITED_RELAXED_ + os.geo.END_, 'i'),
+          regex: new RegExp(os.geo.START_ + os.geo.DDM_DELIMITED_RELAXED_ + os.geo.OPT_DIRECTION_ + os.geo.END_, 'i'),
           coords: {deg: 2, min: 3, sec: null, dir: [1, 5]}
         });
         confs.push({
@@ -913,7 +913,7 @@ os.geo.parseLon = function(str, opt_format) {
         break;
       case 'DMS':
         confs.push({
-          regex: new RegExp(os.geo.START_ + os.geo.DMS_DELIMITED_RELAXED_ + os.geo.END_, 'i'),
+          regex: new RegExp(os.geo.START_ + os.geo.DMS_DELIMITED_RELAXED_ + os.geo.OPT_DIRECTION_ + os.geo.END_, 'i'),
           coords: {deg: 2, min: 3, sec: 5, dir: [1, 7]}
         });
         confs.push({
@@ -994,7 +994,7 @@ os.geo.parseLat = function(str, opt_format) {
         break;
       case 'DDM':
         confs.push({
-          regex: new RegExp(os.geo.START_ + os.geo.DDM_DELIMITED_RELAXED_ + os.geo.END_, 'i'),
+          regex: new RegExp(os.geo.START_ + os.geo.DDM_DELIMITED_RELAXED_ + os.geo.OPT_DIRECTION_ + os.geo.END_, 'i'),
           coords: {deg: 2, min: 3, sec: null, dir: [1, 5]}
         });
         confs.push({
@@ -1008,7 +1008,7 @@ os.geo.parseLat = function(str, opt_format) {
         break;
       case 'DMS':
         confs.push({
-          regex: new RegExp(os.geo.START_ + os.geo.DMS_DELIMITED_RELAXED_ + os.geo.END_, 'i'),
+          regex: new RegExp(os.geo.START_ + os.geo.DMS_DELIMITED_RELAXED_ + os.geo.OPT_DIRECTION_ + os.geo.END_, 'i'),
           coords: {deg: 2, min: 3, sec: 5, dir: [1, 7]}
         });
         confs.push({

--- a/test/os/geo/geo.test.js
+++ b/test/os/geo/geo.test.js
@@ -84,6 +84,13 @@ describe('os.geo', function() {
     expect(result.lat).toBeCloseTo(10.51);
   });
 
+  it('should parse DMS lat and lon separately with unit delimiters with direction and opt_format', function() {
+    var resultLat = os.geo.parseLat('10° 30\' 36" S', 'DMS');
+    var resultLon = os.geo.parseLon('50° 15\' 45" W', 'DMS');
+    expect(resultLat).toBeCloseTo(-10.51);
+    expect(resultLon).toBeCloseTo(-50.2625);
+  });
+
   it('should parse DMS with unit delimiters without spaces or direction', function() {
     var result = os.geo.parseLatLon('10°30\'36"50°15\'45"');
     expect(result.lon).toBeCloseTo(50.2625);


### PR DESCRIPTION
This was to fix an edge case in which values such as `10° 30' 36" S` were being rejected by `parseLat` and `parseLon` because the direction regex was not included when `opt_format` is specified.