### PR TITLE
fix(gpx): fix parse error with timeless gpx data

### DIFF
--- a/src/plugin/file/gpx/gpxparser.js
+++ b/src/plugin/file/gpx/gpxparser.js
@@ -233,6 +233,10 @@ ol.format.GPX.appendCoordinate_ = function(flatCoordinates, layoutOptions, node,
     delete values['extensionsNode_'];
     delete values['time'];
     layoutOptions.hasM = true;
+  } else {
+    // ol.format.GPX.applyLayoutOptions_ assumes coordinates are parsed as XYZM and adjusts accordingly, so always
+    // add a time component to the coordinates
+    flatCoordinates.push(0);
   }
 
   return flatCoordinates;


### PR DESCRIPTION
As mentioned in the comment, OpenLayers parses GPX coordinates as XYZM and adjusts later in `ol.format.GPX.applyLayoutOptions_`. If `flatCoordinates` isn't in XYZM, that function will either botch the coordinates or fail outright when it tries to iterate over the coordinates in groups of 4 values. This happens for GPX data that does not have a time component.