### PR TITLE
refactor(search): moves property/function to module

### DIFF
--- a/src/os/ui/search/place/coordinateresult.js
+++ b/src/os/ui/search/place/coordinateresult.js
@@ -56,21 +56,6 @@ os.implements(os.ui.search.place.CoordinateResult, os.search.ISortableResult.ID)
 
 
 /**
- * @type {Object}
- * @const
- */
-os.ui.search.place.FEATURE_CONFIG = {
-  'image': {
-    'type': 'icon',
-    'scale': 0.75,
-    'src': os.ui.file.kml.GOOGLE_EARTH_URL + os.ui.file.kml.GoogleEarthIcons.WHT_BLANK,
-    'color': 'rgba(0,255,255,1)'
-  },
-  'text': {}
-};
-
-
-/**
  * Create a style config for a feature.
  *
  * @param {ol.Feature} feature The feature.
@@ -132,37 +117,4 @@ os.ui.search.place.CoordinateResult.prototype.getSortValue = function(sortType) 
   }
 
   return value != null ? String(value) : null;
-};
-
-
-/**
- * Creates a feature representing a coordinate result.
- *
- * @param {Object.<string, *>=} opt_options Feature options.
- * @return {!ol.Feature}
- */
-os.ui.search.place.createFeature = function(opt_options) {
-  // grab the label off the options if it exists. we don't want it on the feature.
-  var label;
-  if (opt_options && 'label' in opt_options) {
-    label = /** @type {string} */ (opt_options['label']);
-    delete opt_options['label'];
-  }
-
-  var feature = new ol.Feature(opt_options);
-  feature.setId(ol.getUid(feature));
-
-  var featureConfig = os.object.unsafeClone(os.ui.search.place.FEATURE_CONFIG);
-  feature.set(os.style.StyleType.FEATURE, featureConfig);
-
-  // configure labels for the feature
-  if (label) {
-    featureConfig[os.style.StyleField.LABELS] = [{
-      'column': label,
-      'showColumn': false
-    }];
-  }
-
-  os.style.setFeatureStyle(feature);
-  return feature;
 };

--- a/src/os/ui/search/place/coordinatesearch.js
+++ b/src/os/ui/search/place/coordinatesearch.js
@@ -11,6 +11,7 @@ goog.require('os.geo2');
 goog.require('os.search.AbstractSearch');
 goog.require('os.search.SearchEvent');
 goog.require('os.search.SearchEventType');
+goog.require('os.ui.search.place');
 goog.require('os.ui.search.place.CoordinateResult');
 
 

--- a/src/os/ui/search/place/place.js
+++ b/src/os/ui/search/place/place.js
@@ -1,0 +1,60 @@
+goog.module('os.ui.search.place');
+goog.module.declareLegacyNamespace();
+
+const Feature = goog.require('ol.Feature');
+const osObject = goog.require('os.object');
+const StyleField = goog.require('os.style.StyleField');
+const StyleType = goog.require('os.style.StyleType');
+const {GOOGLE_EARTH_URL, GoogleEarthIcons} = goog.require('os.ui.file.kml');
+const {getUid} = goog.require('ol');
+const {setFeatureStyle} = goog.require('os.style');
+
+
+/**
+ * @type {Object}
+ */
+const FEATURE_CONFIG = {
+  'image': {
+    'type': 'icon',
+    'scale': 0.75,
+    'src': GOOGLE_EARTH_URL + GoogleEarthIcons.WHT_BLANK,
+    'color': 'rgba(0,255,255,1)'
+  },
+  'text': {}
+};
+
+
+/**
+ * Creates a feature representing a coordinate result.
+ *
+ * @param {Object.<string, *>=} opt_options Feature options.
+ * @return {!ol.Feature}
+ */
+const createFeature = function(opt_options) {
+  // grab the label off the options if it exists. we don't want it on the feature.
+  var label;
+  if (opt_options && 'label' in opt_options) {
+    label = /** @type {string} */ (opt_options['label']);
+    delete opt_options['label'];
+  }
+
+  var feature = new Feature(opt_options);
+  feature.setId(getUid(feature));
+
+  var featureConfig = osObject.unsafeClone(FEATURE_CONFIG);
+  feature.set(StyleType.FEATURE, featureConfig);
+
+  // configure labels for the feature
+  if (label) {
+    featureConfig[StyleField.LABELS] = [{
+      'column': label,
+      'showColumn': false
+    }];
+  }
+
+  setFeatureStyle(feature);
+  return feature;
+};
+
+
+exports = {createFeature, FEATURE_CONFIG};


### PR DESCRIPTION
Cleans up an improper declaration to allow for proper module requires.