### PR TITLE
fix(request-source): remove const from request source name

### DIFF
--- a/src/os/source/requestsource.js
+++ b/src/os/source/requestsource.js
@@ -70,7 +70,6 @@ os.implements(os.source.Request, os.source.IImportSource.ID);
 /**
  * Class name
  * @type {string}
- * @const
  */
 os.source.Request.NAME = 'os.source.Request';
 os.registerClass(os.source.Request.NAME, os.source.Request);


### PR DESCRIPTION
Removes the `const` annotation from the RequestSource name. This allows extending ES6 classes to define their own names to register with `os.registerClass`.