### PR TITLE
feat(tile): add tile layer sharpness control

### DIFF
--- a/src/os/color.js
+++ b/src/os/color.js
@@ -820,14 +820,11 @@ const sharpnessMatrix = [
  * @param {!Array<number>} data The image data.
  * @param {number} width The image width.
  * @param {number} height The image height.
- * @param {number} sharpness The sharpness value.
+ * @param {number} value The sharpness value.
  *
  * @see https://www.html5rocks.com/en/tutorials/canvas/imagefilters/
  */
-const adjustSharpness = function(data, width, height, sharpness) {
-  // sharpness is in the range [0, 1], multiply to enhance the convolution effect
-  const value = sharpness * 10;
-
+const adjustSharpness = function(data, width, height, value) {
   const side = Math.round(Math.sqrt(sharpnessMatrix.length));
   const halfSide = Math.floor(side / 2);
   const adjacentPx = sharpnessMatrix[halfSide];

--- a/src/os/layer/ilayer.js
+++ b/src/os/layer/ilayer.js
@@ -207,6 +207,20 @@ os.layer.ILayer.prototype.setSaturation;
 
 
 /**
+ * Gets the sharpness of the layer
+ * @return {number|undefined} between 0 and 1
+ */
+os.layer.ILayer.prototype.getSharpness;
+
+
+/**
+ * Sets the sharpness of the layer
+ * @param {number} value Number between 0 and 1
+ */
+os.layer.ILayer.prototype.setSharpness;
+
+
+/**
  * Whether or not the layer is visible
  * @return {boolean}
  */

--- a/src/os/layer/layer.js
+++ b/src/os/layer/layer.js
@@ -228,6 +228,17 @@ os.layer.getSaturation = function(layer) {
 
 
 /**
+ * Get the sharpness of the provided layer.
+ *
+ * @param {os.layer.ILayer} layer
+ * @return {number|undefined} The sharpness
+ */
+os.layer.getSharpness = function(layer) {
+  return layer.getSharpness();
+};
+
+
+/**
  * Set the brightness of the provided layer.
  *
  * @param {os.layer.ILayer} layer
@@ -279,6 +290,18 @@ os.layer.setOpacity = function(layer, value) {
  */
 os.layer.setSaturation = function(layer, value) {
   layer.setSaturation(value);
+};
+
+
+
+/**
+ * Set the sharpness of the provided layer.
+ *
+ * @param {os.layer.ILayer} layer
+ * @param {number} value
+ */
+os.layer.setSharpness = function(layer, value) {
+  layer.setSharpness(value);
 };
 
 

--- a/src/os/layer/layergroup.js
+++ b/src/os/layer/layergroup.js
@@ -413,6 +413,35 @@ os.layer.LayerGroup.prototype.setSaturation = function(value) {
 /**
  * @inheritDoc
  */
+os.layer.LayerGroup.prototype.getSharpness = function() {
+  var maxSharpness = 0;
+  for (var i = 0, n = this.layers_.length; i < n; i++) {
+    try {
+      maxSharpness = Math.max(maxSharpness, this.layers_[i].getSharpness());
+    } catch (e) {
+    }
+  }
+
+  return goog.math.clamp(maxSharpness, 0, 1);
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.layer.LayerGroup.prototype.setSharpness = function(value) {
+  for (var i = 0, n = this.layers_.length; i < n; i++) {
+    try {
+      this.layers_[i].setSharpness(value);
+    } catch (e) {
+    }
+  }
+};
+
+
+/**
+ * @inheritDoc
+ */
 os.layer.LayerGroup.prototype.getLayerVisible = function() {
   for (var i = 0, n = this.layers_.length; i < n; i++) {
     try {

--- a/src/os/layer/tile.js
+++ b/src/os/layer/tile.js
@@ -360,6 +360,20 @@ os.layer.Tile.prototype.getSaturation = function() {
 
 
 /**
+ * Get the sharpness for the tile layer.
+ *
+ * @override
+ * @return {number}
+ */
+os.layer.Tile.prototype.getSharpness = function() {
+  if (this.layerOptions_ && this.layerOptions_['sharpness'] != null) {
+    return /** @type {number} */ (this.layerOptions_['sharpness']);
+  }
+  return 0;
+};
+
+
+/**
  * Get the whether the tile layer is being colorized.
  *
  * @return {boolean}
@@ -478,6 +492,27 @@ os.layer.Tile.prototype.setSaturation = function(value, opt_options) {
 
 
 /**
+ * Adjust layer sharpness. A value of 0 will not adjust layer sharpness. A value of 1 will apply the maximum
+ * sharpness adjustment to the image.
+ *
+ * @override
+ * @param {number} value The sharpness of the layer (values clamped between 0 and 1)
+ * @param {Object=} opt_options The layer options to use
+ */
+os.layer.Tile.prototype.setSharpness = function(value, opt_options) {
+  goog.asserts.assert(value >= 0 && value <= 1, 'sharpness is between 0 and 1');
+  os.layer.Tile.base(this, 'setSharpness', value);
+  var options = opt_options || this.layerOptions_;
+  if (options) {
+    options['sharpness'] = value;
+    this.updateColorFilter();
+    this.updateIcons_();
+    os.style.notifyStyleChange(this);
+  }
+};
+
+
+/**
  * Updates the color filter, either adding or removing depending on whether the layer is colored to a non-default
  * color or colorized.
  *
@@ -487,7 +522,7 @@ os.layer.Tile.prototype.updateColorFilter = function() {
   var source = this.getSource();
   if (source instanceof ol.source.TileImage) {
     if (this.getColorize() || !os.color.equals(this.getColor(), this.getDefaultColor()) ||
-        this.getBrightness() != 0 || this.getContrast() != 1 || this.getSaturation() != 1) {
+        this.getBrightness() != 0 || this.getContrast() != 1 || this.getSaturation() != 1 || this.getSharpness() != 0) {
       // put the colorFilter in place if we are colorized or the current color is different from the default
       source.addTileFilter(this.colorFilter_);
     } else {
@@ -501,18 +536,25 @@ os.layer.Tile.prototype.updateColorFilter = function() {
  * Filter function that applies the layer color tile image data. This filter is always in the filter array, but it
  * only runs if the current color is different from the default or if the colorize option is active.
  *
- * @param {Array<number>} data
+ * @param {Array<number>} data The image data.
+ * @param {number} width The image width.
+ * @param {number} height The image height.
  * @protected
  */
-os.layer.Tile.prototype.applyColors = function(data) {
+os.layer.Tile.prototype.applyColors = function(data, width, height) {
+  if (!data) {
+    return;
+  }
+
   var srcColor = this.getDefaultColor() || '#fffffe';
   var tgtColor = this.getColor() || '#fffffe';
   var brightness = this.getBrightness();
   var contrast = this.getContrast();
   var saturation = this.getSaturation();
+  var sharpness = this.getSharpness();
   var colorize = this.getColorize();
   if (colorize || !os.color.equals(srcColor, tgtColor) ||
-      this.getBrightness() != 0 || this.getContrast() != 1 || this.getSaturation() != 1) {
+      brightness != 0 || contrast != 1 || saturation != 1 || sharpness != 0) {
     if (tgtColor) {
       if (colorize) {
         // colorize will set all of the colors to the target
@@ -522,6 +564,7 @@ os.layer.Tile.prototype.applyColors = function(data) {
         os.color.transformColor(data, srcColor, tgtColor);
       }
       os.color.adjustColor(data, brightness, contrast, saturation);
+      os.color.adjustSharpness(data, width, height, sharpness);
     }
   }
 };
@@ -1039,6 +1082,7 @@ os.layer.Tile.prototype.persist = function(opt_to) {
   opt_to['contrast'] = this.getContrast();
   opt_to['brightness'] = this.getBrightness();
   opt_to['saturation'] = this.getSaturation();
+  opt_to['sharpness'] = this.getSharpness();
   opt_to['color'] = this.getColor();
   opt_to['colorize'] = this.getColorize();
   opt_to['groupId'] = this.getGroupId();
@@ -1112,6 +1156,10 @@ os.layer.Tile.prototype.restore = function(config) {
 
   if (config['saturation'] != null) {
     this.setSaturation(config['saturation']);
+  }
+
+  if (config['sharpness'] != null) {
+    this.setSharpness(config['sharpness']);
   }
 
   if (config['color']) {

--- a/src/os/layer/tile.js
+++ b/src/os/layer/tile.js
@@ -566,7 +566,8 @@ os.layer.Tile.prototype.applyColors = function(data, width, height) {
       os.color.adjustColor(data, brightness, contrast, saturation);
 
       if (sharpness > 0) {
-        os.color.adjustSharpness(data, width, height, sharpness);
+        // sharpness is in the range [0, 1]. use a multiplier to enhance the convolution effect.
+        os.color.adjustSharpness(data, width, height, sharpness * 20);
       }
     }
   }

--- a/src/os/layer/tile.js
+++ b/src/os/layer/tile.js
@@ -564,7 +564,10 @@ os.layer.Tile.prototype.applyColors = function(data, width, height) {
         os.color.transformColor(data, srcColor, tgtColor);
       }
       os.color.adjustColor(data, brightness, contrast, saturation);
-      os.color.adjustSharpness(data, width, height, sharpness);
+
+      if (sharpness > 0) {
+        os.color.adjustSharpness(data, width, height, sharpness);
+      }
     }
   }
 };

--- a/src/os/mixin/layerbasemixin.js
+++ b/src/os/mixin/layerbasemixin.js
@@ -34,6 +34,12 @@ ol.layer.Property.SATURATION = 'saturation';
 
 
 /**
+ * @type {string}
+ */
+ol.layer.Property.SHARPNESS = 'sharpness';
+
+
+/**
  * Return the brightness of the layer.
  *
  * @return {number} The brightness of the layer.
@@ -70,6 +76,16 @@ ol.layer.Base.prototype.getHue = function() {
  */
 ol.layer.Base.prototype.getSaturation = function() {
   return /** @type {number} */ (this.get(ol.layer.Property.SATURATION));
+};
+
+
+/**
+ * Return the sharpness of the layer.
+ *
+ * @return {number} The sharpness of the layer.
+ */
+ol.layer.Base.prototype.getSharpness = function() {
+  return /** @type {number} */ (this.get(ol.layer.Property.SHARPNESS));
 };
 
 
@@ -132,4 +148,14 @@ ol.layer.Base.prototype.setHue = function(hue) {
  */
 ol.layer.Base.prototype.setSaturation = function(saturation) {
   this.set(ol.layer.Property.SATURATION, saturation);
+};
+
+
+/**
+ * Adjust layer sharpness. A value of 0 will not adjust layer sharpness.
+ *
+ * @param {number} sharpness The sharpness of the layer.
+ */
+ol.layer.Base.prototype.setSharpness = function(sharpness) {
+  this.set(ol.layer.Property.SHARPNESS, sharpness);
 };

--- a/src/os/tile/tile.js
+++ b/src/os/tile/tile.js
@@ -2,7 +2,7 @@ goog.provide('os.tile');
 
 
 /**
- * @typedef {function(Array<number>)}
+ * @typedef {function(Array<number>, number, number)}
  */
 os.tile.TileFilterFn;
 
@@ -24,7 +24,7 @@ os.tile.filterImage = function(image, filterFns) {
 
   // apply each filter function to the image data
   filterFns.forEach(function(fn) {
-    fn(data);
+    fn(data, canvas.width, canvas.height);
   });
   context.putImageData(imageData, 0, 0);
   return canvas;

--- a/src/os/ui/layer/defaultlayerui.js
+++ b/src/os/ui/layer/defaultlayerui.js
@@ -102,7 +102,8 @@ os.ui.layer.DefaultLayerUICtrl = function($scope, $element, $timeout) {
     'contrast': 1,
     'hue': 0,
     'opacity': 1,
-    'saturation': 1
+    'saturation': 1,
+    'sharpness': 0
   };
 
   /**
@@ -158,7 +159,8 @@ os.ui.layer.DefaultLayerUICtrl.prototype.getProperties = function() {
     'brightness': os.layer.setBrightness,
     'contrast': os.layer.setContrast,
     'hue': os.layer.setHue,
-    'saturation': os.layer.setSaturation
+    'saturation': os.layer.setSaturation,
+    'sharpness': os.layer.setSharpness
   };
 };
 
@@ -175,6 +177,7 @@ os.ui.layer.DefaultLayerUICtrl.prototype.initUI = function() {
     this.scope['hue'] = this.getValue(os.layer.getHue, 0);
     this.scope['opacity'] = this.getOpacity();
     this.scope['saturation'] = this.getValue(os.layer.getSaturation);
+    this.scope['sharpness'] = this.getValue(os.layer.getSharpness);
 
     this.updateRefresh();
     this.initColorControls_();
@@ -342,6 +345,9 @@ os.ui.layer.DefaultLayerUICtrl.prototype.setInitialValues_ = function() {
 
       var saturation = os.layer.getSaturation(layer);
       values['saturation'] = saturation != null ? saturation : 0;
+
+      var sharpness = os.layer.getSharpness(layer);
+      values['sharpness'] = sharpness != null ? sharpness : 0;
 
       this.initialValues[layerId] = values;
     }

--- a/views/layer/tile.html
+++ b/views/layer/tile.html
@@ -44,6 +44,15 @@
               </button>
             </td>
           </tr>
+          <tr title="Sets the sharpness of the layer(s)" ng-show="tile.showBasicColor">
+            <td>Sharpness</td>
+            <td class="w-100"><slider min="0" max="1" step="0.05" value="sharpness" name="sharpness"></slider></td>
+            <td class="text-right pl-2">
+              <button class="btn btn-secondary" ng-click="tile.reset('sharpness')" title="Restore default sharpness">
+                <i class="fa fa-undo"></i>
+              </button>
+            </td>
+          </tr>
           <tr title="Sets the color of the layer(s)" ng-show="tile.showColorPicker">
             <td>Color</td>
             <td>

--- a/views/plugin/basemap/basemaplayerui.html
+++ b/views/plugin/basemap/basemaplayerui.html
@@ -44,6 +44,15 @@
               </button>
             </td>
           </tr>
+          <tr title="Sets the sharpness of the layer(s)">
+            <td>Sharpness:</td>
+            <td class="w-100"><slider min="0" max="1" step="0.05" value="sharpness" name="sharpness"></slider></td>
+            <td class="text-right pl-2">
+              <button class="btn btn-secondary" ng-click="basemap.reset('sharpness')" title="Restore default sharpness">
+                <i class="fa fa-undo"></i>
+              </button>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
Adds a sharpness control to Tile and Base Map layers. Access the control from Layers > (Tile/Base Map Layer) > Style.

Sharpness is adjusted using the convolution filter here: https://www.html5rocks.com/en/tutorials/canvas/imagefilters/

Tests will fail until ngageoint/opensphere-state-schema/pull/18 is merged to add the property to the state schema.