### PR TITLE
feat(geojson): adds handler for importing geojson-backed layers

### DIFF
--- a/src/os/data/filedescriptor.js
+++ b/src/os/data/filedescriptor.js
@@ -400,7 +400,7 @@ os.data.FileDescriptor.prototype.updateFromConfig = function(config, opt_isNotPa
  */
 os.data.FileDescriptor.createFromConfig = function(descriptor, provider, config, opt_useDefaultColor) {
   var file = config['file'];
-  descriptor.setId(provider.getUniqueId());
+  descriptor.setId(/** @type {string} */ (config['id']) || provider.getUniqueId());
   descriptor.setProvider(provider.getLabel());
   if (file) {
     descriptor.setUrl(file.getUrl());

--- a/src/os/parse/baseparserconfig.js
+++ b/src/os/parse/baseparserconfig.js
@@ -11,6 +11,11 @@ goog.require('os.data.ColumnDefinition');
  */
 os.parse.BaseParserConfig = function() {
   /**
+   * @type {?string}
+   */
+  this['id'] = null;
+
+  /**
    * @type {Array.<os.data.ColumnDefinition>}
    */
   this['columns'] = [];
@@ -49,6 +54,11 @@ os.parse.BaseParserConfig = function() {
    * @type {T}
    */
   this['previewSelection'] = null;
+
+  /**
+   * @type {?boolean}
+   */
+  this['keepUrl'] = null;
 };
 
 

--- a/src/os/ui/data/descriptornodeui.js
+++ b/src/os/ui/data/descriptornodeui.js
@@ -130,7 +130,8 @@ os.ui.data.DescriptorNodeUICtrl.prototype.removeDescriptor = function() {
     // remove the descriptor from the data manager
     dm.removeDescriptor(descriptor);
 
-    var provider = /** @type {os.ui.data.DescriptorProvider} */ (dm.getProvider(descriptor.getId()));
+    var provider = /** @type {os.ui.data.DescriptorProvider} */ (dm.getProvider(descriptor.getId()) ||
+        dm.getProviderByLabel(descriptor.getProvider() || ''));
     if (provider && provider instanceof os.ui.data.DescriptorProvider) {
       // remove the descriptor from the provider
       provider.removeDescriptor(descriptor, true);

--- a/src/plugin/file/geojson/geojsonimporthandler.js
+++ b/src/plugin/file/geojson/geojsonimporthandler.js
@@ -1,0 +1,76 @@
+goog.module('plugin.file.geojson.GeoJSONImportHandler');
+
+const DataManager = goog.require('os.data.DataManager');
+const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const GeoJSONDescriptor = goog.require('plugin.file.geojson.GeoJSONDescriptor');
+const GeoJSONParserConfig = goog.require('plugin.file.geojson.GeoJSONParserConfig');
+const GeoJSONProvider = goog.require('plugin.file.geojson.GeoJSONProvider');
+const MappingManager = goog.require('os.im.mapping.MappingManager');
+
+
+/**
+ * Import handler for GeoJSON. Skips showing a UI and just uses the default autodetected time mappings.
+ * @extends {FileImportUI<GeoJSONParserConfig>}
+ */
+class GeoJSONImportHandler extends FileImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getTitle() {
+    return 'GeoJSONHandler';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    const config = new GeoJSONParserConfig();
+
+    // if a configuration was provided, merge it in
+    if (opt_config) {
+      this.mergeConfig(opt_config, config);
+    }
+
+    config['file'] = file;
+    config['title'] = file.getFileName() || 'New GeoJSON File';
+
+    try {
+      config.updatePreview();
+
+      const features = config['preview'].slice(0, 24);
+      if ((!config['mappings'] || config['mappings'].length <= 0) && features && features.length > 0) {
+        // no mappings have been set yet, so try to auto detect them
+        const mm = MappingManager.getInstance();
+        const mappings = mm.autoDetect(features);
+        if (mappings && mappings.length > 0) {
+          config['mappings'] = mappings;
+        }
+      }
+    } catch (e) {
+    }
+
+    // create the descriptor and add it
+    const descriptor = GeoJSONDescriptor.createFromConfig(config);
+    GeoJSONProvider.getInstance().addDescriptor(descriptor);
+    DataManager.getInstance().addDescriptor(descriptor);
+    descriptor.setActive(true);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  mergeConfig(from, to) {
+    super.mergeConfig(from, to);
+    to['id'] = from['id'];
+    to['keepUrl'] = from['keepUrl'];
+  }
+}
+
+exports = GeoJSONImportHandler;

--- a/src/plugin/file/geojson/geojsonmixin.js
+++ b/src/plugin/file/geojson/geojsonmixin.js
@@ -34,8 +34,9 @@ goog.require('ol.format.GeoJSON');
     var fields = opt_options.fields;
     for (var key in properties) {
       // exclude private keys, any fields passed in, and any non-primitive value
-      if (key.indexOf('_') !== 0 && (!fields || fields.indexOf(key) > -1) &&
-          Object(properties[key]) !== properties[key]) {
+      if ((opt_options.includePrivateFields || key.indexOf('_') !== 0) &&
+          ((!fields || fields.indexOf(key) > -1) &&
+          Object(properties[key]) !== properties[key])) {
         if (!object.properties) {
           object.properties = {};
         }


### PR DESCRIPTION
Adds support for creating an arbitrary layer backed by GeoJSON data. The GeoJSON import handler will simply run our automapping functionality on the parser file data then add a GeoJSON descriptor backed layer that is persisted and restored.

Includes other specific changes to support a use case for internally creating and persisting a layer as GeoJSON.