### PR TITLE
chore: adds github action for merging release to master on push

### DIFF
--- a/.github/workflows/release-to-master.yml
+++ b/.github/workflows/release-to-master.yml
@@ -1,0 +1,24 @@
+name: 'Merge Release to Master'
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  release-to-master:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Merge Release to Master
+      uses: robotology/gh-action-nightly-merge@v1.2.0
+      with:
+        stable_branch: 'release'
+        development_branch: 'master'
+        allow_forks: false
+        user_name: 'Release to Master Merge Action'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds an action to automate merging changes from release to master. The action is based on/using https://github.com/marketplace/actions/nightly-merge, slightly adapted to our branch names and to do it on push to release rather than from a cron running nightly. 

I tested a dummy version of the script on some branches on my fork: 
https://github.com/jsalankey/opensphere/actions
https://github.com/jsalankey/opensphere/tree/actions-source-branch
https://github.com/jsalankey/opensphere/tree/actions-target-branch

It's pretty straightforward, but nice to see. The merge commit is created automatically by the `actions-user`. According to the action page, it will fail on a merge conflict and we'll have to fix it manually, as we'd expect.