### PR TITLE
chore(query): replace os.query.isWorldQuery into os.query.utils

### DIFF
--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -68,7 +68,7 @@ goog.require('os.ol.control.MousePosition');
 goog.require('os.ol.feature');
 goog.require('os.proj');
 goog.require('os.proj.switch');
-goog.require('os.query');
+goog.require('os.query.utils');
 goog.require('os.source.Vector');
 goog.require('os.style');
 goog.require('os.style.StyleType');
@@ -704,9 +704,9 @@ os.MapContainer.prototype.onZoom_ = function(event) {
     }).filter(os.fn.filterFalsey);
 
     if (features.length) {
-      if (this.is3DEnabled() && features.length == 1 && os.query.isWorldQuery(features[0].getGeometry())) {
+      if (this.is3DEnabled() && features.length == 1 && os.query.utils.isWorldQuery(features[0].getGeometry())) {
         // while in 3D mode only, handle zooming to the world area by looking at the back of the world
-        features[0] = os.query.WORLD_ZOOM_FEATURE;
+        features[0] = os.query.utils.WORLD_ZOOM_FEATURE;
       }
 
       os.feature.flyTo(/** @type {Array<ol.Feature>} */ (features));

--- a/src/os/proj/projswitch.js
+++ b/src/os/proj/projswitch.js
@@ -420,7 +420,7 @@ os.proj.switch.SwitchProjection.prototype.performSwitch = function(layers) {
       cmds.push(new os.command.ToggleWebGL(useWebGL, true));
     }
 
-    os.query.initWorldArea(true);
+    os.query.utils.initWorldArea(true);
 
     // Step 9: Let plugins do stuff
     this.dispatchEvent(new os.proj.switch.CommandListEvent(cmds));

--- a/src/os/query/query.js
+++ b/src/os/query/query.js
@@ -7,6 +7,7 @@ goog.require('ol.proj');
 goog.require('os.interpolate');
 goog.require('os.metrics.MapMetrics');
 goog.require('os.metrics.Metrics');
+goog.require('os.query.utils');
 goog.require('os.ui.im.ImportEvent');
 goog.require('os.ui.im.ImportProcess');
 goog.require('os.ui.menu.MenuEvent');
@@ -83,7 +84,7 @@ os.query.launchChooseArea = function() {
  * Adds an area area covering the whole world.
  */
 os.query.queryWorld = function() {
-  var world = os.query.WORLD_AREA.clone();
+  var world = os.query.utils.WORLD_AREA.clone();
   if (world) {
     os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Map.QUERY_WORLD, 1);
     var geom = world.getGeometry();
@@ -93,101 +94,3 @@ os.query.queryWorld = function() {
     os.query.addArea(world, false);
   }
 };
-
-
-/**
- * Checks if an existing geometry is of type "world query"
- *
- * @param {ol.geom.Geometry|undefined} geometry The geometry to verify.
- * @return {boolean} true the query matches os.query.WORLD_GEOM
- */
-os.query.isWorldQuery = function(geometry) {
-  if (os.query.worldArea_ == null) {
-    os.query.initWorldArea();
-  }
-
-  if (os.query.worldArea_ && geometry && geometry.getType() === ol.geom.GeometryType.POLYGON) {
-    // transform the world extent to the current projection to compute the area
-    var geomArea = /** @type {ol.geom.Polygon} */ (geometry).getArea();
-    return goog.math.nearlyEquals(geomArea / os.query.worldArea_, 1, 1E-4) || geomArea == 0;
-  }
-
-  return false;
-};
-
-
-/**
- * calculates world area
- *
- * @param {boolean=} opt_reset
- */
-os.query.initWorldArea = function(opt_reset) {
-  if (opt_reset) {
-    os.query.worldArea_ = undefined;
-  } else {
-    var worldExtent = ol.proj.transformExtent(os.query.WORLD_EXTENT, os.proj.EPSG4326, os.map.PROJECTION);
-    os.query.worldArea_ = ol.extent.getArea(worldExtent);
-  }
-};
-
-
-/**
- * The world extent in EPSG:4326. This is the max precision that a polygon can handle.
- * @type {ol.Extent}
- * @const
- */
-os.query.WORLD_EXTENT = [-179.9999999999999, -89.99999999999999, 180, 90];
-
-
-/**
- * The world coordinates in EPSG:4326. This is the max precision that a polygon can handle.
- * Note: this includes coordinates at 0 latitude to ensure directionality of the vertical line components in 3D.
- * @type {Array<Array<Array<number>>>}
- * @const
- */
-os.query.WORLD_COORDS = [[
-  [-179.9999999999999, -89.99999999999999],
-  [-179.9999999999999, 0],
-  [-179.9999999999999, 90],
-  [180, 90],
-  [180, 0],
-  [180, -89.99999999999999],
-  [-179.9999999999999, -89.99999999999999]
-]];
-
-
-/**
- * Polygon representing the whole world.
- * @type {ol.geom.Polygon}
- */
-os.query.WORLD_GEOM = new ol.geom.Polygon(os.query.WORLD_COORDS);
-
-
-/**
- * @type {number|undefined}
- * @private
- */
-os.query.worldArea_ = undefined;
-
-
-/**
- * Feature representing the whole world.
- * @type {ol.Feature}
- */
-os.query.WORLD_AREA = new ol.Feature({
-  'geometry': os.query.WORLD_GEOM,
-  'title': 'Whole World'
-});
-
-
-/**
- * Feature representing the area we want to zoom to when zooming to the whole world.
- * @type {ol.Feature}
- */
-os.query.WORLD_ZOOM_FEATURE = new ol.Feature(new ol.geom.Polygon([[
-  [179, 90],
-  [181, 90],
-  [181, -90],
-  [179, -90],
-  [179, 90]
-]]));

--- a/src/os/query/queryutils.js
+++ b/src/os/query/queryutils.js
@@ -109,3 +109,5 @@ exports.WORLD_ZOOM_FEATURE = new olFeature(new Polygon([[
 
 
 exports.WORLD_EXTENT = WORLD_EXTENT;
+exports.WORLD_COORDS = WORLD_COORDS;
+exports.WORLD_GEOM = WORLD_GEOM;

--- a/src/plugin/cesium/cesium.js
+++ b/src/plugin/cesium/cesium.js
@@ -11,6 +11,7 @@ goog.require('ol.source.WMTS');
 goog.require('olcs.core');
 goog.require('os.net');
 goog.require('os.proj');
+goog.require('os.query.utils');
 goog.require('os.string');
 goog.require('plugin.cesium.ImageryProvider');
 goog.require('plugin.cesium.WMSTerrainProvider');
@@ -468,7 +469,7 @@ plugin.cesium.reduceBoundingSphere = function(sphere, geom) {
     var type = geom.getType();
     var scratchSphere = plugin.cesium.scratchSphere_;
 
-    if (os.query.isWorldQuery(geom)) {
+    if (os.query.utils.isWorldQuery(geom)) {
       if (scratchSphere) {
         scratchSphere.center = Cesium.Cartesian3.UNIT_X;
         scratchSphere.radius = 6378137;

--- a/test/os/query/query.test.js
+++ b/test/os/query/query.test.js
@@ -1,9 +1,9 @@
 goog.require('ol.geom.Polygon');
 goog.require('ol.proj');
 goog.require('os.proj');
-goog.require('os.query');
+goog.require('os.query.utils');
 
-describe('os.query', function() {
+describe('os.query.utils', function() {
   it('should detect world queries properly', function() {
     var tests = [{
       extent: [-180, -90, 180, 90],
@@ -22,12 +22,12 @@ describe('os.query', function() {
     projections.forEach(function(code) {
       var proj = ol.proj.get(code);
       os.map.PROJECTION = proj;
-      os.query.initWorldArea();
+      os.query.utils.initWorldArea();
 
       tests.forEach(function(test) {
         var extent = ol.proj.transformExtent(test.extent, os.proj.EPSG4326, proj);
         var geom = ol.geom.Polygon.fromExtent(extent);
-        expect(os.query.isWorldQuery(geom)).toBe(test.expected);
+        expect(os.query.utils.isWorldQuery(geom)).toBe(test.expected);
       });
     });
 


### PR DESCRIPTION
- Consolidate `os.query` and `os.query.utils` by migrating `isWorldQuery` and related functions / constants
- Update `os.query.utils` to be a module
- Update callers

Breaking change for plugins that utilize `os.query.isWorldQuery`.