### PR TITLE
feat(vector): speed up processing of feature removal

### DIFF
--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -1987,7 +1987,6 @@ os.source.Vector.prototype.removeFeatureInternal = function(feature, opt_isBulk)
     this.featureCount_ = Math.max(this.featureCount_ - 1, 0);
     this.unprocessFeature(feature);
 
-    this.featureChangeKeys_[featureKey].forEach(ol.events.unlistenByKey);
     /** @type {Object} */ (this.featureChangeKeys_)[featureKey] = undefined;
 
     if (feature.id_ !== undefined) {


### PR DESCRIPTION
Delays garbage collection for features in `VectorSource`.

### Motivation

Removing a CSV layer with 1,000,000 point geometries forces an unreasonably long time where no action can be taken.

Profiling led to the line featured in this PR, which makes some sense as removing event listeners [deletes](https://github.com/openlayers/openlayers/blob/246aded8192391bbeb9034dbf260e84e0f9d58a3/src/ol/events/Target.js#L179) the keys and forces immediate garbage collection. (though via testing with a mixin replacement, it seems `Array.splice` accounts for about half of the deletion time)

### Rationale

[setupChangeEvents_](https://github.com/ngageoint/opensphere/blob/master/src/os/source/vectorsource.js#L530) attaches the `handleFeatureChange_` function as a listener to the [feature](https://github.com/openlayers/openlayers/blob/246aded8192391bbeb9034dbf260e84e0f9d58a3/src/ol/events.js#L47) [itself](https://github.com/openlayers/openlayers/blob/246aded8192391bbeb9034dbf260e84e0f9d58a3/src/ol/events/Target.js#L64).

All references to the feature and its listener keys are cleared from the vector in [removeFeatureInternal](https://github.com/ngageoint/opensphere/blob/master/src/os/source/vectorsource.js#L1971). It is expected that the feature will be garbage collected at some point even if it is not made to unlisten to everything.

The `VectorSource` object might stick around if non-GC'd features are still referencing it when removed. Arguably that should eventually free itself too.

### Profiling

| | Without Change | With Change |
| --- | --- | --- |
| Removal Speed (1m Features) | 12 seconds | 3.5 seconds |

(Can also upload flame chart / heap snapshots, most of the memory sticking around is with a plugin & crossfilter and persists without this change anyway)

**Goal:** To showcase this does not cause a leak, assuming features (when removed) don't get put into another Source layer. In that case they could probably unlisten when added.

Memory snapshots and comparison with Firefox. Browser was closed and re-opened between individual tests. Profiling was performed on the development version. GC was executed with `about:memory` tool.

ArrayBuffer storage is noted only to show that potential leaks may be external to JavaScript.

All listed values in MB.

#### 1M CSV

Tables are memory on app startup, memory after addition and removal of 1m point CSV (via removing the layer).

##### Heap Profiling Without Change

| | 1 | 2 | 3 | 4 | 5 | avg |
| --- | --- | --- | --- | --- | --- | --- |
| Pre | 105.06 | 133.18 | 131.37 | 138.23 | 109.54 | |
| Post | 358.27 | 360.18 | 358.37 | crash | 358.55 | 358.84 |
| ArrayBuffer (rounded) | +246 | +246 | +252 | ? | +249 | |

##### Heap Profiling With Change

| | 1 | 2 | 3 | 4 | 5 | avg |
| --- | --- | --- | --- | --- | --- | --- |
| Pre | 105.27 | 129.89 | 132.73 | 104.91 | 140.80 | |
| Post | 356.56 | 361.50 | 353.16 | 350.45 | 351.80 | 354.69 |
| ArrayBuffer (rounded) | +248 | | | | | |

#### 300K QUERY

Query on 300K records. Instead of removing layer, query was cancelled.

##### Heap Profiling Without Change

| | 1 | 2 | 3 | 4 | 5 |
| --- | --- | --- | --- | --- | --- |
| Pre | 138.94 | 162.77 | 138.34 | 135.32 | 139.43 |
| Post | 227.43 | 226.60 | 218.82 | 222.72 | 223.06 |

##### Heap Profiling With Change

| | 1 | 2 | 3 | 4 | 5 |
| --- | --- | --- | --- | --- | --- |
| Pre | 117.34 | 105.68 | 159.62 | 131.27 | 131.14 |
| Post | 221.99 | 228.92 | 221.64 | 221.62 | 221.94 |