### PR TITLE
fix(position): fix whitespace and case before mgrs parse

### DIFF
--- a/src/os/ui/geo/geo.js
+++ b/src/os/ui/geo/geo.js
@@ -1,6 +1,7 @@
 goog.provide('os.ui.geo.geoDirective');
 goog.require('os.geo');
 goog.require('os.ui.Module');
+goog.require('os.ui.geo.mgrs');
 
 
 /**
@@ -37,7 +38,7 @@ os.ui.geo.geoLinkFn = function(scope, elm, attrs, ctrl) {
       valid = true;
     } else {
       try {
-        var m = osasm.toLonLat(val);
+        var m = os.ui.geo.mgrs(val);
         valid = goog.isArray(m) && m.length === 2;
       } catch (e) {
         valid = false;

--- a/src/os/ui/geo/mgrs.js
+++ b/src/os/ui/geo/mgrs.js
@@ -1,0 +1,15 @@
+goog.module('os.ui.geo.mgrs');
+goog.module.declareLegacyNamespace();
+
+const {MGRS_REGEXP} = goog.require('os.geo');
+
+/**
+ * @param {string} text
+ * @return {ol.Coordinate|undefined}
+ */
+exports = (text) => {
+  const mgrs = text.replace(/\s+/g, '').toUpperCase();
+  if (mgrs.match(MGRS_REGEXP)) {
+    return osasm.toLonLat(mgrs);
+  }
+};

--- a/src/os/ui/geo/position.js
+++ b/src/os/ui/geo/position.js
@@ -5,6 +5,7 @@ goog.provide('os.ui.geo.positionDirective');
 goog.require('os.geo');
 goog.require('os.ui.Module');
 goog.require('os.ui.geo.geoDirective');
+goog.require('os.ui.geo.mgrs');
 goog.require('os.ui.popover.popoverDirective');
 
 
@@ -189,19 +190,22 @@ os.ui.geo.PositionCtrl.prototype.destroy_ = function() {
  * @private
  */
 os.ui.geo.PositionCtrl.prototype.onPosText_ = function() {
-  if (this.scope_['posText']) {
-    var result = os.geo.parseLatLon(this.scope_['posText'], this.scope_['order']);
+  const text = this.scope_['posText'];
+  if (text) {
+    var result = os.geo.parseLatLon(text, this.scope_['order']);
     if (result != null && Math.abs(result.lat) > 90) {
       // If the result isnt in range, set it to null to invalidate form
       result = null;
     }
     if (result == null) {
       try {
-        var coord = osasm.toLonLat(this.scope_['posText']);
-        result = /** @type {!osx.geo.Location} */ ({
-          lon: coord[0],
-          lat: coord[1]
-        });
+        const coord = os.ui.geo.mgrs(text);
+        if (coord) {
+          result = /** @type {!osx.geo.Location} */ ({
+            lon: coord[0],
+            lat: coord[1]
+          });
+        }
       } catch (e) {
       }
     }

--- a/src/os/ui/search/place/coordinatesearch.js
+++ b/src/os/ui/search/place/coordinatesearch.js
@@ -11,6 +11,7 @@ goog.require('os.geo2');
 goog.require('os.search.AbstractSearch');
 goog.require('os.search.SearchEvent');
 goog.require('os.search.SearchEventType');
+goog.require('os.ui.geo.mgrs');
 goog.require('os.ui.search.place');
 goog.require('os.ui.search.place.CoordinateResult');
 
@@ -89,9 +90,8 @@ os.ui.search.place.CoordinateSearch.prototype.searchTerm = function(term, opt_st
         throw new Error(msg);
       }
     } else {
-      var mgrs = term.replace(/\s+/g, '').toUpperCase();
-      if (mgrs.match(os.geo.MGRS_REGEXP)) {
-        var coord = osasm.toLonLat(mgrs);
+      const coord = os.ui.geo.mgrs(term);
+      if (coord) {
         var feature = os.ui.search.place.createFeature({
           'geometry': new ol.geom.Point(coord).osTransform(),
           'label': term


### PR DESCRIPTION
`CoordinateSearch` strips whitespace, uppercases, and checks a regexp before sending the value off to `osasm`. Now the `position` field does that too.