### PR TITLE
Support multiple terrain providers

### DIFF
--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -177,7 +177,7 @@ osx.map.FlyToOptions;
  * @typedef {{
  *   id: string,
  *   title: string,
- *   type: (string|undefined),
+ *   type: string,
  *   url: (string|undefined),
  *   credit: (Cesium.Credit|string|undefined),
  *   maxLevel: (number|undefined),

--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -175,6 +175,8 @@ osx.map.FlyToOptions;
 
 /**
  * @typedef {{
+ *   id: string,
+ *   title: string,
  *   type: (string|undefined),
  *   url: (string|undefined),
  *   credit: (Cesium.Credit|string|undefined),

--- a/src/os/map/terrain.js
+++ b/src/os/map/terrain.js
@@ -3,8 +3,6 @@ goog.module.declareLegacyNamespace();
 
 const log = goog.require('goog.log');
 
-const Settings = goog.require('os.config.Settings');
-
 
 /**
  * Terrain event types.
@@ -50,13 +48,6 @@ const providers = [];
 
 
 /**
- * The active terrain provider.
- * @type {osx.map.TerrainProviderOptions|undefined}
- */
-let activeProvider = undefined;
-
-
-/**
  * If a terrain provider is available.
  * @return {boolean}
  */
@@ -84,12 +75,6 @@ const addTerrainProvider = (options) => {
     if (!providers.some((p) => p.id === options.id)) {
       providers.push(options);
       os.dispatcher.dispatchEvent(TerrainEventType.PROVIDERS);
-
-      // if the terrain provider was previously active, activate it now
-      const activeId = Settings.getInstance().get(TerrainSetting.ACTIVE_TERRAIN);
-      if (activeId && activeId === options.id) {
-        setActiveTerrainProvider(options);
-      }
     } else {
       log.warning(logger, `Ignoring duplicate terrain provider ${options.name} with id '${options.id}'`);
     }
@@ -106,48 +91,11 @@ const addTerrainProvider = (options) => {
 const getTerrainProviders = () => providers;
 
 
-/**
- * Get the active terrain provider.
- * @return {osx.map.TerrainProviderOptions|undefined}
- */
-const getActiveTerrainProvider = () => {
-  if (!activeProvider && providers.length) {
-    // if the active terrain provider has not yet been set, use the last one added. this ensures the last provider
-    // loaded from settings will be selected first.
-    activeProvider = providers[providers.length - 1];
-  }
-
-  return activeProvider;
-};
-
-
-/**
- * Set the active terrain provider.
- * @param {osx.map.TerrainProviderOptions|string} provider The new provider.
- */
-const setActiveTerrainProvider = (provider) => {
-  let newProvider;
-
-  if (typeof provider === 'string') {
-    newProvider = providers.find((p) => p.id === provider);
-  } else {
-    newProvider = provider;
-  }
-
-  if (newProvider && newProvider !== activeProvider) {
-    activeProvider = newProvider;
-    Settings.getInstance().set(TerrainSetting.ACTIVE_TERRAIN, activeProvider.id);
-  }
-};
-
-
 exports = {
   TerrainEventType,
   TerrainSetting,
   TerrainType,
   hasTerrain,
   addTerrainProvider,
-  getTerrainProviders,
-  getActiveTerrainProvider,
-  setActiveTerrainProvider
+  getTerrainProviders
 };

--- a/src/os/map/terrain.js
+++ b/src/os/map/terrain.js
@@ -1,0 +1,150 @@
+goog.module('os.map.terrain');
+goog.module.declareLegacyNamespace();
+
+const log = goog.require('goog.log');
+
+const Settings = goog.require('os.config.Settings');
+
+
+/**
+ * Terrain event types.
+ * @enum {string}
+ */
+const TerrainEventType = {
+  PROVIDERS: 'terrain:providers'
+};
+
+
+/**
+ * Terrain settings keys.
+ * @enum {string}
+ */
+const TerrainSetting = {
+  ACTIVE_TERRAIN: 'os.map.terrain.activeTerrainId'
+};
+
+
+/**
+ * Supported terrain types.
+ * @enum {string}
+ */
+const TerrainType = {
+  CESIUM: 'cesium',
+  ION: 'cesium-ion',
+  WMS: 'wms'
+};
+
+
+/**
+ * The module log.
+ * @type {log.Logger}
+ */
+const logger = log.getLogger('os.map.terrain');
+
+
+/**
+ * Terrain providers registered in the application.
+ * @type {!Array<!osx.map.TerrainProviderOptions>}
+ */
+const providers = [];
+
+
+/**
+ * The active terrain provider.
+ * @type {osx.map.TerrainProviderOptions|undefined}
+ */
+let activeProvider = undefined;
+
+
+/**
+ * If a terrain provider is available.
+ * @return {boolean}
+ */
+const hasTerrain = () => providers.length > 0;
+
+
+/**
+ * If terrain provider options are valid.
+ * @param {osx.map.TerrainProviderOptions} options The terrain provider options.
+ * @return {boolean}
+ */
+const isValidProvider = (options) => options != null && !!options.id && !!options.type;
+
+
+/**
+ * Add a terrain provider to the application.
+ * @param {!osx.map.TerrainProviderOptions} options The terrain provider options.
+ */
+const addTerrainProvider = (options) => {
+  if (isValidProvider(options)) {
+    if (!options.name) {
+      options.name = 'Unknown Terrain Provider';
+    }
+
+    if (!providers.some((p) => p.id === options.id)) {
+      providers.push(options);
+      os.dispatcher.dispatchEvent(TerrainEventType.PROVIDERS);
+
+      const activeId = Settings.getInstance().get(TerrainSetting.ACTIVE_TERRAIN);
+      if (activeId === options.id) {
+        setActiveTerrainProvider(options);
+      }
+    } else {
+      log.warning(logger, `Ignoring duplicate terrain provider ${options.name} with id '${options.id}'`);
+    }
+  } else {
+    log.error(logger, `Ignoring invalid terrain provider: '${JSON.stringify(options)}'`);
+  }
+};
+
+
+/**
+ * Get terrain providers registered with the application.
+ * @return {!Array<!osx.map.TerrainProviderOptions>}
+ */
+const getTerrainProviders = () => providers;
+
+
+/**
+ * Get the active terrain provider.
+ * @return {osx.map.TerrainProviderOptions|undefined}
+ */
+const getActiveTerrainProvider = () => {
+  if (!activeProvider && providers.length) {
+    activeProvider = providers[providers.length - 1];
+  }
+
+  return activeProvider;
+};
+
+
+/**
+ * Set the active terrain provider.
+ * @param {osx.map.TerrainProviderOptions|string} provider The new provider.
+ */
+const setActiveTerrainProvider = (provider) => {
+  let newProvider;
+
+  if (typeof provider === 'string') {
+    newProvider = providers.find((p) => p.id === provider);
+  } else {
+    newProvider = provider;
+  }
+
+  if (newProvider && newProvider !== activeProvider) {
+    activeProvider = newProvider;
+    Settings.getInstance().set(TerrainSetting.ACTIVE_TERRAIN, activeProvider.id);
+  }
+};
+
+
+exports = {
+  TerrainEventType,
+  TerrainSetting,
+  TerrainType,
+  hasTerrain,
+  addTerrainProvider,
+  getTerrainProviders,
+  getActiveTerrainProvider,
+  setActiveTerrainProvider
+};

--- a/src/os/map/terrain.js
+++ b/src/os/map/terrain.js
@@ -85,8 +85,9 @@ const addTerrainProvider = (options) => {
       providers.push(options);
       os.dispatcher.dispatchEvent(TerrainEventType.PROVIDERS);
 
+      // if the terrain provider was previously active, activate it now
       const activeId = Settings.getInstance().get(TerrainSetting.ACTIVE_TERRAIN);
-      if (activeId === options.id) {
+      if (activeId && activeId === options.id) {
         setActiveTerrainProvider(options);
       }
     } else {
@@ -111,6 +112,8 @@ const getTerrainProviders = () => providers;
  */
 const getActiveTerrainProvider = () => {
   if (!activeProvider && providers.length) {
+    // if the active terrain provider has not yet been set, use the last one added. this ensures the last provider
+    // loaded from settings will be selected first.
     activeProvider = providers[providers.length - 1];
   }
 

--- a/src/os/ui/menu/mapmenu.js
+++ b/src/os/ui/menu/mapmenu.js
@@ -2,6 +2,7 @@ goog.provide('os.ui.menu.map');
 
 goog.require('os.action.EventType');
 goog.require('os.legend');
+goog.require('os.map.terrain');
 goog.require('os.metrics.keys');
 goog.require('os.ui.events.UIEvent');
 goog.require('os.ui.menu.Menu');
@@ -236,7 +237,7 @@ os.ui.menu.map.onSky = function(event) {
  * @this {os.ui.menu.MenuItem}
  */
 os.ui.menu.map.updateTerrainItem = function() {
-  this.visible = os.MapContainer.getInstance().is3DEnabled() && os.config.isTerrainConfigured();
+  this.visible = os.MapContainer.getInstance().is3DEnabled() && os.map.terrain.hasTerrain();
   this.selected = !!os.settings.get(os.config.DisplaySetting.ENABLE_TERRAIN, false);
 };
 

--- a/src/os/webgl/abstractwebglrenderer.js
+++ b/src/os/webgl/abstractwebglrenderer.js
@@ -4,6 +4,7 @@ goog.require('goog.Disposable');
 goog.require('goog.Promise');
 goog.require('os.MapEvent');
 goog.require('os.config.DisplaySetting');
+goog.require('os.map.terrain');
 goog.require('os.webgl.IWebGLRenderer');
 
 
@@ -93,7 +94,7 @@ os.webgl.AbstractWebGLRenderer = function() {
     os.config.DisplaySetting.ENABLE_TERRAIN,
     os.config.DisplaySetting.FOG_ENABLED,
     os.config.DisplaySetting.FOG_DENSITY,
-    os.config.DisplaySetting.TERRAIN_OPTIONS
+    os.map.terrain.TerrainSetting.ACTIVE_TERRAIN
   ];
 
   /**
@@ -305,7 +306,7 @@ os.webgl.AbstractWebGLRenderer.prototype.onSettingChange = function(event) {
         this.setFogDensity(event.newVal);
       }
       break;
-    case os.config.DisplaySetting.TERRAIN_OPTIONS:
+    case os.map.terrain.TerrainSetting.ACTIVE_TERRAIN:
       if (this.getEnabled()) {
         this.updateTerrainProvider();
       }

--- a/src/plugin/basemap/basemapprovider.js
+++ b/src/plugin/basemap/basemapprovider.js
@@ -171,15 +171,18 @@ plugin.basemap.BaseMapProvider.prototype.addBaseMapFromConfig = function(config)
           //
           // TODO: terrain config is still set in base maps because we're adding a descriptor to inform the user that
           //       the controls for it have moved. after a release cycle, remove the descriptor and update configs to
-          //       use the new key (os.config.DisplaySetting.TERRAIN_OPTIONS).
+          //       use the new key (os.map.terrain.TerrainSetting.ACTIVE_TERRAIN).
           //
 
           // if multiple terrain descriptors are configured, the last one will win
           var terrainOptions = /** @type {osx.map.TerrainProviderOptions|undefined} */ (conf['options']);
           var terrainType = /** @type {string|undefined} */ (conf['baseType']);
           if (terrainOptions && terrainType) {
+            terrainOptions.id = id;
+            terrainOptions.title = conf['title'] || '';
             terrainOptions.type = terrainType;
-            os.settings.set(os.config.DisplaySetting.TERRAIN_OPTIONS, terrainOptions);
+
+            os.map.terrain.addTerrainProvider(terrainOptions);
           }
 
           // create a descriptor that will inform the user on where terrain was moved to

--- a/src/plugin/basemap/basemapprovider.js
+++ b/src/plugin/basemap/basemapprovider.js
@@ -168,13 +168,6 @@ plugin.basemap.BaseMapProvider.prototype.addBaseMapFromConfig = function(config)
       if (conf) {
         var type = conf['type'] ? conf['type'].toLowerCase() : null;
         if (type == plugin.basemap.TERRAIN_TYPE) {
-          //
-          // TODO: terrain config is still set in base maps because we're adding a descriptor to inform the user that
-          //       the controls for it have moved. after a release cycle, remove the descriptor and update configs to
-          //       use the new key (os.map.terrain.TerrainSetting.ACTIVE_TERRAIN).
-          //
-
-          // if multiple terrain descriptors are configured, the last one will win
           var terrainOptions = /** @type {osx.map.TerrainProviderOptions|undefined} */ (conf['options']);
           var terrainType = /** @type {string|undefined} */ (conf['baseType']);
           if (terrainOptions && terrainType) {
@@ -183,15 +176,6 @@ plugin.basemap.BaseMapProvider.prototype.addBaseMapFromConfig = function(config)
             terrainOptions.type = terrainType;
 
             os.map.terrain.addTerrainProvider(terrainOptions);
-          }
-
-          // create a descriptor that will inform the user on where terrain was moved to
-          var terrainId = this.getTerrainId();
-          var d = dm.getDescriptor(terrainId);
-          if (!d) {
-            d = new plugin.basemap.TerrainDescriptor();
-            d.setId(terrainId);
-            dm.addDescriptor(d);
           }
         } else if (type == plugin.basemap.TYPE) {
           var mapId = this.getId() + os.data.BaseDescriptor.ID_DELIMITER + id;
@@ -212,6 +196,17 @@ plugin.basemap.BaseMapProvider.prototype.addBaseMapFromConfig = function(config)
           d.updateActiveFromTemp();
         }
       }
+    }
+  }
+
+  if (os.map.terrain.hasTerrain()) {
+    // if at least one terrain provider has been loaded, add a descriptor to enable/disable terrain
+    var terrainId = this.getTerrainId();
+    var d = dm.getDescriptor(terrainId);
+    if (!d) {
+      d = new plugin.basemap.TerrainDescriptor();
+      d.setId(terrainId);
+      dm.addDescriptor(d);
     }
   }
 };
@@ -285,8 +280,6 @@ plugin.basemap.BaseMapProvider.prototype.getTerrainId = function() {
  *
  * @param {goog.events.Event} event The event.
  * @protected
- *
- * @todo Remove when the descriptor is no longer used.
  */
 plugin.basemap.BaseMapProvider.prototype.onTerrainDisabled = function(event) {
   var descriptor = os.dataManager.getDescriptor(this.getTerrainId());

--- a/src/plugin/basemap/terraindescriptor.js
+++ b/src/plugin/basemap/terraindescriptor.js
@@ -6,7 +6,7 @@ goog.require('plugin.basemap');
 
 
 /**
- * Placeholder descriptor to point users at the new terrain control location.
+ * Descriptor to activate/deactivate terrain from the Add Data window.
  *
  * @extends {os.data.BaseDescriptor}
  * @constructor
@@ -20,20 +20,13 @@ plugin.basemap.TerrainDescriptor = function() {
   this.setType(null);
   this.descriptorType = plugin.basemap.TERRAIN_ID;
 
-  /**
-   * Flag to prevent handling settings events triggered by this descriptor.
-   * @type {boolean}
-   * @private
-   */
-  this.ignoreSettingsEvents_ = false;
-
   os.settings.listen(os.config.DisplaySetting.ENABLE_TERRAIN, this.onTerrainChange_, false, this);
 };
 goog.inherits(plugin.basemap.TerrainDescriptor, os.data.BaseDescriptor);
 
 
 /**
- * Tell the user what happened to terrain.
+ * User-facing description.
  * @type {string}
  * @const
  */
@@ -61,9 +54,7 @@ plugin.basemap.TerrainDescriptor.prototype.getIcons = function() {
  * @inheritDoc
  */
 plugin.basemap.TerrainDescriptor.prototype.setActiveInternal = function() {
-  this.ignoreSettingsEvents_ = true;
   os.settings.set(os.config.DisplaySetting.ENABLE_TERRAIN, this.isActive());
-  this.ignoreSettingsEvents_ = false;
 
   return plugin.basemap.TerrainDescriptor.base(this, 'setActiveInternal');
 };
@@ -85,7 +76,7 @@ plugin.basemap.TerrainDescriptor.prototype.restore = function(from) {
  * @private
  */
 plugin.basemap.TerrainDescriptor.prototype.onTerrainChange_ = function(event) {
-  if (!this.ignoreSettingsEvents_ && event.newVal !== this.isActive()) {
+  if (event.newVal !== this.isActive()) {
     this.setActive(/** @type {boolean} */ (event.newVal));
   }
 };

--- a/src/plugin/cesium/cesium.js
+++ b/src/plugin/cesium/cesium.js
@@ -197,6 +197,7 @@ plugin.cesium.promptForAccessToken = function() {
       },
       cancel: reject,
       defaultValue: '',
+      limit: 2000,
       select: true,
       prompt: `
         This layer requires a Cesium Ion access token. If you do not have an access token, please

--- a/src/plugin/cesium/cesiumrenderer.js
+++ b/src/plugin/cesium/cesiumrenderer.js
@@ -524,7 +524,7 @@ plugin.cesium.CesiumRenderer.prototype.showSunlight = function(value) {
  */
 plugin.cesium.CesiumRenderer.prototype.showTerrain = function(value) {
   if (value) {
-    this.terrainPromise_ = this.getTerrainProvider().then((provider) => {
+    this.terrainPromise_ = this.createTerrainProvider().then((provider) => {
       this.terrainPromise_ = null;
       this.terrainProvider_ = provider;
 
@@ -562,13 +562,12 @@ plugin.cesium.CesiumRenderer.prototype.showTerrain = function(value) {
  * @protected
  */
 plugin.cesium.CesiumRenderer.prototype.registerTerrainProviderType = function(type, factory) {
-  type = type.toLowerCase();
-
   if (type in this.terrainProviderTypes_) {
     goog.log.error(this.log, 'The terrain provider type "' + type + '" already exists!');
     return;
   }
 
+  this.supportedTerrainTypes.push(type);
   this.terrainProviderTypes_[type] = factory;
 };
 
@@ -585,12 +584,12 @@ plugin.cesium.CesiumRenderer.prototype.disableTerrain = function() {
 
 
 /**
- * Get the terrain provider instance.
+ * Create a terrain provider instance for the active provider.
  * @return {!goog.Promise<Cesium.TerrainProvider>}
  * @protected
  */
-plugin.cesium.CesiumRenderer.prototype.getTerrainProvider = function() {
-  var terrainOptions = os.map.terrain.getActiveTerrainProvider();
+plugin.cesium.CesiumRenderer.prototype.createTerrainProvider = function() {
+  var terrainOptions = this.getActiveTerrainProvider();
   if (terrainOptions) {
     var terrainType = terrainOptions.type;
     if (terrainType && terrainType in this.terrainProviderTypes_) {

--- a/src/plugin/cesium/tiles/cesium3dtilesdescriptor.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesdescriptor.js
@@ -36,6 +36,13 @@ plugin.cesium.tiles.Descriptor = function() {
    * @protected
    */
   this.tileStyle = null;
+
+  /**
+   * If Cesium World Terrain should be activated with this layer.
+   * @type {boolean}
+   * @protected
+   */
+  this.useWorldTerrain = false;
 };
 goog.inherits(plugin.cesium.tiles.Descriptor, os.data.FileDescriptor);
 
@@ -67,6 +74,8 @@ plugin.cesium.tiles.Descriptor.prototype.getLayerOptions = function() {
   if (this.tileStyle) {
     options['tileStyle'] = this.tileStyle;
   }
+
+  options['useWorldTerrain'] = this.useWorldTerrain;
 
   return options;
 };
@@ -147,5 +156,9 @@ plugin.cesium.tiles.Descriptor.prototype.updateFromConfig = function(config, opt
 
   if (config['tileStyle'] != null) {
     this.tileStyle = /** @type {Object|string} */ (config['tileStyle']);
+  }
+
+  if (config['useWorldTerrain'] != null) {
+    this.useWorldTerrain = !!config['useWorldTerrain'];
   }
 };

--- a/test/plugin/basemap/basemapprovider.test.js
+++ b/test/plugin/basemap/basemapprovider.test.js
@@ -64,7 +64,10 @@ describe('plugin.basemap.BaseMapProvider', function() {
     expect(p.defaults_).toContain('two');
 
     // terrain is configured on the map
-    var terrainOptions = os.settings.get(os.map.terrain.TerrainSetting.ACTIVE_TERRAIN);
+    var providers = os.map.terrain.getTerrainProviders();
+    expect(providers.length).toBe(1);
+
+    var terrainOptions = providers[0];
     expect(terrainOptions).toBeDefined();
     expect(terrainOptions.url).toBe(expectedTerrainOptions.url);
     expect(terrainOptions.type).toBe(expectedTerrainType);

--- a/test/plugin/basemap/basemapprovider.test.js
+++ b/test/plugin/basemap/basemapprovider.test.js
@@ -1,4 +1,5 @@
 goog.require('goog.events.EventTarget');
+goog.require('os.map.terrain');
 goog.require('os.mock');
 goog.require('plugin.basemap.BaseMapProvider');
 
@@ -63,7 +64,7 @@ describe('plugin.basemap.BaseMapProvider', function() {
     expect(p.defaults_).toContain('two');
 
     // terrain is configured on the map
-    var terrainOptions = os.settings.get(os.config.DisplaySetting.TERRAIN_OPTIONS);
+    var terrainOptions = os.settings.get(os.map.terrain.TerrainSetting.ACTIVE_TERRAIN);
     expect(terrainOptions).toBeDefined();
     expect(terrainOptions.url).toBe(expectedTerrainOptions.url);
     expect(terrainOptions.type).toBe(expectedTerrainType);

--- a/views/config/displaysettings.html
+++ b/views/config/displaysettings.html
@@ -96,10 +96,19 @@
     <div class="form-group" ng-if="display.supportsTerrain()">
       <div class="form-check" title="{{display.help.terrain}}">
         <input class="form-check-input" id="terrainEnabled" type="checkbox" ng-model="display.terrainEnabled"
-            ng-change="display.updateTerrain()" >
+            ng-change="display.updateTerrainEnabled()" >
         <label class="form-check-label col-4 p-0" for="terrainEnabled">Enable Terrain</label>
         <popover x-title="'Enable Terrain'" content="display.help.terrain" pos="'right'"></popover>
       </div>
+    </div>
+    <div class="form-group" ng-if="display.supportsTerrain()">
+      <select class="custom-select col-6" id="terrainProvider"
+          title="Source for terrain data"
+          ng-disabled="!display.terrainEnabled"
+          ng-model="display.activeTerrainProvider"
+          ng-change="display.updateTerrainProvider()"
+          ng-options="provider as provider.title for provider in display.terrainProviders">
+      </select>
     </div>
     <div class="form-group" ng-if="display.supportsFog()">
       <div class="form-check" title="{{display.help.fog}}">

--- a/views/config/displaysettings.html
+++ b/views/config/displaysettings.html
@@ -101,10 +101,9 @@
         <popover x-title="'Enable Terrain'" content="display.help.terrain" pos="'right'"></popover>
       </div>
     </div>
-    <div class="form-group" ng-if="display.supportsTerrain()">
+    <div class="form-group" ng-if="display.supportsTerrain() && display.terrainProviders.length > 1">
       <select class="custom-select col-6" id="terrainProvider"
           title="Source for terrain data"
-          ng-disabled="!display.terrainEnabled"
           ng-model="display.activeTerrainProvider"
           ng-change="display.updateTerrainProvider()"
           ng-options="provider as provider.title for provider in display.terrainProviders">

--- a/views/window/confirmtext.html
+++ b/views/window/confirmtext.html
@@ -1,5 +1,5 @@
 <div ng-form="textForm">
-  <div class="form-group" ng-if="prompt">{{prompt}}</div>
+  <div class="form-group" ng-if="prompt" ng-bind-html="prompt"></div>
   <div>
     <label for="title" ng-if="formLabel" class="u-required">{{formLabel}}:</label>
     <div>


### PR DESCRIPTION
OpenSphere is currently limited to a single terrain provider, which is determined by the last config loaded from settings. As a user, it would be useful to switch between available providers and also configure custom terrain. This PR addresses the first of those concerns, exposing all configured (and supported) terrain providers through Settings > Map > Display.

**Testing Notes**

[OpenSphere](https://merciful-yarn.surge.sh/)

- In Settings > Map > Display, there should now be a list of supported terrain providers under the Enable Terrain checkbox. This is only displayed if multiple unique (by `id`) terrain layers have been configured.
- Changing the terrain provider should update the active provider in settings. If terrain is enabled, it should update the provider currently used by the renderer.
- When the OSM Buildings is activated, you should be prompted to enter a Cesium Ion access token and given instructions to do so. Add your token and click OK.
- If Cesium World Terrain isn't already the active terrain provider and enabled, you should be prompted to enable it. Clicking Yes should switch CWT to the active terrain and turn it on. If you have Settings open while this happens, you should see these changes in the UI. Clicking No should do nothing, and you shouldn't be prompted again (this choice is saved in settings).
- **Note:** The "Fake Terrain" provider will black out the globe if enabled because it's not a real terrain provider. This is an existing issue and not addressed in this PR. The provider is simply there to test the above.


**Changes for WebGL Renderers**

- `this.supportedTerrainTypes` was added to `AbstractWebGLRenderer`. Renderers should add their supported types to this list, so Display Settings can populate available options.
- `AbstractWebGLRenderer#getActiveTerrainProvider` should be used to get the options for the active terrain provider. For backward compatibility, these options are still saved to `os.config.DisplaySetting.TERRAIN_OPTIONS` which has been deprecated in favor of `os.map.terrain.TerrainSetting.ACTIVE_TERRAIN`.

**Changes for App Settings**

- Configured terrain should now define a `title` property, which is the user-facing name in settings. If a title is not provided, a generic default title will be used. The new `id` property comes from the existing object key in config.
- Cesium 3D Tile layers can now be configured to enable Cesium World Terrain when activated. In config, set `"useWorldTerrain": true` to enable this. When the layer is turned on, the user will be prompted to activate CWT if not already active, and supported. This is useful for layers like [OSM Buildings](https://cesium.com/content/cesium-osm-buildings/) that use similar elevation data as CWT.

**Additional Changes**

- The `confirmtext` directive now supports rendering HTML in the `prompt` text. This was added to support advanced markup in messages displayed to users. Specifically, the prompt to create/provide a Cesium Ion access token now links out to Ion.