### PR TITLE
fix(cesium): reuse icon resources in point converter

### DIFF
--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -3257,10 +3257,23 @@ Cesium.ImageryProvider.prototype.requestImage = function(x, y, level) {};
  */
 Cesium.ImageryProvider.loadImage = function(imageryProvider, url) {};
 
+
 /**
+ * @typedef {{
+ *   url: string,
+ *   queryParameters: (Object|undefined),
+ *   templateValues: (Object|undefined),
+ *   headers: (Object|undefined),
+ *   retryAttempts: (number|undefined)
+ * }}
+ */
+Cesium.ResourceOptions;
+
+/**
+ * @param {Cesium.ResourceOptions|string} options
  * @constructor
  */
-Cesium.Resource = function() {};
+Cesium.Resource = function(options) {};
 
 /**
  * @param {Cesium.Resource|string} resource
@@ -3285,8 +3298,8 @@ Cesium.Resource.prototype._makeRequest = function(options) {};
 Cesium.ResourceFetchImageOptions;
 
 /**
- * @param {Cesium.ResourceFetchImageOptions} options
- * @return {Promise<ImageBitmap|Image>|undefined}
+ * @param {Cesium.ResourceFetchImageOptions=} options
+ * @return {Promise<Cesium.ImageLike>|undefined}
  */
 Cesium.Resource.prototype.fetchImage = function(options) {}
 

--- a/src/plugin/cesium/sync/point.js
+++ b/src/plugin/cesium/sync/point.js
@@ -312,19 +312,34 @@ const updateSizeDynamicIconProperties = (style, bb) => {
 
 
 /**
+ * Map of icon src to Promise created with Cesium.Resource.fetchImage.
+ * @type {!Object<string, !Promise<Cesium.ImageLike>>}
+ */
+const iconPromises = {};
+
+
+/**
  *
  * @param {!(Point|MultiPoint)} geometry
  * @param {!OLIconStyle} style
  * @param {!VectorContext} context
  * @param {!(Cesium.Billboard|Cesium.optionsBillboardCollectionAdd)} bb
  * @param {number=} opt_index
- * @return {!Promise<HTMLCanvasElement>}
+ * @return {Promise<Cesium.ImageLike>}
  */
 const iconStyleToImagePromise = (geometry, style, context, bb, opt_index) => {
   bb.dirty = false;
   const src = style.getSrc() || '';
-  const resource = Cesium.Resource.createIfNeeded(src);
-  return resource.fetchImage();
+  let iconPromise = iconPromises[src];
+  if (!iconPromise) {
+    const resource = new Cesium.Resource(src);
+    iconPromise = resource.fetchImage();
+
+    if (iconPromise) {
+      iconPromises[src] = iconPromise;
+    }
+  }
+  return iconPromise || null;
 };
 
 

--- a/test/plugin/cesium/sync/pointconverter.test.js
+++ b/test/plugin/cesium/sync/pointconverter.test.js
@@ -205,4 +205,34 @@ describe('plugin.cesium.sync.PointConverter', () => {
 
     expect(billboard._image).toBe(image);
   });
+
+  it('should reuse image resources', () => {
+    style.setImage(new ol.style.Icon({
+      src: '/base/images/icons/pushpin/wht-pushpin.png'
+    }));
+
+    const createBillboard = () => {
+      const geometry = new ol.geom.Point([0, 0]);
+      const feature = new ol.Feature(geometry);
+      return pointConverter.create(feature, geometry, style, context);
+    };
+
+    createBillboard();
+    createBillboard();
+
+    const bb1 = context.billboards.get(0);
+    const bb2 = context.billboards.get(1);
+    expect(bb1._image).toBe(bb2._image);
+    expect(bb1._imageId).toBe(bb2._imageId);
+
+    style.setImage(new ol.style.Icon({
+      src: '/base/images/icons/pushpin/blue-pushpin.png'
+    }));
+
+    createBillboard();
+
+    const bb3 = context.billboards.get(2);
+    expect(bb1._image).not.toBe(bb3._image);
+    expect(bb1._imageId).not.toBe(bb3._imageId);
+  });
 });


### PR DESCRIPTION
`Cesium.Resource.createIfNeeded` will always create a new Resource if passed a string. This means we're creating a new Resource/Promise for every icon, whether we have loaded that icon already or not.

This change caches icons by `src`, so Promises will be reused when requesting an icon that has already been loaded.