### PR TITLE
fix(vector): unlisten if feature attempts to report changes after removal

### DIFF
--- a/src/os/mixin/eventtargetmixin.js
+++ b/src/os/mixin/eventtargetmixin.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Modifications to {@link ol.events.EventTarget}.
+ */
+goog.provide('os.mixin.events.EventTarget');
+
+goog.require('ol.events.EventTarget');
+
+
+/**
+ * Updates an event listener to be removed on its next attempted call after replacing it with no-op function.
+ *
+ * @param {string} type Type
+ * @param {ol.EventsListenerFunctionType} listener Event listener
+ */
+ol.events.EventTarget.prototype.removeEventListenerDelayed = function(type, listener) {
+  var listeners = this.listeners_[type];
+  if (listeners) {
+    var index = listeners.indexOf(listener);
+    if (type in this.pendingRemovals_) {
+      ++this.pendingRemovals_[type];
+    } else {
+      this.pendingRemovals_[type] = 1;
+    }
+    listeners[index] = ol.nullFunction;
+  }
+};

--- a/src/os/mixin/mixin.js
+++ b/src/os/mixin/mixin.js
@@ -14,6 +14,7 @@ goog.require('ol.renderer.canvas.VectorLayer');
 goog.require('os.mixin.ResolutionConstraint');
 goog.require('os.mixin.TileImage');
 goog.require('os.mixin.UrlTileSource');
+goog.require('os.mixin.events.EventTarget');
 goog.require('os.mixin.feature');
 goog.require('os.mixin.geometry');
 goog.require('os.mixin.layerbase');

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -518,6 +518,21 @@ os.source.Vector.prototype.changed = function() {
 
 
 /**
+ * @inheritDoc
+ * @suppress {accessControls}
+ */
+os.source.Vector.prototype.handleFeatureChange_ = function(event) {
+  var feature = /** @type {ol.Feature} */ (event.target);
+  var featureKey = ol.getUid(feature).toString();
+  if (featureKey && this.featureChangeKeys_[featureKey]) {
+    os.source.Vector.base(this, 'handleFeatureChange_', event);
+  } else {
+    feature.removeEventListener(ol.events.EventType.CHANGE, this.handleFeatureChange_);
+  }
+};
+
+
+/**
  * The listeners Openlayers adds are never used, and are a waste of memory. This trims some fat off each feature.
  *
  * @param {string} featureKey

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -518,21 +518,6 @@ os.source.Vector.prototype.changed = function() {
 
 
 /**
- * @inheritDoc
- * @suppress {accessControls}
- */
-os.source.Vector.prototype.handleFeatureChange_ = function(event) {
-  var feature = /** @type {ol.Feature} */ (event.target);
-  var featureKey = ol.getUid(feature).toString();
-  if (featureKey && this.featureChangeKeys_[featureKey]) {
-    os.source.Vector.base(this, 'handleFeatureChange_', event);
-  } else {
-    feature.removeEventListener(ol.events.EventType.CHANGE, this.handleFeatureChange_);
-  }
-};
-
-
-/**
  * The listeners Openlayers adds are never used, and are a waste of memory. This trims some fat off each feature.
  *
  * @param {string} featureKey
@@ -2002,6 +1987,8 @@ os.source.Vector.prototype.removeFeatureInternal = function(feature, opt_isBulk)
     this.featureCount_ = Math.max(this.featureCount_ - 1, 0);
     this.unprocessFeature(feature);
 
+    // Delay event listener deletion for performance gain, but still remove it from the feature
+    feature.removeEventListenerDelayed(ol.events.EventType.CHANGE, this.handleFeatureChange_);
     /** @type {Object} */ (this.featureChangeKeys_)[featureKey] = undefined;
 
     if (feature.id_ !== undefined) {


### PR DESCRIPTION
Resolves a problem caused by #1025 if features decide they want to update after their removal.

Now the listeners will be made to be OL's no-op function, and deleted if they are called again (following the call-once path).