### PR TITLE
refactor(wfs): adds plugin support for different WFS types

### DIFF
--- a/src/os/ogc/ogc.js
+++ b/src/os/ogc/ogc.js
@@ -51,6 +51,19 @@ os.ogc.COLOR_STYLE_REGEX = /(density)|(foreground color)/i;
 
 
 /**
+ * Typedef describing available WFS format types (GML, GeoJSON, etc.)
+ * @typedef {{
+ *   type: !string,
+ *   regex: !RegExp,
+ *   parser: !string,
+ *   priority: !number,
+ *   responseType: (string|undefined)
+ * }}
+ */
+os.ogc.WFSTypeConfig;
+
+
+/**
  * A validator function for requests which checks for OGC exceptions
  *
  * @param {ArrayBuffer|string} response

--- a/src/plugin/ogc/wfs/wfslayerconfig.js
+++ b/src/plugin/ogc/wfs/wfslayerconfig.js
@@ -357,49 +357,6 @@ plugin.ogc.wfs.WFSLayerConfig.prototype.addMappings = function(layer, options) {
 
 
 /**
- * The available WFS type config objects. Plugins can add supported parser types to this.
- * @type {Array<os.ogc.WFSTypeConfig>}
- */
-plugin.ogc.wfs.WFSLayerConfig.TYPE_CONFIGS = [
-  {
-    regex: /^application\/json$/,
-    parser: 'geojson',
-    type: 'geojson',
-    priority: 100
-  },
-  {
-    regex: /gml\/?3/i,
-    parser: 'gml',
-    type: 'gml3',
-    priority: 50
-  },
-  {
-    regex: /gml\/?2/i,
-    parser: 'gml',
-    type: 'gml2',
-    priority: -100
-  }
-];
-
-
-/**
- * Register a type config object.
- * @param {!os.ogc.WFSTypeConfig} config
- * @protected
- */
-plugin.ogc.wfs.WFSLayerConfig.registerType = function(config) {
-  const configs = plugin.ogc.wfs.WFSLayerConfig.TYPE_CONFIGS;
-
-  if (!configs.find((c) => c.type === config.type)) {
-    configs.push(config);
-  }
-
-  // sort them by priority, highest first
-  configs.sort((a, b) => goog.array.defaultCompare(b.priority, a.priority));
-};
-
-
-/**
  * @param {Object<string, *>} options
  * @return {Object} The type config to use.
  * @protected
@@ -437,7 +394,7 @@ plugin.ogc.wfs.WFSLayerConfig.prototype.getBestType = function(options) {
   }
 
   this.params.remove('outputformat');
-  return preferred[1];
+  return plugin.ogc.wfs.WFSLayerConfig.GML3_CONFIG;
 };
 
 
@@ -488,4 +445,68 @@ plugin.ogc.wfs.WFSLayerConfig.prototype.getSource = function(options) {
   var source = plugin.ogc.wfs.WFSLayerConfig.base(this, 'getSource', options);
   source.setLockable(this.lockable);
   return source;
+};
+
+
+/**
+ * Type config for GeoJSON parsing.
+ * @type {os.ogc.WFSTypeConfig}
+ */
+plugin.ogc.wfs.WFSLayerConfig.GEOJSON_CONFIG = {
+  regex: /^application\/json$/,
+  parser: 'geojson',
+  type: 'geojson',
+  priority: 100
+};
+
+
+/**
+ * Type config for GML3 parsing.
+ * @type {os.ogc.WFSTypeConfig}
+ */
+plugin.ogc.wfs.WFSLayerConfig.GML3_CONFIG = {
+  regex: /gml\/?3/i,
+  parser: 'gml',
+  type: 'gml3',
+  priority: 50
+};
+
+
+/**
+ * Type config for GML2 parsing.
+ * @type {os.ogc.WFSTypeConfig}
+ */
+plugin.ogc.wfs.WFSLayerConfig.GML2_CONFIG = {
+  regex: /gml\/?2/i,
+  parser: 'gml',
+  type: 'gml2',
+  priority: -100
+};
+
+
+/**
+ * The available WFS type config objects. Plugins can add supported parser types to this.
+ * @type {Array<os.ogc.WFSTypeConfig>}
+ */
+plugin.ogc.wfs.WFSLayerConfig.TYPE_CONFIGS = [
+  plugin.ogc.wfs.WFSLayerConfig.GEOJSON_CONFIG,
+  plugin.ogc.wfs.WFSLayerConfig.GML3_CONFIG,
+  plugin.ogc.wfs.WFSLayerConfig.GML2_CONFIG
+];
+
+
+/**
+ * Register a type config object.
+ * @param {!os.ogc.WFSTypeConfig} config
+ * @protected
+ */
+plugin.ogc.wfs.WFSLayerConfig.registerType = function(config) {
+  const configs = plugin.ogc.wfs.WFSLayerConfig.TYPE_CONFIGS;
+
+  if (!configs.find((c) => c.type === config.type)) {
+    configs.push(config);
+  }
+
+  // sort them by priority, highest first
+  configs.sort((a, b) => b.priority - a.priority);
 };

--- a/test/plugin/ogc/wfs/wfslayerconfig.test.js
+++ b/test/plugin/ogc/wfs/wfslayerconfig.test.js
@@ -2,6 +2,15 @@ goog.require('plugin.ogc.wfs.WFSLayerConfig');
 
 
 describe('plugin.ogc.wfs.WFSLayerConfig', function() {
+  const preferredTypes = plugin.ogc.wfs.WFSLayerConfig.TYPE_CONFIGS;
+  const avroConfig = {
+    regex: /^avro\/binary$/,
+    parser: 'avro',
+    type: 'avro',
+    priority: 500,
+    responseType: 'arraybuffer'
+  };
+
   it('should use provided outputformat given available supported server formats', function() {
     ['application/json', 'gml3', 'gml2'].forEach((format, i) => {
       const wfs = new plugin.ogc.wfs.WFSLayerConfig();
@@ -16,7 +25,7 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
 
       wfs.initializeConfig(config);
       const result = wfs.getBestType(config);
-      expect(result).toBe(i);
+      expect(result).toBe(preferredTypes[i]);
       expect(wfs.params.get('outputformat')).toBe(format);
     });
   });
@@ -34,7 +43,7 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
 
       wfs.initializeConfig(config);
       const result = wfs.getBestType(config);
-      expect(result).toBe(i);
+      expect(result).toBe(preferredTypes[i]);
       expect(wfs.params.get('outputformat')).toBe(format);
     });
   });
@@ -52,7 +61,7 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
 
     wfs.initializeConfig(config);
     const result = wfs.getBestType(config);
-    expect(result).toBe(0);
+    expect(result).toBe(preferredTypes[0]);
     expect(wfs.params.get('outputformat')).toBe('application/json');
   });
 
@@ -68,7 +77,7 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
 
     wfs.initializeConfig(config);
     const result = wfs.getBestType(config);
-    expect(result).toBe(1);
+    expect(result).toBe(preferredTypes[1]);
     expect(wfs.params.get('outputformat')).toBe(undefined);
   });
 
@@ -85,7 +94,31 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
 
     wfs.initializeConfig(config);
     const result = wfs.getBestType(config);
-    expect(result).toBe(0);
+    expect(result).toBe(preferredTypes[0]);
     expect(wfs.params.get('outputformat')).toBe('application/json');
+  });
+
+  it('should register new type configs and sort them by priority', function() {
+    plugin.ogc.wfs.WFSLayerConfig.registerType(avroConfig);
+
+    expect(preferredTypes.length).toBe(4);
+    expect(preferredTypes[0]).toBe(avroConfig);
+  });
+
+  it('should select new type configs if they match a layer', function() {
+    const wfs = new plugin.ogc.wfs.WFSLayerConfig();
+    const config = {
+      'url': 'https://example.com/geoserver/ogc',
+      'params': {
+        'typename': 'test#layer1',
+        'outputformat': 'avro/binary'
+      },
+      'formats': ['application/json', 'avro/binary', 'gml3', 'GML2']
+    };
+
+    wfs.initializeConfig(config);
+    const result = wfs.getBestType(config);
+    expect(result).toBe(avroConfig);
+    expect(wfs.params.get('outputformat')).toBe('avro/binary');
   });
 });

--- a/test/plugin/ogc/wfs/wfslayerconfig.test.js
+++ b/test/plugin/ogc/wfs/wfslayerconfig.test.js
@@ -1,3 +1,4 @@
+goog.require('goog.net.XhrIo');
 goog.require('plugin.ogc.wfs.WFSLayerConfig');
 
 
@@ -8,7 +9,7 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
     parser: 'avro',
     type: 'avro',
     priority: 500,
-    responseType: 'arraybuffer'
+    responseType: goog.net.XhrIo.ResponseType.ARRAY_BUFFER
   };
 
   it('should use provided outputformat given available supported server formats', function() {
@@ -120,5 +121,21 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
     const result = wfs.getBestType(config);
     expect(result).toBe(avroConfig);
     expect(wfs.params.get('outputformat')).toBe('avro/binary');
+  });
+
+  it('should respect the responseType defined on a type config', function() {
+    const wfs = new plugin.ogc.wfs.WFSLayerConfig();
+    const config = {
+      'url': 'https://example.com/geoserver/ogc',
+      'params': {
+        'typename': 'test#layer1',
+        'outputformat': 'avro/binary'
+      },
+      'formats': ['application/json', 'avro/binary', 'gml3', 'GML2']
+    };
+
+    wfs.initializeConfig(config);
+    const request = wfs.getRequest(config);
+    expect(request.getResponseType()).toBe(goog.net.XhrIo.ResponseType.ARRAY_BUFFER);
   });
 });


### PR DESCRIPTION
Adds the ability to register parser config/type detection for requesting and parsing different WFS formats.