### PR TITLE
fix(tuiedit): don't try to access scope after destroy

### DIFF
--- a/src/os/ui/text/tuieditor.js
+++ b/src/os/ui/text/tuieditor.js
@@ -249,7 +249,7 @@ os.ui.text.TuiEditorCtrl.prototype.onKeyboardEvent_ = function(event) {
 os.ui.text.TuiEditorCtrl.prototype.getWordCount = function() {
   var len = this['text'] ? this['text'].length : 0;
   var value = len;
-  if (this.scope['maxlength']) {
+  if (this.scope && this.scope['maxlength']) {
     value += ' / ' + this.scope['maxlength'];
   }
 


### PR DESCRIPTION
We're running a scope apply in the middle of destroying one of the forms that uses the tuieditor. 