### PR TITLE
feat(import): use manual mapping configs directly

### DIFF
--- a/src/plugin/file/geojson/geojsonlayerconfig.js
+++ b/src/plugin/file/geojson/geojsonlayerconfig.js
@@ -45,7 +45,8 @@ plugin.file.geojson.GeoJSONLayerConfig.prototype.getImporter = function(options)
       os.im.mapping.SemiMinorMapping.ID,
       os.im.mapping.time.DateTimeMapping.ID]);
   } else {
-    importer.setAutoMappings(this.parserConfig['mappings']);
+    // setAutoMappings() ignores manual configs (e.g. custom Datetime format) since it re-autodetects
+    importer.setExecMappings(this.parserConfig['mappings']);
   }
   return importer;
 };

--- a/src/plugin/file/gml/gmllayerconfig.js
+++ b/src/plugin/file/gml/gmllayerconfig.js
@@ -36,8 +36,9 @@ plugin.file.gml.GMLLayerConfig.prototype.initializeConfig = function(options) {
  */
 plugin.file.gml.GMLLayerConfig.prototype.getImporter = function(options) {
   var importer = plugin.file.gml.GMLLayerConfig.base(this, 'getImporter', options);
-  if (this.parserConfig['mappings'] != null) {
-    importer.setAutoMappings(this.parserConfig['mappings']);
+  if (this.parserConfig['mappings'] != null && this.parserConfig['mappings'].length) {
+    // setAutoMappings() ignores manual configs (e.g. custom Datetime format) since it re-autodetects
+    importer.setExecMappings(this.parserConfig['mappings']);
   } else {
     // there was no user interaction, so default the mappings to a set the importer would have used
     importer.selectAutoMappings([

--- a/src/plugin/file/shp/shplayerconfig.js
+++ b/src/plugin/file/shp/shplayerconfig.js
@@ -89,7 +89,10 @@ plugin.file.shp.SHPLayerConfig.prototype.createLayer = function(options) {
  */
 plugin.file.shp.SHPLayerConfig.prototype.getImporter = function(options) {
   var importer = plugin.file.shp.SHPLayerConfig.base(this, 'getImporter', options);
-  importer.setAutoMappings(this.parserConfig['mappings']);
+
+  // setAutoMappings() ignores manual configs (e.g. custom Datetime format) since it re-autodetects
+  importer.setExecMappings(this.parserConfig['mappings']);
+
   return importer;
 };
 


### PR DESCRIPTION
use mappings adjusted during import wizard instead of retrying the autodetects