### PR TITLE
build(webpack): adjust performance hints for larger assets

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,12 @@ module.exports = (env, argv) => {
         minSize: 0
       }
     },
+    performance: {
+      // In production, warn if the asset size exceeds 5MB
+      hints: isProduction ? 'warning' : false,
+      maxAssetSize: 5000000,
+      maxEntrypointSize: 5000000
+    },
     plugins: [
       new ClosurePlugin.LibraryPlugin({
         closureLibraryBase: require.resolve('google-closure-library/closure/goog/base'),


### PR DESCRIPTION
Adjusts [Webpack performance hints](https://webpack.js.org/configuration/performance/#performancehints) to allow larger assets. This may be further addressed in the future by chunking output, but that is not currently supported.