### PR TITLE
feat(search): match quoted terms and fix infinite loop without capture

### DIFF
--- a/src/os/search/searchtermfacet.js
+++ b/src/os/search/searchtermfacet.js
@@ -96,7 +96,7 @@ os.search.SearchTermFacet.prototype.getTexts = function(item) {
 
 
 /**
- * Get the terms from the search string.
+ * Get the terms from the search string. Terms are returned in lowercase, with duplicates removed.
  * @return {!Array<string>} The terms.
  * @protected
  */
@@ -109,7 +109,11 @@ os.search.SearchTermFacet.prototype.getTerms = function() {
       if (match) {
         // Index 1 in the array is the captured group if it exists
         // Index 0 is the matched text, which we use if no captured group exists
-        terms.push((match[1] ? match[1] : match[0]).toLowerCase());
+        // Don't allow empty terms.
+        const term = (match[1] ? match[1] : match[0]).trim().toLowerCase();
+        if (term) {
+          terms.push(term);
+        }
       }
       match = termRegex.exec(this.term_);
     }
@@ -128,47 +132,50 @@ os.search.SearchTermFacet.prototype.getTerms = function() {
  * @protected
  */
 os.search.SearchTermFacet.prototype.getScore = function(regex, text, opt_base = 3) {
-  var results = regex.exec(text);
-  if (results && results.length === 1) {
-    // Matched but there weren't any capture groups. Return the base score.
-    return opt_base;
-  }
-
-  // set up the term map
+  var results = regex ? regex.exec(text) : null;
   var terms = this.getTerms();
-  var termMap = {};
-
-  for (var i = 0, n = terms.length; i < n; i++) {
-    if (terms[i]) {
-      termMap[terms[i].toLowerCase()] = 0;
+  if (results && terms.length) {
+    if (results.length === 1) {
+      // Matched but there weren't any capture groups. Return the base score.
+      return opt_base;
     }
-  }
 
-  // check the text for matches
-  var score = 0;
-  while (results && results.length) {
-    for (i = 1, n = results.length; i < n; i++) {
-      score += opt_base * results[i].length / text.length;
+    // set up the term map
+    var termMap = {};
 
-      // if the result is in the term map, we will mark that term as found
-      var result = results[i].toLowerCase();
-      if (result in termMap) {
-        termMap[result] = 1;
+    for (var i = 0, n = terms.length; i < n; i++) {
+      if (terms[i]) {
+        termMap[terms[i].toLowerCase()] = 0;
       }
     }
-    results = regex.exec(text);
+
+    // Check the text for matches. If the match contains an empty string, this is indicative of a bad regex which can
+    // cause an infinite loop. Bail if that happens.
+    var score = 0;
+    while (results && results.length && !results.some((r) => !r)) {
+      for (i = 1, n = results.length; i < n; i++) {
+        score += opt_base * results[i].length / text.length;
+
+        // if the result is in the term map, we will mark that term as found
+        var result = results[i].toLowerCase();
+        if (result in termMap) {
+          termMap[result] = 1;
+        }
+      }
+      results = regex.exec(text);
+    }
+
+    // get the number of matched terms and the total number of terms
+    var termCount = 0;
+    var termTotal = 0;
+    for (var term in termMap) {
+      termCount += termMap[term];
+      termTotal++;
+    }
+
+    regex.lastIndex = 0;
+    return score * termCount / termTotal;
   }
 
-  // get the number of matched terms and the total number of terms
-  var termCount = 0;
-  var termTotal = 0;
-  for (var term in termMap) {
-    termCount += termMap[term];
-    termTotal++;
-  }
-
-  regex.lastIndex = 0;
-  return score * termCount / termTotal;
+  return 0;
 };
-
-

--- a/test/os/search/searchtermfacet.test.js
+++ b/test/os/search/searchtermfacet.test.js
@@ -1,6 +1,6 @@
 goog.require('os.search.SearchTermFacet');
 
-describe('os.search.SearchTermFacet', () => {
+ddescribe('os.search.SearchTermFacet', () => {
   const SearchTermFacet = goog.module.get('os.search.SearchTermFacet');
 
   const texts = [
@@ -37,6 +37,15 @@ describe('os.search.SearchTermFacet', () => {
 
   it('gets the list of terms', () => {
     let terms;
+
+    // Empty terms
+    facet.setTerm('');
+    terms = facet.getTerms();
+    expect(terms.length).toBe(0);
+
+    facet.setTerm('"   "');
+    terms = facet.getTerms();
+    expect(terms.length).toBe(0);
 
     // Single term
     facet.setTerm('Lorem');
@@ -117,5 +126,12 @@ describe('os.search.SearchTermFacet', () => {
     // Multiple quoted/unquoted terms
     facet.setTerm('"Lorem ipsum" fringilla "hendrerit nulla" rutrum');
     expect(facet.testInternal()).toBeCloseTo(5.8554438982070565, 10);
+
+    // Empty terms
+    facet.setTerm('');
+    expect(facet.testInternal()).toBe(0);
+
+    facet.setTerm('"  "');
+    expect(facet.testInternal()).toBe(0);
   });
 });

--- a/test/os/search/searchtermfacet.test.js
+++ b/test/os/search/searchtermfacet.test.js
@@ -1,0 +1,121 @@
+goog.require('os.search.SearchTermFacet');
+
+describe('os.search.SearchTermFacet', () => {
+  const SearchTermFacet = goog.module.get('os.search.SearchTermFacet');
+
+  const texts = [
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    'Aliquam congue erat, et hendrerit nulla fringilla varius.',
+    'Etiam rutrum odio id convallis aliquet.'
+  ];
+
+  let facet;
+
+  beforeEach(() => {
+    facet = new SearchTermFacet();
+    facet.getTexts = (item) => texts;
+  });
+
+  it('initializes', () => {
+    expect(facet.regex_).toBeNull();
+    expect(facet.term_).toBeNull();
+  });
+
+  it('sets the search term', () => {
+    facet.setTerm('');
+    expect(facet.regex_).toBeNull();
+    expect(facet.term_).toBeNull();
+
+    facet.setTerm('*');
+    expect(facet.regex_.toString()).toBe('/(?:)/gi');
+    expect(facet.term_).toBe('*');
+
+    facet.setTerm('Lorem ipsum');
+    expect(facet.regex_.toString()).toBe('/(lorem|ipsum)/gi');
+    expect(facet.term_).toBe('Lorem ipsum');
+  });
+
+  it('gets the list of terms', () => {
+    let terms;
+
+    // Single term
+    facet.setTerm('Lorem');
+    terms = facet.getTerms();
+    expect(terms.length).toBe(1);
+    expect(terms).toContain('lorem');
+
+    // Duplicates removed
+    facet.setTerm('Lorem lorem LOREM');
+    terms = facet.getTerms();
+    expect(terms.length).toBe(1);
+    expect(terms).toContain('lorem');
+
+    // Multiple terms
+    facet.setTerm('Lorem ipsum');
+    terms = facet.getTerms();
+    expect(terms.length).toBe(2);
+    expect(terms).toContain('lorem');
+    expect(terms).toContain('ipsum');
+
+    // Longer, quoted term
+    facet.setTerm('"Lorem ipsum"');
+    terms = facet.getTerms();
+    expect(terms.length).toBe(1);
+    expect(terms).toContain('lorem ipsum');
+
+    // Quoted duplicates removed
+    facet.setTerm('"Lorem ipsum" "LOREM IPSUM"');
+    terms = facet.getTerms();
+    expect(terms.length).toBe(1);
+    expect(terms).toContain('lorem ipsum');
+
+    // Quoted + unquoted term
+    facet.setTerm('"Lorem ipsum" aliquam');
+    terms = facet.getTerms();
+    expect(terms.length).toBe(2);
+    expect(terms).toContain('lorem ipsum');
+    expect(terms).toContain('aliquam');
+
+    // Multiple quoted terms
+    facet.setTerm('"Lorem ipsum" "hendrerit nulla"');
+    terms = facet.getTerms();
+    expect(terms.length).toBe(2);
+    expect(terms).toContain('lorem ipsum');
+    expect(terms).toContain('hendrerit nulla');
+
+    // Multiple quoted/unquoted terms
+    facet.setTerm('"Lorem ipsum" fringilla "hendrerit nulla" rutrum');
+    terms = facet.getTerms();
+    expect(terms.length).toBe(4);
+    expect(terms).toContain('lorem ipsum');
+    expect(terms).toContain('hendrerit nulla');
+    expect(terms).toContain('fringilla');
+    expect(terms).toContain('rutrum');
+  });
+
+  it('gets the score from an item', () => {
+    // Single term
+    facet.setTerm('Lorem');
+    expect(facet.testInternal()).toBeCloseTo(0.8928571428571429, 10);
+
+    // Multiple terms
+    facet.setTerm('Lorem ipsum');
+    expect(facet.testInternal()).toBeCloseTo(1.7857142857142858, 10);
+
+    // Longer, quoted term
+    facet.setTerm('"Lorem ipsum"');
+    expect(facet.testInternal()).toBeCloseTo(1.9642857142857142, 10);
+
+    // Multiple terms with/without quotes
+    facet.setTerm('"Lorem ipsum" aliquam');
+    expect(facet.testInternal()).toBeCloseTo(2.2102130325814535, 10);
+
+    // Multiple quoted terms
+    facet.setTerm('"Lorem ipsum" "hendrerit nulla"');
+    expect(facet.testInternal()).toBeCloseTo(3.6137218045112784, 10);
+
+    // Multiple quoted/unquoted terms
+    facet.setTerm('"Lorem ipsum" fringilla "hendrerit nulla" rutrum');
+    expect(facet.testInternal()).toBeCloseTo(5.8554438982070565, 10);
+  });
+});


### PR DESCRIPTION
This addresses a few issues in `os.search.SearchTermFacet`.

- Quoted terms did not work properly because terms were simply split on spaces.
- Searching for `*` freezes the app because of an infinite loop in `getScore`.

**Testing**

[OpenSphere (branch)](https://marvelous-quiver.surge.sh/)
[OpenSphere (master)](https://master-branch-opensphere-ngageoint.surge.sh/)

Try whatever terms come to mind. Here are some examples that isolate fixes in this PR.

- `street map` should return results matching `street` or `map`.
- `"street map"` should return results matching `street map`.
- `*` should return all layers. This previously froze the app in an infinite loop.
 