### PR TITLE
test(ng): preprocess angular templates so directives may be tested

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,8 +33,10 @@ module.exports = function(config) {
       {pattern: resolver.resolveModulePath('opensphere-asm/dist/os-load.js', __dirname), watched: false, included: true, served: true},
       {pattern: resolver.resolveModulePath('jquery/dist/jquery.min.js', __dirname), watched: false, included: true, served: true},
       {pattern: resolver.resolveModulePath('angular/angular.min.js', __dirname), watched: false, included: true, served: true},
+      {pattern: resolver.resolveModulePath('angular-animate/angular-animate.js', __dirname), watched: false, included: true, served: true},
       {pattern: resolver.resolveModulePath('angular-sanitize/angular-sanitize.min.js', __dirname), watched: false, included: true, served: true},
       {pattern: resolver.resolveModulePath('angular-mocks/angular-mocks.js', __dirname), watched: false, included: true, served: true},
+      {pattern: 'vendor/angular-ui/angular-ui.js', watched: false, included: true, served: true},
       {pattern: resolver.resolveModulePath('d3/d3.min.js', __dirname), watched: false, included: true, served: true},
       {pattern: resolver.resolveModulePath('jsts/dist/jsts.min.js', __dirname), watched: false, included: true, served: true},
       {pattern: resolver.resolveModulePath('proj4/dist/proj4.js', __dirname), watched: false, included: true, served: true},
@@ -63,6 +65,9 @@ module.exports = function(config) {
 
       // initialization to run prior to tests
       'test/init.js',
+
+      // Load Angular templates. These will be preprocessed into JS by ng-html2js.
+      'views/**/*.html',
 
       // test resources
       {pattern: 'test/**/*.test.worker.js', included: false},
@@ -111,7 +116,17 @@ module.exports = function(config) {
       'src/**/*.js': ['googmodule', 'coverage'],
       'test/**/*.mock.js': ['googmodule'],
       // support goog.module in Closure library
-      [`${closureLibJsPattern}`]: ['googmodule']
+      [`${closureLibJsPattern}`]: ['googmodule'],
+      // preprocess Angular templates
+      'views/**/*.html': ['ng-html2js']
+    },
+
+    //
+    // Angular template preprocessor.
+    //
+    ngHtml2JsPreprocessor: {
+      // Prepend os.ROOT to the preprocessed template path
+      prependPrefix: '../opensphere/'
     },
 
     junitReporter: {

--- a/package.json
+++ b/package.json
@@ -281,6 +281,7 @@
     "karma-googmodule-preprocessor": "^1.0.1",
     "karma-jasmine": "^0.1.0",
     "karma-junit-reporter": "^1.2.0",
+    "karma-ng-html2js-preprocessor": "^1.0.0",
     "lolex": "=2.3.2",
     "mkdirp": "^0.5.1",
     "node-sass": "^4.12.0",

--- a/src/os/ui/menu/menubutton.js
+++ b/src/os/ui/menu/menubutton.js
@@ -148,7 +148,9 @@ os.ui.menu.MenuButtonCtrl.prototype.isWindowActive = function(opt_flag) {
 
   if (flag) {
     var s = angular.element(os.ui.windowSelector.CONTAINER).scope();
-    return os.ui.window.exists(flag) || (s['mainCtrl'] && s['mainCtrl'][flag]);
+    if (s) {
+      return os.ui.window.exists(flag) || (s['mainCtrl'] && s['mainCtrl'][flag]);
+    }
   }
 
   return false;

--- a/test/os/os.mock.js
+++ b/test/os/os.mock.js
@@ -50,8 +50,11 @@ beforeEach(function() {
   }
 
   if (!os.ui.injector) {
-    inject(function($injector) {
-      os.ui.injector = $injector;
+    // Register the injector after the call stack clears so tests may call angular.mock.module.
+    setTimeout(() => {
+      inject(function($injector) {
+        os.ui.injector = $injector;
+      });
     });
   }
 

--- a/test/os/ui/settingsbutton.test.js
+++ b/test/os/ui/settingsbutton.test.js
@@ -1,0 +1,32 @@
+goog.require('os.ui.settingsButtonDirective');
+
+describe('os.ui.settingsButtonDirective', () => {
+  let controller;
+  let scope;
+
+  // Load the Angular module
+  beforeEach(module('app'));
+
+  beforeEach(inject(($compile, $rootScope) => {
+    scope = $rootScope.$new(true);
+    const $element = angular.element(`<settings-button></settings-button>`);
+    $compile($element)(scope);
+    scope.$apply();
+
+    controller = $element.controller('settings-button');
+  }));
+
+  afterEach(() => {
+    scope.$destroy();
+  });
+
+  it('should initialize', () => {
+    expect(controller.flag).toBe('settings');
+  });
+
+  it('should toggle settings on click', () => {
+    spyOn(controller, 'toggle');
+    controller.element.click();
+    expect(controller.toggle).toHaveBeenCalled();
+  });
+});

--- a/test/os/ui/window/confirm.test.js
+++ b/test/os/ui/window/confirm.test.js
@@ -1,0 +1,128 @@
+goog.require('goog.events.KeyCodes');
+goog.require('os.defines');
+goog.require('os.ui.window.ConfirmUI');
+
+describe('os.ui.window.ConfirmUI', () => {
+  const KeyCodes = goog.module.get('goog.events.KeyCodes');
+
+  let compile;
+  let rootScope;
+  let controller;
+  let scope;
+
+  /**
+   * Initialize the Angular component.
+   * @param {Object=} opt_scope Properties to assign to the scope.
+   */
+  const initComponent = (opt_scope = {}) => {
+    destroyComponent();
+
+    scope = Object.assign(rootScope.$new(true), opt_scope);
+
+    const $element = angular.element(`<confirm></confirm>`);
+    compile($element)(scope);
+    scope.$apply();
+
+    controller = $element.controller('confirm');
+  };
+
+  /**
+   * Destroy the Angular component.
+   */
+  const destroyComponent = () => {
+    if (scope) {
+      scope.$destroy();
+      scope = null;
+      controller = null;
+    }
+  };
+
+  // Load the Angular module and template
+  beforeEach(module('app'));
+  beforeEach(module(`${os.ROOT}views/window/confirm.html`));
+
+  beforeEach(inject(($compile, $rootScope) => {
+    compile = $compile;
+    rootScope = $rootScope;
+  }));
+
+  afterEach(() => {
+    destroyComponent();
+  });
+
+  it('should initialize', () => {
+    initComponent();
+    expect(controller.scope_.valid).toBe(true);
+
+    initComponent({valid: false});
+    expect(controller.scope_.valid).toBe(false);
+  });
+
+  it('should clean up on scope $destroy', () => {
+    initComponent();
+    scope.$destroy();
+
+    expect(controller.scope_).toBeNull();
+    expect(controller.element_).toBeNull();
+    expect(controller.keyHandler_.isDisposed()).toBe(true);
+  });
+
+  it('should fire a callback and close when cancelled', () => {
+    let called = false;
+    initComponent({
+      cancelCallback: () => {
+        called = true;
+      }
+    });
+
+    spyOn(controller, 'close_');
+
+    controller.cancel();
+
+    expect(called).toBe(true);
+    expect(controller.close_).toHaveBeenCalled();
+  });
+
+  it('should fire a callback and close when confirmed', () => {
+    const expected = 'It works!';
+    let confirmValue;
+
+    initComponent({
+      confirmCallback: (value) => {
+        confirmValue = value;
+      },
+      confirmValue: expected
+    });
+
+    spyOn(controller, 'close_');
+
+    controller.confirm();
+
+    expect(confirmValue).toBe(expected);
+    expect(controller.close_).toHaveBeenCalled();
+  });
+
+  it('should fire a callback on checkbox change', () => {
+    let checkValue;
+
+    initComponent({
+      checkboxCallback: (value) => {
+        checkValue = value;
+      }
+    });
+
+    controller.updateCheckbox(true);
+    expect(checkValue).toBe(true);
+
+    controller.updateCheckbox(false);
+    expect(checkValue).toBe(false);
+  });
+
+  it('should close on Escape keypress', () => {
+    initComponent();
+
+    spyOn(controller, 'cancel');
+    controller.handleKeyEvent_({keyCode: KeyCodes.ESC});
+    expect(controller.cancel).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Unit testing directives was not fully functional for a few reasons:

- Directives using `templateUrl` cannot be loaded in tests because the URL will not be correct in Karma. [It is recommended](https://docs.angularjs.org/guide/unit-testing#testing-directives-with-external-templates) to use [a Karma preprocessor](https://github.com/karma-runner/karma-ng-html2js-preprocessor) to preload templates and add them to the `$templateCache`. This preprocessor has been added/configured.
- The `os.ui` module could not be loaded because dependent modules `ui.directives` and `ngAnimate` were not available in Karma. Fixed by loading those libraries in the Karma config.
- `os.mock.js` was calling `inject` in `beforeEach`, which prevents tests from loading modules/templates in their own `beforeEach`, because `angular.module` cannot be called after the injector is created. This was resolved by setting the global injector in a timeout.

I have added examples of unit testing directives with both `template` and `templateUrl` in this PR.