### PR TITLE
fix(test): fixes issue where injector is assigned too late

### DIFF
--- a/test/os/os.mock.js
+++ b/test/os/os.mock.js
@@ -50,11 +50,8 @@ beforeEach(function() {
   }
 
   if (!os.ui.injector) {
-    // Register the injector after the call stack clears so tests may call angular.mock.module.
-    setTimeout(() => {
-      inject(function($injector) {
-        os.ui.injector = $injector;
-      });
+    inject(function($injector) {
+      os.ui.injector = $injector;
     });
   }
 


### PR DESCRIPTION
Moves the injector assignment out of the `setTimeout`. There were cases where it wasn't registered in time for when it was needed, causing tests to fail.