### PR TITLE
test(init): add test suite to verify globals are initialized

### DIFF
--- a/test/os/os.mock.js
+++ b/test/os/os.mock.js
@@ -37,6 +37,10 @@ goog.require('test.os.config.SettingsUtil');
 angular.element(document.body).append('<div id="map-container"></div');
 
 beforeEach(function() {
+  const Settings = goog.module.get('os.config.Settings');
+
+  const settings = Settings.getInstance();
+
   // the bracket notation gets the compiler to quit complaining about this
   os['config']['appNs'] = 'unittest';
 
@@ -55,12 +59,12 @@ beforeEach(function() {
     });
   }
 
-  if (!os.settings.isLoaded() || !os.settings.isInitialized()) {
-    os.settings.getStorageRegistry().addStorage(new os.config.storage.SettingsObjectStorage(['unit']));
-    test.os.config.SettingsUtil.initAndLoad(os.settings);
+  if (!settings.isLoaded() || !settings.isInitialized()) {
+    settings.getStorageRegistry().addStorage(new os.config.storage.SettingsObjectStorage(['unit']));
+    test.os.config.SettingsUtil.initAndLoad(settings);
 
     waitsFor(function() {
-      return os.settings.isLoaded() && os.settings.isInitialized();
+      return settings.isLoaded() && settings.isInitialized();
     });
   }
 
@@ -69,12 +73,12 @@ beforeEach(function() {
 
   runs(function() {
     // vector source will need this
-    if (!os.settings.get('maxFeatures.2d')) {
-      os.settings.set('maxFeatures.2d', 50000);
+    if (!settings.get('maxFeatures.2d')) {
+      settings.set('maxFeatures.2d', 50000);
     }
 
-    if (!os.settings.get('maxFeatures.3d')) {
-      os.settings.set('maxFeatures.3d', 150000);
+    if (!settings.get('maxFeatures.3d')) {
+      settings.set('maxFeatures.3d', 150000);
     }
 
     if (!os.dataManager || !os.osDataManager) {
@@ -106,6 +110,25 @@ beforeEach(function() {
     if (!os.settingsManager) {
       os.settingsManager = os.ui.config.SettingsManager.getInstance();
     }
+  });
+});
+
+
+//
+// Verify test initialization is complete.
+//
+// If UI tests are using ddescribe or iit, this must also be included to ensure angular.mock.module calls succeed.
+//
+describe('OpenSphere Test Initialization', () => {
+  const Settings = goog.module.get('os.config.Settings');
+
+  const settings = Settings.getInstance();
+
+  it('initializes globals for tests', () => {
+    expect(settings.isLoaded()).toBe(true);
+    expect(settings.isInitialized()).toBe(true);
+
+    expect(os.ui.injector).toBeDefined();
   });
 });
 


### PR DESCRIPTION
The global injector instance is added with `angular.mock.inject`, which must be called after all calls to `angular.mock.module` for the current test suite. This currently doesn't cause problems when running all tests, because we only call `inject` if the global injector isn't set yet. So long as the first test that runs does not use `angular.mock.module`, future tests will be fine.

This becomes a problem when using `ddescribe` or `iit` in a UI test, because only that test will run and the `inject` call in `os.mock.js` will precede the `module` calls in the UI test. This PR offers a solution to that by providing a test suite that can also be included via `ddescribe` to ensure the UI test runs normally.

While this is a bit of a workaround, it does work with existing tests. A more complete solution would stop setting the global injector in `beforeEach`, provide a function to register it, and require UI tests to call that after they register their modules.