### PR TITLE
fix(mapping): execute rename mapping on falsey values

### DIFF
--- a/src/os/im/mapping/renamemapping.js
+++ b/src/os/im/mapping/renamemapping.js
@@ -80,7 +80,7 @@ os.im.mapping.RenameMapping.prototype.getFieldsChanged = function() {
 os.im.mapping.RenameMapping.prototype.execute = function(item) {
   if (this.field && this.toField && this.toField != this.field) {
     var current = os.im.mapping.getItemField(item, this.field);
-    if (current) {
+    if (current != null) {
       os.im.mapping.setItemField(item, this.toField, current);
 
       if (!this.keepOriginal) {

--- a/test/os/im/mapping/renamemapping.test.js
+++ b/test/os/im/mapping/renamemapping.test.js
@@ -36,6 +36,26 @@ describe('os.im.mapping.RenameMapping', function() {
     expect(record.TestField).toBe(true);
   });
 
+  it('should rename with falsey values', function() {
+    const values = [false, 0, ''];
+    values.forEach((v) => {
+      const record = {TestField: v};
+      rm.execute(record);
+      expect(record.ResultField).toBe(v);
+      expect(record.TestField).toBe(undefined);
+    });
+  });
+
+  it('should not rename with null/undefined values', function() {
+    const values = [null, undefined];
+    values.forEach((v) => {
+      const record = {TestField: v};
+      rm.execute(record);
+      expect(record.hasOwnProperty('ResultField')).toBe(false);
+      expect(record.TestField).toBe(v);
+    });
+  });
+
   it('should report a null sosType (meaning no autodetection)', function() {
     expect(rm.getScoreType()).toBe(os.im.mapping.DEFAULT_SCORETYPE);
   });


### PR DESCRIPTION
The rename mapping will not be executed with falsey values like `false`, `0`, and an empty string. I believe this was only intended to handle the null/undefined case.