### PR TITLE
test(ng): simplify angular template load in tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -124,9 +124,18 @@ module.exports = function(config) {
     //
     // Angular template preprocessor.
     //
+    // In debug/tests, templateUrl paths have os.ROOT prepended. This config adds each preloaded template to the
+    // template cache using the debug path so Angular will not try to request it.
+    //
+    // Tests using Angular directives should load this module before each test with:
+    //
+    //   beforeEach(module('app'));
+    //
     ngHtml2JsPreprocessor: {
       // Prepend os.ROOT to the preprocessed template path
-      prependPrefix: '../opensphere/'
+      prependPrefix: '../opensphere/',
+      // Register templates with the 'app' module
+      moduleName: 'app'
     },
 
     junitReporter: {

--- a/src/os/ui/window/confirm.js
+++ b/src/os/ui/window/confirm.js
@@ -143,16 +143,12 @@ class Controller {
     $timeout(function() {
       $scope.$emit(WindowEventType.READY);
     });
-
-    $scope.$on('$destroy', this.onDestroy_.bind(this));
   }
 
   /**
-   * Clean up
-   *
-   * @private
+   * Angular $onDestroy lifecycle hook.
    */
-  onDestroy_() {
+  $onDestroy() {
     goog.dispose(this.keyHandler_);
 
     this.element_ = null;

--- a/test/os/ui/settingsbutton.test.js
+++ b/test/os/ui/settingsbutton.test.js
@@ -2,6 +2,7 @@ goog.require('os.ui.settingsButtonDirective');
 
 describe('os.ui.settingsButtonDirective', () => {
   let controller;
+  let element;
   let scope;
 
   // Load the Angular module
@@ -9,11 +10,11 @@ describe('os.ui.settingsButtonDirective', () => {
 
   beforeEach(inject(($compile, $rootScope) => {
     scope = $rootScope.$new(true);
-    const $element = angular.element(`<settings-button></settings-button>`);
-    $compile($element)(scope);
+    element = angular.element(`<settings-button></settings-button>`);
+    $compile(element)(scope);
     scope.$apply();
 
-    controller = $element.controller('settings-button');
+    controller = element.controller('settings-button');
   }));
 
   afterEach(() => {
@@ -21,12 +22,34 @@ describe('os.ui.settingsButtonDirective', () => {
   });
 
   it('should initialize', () => {
+    expect(controller.scope).toBeDefined();
+    expect(controller.scope.$parent).toBe(scope);
+    expect(controller.element[0]).toBe(element[0]);
     expect(controller.flag).toBe('settings');
+  });
+
+  it('should dispose on scope $destroy', () => {
+    scope.$destroy();
+
+    expect(controller.scope).toBeNull();
+    expect(controller.element).toBeNull();
   });
 
   it('should toggle settings on click', () => {
     spyOn(controller, 'toggle');
     controller.element.click();
     expect(controller.toggle).toHaveBeenCalled();
+  });
+
+  it('should be active when the window is open', () => {
+    let isActive = false;
+    spyOn(controller, 'isWindowActive').andCallFake(() => isActive);
+
+    scope.$apply();
+    expect(element.hasClass('active')).toBe(false);
+
+    isActive = true;
+    scope.$apply();
+    expect(element.hasClass('active')).toBe(true);
   });
 });

--- a/test/os/ui/window/confirm.test.js
+++ b/test/os/ui/window/confirm.test.js
@@ -8,6 +8,7 @@ describe('os.ui.window.ConfirmUI', () => {
   let compile;
   let rootScope;
   let controller;
+  let element;
   let scope;
 
   /**
@@ -19,11 +20,11 @@ describe('os.ui.window.ConfirmUI', () => {
 
     scope = Object.assign(rootScope.$new(true), opt_scope);
 
-    const $element = angular.element(`<confirm></confirm>`);
-    compile($element)(scope);
+    element = angular.element(`<confirm></confirm>`);
+    compile(element)(scope);
     scope.$apply();
 
-    controller = $element.controller('confirm');
+    controller = element.controller('confirm');
   };
 
   /**
@@ -37,9 +38,8 @@ describe('os.ui.window.ConfirmUI', () => {
     }
   };
 
-  // Load the Angular module and template
+  // Load the Angular module
   beforeEach(module('app'));
-  beforeEach(module(`${os.ROOT}views/window/confirm.html`));
 
   beforeEach(inject(($compile, $rootScope) => {
     compile = $compile;
@@ -52,7 +52,10 @@ describe('os.ui.window.ConfirmUI', () => {
 
   it('should initialize', () => {
     initComponent();
+    expect(controller.scope_).toBeDefined();
+    expect(controller.scope_.$parent).toBe(scope);
     expect(controller.scope_.valid).toBe(true);
+    expect(controller.element_[0]).toBe(element[0]);
 
     initComponent({valid: false});
     expect(controller.scope_.valid).toBe(false);
@@ -65,6 +68,37 @@ describe('os.ui.window.ConfirmUI', () => {
     expect(controller.scope_).toBeNull();
     expect(controller.element_).toBeNull();
     expect(controller.keyHandler_.isDisposed()).toBe(true);
+  });
+
+  it('should create yes/no buttons from scope options', () => {
+    const options = {
+      yesText: 'Yes Test',
+      yesIcon: 'fa-yep',
+      yesButtonTitle: 'Yes tooltip',
+      noText: 'No Test',
+      noIcon: 'fa-nope',
+      noButtonTitle: 'No tooltip'
+    };
+
+    initComponent(options);
+
+    const yesButton = element.find('button[type="submit"]');
+    expect(yesButton.length).toBe(1);
+    expect(yesButton[0].innerText.trim()).toBe(options.yesText);
+    expect(yesButton[0].title).toBe(options.yesButtonTitle);
+    expect(yesButton.find('i').hasClass(options.yesIcon)).toBe(true);
+
+    let noButton = element.find('button[type="button"]');
+    expect(noButton.length).toBe(1);
+    expect(noButton[0].innerText.trim()).toBe(options.noText);
+    expect(noButton[0].title).toBe(options.noButtonTitle);
+    expect(noButton.find('i').hasClass(options.noIcon)).toBe(true);
+
+    options.hideCancel = true;
+    initComponent(options);
+
+    noButton = element.find('button[type="button"]');
+    expect(noButton.length).toBe(0);
   });
 
   it('should fire a callback and close when cancelled', () => {


### PR DESCRIPTION
The current [`karma-ng-html2js-preprocessor`](https://github.com/karma-runner/karma-ng-html2js-preprocessor) configuration registers templates by their file path, which requires loading them in tests with `beforeEach(module(<path>))`. This change registers them with the `app` module, so tests only need to call `beforeEach(module('app'))` to load all available templates.

Tests were added/updated to verify templates are being compiled/linked appropriately, including using the `$onDestroy` lifecycle hook in the `confirm` directive instead of listening to the scope `$destroy` event. The old listener was private, so this is a non-breaking change.

**Note for other projects:**

This configuration assumes all loaded directives have the `../opensphere/` prefix in their `templateUrl`, which is true within OpenSphere. Apps/plugins/libraries that reference templates from OpenSphere or other external projects in their tests will need to use `cacheIdFromPath` to register the appropriate path for each template. For example:

```
files: [
  ...
  // Load Angular templates.
  'views/**/*.html',
  path.join(resolved['opensphere'], 'views/**/*.html'),
  ...
],
preprocessors: {
  ...
  // Preprocess all views in the workspace
  '../**/views/**/*.html': ['ng-html2js']
},
ngHtml2JsPreprocessor: {
  cacheIdFromPath: (filepath) => {
    let cacheId = path.relative(__dirname, filepath);
    if (cacheId.startsWith('views')) {
      cacheId = path.join('..', path.basename(__dirname), cacheId);
    }
    return cacheId;
  },
  moduleName: 'app'
}
```

This ensures all templates are registered in the template cache using the appropriate relative debug path.