### PR TITLE
fix: fix url modifier with multiple configs

### DIFF
--- a/src/os/net/urlmodifier.js
+++ b/src/os/net/urlmodifier.js
@@ -28,8 +28,6 @@ os.net.URLModifier.replace_ = [];
  * @param {?Object<string, string>} options
  */
 os.net.URLModifier.configure = function(options) {
-  os.net.URLModifier.replace_.length = 0;
-
   if (options) {
     for (var pattern in options) {
       os.net.URLModifier.replace_.push({

--- a/test/os/net/urlmodifier.test.js
+++ b/test/os/net/urlmodifier.test.js
@@ -2,6 +2,10 @@ goog.require('os.net.URLModifier');
 
 
 describe('os.net.URLModifier', function() {
+  afterEach(() => {
+    os.net.URLModifier.replace_.length = 0;
+  });
+
   it('should not modify without replacements', function() {
     var mod = new os.net.URLModifier();
 


### PR DESCRIPTION
The config here is called multiple times because the `baseUrl` stuff runs a separate config from `urlReplace`. Do not reset the replacement config so that all of those configs can be added.