### PR TITLE
fix(tile): reduce the sharpness multiplier

### DIFF
--- a/src/os/layer/tile.js
+++ b/src/os/layer/tile.js
@@ -567,7 +567,7 @@ os.layer.Tile.prototype.applyColors = function(data, width, height) {
 
       if (sharpness > 0) {
         // sharpness is in the range [0, 1]. use a multiplier to enhance the convolution effect.
-        os.color.adjustSharpness(data, width, height, sharpness * 20);
+        os.color.adjustSharpness(data, width, height, sharpness * 10);
       }
     }
   }


### PR DESCRIPTION
The multiplier was causing the Sharpness slider to be extremely sensitive. This should make the slider more useful across the entire range.