### PR TITLE
feat(track): prompt to include metadata in tracks

### DIFF
--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -381,6 +381,7 @@ osx.window.WindowOptions;
  *   checkboxText: (string|undefined),
  *   checkboxClass: (string|undefined),
  *   checkbox: (Function|undefined),
+ *   checkboxValue: (boolean|undefined),
  *
  *   windowOptions: (osx.window.WindowOptions|undefined),
  *
@@ -397,16 +398,24 @@ osx.window.ConfirmOptions;
  *   cancel: (Function|undefined),
  *   yesText: (string|undefined),
  *   yesButtonClass: (string|undefined),
+ *   yesButtonTitle: (string|undefined),
  *   yesIcon: (string|undefined),
  *   noText: (string|undefined),
  *   noIcon: (string|undefined),
  *   noButtonClass: (string|undefined),
+ *   noButtonTitle: (string|undefined),
+ *   checkboxText: (string|undefined),
+ *   checkboxClass: (string|undefined),
+ *   checkbox: (Function|undefined),
+ *   checkboxValue: (boolean|undefined),
  *
  *   windowOptions: (osx.window.WindowOptions|undefined),
  *
  *   prompt: (string|undefined),
  *   defaultValue: (string|undefined),
- *   formLabel: (string|undefined)
+ *   formLabel: (string|undefined),
+ *   limit: (number|undefined),
+ *   select: (boolean|undefined)
  * }}
  */
 osx.window.ConfirmTextOptions;

--- a/src/os/track.js
+++ b/src/os/track.js
@@ -1159,6 +1159,41 @@ os.track.promptForTitle = function(opt_default) {
 
 
 /**
+ * Prompt the user to choose a track title, and if original metadata should be included.
+ *
+ * @param {string=} opt_default The default title. Defaults to an empty string.
+ * @param {boolean=} opt_includeMetadata If metadata should be included. Defaults to false.
+ * @return {!goog.Promise}
+ */
+os.track.promptForTitleAndMetadata = function(opt_default = '', opt_includeMetadata = false) {
+  let includeMetadata = opt_includeMetadata;
+  const setIncludeMetadata = (value) => {
+    includeMetadata = value;
+  };
+
+  return new goog.Promise(function(resolve, reject) {
+    os.ui.window.launchConfirmText(/** @type {!osx.window.ConfirmTextOptions} */ ({
+      confirm: (title) => {
+        resolve({title, includeMetadata});
+      },
+      cancel: reject,
+      defaultValue: opt_default,
+      checkboxText: 'Include original metadata in track',
+      checkbox: setIncludeMetadata,
+      checkValue: includeMetadata,
+      select: true,
+      prompt: 'Please provide a name for the track:',
+      windowOptions: /** @type {!osx.window.WindowOptions} */ ({
+        label: 'Track Name',
+        icon: 'fa ' + os.track.ICON,
+        modal: true
+      })
+    }));
+  });
+};
+
+
+/**
  * Prompt the user to choose a track.
  *
  * @param {Array<os.data.ColumnDefinition>} columns The columns

--- a/src/os/ui/window/confirm.js
+++ b/src/os/ui/window/confirm.js
@@ -56,6 +56,7 @@ const launchConfirm = function(opt_options, opt_scopeOptions) {
   scopeOptions['checkboxText'] = options.checkboxText || '';
   scopeOptions['checkboxClass'] = options.checkboxClass || '';
   scopeOptions['checkboxCallback'] = options.checkbox || goog.nullFunction;
+  scopeOptions['checkboxValue'] = !!options.checkboxValue;
 
   var windowOverrides = /** @type {!osx.window.WindowOptions} */ (options.windowOptions || {});
 
@@ -129,9 +130,10 @@ class Controller {
     }
 
     /**
+     * The current checkbox state.
      * @type {boolean}
      */
-    this.scope_['checkboxSelection'] = false;
+    this['checkboxSelection'] = !!this.scope_['checkboxValue'];
 
     /**
      * @type {!KeyHandler}
@@ -187,22 +189,16 @@ class Controller {
         value = transScope['confirmValue'];
       }
 
+      var checkboxCallback = this.scope_['checkboxCallback'];
+      if (typeof checkboxCallback === 'function') {
+        checkboxCallback(this['checkboxSelection']);
+      }
+
       this.scope_['confirmCallback'](value);
     }
 
     this.close_();
   }
-
-
-  /**
-   * Fire the dont show again callback to save user choice
-   * @param {boolean} checkbox
-   * @export
-   */
-  updateCheckbox(checkbox) {
-    this.scope_['checkboxCallback'](checkbox);
-  }
-
 
   /**
    * Close the window.

--- a/src/os/ui/window/confirmtext.js
+++ b/src/os/ui/window/confirmtext.js
@@ -68,13 +68,19 @@ os.ui.window.launchConfirmText = function(opt_options) {
     'yesText': options.yesText || 'OK',
     'yesIcon': options.yesIcon || 'fa fa-check',
     'yesButtonClass': options.yesButtonClass || 'btn-primary',
+    'yesButtonTitle': options.yesButtonTitle || '',
     'noText': options.noText || 'Cancel',
     'noIcon': options.noIcon || 'fa fa-ban',
     'noButtonClass': options.noButtonClass || 'btn-secondary',
-    'select': !!options.select,
-    'limit': options.limit || 200,
+    'noButtonTitle': options.noButtonTitle || '',
+    'checkboxText': options.checkboxText || '',
+    'checkboxClass': options.checkboxClass || '',
+    'checkboxCallback': options.checkbox || goog.nullFunction,
+    'checkboxValue': !!options.checkboxValue,
 
     // confirm text options
+    'select': !!options.select,
+    'limit': options.limit || 200,
     'formLabel': options.formLabel,
     'prompt': options.prompt
   };

--- a/src/plugin/track/track.js
+++ b/src/plugin/track/track.js
@@ -570,11 +570,26 @@ plugin.track.updateTrackSource = function(track) {
   if (track) {
     var source = os.feature.getSource(track);
     if (source) {
+      // Add track-specific columns to the source for display in feature UI's.
       source.addColumn(os.track.TrackField.ELAPSED_AVERAGE_SPEED);
       source.addColumn(os.track.TrackField.ELAPSED_DISTANCE);
       source.addColumn(os.track.TrackField.ELAPSED_DURATION);
       source.addColumn(os.track.TrackField.TOTAL_DISTANCE);
       source.addColumn(os.track.TrackField.TOTAL_DURATION);
+
+      // Add metadata fields captured from the original data to the source, for display in feature UI's.
+      // This assumes all added features have the same fields to avoid unnecessary iteration over the entire map.
+      var metadataMap = track.get(os.track.TrackField.METADATA_MAP);
+      if (metadataMap) {
+        for (var key in metadataMap) {
+          var first = metadataMap[key];
+          for (var field in first) {
+            source.addColumn(field);
+          }
+
+          break;
+        }
+      }
     }
   }
 };

--- a/src/plugin/track/trackevent.js
+++ b/src/plugin/track/trackevent.js
@@ -6,11 +6,15 @@ goog.require('goog.events.Event');
 
 /**
  * Events for the track plugin.
+ *
+ * Track events operating on selected data only should be suffixed with ':selected'. See
  * @enum {string}
  */
 plugin.track.EventType = {
   CREATE_TRACK: 'track:create',
+  CREATE_FROM_SELECTED: 'track:create:selected',
   ADD_TO: 'track:addTo',
+  ADD_FROM_SELECTED: 'track:addTo:selected',
   FOLLOW: 'track:followTrack',
   UNFOLLOW: 'track:unfollowTrack',
   HIDE_LINE: 'track:hideLine',
@@ -75,3 +79,13 @@ plugin.track.Event = function(type) {
   this.sourceId = undefined;
 };
 goog.inherits(plugin.track.Event, goog.events.Event);
+
+
+/**
+ * If the event is operating on selected features only.
+ * @param {string|undefined} eventType The event type.
+ * @return {boolean}
+ */
+plugin.track.Event.isSelectedEvent = function(eventType) {
+  return eventType != null && eventType.endsWith(':selected');
+};

--- a/src/plugin/track/trackmenu.js
+++ b/src/plugin/track/trackmenu.js
@@ -15,100 +15,128 @@ goog.require('plugin.track.confirmTrackDirective');
 
 
 /**
+ * Menu group for track actions.
+ * @type {string}
+ * @const
+ */
+plugin.track.menu.TRACK_GROUP = 'Tracks';
+
+
+/**
  * Add track items to the layer menu.
  */
 plugin.track.menu.layerSetup = function() {
   var menu = os.ui.menu.layer.MENU;
-  if (menu && !menu.getRoot().find(plugin.track.EventType.CREATE_TRACK)) {
+  if (menu && !menu.getRoot().find(plugin.track.menu.TRACK_GROUP)) {
     var group = menu.getRoot().find(os.ui.menu.layer.GroupLabel.TOOLS);
     goog.asserts.assert(group, 'Group should exist! Check spelling?');
 
     group.addChild({
-      label: 'Create Track',
-      eventType: plugin.track.EventType.CREATE_TRACK,
-      tooltip: 'Creates a new track by linking selected features (or all features if none are selected) in time order.',
+      label: plugin.track.menu.TRACK_GROUP,
       icons: ['<i class="fa fa-fw fa-share-alt"></i>'],
-      metricKey: plugin.track.Metrics.Keys.CREATE_LAYER,
-      beforeRender: plugin.track.menu.visibleIfHasFeatures,
-      handler: plugin.track.menu.handleAddCreateTrackEvent_,
-      sort: 200
-    });
-
-    group.addChild({
-      label: 'Add to Track...',
-      eventType: plugin.track.EventType.ADD_TO,
-      tooltip: 'Adds selected features (or all features if none are selected) to an existing track.',
-      icons: ['<i class="fa fa-fw fa-share-alt"></i>'],
-      metricKey: plugin.track.Metrics.Keys.ADD_TO_LAYER,
-      beforeRender: plugin.track.menu.visibleIfTracksExist,
-      handler: plugin.track.menu.handleAddCreateTrackEvent_,
-      sort: 210
-    });
-
-    group.addChild({
-      label: 'Follow Track',
-      eventType: plugin.track.EventType.FOLLOW,
-      tooltip: 'Follow the track as it animates.',
-      icons: ['<i class="fa fa-fw fa-globe"></i>'],
-      metricKey: plugin.track.Metrics.Keys.FOLLOW_TRACK,
-      beforeRender: plugin.track.menu.visibleIfIsNotFollowed,
-      handler: plugin.track.menu.handleFollowTrackEvent,
-      sort: 220
-    });
-
-    group.addChild({
-      label: 'Unfollow Track',
-      eventType: plugin.track.EventType.UNFOLLOW,
-      tooltip: 'Cancel following the track during animation.',
-      icons: ['<i class="fa fa-fw fa-globe"></i>'],
-      metricKey: plugin.track.Metrics.Keys.UNFOLLOW_TRACK,
-      beforeRender: plugin.track.menu.visibleIfIsFollowed,
-      handler: plugin.track.menu.handleUnfollowTrackEvent,
-      sort: 220
-    });
-
-    group.addChild({
-      label: 'Hide Track Line',
-      eventType: plugin.track.EventType.HIDE_LINE,
-      tooltip: 'Do not show the track line.',
-      icons: ['<i class="fa fa-fw fa-level-up"></i>'],
-      metricKey: plugin.track.Metrics.Keys.HIDE_TRACK_LINE,
-      beforeRender: plugin.track.menu.visibleIfLineIsShown,
-      handler: goog.partial(plugin.track.menu.setShowTrackLine, false),
-      sort: 230
-    });
-
-    group.addChild({
-      label: 'Show Track Line',
-      eventType: plugin.track.EventType.SHOW_LINE,
-      tooltip: 'Show the track line.',
-      icons: ['<i class="fa fa-fw fa-level-up"></i>'],
-      metricKey: plugin.track.Metrics.Keys.SHOW_TRACK_LINE,
-      beforeRender: plugin.track.menu.visibleIfLineIsHidden,
-      handler: goog.partial(plugin.track.menu.setShowTrackLine, true),
-      sort: 230
-    });
-
-    group.addChild({
-      label: 'Disable Track Interpolation',
-      eventType: plugin.track.EventType.ENABLE_INTERPOLATE_MARKER,
-      tooltip: 'Only move track marker when there is a supporting feature.',
-      icons: ['<i class="fa fa-fw fa-star-half-o fa-rotate-270"></i>'],
-      metricKey: plugin.track.Metrics.Keys.ENABLE_INTERPOLATE_MARKER,
-      beforeRender: plugin.track.menu.visibleIfMarkerInterpolationEnabled,
-      handler: goog.partial(plugin.track.menu.setMarkerInterpolationEnabled, false),
-      sort: 240
-    });
-
-    group.addChild({
-      label: 'Enable Track Interpolation',
-      eventType: plugin.track.EventType.DISABLE_INTERPOLATE_MARKER,
-      tooltip: 'Show the interpolated position of the track marker.',
-      icons: ['<i class="fa fa-fw fa-star-half-o fa-rotate-270"></i>'],
-      metricKey: plugin.track.Metrics.Keys.DISABLE_INTERPOLATE_MARKER,
-      beforeRender: plugin.track.menu.visibleIfMarkerInterpolationDisabled,
-      handler: goog.partial(plugin.track.menu.setMarkerInterpolationEnabled, true),
-      sort: 250
+      type: os.ui.menu.MenuItemType.SUBMENU,
+      children: [
+        {
+          label: 'Create Track',
+          eventType: plugin.track.EventType.CREATE_TRACK,
+          tooltip: 'Creates a new track by linking all features in time order.',
+          icons: ['<i class="fa fa-fw fa-share-alt"></i>'],
+          metricKey: plugin.track.Metrics.Keys.CREATE_LAYER,
+          beforeRender: plugin.track.menu.visibleIfHasFeatures,
+          handler: plugin.track.menu.handleAddCreateTrackEvent_,
+          sort: 200
+        },
+        {
+          label: 'Create Track From Selected',
+          eventType: plugin.track.EventType.CREATE_FROM_SELECTED,
+          tooltip: 'Creates a new track by linking selected features in time order.',
+          icons: ['<i class="fa fa-fw fa-share-alt"></i>'],
+          metricKey: plugin.track.Metrics.Keys.CREATE_LAYER,
+          beforeRender: plugin.track.menu.visibleIfHasFeatures,
+          handler: plugin.track.menu.handleAddCreateTrackEvent_,
+          sort: 201
+        },
+        {
+          label: 'Add to Track...',
+          eventType: plugin.track.EventType.ADD_TO,
+          tooltip: 'Adds all features to an existing track.',
+          icons: ['<i class="fa fa-fw fa-share-alt"></i>'],
+          metricKey: plugin.track.Metrics.Keys.ADD_TO_LAYER,
+          beforeRender: plugin.track.menu.visibleIfTracksExist,
+          handler: plugin.track.menu.handleAddCreateTrackEvent_,
+          sort: 210
+        },
+        {
+          label: 'Add Selected to Track...',
+          eventType: plugin.track.EventType.ADD_FROM_SELECTED,
+          tooltip: 'Adds selected features to an existing track.',
+          icons: ['<i class="fa fa-fw fa-share-alt"></i>'],
+          metricKey: plugin.track.Metrics.Keys.ADD_TO_LAYER,
+          beforeRender: plugin.track.menu.visibleIfTracksExist,
+          handler: plugin.track.menu.handleAddCreateTrackEvent_,
+          sort: 211
+        },
+        {
+          label: 'Follow Track',
+          eventType: plugin.track.EventType.FOLLOW,
+          tooltip: 'Follow the track as it animates.',
+          icons: ['<i class="fa fa-fw fa-globe"></i>'],
+          metricKey: plugin.track.Metrics.Keys.FOLLOW_TRACK,
+          beforeRender: plugin.track.menu.visibleIfIsNotFollowed,
+          handler: plugin.track.menu.handleFollowTrackEvent,
+          sort: 220
+        },
+        {
+          label: 'Unfollow Track',
+          eventType: plugin.track.EventType.UNFOLLOW,
+          tooltip: 'Cancel following the track during animation.',
+          icons: ['<i class="fa fa-fw fa-globe"></i>'],
+          metricKey: plugin.track.Metrics.Keys.UNFOLLOW_TRACK,
+          beforeRender: plugin.track.menu.visibleIfIsFollowed,
+          handler: plugin.track.menu.handleUnfollowTrackEvent,
+          sort: 220
+        },
+        {
+          label: 'Hide Track Line',
+          eventType: plugin.track.EventType.HIDE_LINE,
+          tooltip: 'Do not show the track line.',
+          icons: ['<i class="fa fa-fw fa-level-up"></i>'],
+          metricKey: plugin.track.Metrics.Keys.HIDE_TRACK_LINE,
+          beforeRender: plugin.track.menu.visibleIfLineIsShown,
+          handler: goog.partial(plugin.track.menu.setShowTrackLine, false),
+          sort: 230
+        },
+        {
+          label: 'Show Track Line',
+          eventType: plugin.track.EventType.SHOW_LINE,
+          tooltip: 'Show the track line.',
+          icons: ['<i class="fa fa-fw fa-level-up"></i>'],
+          metricKey: plugin.track.Metrics.Keys.SHOW_TRACK_LINE,
+          beforeRender: plugin.track.menu.visibleIfLineIsHidden,
+          handler: goog.partial(plugin.track.menu.setShowTrackLine, true),
+          sort: 230
+        },
+        {
+          label: 'Disable Track Interpolation',
+          eventType: plugin.track.EventType.ENABLE_INTERPOLATE_MARKER,
+          tooltip: 'Only move track marker when there is a supporting feature.',
+          icons: ['<i class="fa fa-fw fa-star-half-o fa-rotate-270"></i>'],
+          metricKey: plugin.track.Metrics.Keys.ENABLE_INTERPOLATE_MARKER,
+          beforeRender: plugin.track.menu.visibleIfMarkerInterpolationEnabled,
+          handler: goog.partial(plugin.track.menu.setMarkerInterpolationEnabled, false),
+          sort: 240
+        },
+        {
+          label: 'Enable Track Interpolation',
+          eventType: plugin.track.EventType.DISABLE_INTERPOLATE_MARKER,
+          tooltip: 'Show the interpolated position of the track marker.',
+          icons: ['<i class="fa fa-fw fa-star-half-o fa-rotate-270"></i>'],
+          metricKey: plugin.track.Metrics.Keys.DISABLE_INTERPOLATE_MARKER,
+          beforeRender: plugin.track.menu.visibleIfMarkerInterpolationDisabled,
+          handler: goog.partial(plugin.track.menu.setMarkerInterpolationEnabled, true),
+          sort: 250
+        }
+      ]
     });
   }
 };
@@ -142,13 +170,41 @@ plugin.track.menu.hasFeatures = function(context) {
 
 
 /**
+ * Test if a layer menu context has selected features.
+ *
+ * @param {os.ui.menu.layer.Context} context The menu context.
+ * @return {boolean} If the context has a single layer containing one or more selected features.
+ */
+plugin.track.menu.hasSelectedFeatures = function(context) {
+  if (context && context.length == 1) {
+    var node = context[0];
+    if (node instanceof os.data.LayerNode) {
+      var layer = node.getLayer();
+      if (layer instanceof os.layer.Vector) {
+        var source = layer.getSource();
+        if (source instanceof os.source.Vector) {
+          return source.getSelectedItems().length > 0;
+        }
+      }
+    }
+  }
+
+  return false;
+};
+
+
+/**
  * Show a menu item if one or more tracks exist and the layer has features.
  *
  * @param {os.ui.menu.layer.Context} context The menu context.
  * @this {os.ui.menu.MenuItem}
  */
 plugin.track.menu.visibleIfHasFeatures = function(context) {
-  this.visible = plugin.track.menu.hasFeatures(context);
+  if (plugin.track.Event.isSelectedEvent(this.eventType)) {
+    this.visible = plugin.track.menu.hasSelectedFeatures(context);
+  } else {
+    this.visible = plugin.track.menu.hasFeatures(context);
+  }
 };
 
 
@@ -160,7 +216,11 @@ plugin.track.menu.visibleIfHasFeatures = function(context) {
  */
 plugin.track.menu.visibleIfTracksExist = function(context) {
   var trackNode = plugin.places.PlacesManager.getInstance().getPlacesRoot();
-  this.visible = trackNode != null && trackNode.hasFeatures() && plugin.track.menu.hasFeatures(context);
+  if (plugin.track.Event.isSelectedEvent(this.eventType)) {
+    this.visible = trackNode != null && trackNode.hasFeatures() && plugin.track.menu.hasSelectedFeatures(context);
+  } else {
+    this.visible = trackNode != null && trackNode.hasFeatures() && plugin.track.menu.hasFeatures(context);
+  }
 };
 
 
@@ -579,9 +639,9 @@ plugin.track.menu.handleAddCreateTrackEvent_ = function(event) {
 
         var source = layer.getSource();
         if (source) {
-          features = source.getSelectedItems();
-
-          if (features.length == 0) {
+          if (plugin.track.Event.isSelectedEvent(event.type)) {
+            features = source.getSelectedItems();
+          } else {
             features = source.getFeatures();
           }
         }
@@ -592,7 +652,7 @@ plugin.track.menu.handleAddCreateTrackEvent_ = function(event) {
     }
 
     if (features && features.length) {
-      if (event.type === plugin.track.EventType.CREATE_TRACK) {
+      if (event.type.startsWith(plugin.track.EventType.CREATE_TRACK)) {
         os.track.promptForTitleAndMetadata(title).then(function({includeMetadata, title}) {
           os.track.getSortField(features[0]).then(function(sortField) {
             var options = /** @type {!os.track.CreateOptions} */ ({
@@ -605,7 +665,7 @@ plugin.track.menu.handleAddCreateTrackEvent_ = function(event) {
             plugin.track.createAndAdd(options);
           });
         });
-      } else if (event.type === plugin.track.EventType.ADD_TO) {
+      } else if (event.type.startsWith(plugin.track.EventType.ADD_TO)) {
         plugin.track.promptForTrack().then(function(track) {
           if (track) {
             var metadataMap = track.get(os.track.TrackField.METADATA_MAP);

--- a/src/plugin/track/trackmenu.js
+++ b/src/plugin/track/trackmenu.js
@@ -593,10 +593,11 @@ plugin.track.menu.handleAddCreateTrackEvent_ = function(event) {
 
     if (features && features.length) {
       if (event.type === plugin.track.EventType.CREATE_TRACK) {
-        os.track.promptForTitle(title).then(function(title) {
+        os.track.promptForTitleAndMetadata(title).then(function({includeMetadata, title}) {
           os.track.getSortField(features[0]).then(function(sortField) {
             var options = /** @type {!os.track.CreateOptions} */ ({
               features: features,
+              includeMetadata,
               name: title,
               sortField: sortField
             });
@@ -607,9 +608,12 @@ plugin.track.menu.handleAddCreateTrackEvent_ = function(event) {
       } else if (event.type === plugin.track.EventType.ADD_TO) {
         plugin.track.promptForTrack().then(function(track) {
           if (track) {
+            var metadataMap = track.get(os.track.TrackField.METADATA_MAP);
             os.track.addToTrack({
               track: track,
-              features: features
+              features: features,
+              // Include metadata if previously included.
+              includeMetadata: !!metadataMap
             });
           }
         });

--- a/test/os/ui/window/confirm.test.js
+++ b/test/os/ui/window/confirm.test.js
@@ -117,11 +117,16 @@ describe('os.ui.window.ConfirmUI', () => {
     expect(controller.close_).toHaveBeenCalled();
   });
 
-  it('should fire a callback and close when confirmed', () => {
+  it('should fire callbacks and close when confirmed', () => {
     const expected = 'It works!';
+
     let confirmValue;
+    let checkValue;
 
     initComponent({
+      checkboxCallback: (value) => {
+        checkValue = value;
+      },
       confirmCallback: (value) => {
         confirmValue = value;
       },
@@ -130,26 +135,12 @@ describe('os.ui.window.ConfirmUI', () => {
 
     spyOn(controller, 'close_');
 
+    controller.checkboxSelection = true;
     controller.confirm();
 
     expect(confirmValue).toBe(expected);
-    expect(controller.close_).toHaveBeenCalled();
-  });
-
-  it('should fire a callback on checkbox change', () => {
-    let checkValue;
-
-    initComponent({
-      checkboxCallback: (value) => {
-        checkValue = value;
-      }
-    });
-
-    controller.updateCheckbox(true);
     expect(checkValue).toBe(true);
-
-    controller.updateCheckbox(false);
-    expect(checkValue).toBe(false);
+    expect(controller.close_).toHaveBeenCalled();
   });
 
   it('should close on Escape keypress', () => {

--- a/views/window/confirm.html
+++ b/views/window/confirm.html
@@ -6,7 +6,7 @@
     </form>
     <div class="flex-row ml-4" ng-class="checkboxClass" ng-if="checkboxText">
       <label class="form-check-label" for="checkboxText">
-        <input class="form-check-input" ng-model="checkboxSelection" type="checkbox" id="checkboxText" ng-change="confirm.updateCheckbox(checkboxSelection)">
+        <input class="form-check-input" ng-model="confirm.checkboxSelection" type="checkbox" id="checkboxText">
         {{checkboxText}}
       </label>
     </div>


### PR DESCRIPTION
This PR addresses a few things with tracks:

- The Create Track option in the layer menu did not support including original metadata in the resulting track. This is now possible via checkbox in the UI prompt (defaults to false per existing behavior).
- The Add to Track now automatically includes metadata if previously included on the target track. This is intended to avoid gaps in metadata when features are added to the track.
- When including metadata in tracks, the additional fields are not added as columns to the track source (Saved Places currently). This prevented the fields from showing up in UI's that are based on source columns (Feature Info, Show Features, etc).
- The Create/Add To track options in the layer menu have confused some because they use selected data if available, all data if there isn't a selection. This is communicated in the tooltip, but we often get feedback that tooltips aren't read or folks don't know/care to read them. To resolve this, I have create separate events for creating/adding using all and selected data. This expanded the menu a bit, so I created a Tracks submenu to hold all track actions.

The `confirmtext` dialog did not previously support the checkbox control from `confirm`, so this has been added. I also changed the checkbox callback behavior so it _only_ fires when `confirm` is called (pressing OK). This is consistent with how the value callback is fired, and prevents changing the value backing the checkbox when the user cancels the dialog.

The new `promptForTitleAndMetadata` could replace `promptForTitle`, if we want to deprecate the latter. The resolve value is different so I couldn't update `promptForTitle` without a breaking change.