### PR TITLE
fix(cesium): ensure viewhint is reset when disabling cesium

### DIFF
--- a/src/plugin/cesium/cesiumrenderer.js
+++ b/src/plugin/cesium/cesiumrenderer.js
@@ -252,6 +252,9 @@ plugin.cesium.CesiumRenderer.prototype.setEnabled = function(value) {
     }
 
     this.csListeners_.length = 0;
+
+    // flag as no longer moving to ensure the ViewHint is updated
+    this.setCesiumMoving_(false);
   }
 };
 
@@ -665,27 +668,32 @@ plugin.cesium.CesiumRenderer.prototype.createCesiumSynchronizers_ = function(map
 
 
 /**
+ * Set if Cesium is currently moving the camera.
+ * @param {boolean} value If the camera is moving.
+ * @private
+ */
+plugin.cesium.CesiumRenderer.prototype.setCesiumMoving_ = function(value) {
+  if (this.cesiumMoving_ !== value) {
+    this.cesiumMoving_ = value;
+
+    if (this.map) {
+      var view = this.map.getView();
+      if (view) {
+        view.setHint(ol.ViewHint.INTERACTING, value ? 1 : -1);
+      }
+    }
+  }
+};
+
+
+/**
  * Handles Cesium camera move start/end events.
  *
  * @param {boolean} isMoving If the camera is moving.
  * @private
  */
 plugin.cesium.CesiumRenderer.prototype.onCesiumCameraMoveChange_ = function(isMoving) {
-  if (this.map) {
-    // fool proof this to ensure we only increment/decrement by 1
-    var view = this.map.getView();
-    if (isMoving && !this.cesiumMoving_) {
-      this.cesiumMoving_ = true;
-      view.setHint(ol.ViewHint.INTERACTING, 1);
-    } else if (!isMoving && this.cesiumMoving_) {
-      this.cesiumMoving_ = false;
-      view.setHint(ol.ViewHint.INTERACTING, -1);
-
-      if (this.rootSynchronizer) {
-        this.rootSynchronizer.updateFromCamera();
-      }
-    }
-  }
+  this.setCesiumMoving_(isMoving);
 };
 
 

--- a/src/plugin/cesium/cesiumrenderer.js
+++ b/src/plugin/cesium/cesiumrenderer.js
@@ -676,11 +676,17 @@ plugin.cesium.CesiumRenderer.prototype.setCesiumMoving_ = function(value) {
   if (this.cesiumMoving_ !== value) {
     this.cesiumMoving_ = value;
 
+    // Update the OpenLayers interacting flag, to disable performance-intensive operations during animation.
     if (this.map) {
       var view = this.map.getView();
       if (view) {
         view.setHint(ol.ViewHint.INTERACTING, value ? 1 : -1);
       }
+    }
+
+    // Update synchronizers when the camera stops moving, to update view-based rendering.
+    if (!value && this.rootSynchronizer) {
+      this.rootSynchronizer.updateFromCamera();
     }
   }
 };


### PR DESCRIPTION
When disabling Cesium, the camera move listener was removed without fixing the view hint. This moves management of the `cesiumMoving_` flag to a function that protects against setting the hint by more than +/- 1, and calls the function when Cesium is disabled to reset the hint if needed.

Fixes #1081.