### PR TITLE
feat(map): support rotation in 2D flyTo

### DIFF
--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -588,9 +588,13 @@ os.MapContainer.prototype.flyTo = function(options) {
         camera.flyTo(options);
       }
     } else {
+      // translate 3D heading to OpenLayers rotation if defined and non-zero
+      var rotation = options.heading ? ol.math.toRadians(-options.heading) : 0;
+
       var animateOptions = /** @type {!olx.AnimationOptions} */ ({
-        center: center,
-        duration: duration
+        center,
+        duration,
+        rotation
       });
 
       if (options.zoom !== undefined) {


### PR DESCRIPTION
Rotation is currently always 0 in 2D because the canvas renderer is less performant when rotation is applied. There are cases where rotation is desirable, such as orienting imagery to the up angle. This PR enables 2D rotation via the `MapContainer#flyTo` function, so it can be programmatically set by plugins in the 2D view.