### PR TITLE
fix(places): instance not initialized across different window contexts

### DIFF
--- a/src/plugin/places/placesmanager.js
+++ b/src/plugin/places/placesmanager.js
@@ -50,26 +50,10 @@ const STORAGE_URL = getLocalUrl(btoa(STORAGE_NAME));
 const LAYER_OPTIONS = 'places.options';
 
 /**
- * Places layer options.
- * @type {Object}
- * @const
+ * The PlacesManager instance.
+ * @type {PlacesManager}
  */
-const OPTIONS = {
-  'animate': true,
-  'color': DEFAULT_LAYER_COLOR,
-  'collapsed': true,
-  'columns': places.SourceFields,
-  'editable': true,
-  'id': places.ID,
-  'layerType': LayerType.REF,
-  'load': true,
-  'logger': 'plugin.places.PlacesManager',
-  'showLabels': false,
-  'showRoot': false,
-  'title': places.TITLE,
-  'type': PlacesLayerConfig.ID,
-  'url': STORAGE_URL
-};
+let PlacesManagerInstance;
 
 
 /**
@@ -77,10 +61,9 @@ const OPTIONS = {
  */
 class PlacesManager extends AbstractKMLManager {
   /**
-   * Constructor
+   * @inheritDoc
    */
-  constructor() {
-    OPTIONS['provider'] = config.getAppName() || null;
+  constructor(options) {
     super(OPTIONS);
 
     // clear storage when the reset event is fired
@@ -274,7 +257,44 @@ class PlacesManager extends AbstractKMLManager {
   getAnnotationsFolder() {
     return this.getRoot();
   }
+
+  /**
+   * Get a singleton instance of the PlacesManager.
+   * @return {!PlacesManager}
+   */
+  static getInstance() {
+    if (!PlacesManagerInstance) {
+      const OPTIONS = {
+        'animate': true,
+        'color': DEFAULT_LAYER_COLOR,
+        'collapsed': true,
+        'columns': places.SourceFields,
+        'editable': true,
+        'id': places.ID,
+        'layerType': LayerType.REF,
+        'load': true,
+        'logger': 'plugin.places.PlacesManager',
+        'provider': config.getAppName() || null,
+        'showLabels': false,
+        'showRoot': false,
+        'title': places.TITLE,
+        'type': PlacesLayerConfig.ID,
+        'url': STORAGE_URL
+      };
+
+      PlacesManagerInstance = new PlacesManager(OPTIONS);
+    }
+
+    return PlacesManagerInstance;
+  }
+
+  /**
+   * Set a singleton instance of the PlacesManager.
+   * @param {!PlacesManager} value The singleton instance.
+   */
+  static setInstance(value) {
+    PlacesManagerInstance = value;
+  }
 }
-goog.addSingletonGetter(PlacesManager);
 
 exports = PlacesManager;

--- a/src/plugin/places/placesmanager.js
+++ b/src/plugin/places/placesmanager.js
@@ -29,12 +29,6 @@ const KMLNode = goog.requireType('plugin.file.kml.ui.KMLNode');
 
 
 /**
- * The PlacesManager instance.
- * @type {PlacesManager}
- */
-let PlacesManagerInstance;
-
-/**
  * The Places storage location.
  * @type {string}
  * @const
@@ -55,16 +49,39 @@ const STORAGE_URL = getLocalUrl(btoa(STORAGE_NAME));
  */
 const LAYER_OPTIONS = 'places.options';
 
+/**
+ * Places layer options.
+ * @type {Object}
+ * @const
+ */
+const OPTIONS = {
+  'animate': true,
+  'color': DEFAULT_LAYER_COLOR,
+  'collapsed': true,
+  'columns': places.SourceFields,
+  'editable': true,
+  'id': places.ID,
+  'layerType': LayerType.REF,
+  'load': true,
+  'logger': 'plugin.places.PlacesManager',
+  'showLabels': false,
+  'showRoot': false,
+  'title': places.TITLE,
+  'type': PlacesLayerConfig.ID,
+  'url': STORAGE_URL
+};
+
 
 /**
  * Allows the user to manage saved features as a KML tree.
  */
 class PlacesManager extends AbstractKMLManager {
   /**
-   * @inheritDoc
+   * Constructor
    */
-  constructor(options) {
-    super(options);
+  constructor() {
+    OPTIONS['provider'] = config.getAppName() || null;
+    super(OPTIONS);
 
     // clear storage when the reset event is fired
     dispatcher.getInstance().listen(OsEventType.RESET, this.onSettingsReset_, false, this);
@@ -257,34 +274,7 @@ class PlacesManager extends AbstractKMLManager {
   getAnnotationsFolder() {
     return this.getRoot();
   }
-
-  /**
-   * @return {PlacesManager}
-   */
-  static getInstance() {
-    if (!PlacesManagerInstance) {
-      const OPTIONS = {
-        'animate': true,
-        'color': DEFAULT_LAYER_COLOR,
-        'collapsed': true,
-        'columns': places.SourceFields,
-        'editable': true,
-        'id': places.ID,
-        'layerType': LayerType.REF,
-        'load': true,
-        'logger': 'plugin.places.PlacesManager',
-        'provider': config.getAppName() || null,
-        'showLabels': false,
-        'showRoot': false,
-        'title': places.TITLE,
-        'type': PlacesLayerConfig.ID,
-        'url': STORAGE_URL
-      };
-
-      PlacesManagerInstance = new PlacesManager(OPTIONS);
-    }
-    return PlacesManagerInstance;
-  }
 }
+goog.addSingletonGetter(PlacesManager);
 
 exports = PlacesManager;

--- a/src/plugin/places/placesmanager.js
+++ b/src/plugin/places/placesmanager.js
@@ -64,7 +64,7 @@ class PlacesManager extends AbstractKMLManager {
    * @inheritDoc
    */
   constructor(options) {
-    super(OPTIONS);
+    super(options);
 
     // clear storage when the reset event is fired
     dispatcher.getInstance().listen(OsEventType.RESET, this.onSettingsReset_, false, this);

--- a/src/plugin/places/ui/saveplaces.js
+++ b/src/plugin/places/ui/saveplaces.js
@@ -1,4 +1,5 @@
 goog.provide('plugin.places.ui.SavePlacesCtrl');
+goog.provide('plugin.places.ui.launchSavePlaces');
 goog.provide('plugin.places.ui.savePlacesDirective');
 
 goog.require('os.defines');


### PR DESCRIPTION
There was an issue where `PlacesManager` would be reset (source was null) in the main window context if `getInstance` was called in a separate window, even though dev tools claimed it wasn't.

`launchSavePlaces` is also now `provide`d so that it can be used more easily when updating other files for `goog.module`.