### PR TITLE
fix: use style-specified line width in kml export

### DIFF
--- a/src/os/feature/feature.js
+++ b/src/os/feature/feature.js
@@ -1029,6 +1029,25 @@ os.feature.getStrokeColor = function(feature, opt_source, opt_default) {
   return os.feature.getColor(feature, opt_source, opt_default || null, os.style.StyleField.STROKE);
 };
 
+/**
+ * Get the stroke width of a feature.
+ * @param {ol.Feature} feature The feature.
+ * @return {number|null} The stroke width.
+ */
+os.feature.getStrokeWidth = function(feature) {
+  if (feature.getStyle() && feature.getStyle().length > 0) {
+    var style = /** @type {Array<ol.style.Style>} */(feature.getStyle())[0];
+    if (style.getStroke() && style.getStroke().getWidth()) {
+      var width = style.getStroke().getWidth();
+      if (width !== undefined) {
+        return width;
+      } else {
+        return null;
+      }
+    }
+  }
+  return null;
+};
 
 /**
  * Gets the shape name for a feature.

--- a/src/os/ui/file/kml/abstractkmlexporter.js
+++ b/src/os/ui/file/kml/abstractkmlexporter.js
@@ -726,12 +726,13 @@ os.ui.file.kml.AbstractKMLExporter.prototype.addGeometryNode = function(item, no
  * @param {string} styleId The style id
  * @param {string} color The item color
  * @param {?string} fillColor The item fill color
- * @param {?string} strokeColor The item fill color
+ * @param {?string} strokeColor The item line (stroke) color
  * @param {os.ui.file.kml.Icon=} opt_icon The item icon
+ * @param {?number=} opt_strokeWidth the width of the line (stroke)
  * @protected
  */
 os.ui.file.kml.AbstractKMLExporter.prototype.createStyle = function(item, styleId, color, fillColor, strokeColor,
-    opt_icon) {
+    opt_icon, opt_strokeWidth) {
   var styleEl = os.xml.createElementNS('Style', this.kmlNS, this.doc, undefined, {
     'id': styleId
   });
@@ -768,7 +769,7 @@ os.ui.file.kml.AbstractKMLExporter.prototype.createStyle = function(item, styleI
 
   var lineStyleEl = os.xml.appendElementNS('LineStyle', this.kmlNS, styleEl);
   os.xml.appendElementNS('color', this.kmlNS, lineStyleEl, strokeColor || color);
-  os.xml.appendElementNS('width', this.kmlNS, lineStyleEl, 2);
+  os.xml.appendElementNS('width', this.kmlNS, lineStyleEl, opt_strokeWidth || 2);
 
   var polyStyleEl = os.xml.appendElementNS('PolyStyle', this.kmlNS, styleEl);
   os.xml.appendElementNS('color', this.kmlNS, polyStyleEl, fillColor || color);
@@ -850,6 +851,15 @@ os.ui.file.kml.AbstractKMLExporter.prototype.getFillColor = function(item) {};
  * @protected
  */
 os.ui.file.kml.AbstractKMLExporter.prototype.getStrokeColor = function(item) {};
+
+/**
+ * Get the stroke width of an item.
+ * @abstract
+ * @param {T} item The item
+ * @return {?number} The item's stroke width as an integer, or null to use default value
+ * @protected
+ */
+os.ui.file.kml.AbstractKMLExporter.prototype.getStrokeWidth = function(item) {};
 
 
 /**
@@ -1064,11 +1074,14 @@ os.ui.file.kml.AbstractKMLExporter.prototype.getStyleId = function(item) {
     }
   }
 
+  var strokeWidth = this.getStrokeWidth(item);
+  styleParts.push(strokeWidth);
+
   // hyphen separate the id components
   styleId = styleParts.join('-');
 
   if (!(styleId in this.styles_)) {
-    this.createStyle(item, styleId, color, fillColor, strokeColor, icon);
+    this.createStyle(item, styleId, color, fillColor, strokeColor, icon, strokeWidth);
   }
 
   return styleId;

--- a/src/plugin/file/kml/kmlexporter.js
+++ b/src/plugin/file/kml/kmlexporter.js
@@ -128,6 +128,12 @@ plugin.file.kml.KMLExporter.prototype.getStrokeColor = function(item) {
   return itemColor ? os.style.toAbgrString(itemColor) : null;
 };
 
+/**
+ * @inheritDoc
+ */
+plugin.file.kml.KMLExporter.prototype.getStrokeWidth = function(item) {
+  return os.feature.getStrokeWidth(item);
+};
 
 /**
  * @inheritDoc

--- a/src/plugin/file/kml/kmltreeexporter.js
+++ b/src/plugin/file/kml/kmltreeexporter.js
@@ -133,6 +133,12 @@ plugin.file.kml.KMLTreeExporter.prototype.getStrokeColor = function(item) {
   return featureColor ? os.style.toAbgrString(featureColor) : null;
 };
 
+/**
+ * @inheritDoc
+ */
+plugin.file.kml.KMLTreeExporter.prototype.getStrokeWidth = function(item) {
+  return os.feature.getStrokeWidth(item.getFeature());
+};
 
 /**
  * @inheritDoc


### PR DESCRIPTION
Resolves #798.

One way to test is to import a KML file with a non-standard width (say 5) into Places, then export it, and verify the export has the expected (round-tripped) width.

Sample:
```
<?xml version="1.0"?>
<kml xmlns="http://www.opengis.net/kml/2.2"
    xmlns:gx="http://www.google.com/kml/ext/2.2"
    xmlns:os="http://opensphere.io/kml/ext/1.0">
    <Document>
        <name>temp area 1</name>
        <visibility>1</visibility>
        <Placemark id="area_z8biobqpdtxi">
            <name>temp area 1</name>
            <styleUrl>#default-ffffffff-00ffffff-ffffffff</styleUrl>
            <visibility>1</visibility>
            <Polygon>
                <outerBoundaryIs>
                    <LinearRing>
                        <coordinates>147.46239577961353,-27.46437091023244,0 147.46239577961353,-25.727198308700153,0 150.500308352867,-25.727198308700153,0 150.500308352867,-27.46437091023244,0 147.46239577961353,-27.46437091023244,0</coordinates>
                    </LinearRing>
                </outerBoundaryIs>
            </Polygon>
            <ExtendedData>
                <Data name="title">
                    <value>temp area 1</value>
                </Data>
                <Data name="interpolationMethod">
                    <value>rhumb</value>
                </Data>
                <Data name="mapVisualizationType">
                    <value>ANNOTATION_REGIONS</value>
                </Data>
            </ExtendedData>
        </Placemark>
        <Style id="default-ffffffff-00ffffff-ffffffff">
            <IconStyle>
                <color>ffffffff</color>
            </IconStyle>
            <LineStyle>
                <color>ffffffff</color>
                <width>5</width>
            </LineStyle>
            <PolyStyle>
                <color>00ffffff</color>
                <fill>1</fill>
                <outline>1</outline>
            </PolyStyle>
        </Style>
    </Document>
</kml>
```

