### PR TITLE
feat(presets): support sharing presets among matching layerFilterKeys

### DIFF
--- a/src/os/layer/preset/layerpresetmanager.js
+++ b/src/os/layer/preset/layerpresetmanager.js
@@ -74,10 +74,11 @@ class LayerPresetManager extends Disposable {
 
     if (layer) {
       const layerId = layer.getId();
-      const layerOptions = layer.getLayerOptions();
-      if (layerId && layerOptions && layerOptions['applyDefaultPresets']) {
-        // Apply default presets to the layer when configured.
-        this.getPresets(layerId, true);
+      const promise = this.getPresets(layerId);
+      if (promise) {
+        promise.then((presets) => {
+          this.applyDefaults(layerId, presets);
+        });
       }
     }
   }
@@ -137,11 +138,21 @@ class LayerPresetManager extends Disposable {
    * @return {Promise<Array<osx.layer.Preset>>|undefined}
    */
   getPresets(id, opt_applyDefault) {
-    if (!this.presets_[id]) {
-      this.initPreset(id, opt_applyDefault);
+    var promise = this.presets_[id];
+
+    if (!promise) {
+      // Do NOT pass opt_applyDefault down to initPreset; applyDefaults() is called on-demand below, possibly
+      // on an already-resolved promise
+      promise = this.initPreset(id);
     }
 
-    return this.presets_[id];
+    // handle this separately from the initPreset so future calls to getPresets can try to applyDefaults()
+    if (promise && opt_applyDefault) {
+      promise.then((presets) => {
+        this.applyDefaults(id, presets);
+      });
+    }
+    return promise;
   }
 
   /**
@@ -172,7 +183,7 @@ class LayerPresetManager extends Disposable {
       for (var [, service, isAdmin] of entries) {
         if (isAdmin) this.isAdmin(true); // enable the admin UI if User has admin in any service
 
-        if (service.supports(OsLayerPreset.PresetServiceAction.FIND)) {
+        if (filterKey && service.supports(OsLayerPreset.PresetServiceAction.FIND)) {
           promises.push(service.find(/** @type {osx.layer.PresetSearch} */ ({
             layerId: [id],
             layerFilterKey: [filterKey],
@@ -204,11 +215,6 @@ class LayerPresetManager extends Disposable {
             OsLayerPreset.addDefault(presets, id, filterKey || undefined);
           }
 
-          // apply the "isDefault" preset if asked
-          if (opt_applyDefault) {
-            this.applyDefaults(id, presets);
-          }
-
           // return the list to any .then() bindings
           resolve(presets);
         });
@@ -216,6 +222,13 @@ class LayerPresetManager extends Disposable {
         resolve(null);
       }
     });
+
+    // apply the "isDefault" preset if asked
+    if (opt_applyDefault) {
+      promise.then((presets) => {
+        this.applyDefaults(id, presets);
+      });
+    }
 
     this.presets_[id] = promise;
   }
@@ -228,22 +241,24 @@ class LayerPresetManager extends Disposable {
    * @protected
    */
   applyDefaults(id, presets) {
-    var applied = /** @type {!Object<boolean>} */
-        (settings.getInstance().get(OsLayerPreset.SettingKey.APPLIED_DEFAULTS, {}));
+    if (Array.isArray(presets) && presets.length) {
+      var applied = /** @type {!Object<boolean>} */
+          (settings.getInstance().get(OsLayerPreset.SettingKey.APPLIED_DEFAULTS, {}));
 
-    if (Array.isArray(presets) && presets.length && !applied[id]) {
-      var preset = presets.find(function(preset) {
-        return preset.default || false; // TODO gets the first one; instead, look for the first and latest updated
-      });
+      if (!applied[id]) {
+        var preset = presets.find(function(preset) {
+          return preset.default || false; // TODO gets the first one; instead, look for the first and latest updated
+        });
 
-      if (preset) {
-        var cmd = new VectorLayerPreset(id, preset);
-        cmd.execute();
+        if (preset) {
+          var cmd = new VectorLayerPreset(id, preset);
+          cmd.execute();
+        }
+
+        // apply the Default style for a layer only once as long as the settings remain intact
+        applied[id] = true;
+        settings.getInstance().set(OsLayerPreset.SettingKey.APPLIED_DEFAULTS, applied);
       }
-
-      // apply the Default style for a layer only once as long as the settings remain intact
-      applied[id] = true;
-      settings.getInstance().set(OsLayerPreset.SettingKey.APPLIED_DEFAULTS, applied);
     }
   }
 }

--- a/src/os/layer/preset/layerpresetmanager.js
+++ b/src/os/layer/preset/layerpresetmanager.js
@@ -74,11 +74,13 @@ class LayerPresetManager extends Disposable {
 
     if (layer) {
       const layerId = layer.getId();
-      const promise = this.getPresets(layerId);
-      if (promise) {
-        promise.then((presets) => {
-          this.applyDefaults(layerId, presets);
-        });
+      if (layerId) {
+        const promise = this.getPresets(layerId);
+        if (promise) {
+          promise.then((presets) => {
+            this.applyDefaults(layerId, presets);
+          });
+        }
       }
     }
   }
@@ -143,7 +145,8 @@ class LayerPresetManager extends Disposable {
     if (!promise) {
       // Do NOT pass opt_applyDefault down to initPreset; applyDefaults() is called on-demand below, possibly
       // on an already-resolved promise
-      promise = this.initPreset(id);
+      this.initPreset(id);
+      promise = this.presets_[id];
     }
 
     // handle this separately from the initPreset so future calls to getPresets can try to applyDefaults()
@@ -168,7 +171,9 @@ class LayerPresetManager extends Disposable {
 
     // HACK: doing goog.require('os.MapContainer') properly creates a circular dependency somewhere in
     // the os.layer chain. TODO Fix it when there's time
-    var layer = os.map.mapContainer.getLayer(id);
+    var layer = (os.map.mapContainer) ? os.map.mapContainer.getLayer(id) : null;
+
+    if (!layer) return; // extra check; can't do presets without a working layer to which to add them
 
     if (osImplements(layer, IFilterable.ID)) {
       filterKey = /** @type {IFilterable} */ (layer).getFilterKey();

--- a/src/os/ui/im/action/filteractiontreesearch.js
+++ b/src/os/ui/im/action/filteractiontreesearch.js
@@ -32,7 +32,10 @@ os.ui.im.action.FilterActionTreeSearch = function(property, onObj, opt_type) {
   this.showDefaultActions = true;
 
   // filter out default actions when the flag is false
-  this.setFilterFunction((node) => this.showDefaultActions ? true : !node.getEntry().isDefault());
+  this.setFilterFunction((node) => {
+    var entry = node.getEntry();
+    return !entry.getParent() && (this.showDefaultActions || !entry.isDefault());
+  });
 };
 goog.inherits(os.ui.im.action.FilterActionTreeSearch, os.ui.slick.AbstractGroupByTreeSearch);
 

--- a/src/os/ui/layer/vectorlayerui.js
+++ b/src/os/ui/layer/vectorlayerui.js
@@ -390,6 +390,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.loadPresets = function() {
 
 /**
  * Apply the layer preset.
+ * @export
  */
 os.ui.layer.VectorLayerUICtrl.prototype.applyPreset = function() {
   var items = /** @type {Array} */ (this.scope['items']);
@@ -400,9 +401,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.applyPreset = function() {
          * @param {os.layer.ILayer} layer
          * @return {os.command.ICommand}
          */
-        function(layer) {
-          return new os.command.VectorLayerPreset(layer.getId(), value);
-        };
+        (layer) => new os.command.VectorLayerPreset(layer.getId(), value);
 
     this.createCommand(fn);
   }

--- a/src/plugin/featureaction/featureactionmanager.js
+++ b/src/plugin/featureaction/featureactionmanager.js
@@ -9,10 +9,10 @@ goog.require('os.data.event.DataEventType');
 goog.require('os.im.action.ImportActionCallbackConfig');
 goog.require('os.im.action.ImportActionManager');
 goog.require('os.implements');
+goog.require('os.layer.preset.LayerPresetManager');
 goog.require('os.source.IImportSource');
 goog.require('plugin.im.action.feature');
 goog.require('plugin.im.action.feature.Entry');
-
 
 
 /**
@@ -309,9 +309,15 @@ plugin.im.action.feature.Manager.prototype.addSource_ = function(source) {
       this.sourceListeners_[id] = ol.events.listen(/** @type {ol.events.EventTarget} */ (source),
           goog.events.EventType.PROPERTYCHANGE, this.onSourcePropertyChange_, this);
 
-      this.loadDefaults(id).thenAlways(function() {
+      var promise = os.layer.preset.LayerPresetManager.getInstance().getPresets(id);
+
+      if (promise) {
+        promise.thenAlways(() => {
+          this.processItems(id);
+        });
+      } else {
         this.processItems(id);
-      }, this);
+      }
     }
   }
 };

--- a/src/plugin/featureaction/featureactionmanager.js
+++ b/src/plugin/featureaction/featureactionmanager.js
@@ -309,7 +309,7 @@ plugin.im.action.feature.Manager.prototype.addSource_ = function(source) {
       this.sourceListeners_[id] = ol.events.listen(/** @type {ol.events.EventTarget} */ (source),
           goog.events.EventType.PROPERTYCHANGE, this.onSourcePropertyChange_, this);
 
-      var promise = os.layer.preset.LayerPresetManager.getInstance().getPresets(id);
+      var promise = os.layer.preset.LayerPresetManager.getInstance().getPresets(id, true);
 
       if (promise) {
         promise.thenAlways(() => {

--- a/src/plugin/featureaction/ui/featureactionsui.js
+++ b/src/plugin/featureaction/ui/featureactionsui.js
@@ -4,6 +4,7 @@ goog.provide('plugin.im.action.feature.ui.featureActionsDirective');
 goog.require('os.source');
 goog.require('os.ui.Module');
 goog.require('os.ui.im.action.FilterActionsCtrl');
+goog.require('os.ui.slick.TreeSearch');
 goog.require('plugin.im.action.feature');
 goog.require('plugin.im.action.feature.node');
 
@@ -142,7 +143,9 @@ plugin.im.action.feature.ui.FeatureActionsCtrl.prototype.onSearch = function() {
   plugin.im.action.feature.ui.FeatureActionsCtrl.base(this, 'onSearch');
 
   if (this['hasDefaultActions'] === undefined && this.scope['entries'] && this.scope['entries'].length > 0) {
-    this['hasDefaultActions'] = this.scope['entries'].some((node) => node.getEntry().isDefault());
+    this['hasDefaultActions'] = this.scope['entries'].some((node) => {
+      return node.getId() != os.ui.slick.TreeSearch.NO_RESULT_ID && node.getEntry().isDefault();
+    });
     os.ui.apply(this.scope);
   }
 };


### PR DESCRIPTION
Fixed minor issues with Feature Action searches and filters in edge cases.
Used more robust layerpresetmanager.getPresets() to load all feature actions when adding a source instead of only the embedded loadDefaults().