### PR TITLE
fix(arc): don't detect wms url's from an arc server

### DIFF
--- a/src/plugin/arc/arc.js
+++ b/src/plugin/arc/arc.js
@@ -91,6 +91,13 @@ plugin.arc.URI_REGEXP = /arcgis/i;
  * @type {RegExp}
  * @const
  */
+plugin.arc.WMS_URI_REGEXP = /(\/WMSServer|service=WMS)/i;
+
+
+/**
+ * @type {RegExp}
+ * @const
+ */
 plugin.arc.CONTENT_REGEXP = /ArcGIS REST Services Directory/i;
 
 

--- a/src/plugin/arc/mime.js
+++ b/src/plugin/arc/mime.js
@@ -13,11 +13,12 @@ goog.require('plugin.arc');
  * @return {!goog.Promise<*|undefined>}
  */
 plugin.arc.mime.detectArc = function(buffer, file, opt_context) {
+  var url = file ? file.getUrl() : null;
   var content = typeof opt_context === 'string' ? opt_context :
   /** @type {os.file.mime.xml.Context} */ (opt_context.content);
   return /** @type {!goog.Promise<*|undefined>} */ (goog.Promise.resolve((content &&
     plugin.arc.CONTENT_REGEXP.test(content)) ||
-    (file && file.getUrl() && plugin.arc.URI_REGEXP.test(file.getUrl()))));
+    (plugin.arc.URI_REGEXP.test(url) && !plugin.arc.WMS_URI_REGEXP.test(url))));
 };
 
 

--- a/test/plugin/arc/mime.test.js
+++ b/test/plugin/arc/mime.test.js
@@ -11,8 +11,12 @@ describe('plugin.arc.mime', function() {
       '/base/test/resources/ogc/wms-111.xml',
       '/base/test/resources/ogc/wfs-200.xml',
       '/base/test/resources/ogc/wfs-110.xml',
-      '/base/test/resources/ogc/exception-report.xml'],
-        os.file.mime.mock.testNo(plugin.arc.ID));
+      '/base/test/resources/ogc/exception-report.xml',
+      // Test URL-based detection. "arcgis" is a positive match, but "/wmsserver" should be negative.
+      '/base/test/resources/arc/arcgis/wmsserver/wms-130.xml',
+      // Similarly, "arcgis" is a positive match, but "service=WMS" should be negative.
+      '/base/test/resources/arc/arcgis/wms-130.xml?service=WMS&request=GetCapabilities'
+    ], os.file.mime.mock.testNo(plugin.arc.ID));
   });
 
   it('should detect files that are ArcGIS Server files', function() {

--- a/test/resources/arc/arcgis/wms-130.xml
+++ b/test/resources/arc/arcgis/wms-130.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<WMS_Capabilities xmlns="http://www.opengis.net/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.3.0" xsi:schemaLocation="http://www.opengis.net/wms https://example.com/ogc/schemas/wms/1.3.0/capabilities_1_3_0.xsd">
+  <Capability>
+    <Request>
+      <GetCapabilities>
+        <Format>text/xml</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:type="simple" xlink:href="https://example.com/ogc/wmsServer?"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetCapabilities>
+      <GetMap>
+        <Format>image/png</Format>
+        <Format>image/png; color=GRAYSCALE</Format>
+        <Format>image/png; color=INDEXED</Format>
+        <Format>image/png; interlaced=true</Format>
+        <Format>application/zip; subtype=image/bil</Format>
+        <Format>image/bil</Format>
+        <Format>image/dds</Format>
+        <Format>image/gif</Format>
+        <Format>image/jpeg</Format>
+        <Format>image/jpeg; quality=10</Format>
+        <Format>image/jpeg; quality=100</Format>
+        <Format>image/jpeg; quality=50</Format>
+        <Format>image/jpeg; quality=90</Format>
+        <Format>image/tiff</Format>
+        <Format>image/tiff; compression=DEFLATE</Format>
+        <Format>image/tiff; compression=DEFLATE; level=1</Format>
+        <Format>image/tiff; compression=DEFLATE; level=9</Format>
+        <Format>image/tiff; compression=GROUP3_1D</Format>
+        <Format>image/tiff; compression=GROUP3_2D</Format>
+        <Format>image/tiff; compression=GROUP4</Format>
+        <Format>image/tiff; compression=JPEG_TTN2</Format>
+        <Format>image/tiff; compression=JPEG_TTN2; quality=10</Format>
+        <Format>image/tiff; compression=JPEG_TTN2; quality=100</Format>
+        <Format>image/tiff; compression=JPEG_TTN2; quality=50</Format>
+        <Format>image/tiff; compression=JPEG_TTN2; quality=90</Format>
+        <Format>image/tiff; compression=NONE</Format>
+        <Format>image/tiff; compression=PACKBITS</Format>
+        <Format>image/webp</Format>
+        <Format>image/webp; compression=lossless; quality=0</Format>
+        <Format>image/webp; compression=lossless; quality=25</Format>
+        <Format>image/webp; compression=lossless; quality=50</Format>
+        <Format>image/webp; compression=lossy; quality=10</Format>
+        <Format>image/webp; compression=lossy; quality=100</Format>
+        <Format>image/webp; compression=lossy; quality=50</Format>
+        <Format>image/webp; compression=lossy; quality=90</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:type="simple" xlink:href="https://example.com/ogc/wmsServer?"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetMap>
+    </Request>
+    <Exception>
+      <Format>XML</Format>
+      <Format>INIMAGE</Format>
+      <Format>BLANK</Format>
+    </Exception>
+    <Layer queryable="false" opaque="false" fixedWidth="0" fixedHeight="0">
+      <Title>Root_Folder</Title>
+      <Abstract>This is the root folder</Abstract>
+      <CRS>EPSG:4326</CRS>
+      <CRS>CRS:84</CRS>
+      <CRS>EPSG:3857</CRS>
+      <BoundingBox CRS="EPSG:4326" minx="-90.0" miny="-180.0" maxx="90.0" maxy="180.0"/>
+      <BoundingBox CRS="CRS:84" minx="-180.0" miny="-90.0" maxx="180.0" maxy="90.0"/>
+      <Layer queryable="false" opaque="false" fixedWidth="0" fixedHeight="0">
+        <Name>inherit</Name>
+        <Title>inherit</Title>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-180.0</westBoundLongitude>
+          <eastBoundLongitude>180.0</eastBoundLongitude>
+          <southBoundLatitude>-90.0</southBoundLatitude>
+          <northBoundLatitude>90.0</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:4326" minx="-90.0" miny="-180.0" maxx="90.0" maxy="180.0"/>
+        <BoundingBox CRS="CRS:84" minx="-180.0" miny="-90.0" maxx="180.0" maxy="90.0"/>
+      </Layer>
+      <Layer queryable="false" opaque="false" fixedWidth="0" fixedHeight="0">
+        <Name>add_crs</Name>
+        <Title>add_crs</Title>
+        <CRS>EPSG:3395</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-180.0</westBoundLongitude>
+          <eastBoundLongitude>180.0</eastBoundLongitude>
+          <southBoundLatitude>-90.0</southBoundLatitude>
+          <northBoundLatitude>90.0</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:4326" minx="-90.0" miny="-180.0" maxx="90.0" maxy="180.0"/>
+        <BoundingBox CRS="CRS:84" minx="-180.0" miny="-90.0" maxx="180.0" maxy="90.0"/>
+        <Dimension name="time" units="ISO8601">2017-06-01T00:08:23.000Z/2018-06-06T23:59:37.000Z/PT1S</Dimension>
+      </Layer>
+    </Layer>
+  </Capability>
+</WMS_Capabilities>

--- a/test/resources/arc/arcgis/wmsserver/wms-130.xml
+++ b/test/resources/arc/arcgis/wmsserver/wms-130.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<WMS_Capabilities xmlns="http://www.opengis.net/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.3.0" xsi:schemaLocation="http://www.opengis.net/wms https://example.com/ogc/schemas/wms/1.3.0/capabilities_1_3_0.xsd">
+  <Capability>
+    <Request>
+      <GetCapabilities>
+        <Format>text/xml</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:type="simple" xlink:href="https://example.com/ogc/wmsServer?"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetCapabilities>
+      <GetMap>
+        <Format>image/png</Format>
+        <Format>image/png; color=GRAYSCALE</Format>
+        <Format>image/png; color=INDEXED</Format>
+        <Format>image/png; interlaced=true</Format>
+        <Format>application/zip; subtype=image/bil</Format>
+        <Format>image/bil</Format>
+        <Format>image/dds</Format>
+        <Format>image/gif</Format>
+        <Format>image/jpeg</Format>
+        <Format>image/jpeg; quality=10</Format>
+        <Format>image/jpeg; quality=100</Format>
+        <Format>image/jpeg; quality=50</Format>
+        <Format>image/jpeg; quality=90</Format>
+        <Format>image/tiff</Format>
+        <Format>image/tiff; compression=DEFLATE</Format>
+        <Format>image/tiff; compression=DEFLATE; level=1</Format>
+        <Format>image/tiff; compression=DEFLATE; level=9</Format>
+        <Format>image/tiff; compression=GROUP3_1D</Format>
+        <Format>image/tiff; compression=GROUP3_2D</Format>
+        <Format>image/tiff; compression=GROUP4</Format>
+        <Format>image/tiff; compression=JPEG_TTN2</Format>
+        <Format>image/tiff; compression=JPEG_TTN2; quality=10</Format>
+        <Format>image/tiff; compression=JPEG_TTN2; quality=100</Format>
+        <Format>image/tiff; compression=JPEG_TTN2; quality=50</Format>
+        <Format>image/tiff; compression=JPEG_TTN2; quality=90</Format>
+        <Format>image/tiff; compression=NONE</Format>
+        <Format>image/tiff; compression=PACKBITS</Format>
+        <Format>image/webp</Format>
+        <Format>image/webp; compression=lossless; quality=0</Format>
+        <Format>image/webp; compression=lossless; quality=25</Format>
+        <Format>image/webp; compression=lossless; quality=50</Format>
+        <Format>image/webp; compression=lossy; quality=10</Format>
+        <Format>image/webp; compression=lossy; quality=100</Format>
+        <Format>image/webp; compression=lossy; quality=50</Format>
+        <Format>image/webp; compression=lossy; quality=90</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xlink:type="simple" xlink:href="https://example.com/ogc/wmsServer?"/>
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetMap>
+    </Request>
+    <Exception>
+      <Format>XML</Format>
+      <Format>INIMAGE</Format>
+      <Format>BLANK</Format>
+    </Exception>
+    <Layer queryable="false" opaque="false" fixedWidth="0" fixedHeight="0">
+      <Title>Root_Folder</Title>
+      <Abstract>This is the root folder</Abstract>
+      <CRS>EPSG:4326</CRS>
+      <CRS>CRS:84</CRS>
+      <CRS>EPSG:3857</CRS>
+      <BoundingBox CRS="EPSG:4326" minx="-90.0" miny="-180.0" maxx="90.0" maxy="180.0"/>
+      <BoundingBox CRS="CRS:84" minx="-180.0" miny="-90.0" maxx="180.0" maxy="90.0"/>
+      <Layer queryable="false" opaque="false" fixedWidth="0" fixedHeight="0">
+        <Name>inherit</Name>
+        <Title>inherit</Title>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-180.0</westBoundLongitude>
+          <eastBoundLongitude>180.0</eastBoundLongitude>
+          <southBoundLatitude>-90.0</southBoundLatitude>
+          <northBoundLatitude>90.0</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:4326" minx="-90.0" miny="-180.0" maxx="90.0" maxy="180.0"/>
+        <BoundingBox CRS="CRS:84" minx="-180.0" miny="-90.0" maxx="180.0" maxy="90.0"/>
+      </Layer>
+      <Layer queryable="false" opaque="false" fixedWidth="0" fixedHeight="0">
+        <Name>add_crs</Name>
+        <Title>add_crs</Title>
+        <CRS>EPSG:3395</CRS>
+        <EX_GeographicBoundingBox>
+          <westBoundLongitude>-180.0</westBoundLongitude>
+          <eastBoundLongitude>180.0</eastBoundLongitude>
+          <southBoundLatitude>-90.0</southBoundLatitude>
+          <northBoundLatitude>90.0</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:4326" minx="-90.0" miny="-180.0" maxx="90.0" maxy="180.0"/>
+        <BoundingBox CRS="CRS:84" minx="-180.0" miny="-90.0" maxx="180.0" maxy="90.0"/>
+        <Dimension name="time" units="ISO8601">2017-06-01T00:08:23.000Z/2018-06-06T23:59:37.000Z/PT1S</Dimension>
+      </Layer>
+    </Layer>
+  </Capability>
+</WMS_Capabilities>


### PR DESCRIPTION
ArcGIS supports serving content via WMS, which is incorrectly being detected as an Arc server if `arcgis` is in the URL. This ignores those matches if the URL contains `/WMSServer` or `service=WMS`, so the content may be detected by the OGC plugin.

Example URL: https://nowcoast.noaa.gov/arcgis/services/nowcoast/analysis_ocean_sfc_sst_time/MapServer/WMSServer?request=GetCapabilities&service=WMS&version=1.3.0