### PR TITLE
feat(map): allow rotation in 2d and don't reset when switching to 2d

### DIFF
--- a/src/os/control/rotatecontrol.js
+++ b/src/os/control/rotatecontrol.js
@@ -53,7 +53,8 @@ os.control.Rotate.render = function(mapEvent) {
       return;
     }
 
-    rotation = camera.getHeading();
+    // OpenLayers rotation is in the opposite direction of WebGL camera heading.
+    rotation = -camera.getHeading();
   } else {
     var frameState = mapEvent.frameState;
     if (!frameState) {

--- a/src/os/interaction/interaction.js
+++ b/src/os/interaction/interaction.js
@@ -9,6 +9,14 @@ goog.requireType('ol.render.Feature');
 
 
 /**
+ * Rotation delta, in radians.
+ * @type {number}
+ * @const
+ */
+os.interaction.ROTATE_DELTA = Math.PI / 60;
+
+
+/**
  * Feature hit detection callback.
  *
  * @param {(ol.Feature|ol.render.Feature)} feature The feature

--- a/src/os/map/mapinteractions.js
+++ b/src/os/map/mapinteractions.js
@@ -18,6 +18,7 @@ goog.require('os.interaction.KeyboardPan');
 goog.require('os.interaction.KeyboardTiltRotate');
 goog.require('os.interaction.KeyboardZoom');
 goog.require('os.interaction.Measure');
+goog.require('os.interaction.MouseRotate');
 goog.require('os.interaction.MouseZoom');
 goog.require('os.interaction.PinchZoom');
 goog.require('os.interaction.Reset');
@@ -45,6 +46,9 @@ os.map.interaction.getInteractions = function() {
   var mwZoom = new os.ui.ol.interaction.MouseWheelZoom(options);
   var mZoom = new os.interaction.MouseZoom(options);
   var dcZoom = new os.interaction.DoubleClickZoom();
+
+  // Mouse rotate
+  var mRotate = new os.interaction.MouseRotate(options);
 
   // Screen pinch-zoom
   var pinchZoom = new os.interaction.PinchZoom();
@@ -107,6 +111,7 @@ os.map.interaction.getInteractions = function() {
     mwZoom,
     mZoom,
     dcZoom,
+    mRotate,
     contextMenu,
     select,
     drawBox,

--- a/views/config/displaysettings.html
+++ b/views/config/displaysettings.html
@@ -122,6 +122,14 @@
       <slider class="col-6" min="0" max="1" step="0.1" value="display.fogDensity" live="true" name="fogDensity">
       </slider>
     </div>
+    <div class="form-group">
+      <div class="form-check" title="{{display.help.resetRotation2d}}">
+        <input class="form-check-input" id="resetRotation2d" type="checkbox" ng-model="display.resetRotation2d"
+            ng-change="display.updateResetRotation()" >
+        <label class="form-check-label col-4 p-0" for="resetRotation2d">Reset Rotation in 2D</label>
+        <popover x-title="'Reset Rotation in 2D'" content="display.help.resetRotation2d" pos="'right'"></popover>
+      </div>
+    </div>
   </div>
 
   <div ng-form="features">


### PR DESCRIPTION
Rotation was disabled in 2D and reset when switching from 3D to 2D for performance reasons. This was largely due to inefficient tile rendering in Chrome, which has since been fixed. The canvas renderer still goes down a less efficient path, but works perfectly fine in many situations. It seems the preferred behavior is to maintain rotation when switching between 3D/2D, so the current view is maintained between the two.

This PR makes the following changes:

- Rotation is no longer reset when switching from 3D to 2D.
- The above can be toggled in Settings > Display if the old behavior is preferred.
- 3D rotation controls now work in 2D. This includes the keyboard (Shift + Left/Right Arrow) and mouse (Right/Middle Click + Drag) interactions.
- The above controls are documented in the Controls UI (Support > Controls).
- WebGL heading and OpenLayers rotation both use 0 for north, but the directions are opposite. This caused a few bugs we hadn't noticed. The rotate map control (top/right) will now rotate towards north (3D was rotating the wrong direction), and view persist/restore will no longer flip rotation direction in situations where 2D saved the view and 3D restored it.

[Test Deployment](https://noisy-arithmetic.surge.sh/)