### PR TITLE
chore: update provides for easier es6 transition

### DIFF
--- a/docs/cookbook/metrics/src/cookbook-metrics.js
+++ b/docs/cookbook/metrics/src/cookbook-metrics.js
@@ -86,7 +86,7 @@ plugin.cookbook_metrics.CookbookMetrics.prototype.init = function() {
   var metricsManager = os.ui.metrics.MetricsManager.getInstance();
   metricsManager.addMetricsPlugin(new plugin.cookbook_metrics.Metrics());
 
-  var menu = os.ui.menu.SPATIAL;
+  var menu = os.ui.menu.spatial.MENU;
   if (menu) {
     var root = menu.getRoot();
     var group = root.find(plugin.cookbook_metrics.MYGROUP);

--- a/docs/cookbook/submenu/index.rst
+++ b/docs/cookbook/submenu/index.rst
@@ -22,13 +22,13 @@ Extend the existing menu with Group, SubMenu and Item elements to provide your p
 Discussion
 ----------
 
-The Spatial menu (:code:`os.ui.menu.SPATIAL`) is extensible from plugins. You can then attach groups, separators, submenus and items (plain items, checkboxes, or radio buttons) to the root, or to sub-items. In the image and code, a group item is added to the root, then submenus are nested below that group, and some items are available for selection.
+The Spatial menu (:code:`os.ui.menu.spatial.MENU`) is extensible from plugins. You can then attach groups, separators, submenus and items (plain items, checkboxes, or radio buttons) to the root, or to sub-items. In the image and code, a group item is added to the root, then submenus are nested below that group, and some items are available for selection.
 
 If your plugin has all items known in advance, its possible to use the :code:`children` property to nest the whole structure, as shown here:
 
 .. code-block:: javascript
 
-  var menu = os.ui.menu.SPATIAL;
+  var menu = os.ui.menu.spatial.MENU;
   if (menu) {
     var root = menu.getRoot();
     var group = root.find(plugin.cookbook_submenu.MYGROUP);

--- a/docs/cookbook/submenu/src/cookbook-submenu.js
+++ b/docs/cookbook/submenu/src/cookbook-submenu.js
@@ -42,7 +42,7 @@ plugin.cookbook_submenu.EventType = {
  * @inheritDoc
  */
 plugin.cookbook_submenu.CookbookSubmenu.prototype.init = function() {
-  var menu = os.ui.menu.SPATIAL;
+  var menu = os.ui.menu.spatial.MENU;
   if (menu) {
     var root = menu.getRoot();
     var group = root.find(plugin.cookbook_submenu.MYGROUP);

--- a/src/os/bearing/bearing.js
+++ b/src/os/bearing/bearing.js
@@ -1,4 +1,5 @@
 goog.provide('os.bearing');
+goog.provide('os.bearing.BearingSettingsKeys');
 goog.provide('os.bearing.BearingType');
 
 goog.require('os.config.Settings');

--- a/src/os/data/areanode.js
+++ b/src/os/data/areanode.js
@@ -48,7 +48,7 @@ os.data.AreaNode.prototype.disposeInternal = function() {
  * @inheritDoc
  */
 os.data.AreaNode.prototype.getMenu = function() {
-  return os.ui.menu.SPATIAL;
+  return os.ui.menu.spatial.MENU;
 };
 
 

--- a/src/os/data/drawingfeaturenode.js
+++ b/src/os/data/drawingfeaturenode.js
@@ -48,7 +48,7 @@ os.data.DrawingFeatureNode.ORIGINAL_STYLE = '_originalStyle';
  * @inheritDoc
  */
 os.data.DrawingFeatureNode.prototype.getMenu = function() {
-  return os.ui.menu.SPATIAL;
+  return os.ui.menu.spatial.MENU;
 };
 
 

--- a/src/os/filter/filterentry.js
+++ b/src/os/filter/filterentry.js
@@ -1,4 +1,5 @@
 goog.provide('os.filter.FilterEntry');
+goog.provide('os.filter.cloneToContext');
 
 goog.require('goog.dom.xml');
 goog.require('goog.events.EventTarget');

--- a/src/os/mainctrl.js
+++ b/src/os/mainctrl.js
@@ -306,7 +306,7 @@ os.MainCtrl = function($scope, $element, $compile, $timeout, $injector) {
   os.ui.menu.windows.default.setup();
 
   // assign the spatial menu
-  os.ui.draw.MENU = os.ui.menu.SPATIAL;
+  os.ui.draw.MENU = os.ui.menu.spatial.MENU;
 
   // register base legend plugins
   os.data.histo.legend.registerLegendPlugin();

--- a/src/os/map/mapinteractions.js
+++ b/src/os/map/mapinteractions.js
@@ -90,12 +90,12 @@ os.map.interaction.getInteractions = function() {
 
   var reset = new os.interaction.Reset();
 
-  goog.asserts.assert(os.ui.menu.MAP != null, 'map manager has not been initialized');
+  goog.asserts.assert(os.ui.menu.map.MENU != null, 'map manager has not been initialized');
   goog.asserts.assert(os.ui.menu.spatial.MENU != null, 'spatial manager has not been initialized');
 
   var contextOptions = /** @type {os.ui.ol.interaction.ContextMenuOptions} */ ({
     featureMenu: os.ui.menu.spatial.MENU,
-    mapMenu: os.ui.menu.MAP
+    mapMenu: os.ui.menu.map.MENU
   });
   var contextMenu = new os.interaction.ContextMenu(contextOptions);
 

--- a/src/os/map/mapinteractions.js
+++ b/src/os/map/mapinteractions.js
@@ -91,10 +91,10 @@ os.map.interaction.getInteractions = function() {
   var reset = new os.interaction.Reset();
 
   goog.asserts.assert(os.ui.menu.MAP != null, 'map manager has not been initialized');
-  goog.asserts.assert(os.ui.menu.SPATIAL != null, 'spatial manager has not been initialized');
+  goog.asserts.assert(os.ui.menu.spatial.MENU != null, 'spatial manager has not been initialized');
 
   var contextOptions = /** @type {os.ui.ol.interaction.ContextMenuOptions} */ ({
-    featureMenu: os.ui.menu.SPATIAL,
+    featureMenu: os.ui.menu.spatial.MENU,
     mapMenu: os.ui.menu.MAP
   });
   var contextMenu = new os.interaction.ContextMenu(contextOptions);

--- a/src/os/track.js
+++ b/src/os/track.js
@@ -1,4 +1,10 @@
 goog.provide('os.track');
+goog.provide('os.track.AddOptions');
+goog.provide('os.track.CreateOptions');
+goog.provide('os.track.SplitOptions');
+goog.provide('os.track.TrackFeatureLike');
+goog.provide('os.track.TrackField');
+goog.provide('os.track.TrackLike');
 
 goog.require('goog.Promise');
 goog.require('ol.Feature');

--- a/src/os/ui/areas.js
+++ b/src/os/ui/areas.js
@@ -60,7 +60,7 @@ os.ui.AreasCtrl = function($scope, $element) {
 
   this.title = 'areas';
   try {
-    this.scope['contextMenu'] = os.ui.menu.SPATIAL;
+    this.scope['contextMenu'] = os.ui.menu.spatial.MENU;
   } catch (e) {
   }
 

--- a/src/os/ui/menu/buffermenu.js
+++ b/src/os/ui/menu/buffermenu.js
@@ -103,7 +103,7 @@ os.ui.menu.buffer.mapDispose = function() {
  * Set up buffer region listeners on the map.
  */
 os.ui.menu.buffer.spatialSetup = function() {
-  var menu = os.ui.menu.SPATIAL;
+  var menu = os.ui.menu.spatial.MENU;
   if (menu) {
     var root = menu.getRoot();
     var group = root.find(os.ui.menu.spatial.Group.TOOLS);
@@ -125,7 +125,7 @@ os.ui.menu.buffer.spatialSetup = function() {
  * Clean up buffer region listeners on the spatial.
  */
 os.ui.menu.buffer.spatialDispose = function() {
-  var menu = os.ui.menu.SPATIAL;
+  var menu = os.ui.menu.spatial.MENU;
   if (menu) {
     var root = menu.getRoot();
     var group = root.find(os.ui.menu.spatial.Group.TOOLS);

--- a/src/os/ui/menu/buffermenu.js
+++ b/src/os/ui/menu/buffermenu.js
@@ -69,7 +69,7 @@ os.ui.menu.buffer.layerDispose = function() {
  * Set up buffer region listeners on the map.
  */
 os.ui.menu.buffer.mapSetup = function() {
-  var menu = os.ui.menu.MAP;
+  var menu = os.ui.menu.map.MENU;
   if (menu && !menu.getRoot().find(os.action.EventType.BUFFER)) {
     var group = menu.getRoot().find(os.ui.menu.map.GroupLabel.COORDINATE);
     goog.asserts.assert(group, 'Group should exist! Check spelling?');
@@ -89,7 +89,7 @@ os.ui.menu.buffer.mapSetup = function() {
  * Clean up buffer region listeners on the map.
  */
 os.ui.menu.buffer.mapDispose = function() {
-  var menu = os.ui.menu.MAP;
+  var menu = os.ui.menu.map.MENU;
   if (menu) {
     var group = menu.getRoot().find(os.ui.menu.map.GroupLabel.COORDINATE);
     if (group) {

--- a/src/os/ui/menu/mapmenu.js
+++ b/src/os/ui/menu/mapmenu.js
@@ -49,7 +49,7 @@ os.ui.menu.map.GroupLabel = {
  * Set up the menu
  */
 os.ui.menu.map.setup = function() {
-  if (os.ui.menu.MAP) {
+  if (os.ui.menu.map.MENU) {
     // already created
     return;
   }
@@ -143,7 +143,7 @@ os.ui.menu.map.setup = function() {
  * Disposes map menu
  */
 os.ui.menu.map.dispose = function() {
-  goog.dispose(os.ui.menu.MAP);
+  goog.dispose(os.ui.menu.map.MENU);
   os.ui.menu.MAP = os.ui.menu.map.MENU = undefined;
 };
 

--- a/src/os/ui/menu/mapmenu.js
+++ b/src/os/ui/menu/mapmenu.js
@@ -12,8 +12,15 @@ goog.require('os.ui.window.confirmColorDirective');
 
 /**
  * @type {os.ui.menu.Menu<ol.Coordinate>|undefined}
+ * @deprecated
  */
 os.ui.menu.MAP = undefined;
+
+
+/**
+ * @type {os.ui.menu.Menu<ol.Coordinate>|undefined}
+ */
+os.ui.menu.map.MENU = undefined;
 
 
 /**
@@ -47,7 +54,7 @@ os.ui.menu.map.setup = function() {
     return;
   }
 
-  os.ui.menu.MAP = new os.ui.menu.Menu(new os.ui.menu.MenuItem({
+  os.ui.menu.MAP = os.ui.menu.map.MENU = new os.ui.menu.Menu(new os.ui.menu.MenuItem({
     type: os.ui.menu.MenuItemType.ROOT,
     children: [{
       label: os.ui.menu.map.GroupLabel.MAP,
@@ -137,7 +144,7 @@ os.ui.menu.map.setup = function() {
  */
 os.ui.menu.map.dispose = function() {
   goog.dispose(os.ui.menu.MAP);
-  os.ui.menu.MAP = undefined;
+  os.ui.menu.MAP = os.ui.menu.map.MENU = undefined;
 };
 
 

--- a/src/os/ui/menu/spatialmenu.js
+++ b/src/os/ui/menu/spatialmenu.js
@@ -99,12 +99,20 @@ os.ui.menu.spatial.MENU = undefined;
 
 
 /**
+ * Old reference, maintained for compatibility.
+ * @type {os.ui.menu.SpatialMenu|undefined}
+ * @deprecated
+ */
+os.ui.menu.SPATIAL = undefined;
+
+
+/**
  * Set up the menu.
  */
 os.ui.menu.spatial.setup = function() {
   var menu = os.ui.menu.spatial.MENU;
   if (!menu) {
-    menu = os.ui.menu.spatial.MENU = new os.ui.menu.SpatialMenu(new os.ui.menu.MenuItem({
+    menu = os.ui.menu.SPATIAL = os.ui.menu.spatial.MENU = new os.ui.menu.SpatialMenu(new os.ui.menu.MenuItem({
       type: os.ui.menu.MenuItemType.ROOT,
       beforeRender: os.ui.menu.spatial.updateTemporaryItems,
       children: [{
@@ -297,7 +305,7 @@ os.ui.menu.spatial.setup = function() {
  */
 os.ui.menu.spatial.dispose = function() {
   goog.dispose(os.ui.menu.spatial.MENU);
-  os.ui.menu.spatial.MENU = undefined;
+  os.ui.menu.spatial.MENU = os.ui.menu.SPATIAL = undefined;
 };
 
 

--- a/src/os/ui/menu/spatialmenu.js
+++ b/src/os/ui/menu/spatialmenu.js
@@ -95,16 +95,16 @@ os.ui.menu.spatial.Group = {
 /**
  * @type {os.ui.menu.SpatialMenu|undefined}
  */
-os.ui.menu.SPATIAL = undefined;
+os.ui.menu.spatial.MENU = undefined;
 
 
 /**
  * Set up the menu.
  */
 os.ui.menu.spatial.setup = function() {
-  var menu = os.ui.menu.SPATIAL;
+  var menu = os.ui.menu.spatial.MENU;
   if (!menu) {
-    menu = os.ui.menu.SPATIAL = new os.ui.menu.SpatialMenu(new os.ui.menu.MenuItem({
+    menu = os.ui.menu.spatial.MENU = new os.ui.menu.SpatialMenu(new os.ui.menu.MenuItem({
       type: os.ui.menu.MenuItemType.ROOT,
       beforeRender: os.ui.menu.spatial.updateTemporaryItems,
       children: [{
@@ -296,8 +296,8 @@ os.ui.menu.spatial.setup = function() {
  * Dispose the menu.
  */
 os.ui.menu.spatial.dispose = function() {
-  goog.dispose(os.ui.menu.SPATIAL);
-  os.ui.menu.SPATIAL = undefined;
+  goog.dispose(os.ui.menu.spatial.MENU);
+  os.ui.menu.spatial.MENU = undefined;
 };
 
 

--- a/src/plugin/file/kml/kmlfield.js
+++ b/src/plugin/file/kml/kmlfield.js
@@ -1,3 +1,4 @@
+goog.provide('plugin.file.kml.JsonField');
 goog.provide('plugin.file.kml.KMLField');
 
 goog.require('os.Fields');

--- a/src/plugin/places/placesmenu.js
+++ b/src/plugin/places/placesmenu.js
@@ -287,7 +287,7 @@ plugin.places.menu.visibleIfLayerNodeSupported_ = function(context) {
  * Set up places items on the map.
  */
 plugin.places.menu.mapSetup = function() {
-  var menu = os.ui.menu.MAP;
+  var menu = os.ui.menu.map.MENU;
 
   if (menu && !menu.getRoot().find(plugin.places.menu.GROUP_LABEL)) {
     var root = menu.getRoot();
@@ -335,7 +335,7 @@ plugin.places.menu.mapSetup = function() {
  * Clean up places items on the map.
  */
 plugin.places.menu.mapDispose = function() {
-  var menu = os.ui.menu.MAP;
+  var menu = os.ui.menu.map.MENU;
   if (menu) {
     var group = menu.getRoot().find(os.ui.menu.map.GroupLabel.COORDINATE);
     if (group) {
@@ -406,7 +406,7 @@ plugin.places.menu.spatialSetup = function() {
  * Clean up places items in the spatial menu.
  */
 plugin.places.menu.spatialDispose = function() {
-  var menu = os.ui.menu.MAP;
+  var menu = os.ui.menu.map.MENU;
   if (menu) {
     var group = menu.getRoot().find(os.ui.menu.spatial.Group.TOOLS);
     if (group) {

--- a/src/plugin/places/placesmenu.js
+++ b/src/plugin/places/placesmenu.js
@@ -349,7 +349,7 @@ plugin.places.menu.mapDispose = function() {
  * Set up places items in the spatial menu.
  */
 plugin.places.menu.spatialSetup = function() {
-  var menu = os.ui.menu.SPATIAL;
+  var menu = os.ui.menu.spatial.MENU;
 
   if (menu && !menu.getRoot().find(plugin.places.menu.GROUP_LABEL)) {
     var root = menu.getRoot();

--- a/src/plugin/position/positionplugin.js
+++ b/src/plugin/position/positionplugin.js
@@ -35,8 +35,8 @@ plugin.position.PositionPlugin.ID = 'position';
  * @inheritDoc
  */
 plugin.position.PositionPlugin.prototype.init = function() {
-  if (os.ui.menu.MAP) {
-    var menu = os.ui.menu.MAP;
+  if (os.ui.menu.map.MENU) {
+    var menu = os.ui.menu.map.MENU;
 
     var group = menu.getRoot().find(os.ui.menu.map.GroupLabel.COORDINATE);
     if (group) {

--- a/src/plugin/suncalc/suncalcplugin.js
+++ b/src/plugin/suncalc/suncalcplugin.js
@@ -31,7 +31,7 @@ plugin.suncalc.ID = 'suncalc';
  * @inheritDoc
  */
 plugin.suncalc.Plugin.prototype.init = function() {
-  var menu = os.ui.menu.MAP;
+  var menu = os.ui.menu.map.MENU;
   if (menu) {
     var group = menu.getRoot().find(os.ui.menu.map.GroupLabel.COORDINATE);
 

--- a/src/plugin/track/trackmenu.js
+++ b/src/plugin/track/trackmenu.js
@@ -244,7 +244,7 @@ plugin.track.menu.visibleIfTrackNode = function(context) {
  * Set up track items in the spatial menu.
  */
 plugin.track.menu.spatialSetup = function() {
-  var menu = os.ui.menu.SPATIAL;
+  var menu = os.ui.menu.spatial.MENU;
   if (menu) {
     var root = menu.getRoot();
     var group = root.find(os.ui.menu.spatial.Group.FEATURES);

--- a/src/plugin/weather/weatherplugin.js
+++ b/src/plugin/weather/weatherplugin.js
@@ -32,7 +32,7 @@ plugin.weather.WeatherPlugin.ID = 'weather';
  */
 plugin.weather.WeatherPlugin.prototype.init = function() {
   var url = plugin.weather.getUrl_();
-  var menu = os.ui.menu.MAP;
+  var menu = os.ui.menu.map.MENU;
 
   if (url && menu) {
     var group = menu.getRoot().find(os.ui.menu.map.GroupLabel.COORDINATE);


### PR DESCRIPTION
- `os.ui.menu.spatial` and `os.ui.menu.map` now have `.MENU`, similar to `os.ui.menu.list` etc.
  - The old `os.ui.menu.SPATIAL` and `os.ui.menu.MAP` still exist, but have been tagged as deprecated. (is this OK?)
- Some typedefs and enums that are used globally, but have not been provided, now are