### PR TITLE
chore: bump opensphere-state-schema dependency to 2.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
     "opensphere-build-docs": "^2.0.0",
     "opensphere-build-index": "^4.0.0",
     "opensphere-build-resolver": "^7.6.0",
-    "opensphere-state-schema": "^2.7.0",
+    "opensphere-state-schema": "^2.10.0",
     "postcss-cli": "^5.0.0",
     "rimraf": "^2.5.4",
     "run-script-os": "^1.0.7",


### PR DESCRIPTION
Layer sharpness was added in
https://github.com/ngageoint/opensphere-state-schema/commit/ae311e16464c767f3643773e32f14dd88c5f1a3d
and is required for tests to pass. Likely important for users.

Resolves #1098.