### PR TITLE
feat(featureinfo): Added a new SimpleProperties Directive

### DIFF
--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -586,3 +586,12 @@ osx.feature.RingDefinition;
  * }}
  */
 osx.feature.RingOptions;
+
+
+/**
+ * @typedef {{
+ *   regexes: (Array<string>|undefined),
+ *   default: (string|undefined)
+ * }}
+ */
+osx.feature.SimplePropertyOptions;

--- a/src/os/ui/feature/featureinfo.js
+++ b/src/os/ui/feature/featureinfo.js
@@ -10,6 +10,7 @@ goog.require('os.map');
 goog.require('os.plugin.PluginManager');
 goog.require('os.ui.Module');
 goog.require('os.ui.feature.FeatureInfoTabManager');
+goog.require('os.ui.feature.simpleproperties');
 goog.require('os.ui.location.SimpleLocationDirective');
 goog.require('os.ui.tab.FeatureTab');
 goog.require('os.ui.uiSwitchDirective');

--- a/src/os/ui/feature/featureinfo.js
+++ b/src/os/ui/feature/featureinfo.js
@@ -10,7 +10,7 @@ goog.require('os.map');
 goog.require('os.plugin.PluginManager');
 goog.require('os.ui.Module');
 goog.require('os.ui.feature.FeatureInfoTabManager');
-goog.require('os.ui.feature.simpleproperties');
+goog.require('os.ui.feature.SimplePropertiesUI');
 goog.require('os.ui.location.SimpleLocationDirective');
 goog.require('os.ui.tab.FeatureTab');
 goog.require('os.ui.uiSwitchDirective');

--- a/src/os/ui/feature/simpleproperties.js
+++ b/src/os/ui/feature/simpleproperties.js
@@ -1,0 +1,201 @@
+goog.module('os.ui.feature.simpleproperties');
+goog.module.declareLegacyNamespace();
+
+goog.require('os.ui.feature.featureInfoCellDirective');
+
+const OsFeature = goog.require('os.feature');
+const OsModule = goog.require('os.ui.Module');
+const OsSettings = goog.require('os.config.Settings');
+
+const Feature = goog.requireType('ol.Feature');
+
+
+
+/**
+ * @type {!string}
+ * @const
+ */
+const SIMPLE_PROPERTIES = 'feature.info.simple';
+
+
+/**
+ * Reuse the simple properties column filter across controller instances
+ * @param {Feature} feature
+ * @return {Array<Object<string, *>>}
+ * @private
+ */
+const getProperties_ = (() => {
+  // flag for first run
+  var initialized_ = false;
+
+  // get the desired columns from config
+  var config_ = null;
+
+  // lookup by source
+  var lookup_ = {};
+
+  // lookup by column name/field
+  var matches_ = {};
+
+  /**
+   * Check the configs against the current column. If the key matches one of the configs, save it
+   * into matches_ for faster comparisons in the future
+   * @param {string} key
+   * @return {boolean}
+   */
+  var match = function(key) {
+    if (matches_[key]) return true;
+
+    // TODO loosen this up; use regex?
+    var found = config_[key];
+
+    if (found) {
+      matches_[key] = true; // this column hit on one or more of the configs; save it for future use
+    }
+
+    return found;
+  };
+
+  return (feature) => {
+    var properties = [];
+
+    if (!initialized_) {
+      config_ = OsSettings.getInstance().get(SIMPLE_PROPERTIES, {
+        'CALLSIGN': true
+      });
+      initialized_ = true;
+    }
+
+    if (config_) {
+      var source = OsFeature.getSource(feature);
+
+      if (source) {
+        // try the lookup... otherwise build a list of column(s)
+        var columns = lookup_[source.getId()] || source.getColumns().filter(
+            (column) => {
+              return match(column['field']);
+            });
+
+        // save the entire collection of columns for next time
+        if (!lookup_[source.getId()]) {
+          lookup_[source.getId()] = columns;
+        }
+
+        // get values of configured columns
+        columns.forEach(function(col) {
+          var field = /** @type {string} */ (col['field']);
+          var value = feature.get(field);
+
+          properties.push({
+            'id': field,
+            'field': field,
+            'value': value
+          });
+        }, this);
+      } else {
+        // if we don't have a source, look at the properties by hand
+        var featureProperties = feature.getProperties();
+
+        for (var key in featureProperties) {
+          if (match(key)) {
+            properties.push({
+              'id': key,
+              'field': key,
+              'value': featureProperties[key]
+            });
+          }
+        }
+      }
+    }
+
+    return properties;
+  };
+})();
+
+/**
+ * The controller for the simple properties directive; automatically finds and displays property(ies) as configured
+ * @unrestricted
+ */
+class Controller {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element The element
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    /**
+     * @type {angular.Scope}
+     */
+    this.scope = $scope;
+
+    /**
+     * @type {Array<Object<string, *>>}
+     */
+    this['properties'] = [];
+
+    $scope.$watch('items', this.onFeatureChange.bind(this));
+  }
+
+  /**
+   * Angular $onDestroy lifecycle hook.
+   */
+  $onDestroy() {
+    this.scope = null;
+    this['properties'] = null;
+  }
+
+  /**
+   * Handle feature changes on the scope.
+   * @param {Array<ol.Feature>} newVal The new value
+   */
+  onFeatureChange(newVal) {
+    this.updateProperties_();
+  }
+
+  /**
+   * Update the title for the active feature.
+   *
+   * @private
+   */
+  updateProperties_() {
+    var feature = /** @type {ol.Feature} */ (
+      (this.scope['items'] && this.scope['items'].length)
+        ? this.scope['items'][0]
+        : null);
+    if (feature) {
+      this['properties'] = getProperties_(feature);
+    }
+  }
+}
+
+/**
+ * The simple properties directive.
+ * @return {angular.Directive}
+ */
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  scope: {
+    'items': '='
+  },
+  controller: Controller,
+  controllerAs: 'propCtrl',
+  template: `
+<div>
+  <span ng-repeat="property in propCtrl.properties">
+    <span>{{property.field}}</span>: <featureinfocell property="property"></featureinfocell><br />
+  </span>
+</div>
+`
+});
+
+/**
+ * Add the directive to the module.
+ */
+OsModule.directive('simpleProperties', [directive]);
+
+exports = {
+  Controller,
+  directive
+};

--- a/src/os/ui/feature/simplepropertiesui.js
+++ b/src/os/ui/feature/simplepropertiesui.js
@@ -1,4 +1,4 @@
-goog.module('os.ui.feature.simpleproperties');
+goog.module('os.ui.feature.SimplePropertiesUI');
 goog.module.declareLegacyNamespace();
 
 goog.require('os.ui.feature.featureInfoCellDirective');
@@ -239,6 +239,5 @@ OsModule.directive('simpleProperties', [directive]);
 
 exports = {
   Controller,
-  directive,
-  SIMPLE_PROPERTIES_COLUMNS_KEY
+  directive
 };

--- a/views/feature/featureinfo.html
+++ b/views/feature/featureinfo.html
@@ -3,6 +3,7 @@
   <div class="flex-shrink-0 mb-1 w-100">
     <simple-location latdeg="lat" londeg="lon" ng-if="lat !== undefined && lon !== undefined"></simple-location>
     <span ng-if="alt">Altitude: {{alt}}</span>
+    <simple-properties items="items"></simple-properties>
   </div>
   <div class="flex-shrink-0" ng-if="info.numTabsShown > 1">
     <ul class="nav nav-tabs border-0">


### PR DESCRIPTION
For data-dense Features, you can now configure the `<simple-properties>` Directive to additionally show the desired field(s) above the alphabetically-sorted Fields table. Configs allow for a per-field exact match and/or regex match(es). "Default" text is optional per-field as well.