### PR TITLE
feat(urldragdrop): fix mis-interpretation of URL

### DIFF
--- a/src/os/ui/dragdrop/urldragdrop.js
+++ b/src/os/ui/dragdrop/urldragdrop.js
@@ -226,6 +226,8 @@ os.ui.UrlDragDrop.prototype.handleDrop_ = function(event) {
         }
 
         if (sourceUri) {
+          sourceUri = sourceUri.trim(); // clean up newlines and spaces
+
           if (os.url.URL_REGEXP.test(sourceUri)) {
             os.url.UrlManager.getInstance().handleUrl(sourceUri);
           } else {


### PR DESCRIPTION
run a trim() on text dragged in from the end of the row, because it has a newline in it