### PR TITLE
docs: add columnActions documentation

### DIFF
--- a/docs/guides/settings_guide.rst
+++ b/docs/guides/settings_guide.rst
@@ -356,6 +356,8 @@ Column Actions are specific actions that are performed when displaying field dat
 
 The only action Opensphere currently supports is the ``UrlColumnAction``.  When displaying feature information, this action will scan column names and values via regular expression to create a clickable link.
 
+The value of the matched field will be substituted for ``%s`` in the ``"action"`` string.
+
 Example:
 
 .. code-block:: json
@@ -379,4 +381,4 @@ Example:
 
 One of ``"col"`` or ``"val"`` is required. ``"search"`` and ``"replace"`` can be used to transform the text before substituting into the URL, but are entirely optional.
 
-While this is only executed on visible cells in SlickGrid, it is applied to every field/column and may cause performance problems depending on the complexity of the regex. If you know specific columns that you want to apply actions to, and know their format in advance, it may be better to simply match on the exact column name.
+While this is only executed on visible cells in Slickgrid, it is applied to every field's column and value and may cause performance problems depending on the complexity and specificity of the regular expression. If you know specific columns that you want to apply actions to, and know their format in advance, it may be better to simply match on the exact column name.

--- a/docs/guides/settings_guide.rst
+++ b/docs/guides/settings_guide.rst
@@ -378,3 +378,5 @@ Example:
   }
 
 One of ``"col"`` or ``"val"`` is required. ``"search"`` and ``"replace"`` can be used to transform the text before substituting into the URL, but are entirely optional.
+
+While this is only executed on visible cells in SlickGrid, it is applied to every field/column and may cause performance problems depending on the complexity of the regex. If you know specific columns that you want to apply actions to, and know their format in advance, it may be better to simply match on the exact column name.

--- a/docs/guides/settings_guide.rst
+++ b/docs/guides/settings_guide.rst
@@ -347,3 +347,34 @@ Example:
 
 .. _Cesium World Terrain: https://cesium.com/content/cesium-world-terrain/
 .. _Cesium Ion: https://cesium.com/ion/
+
+columnActions
+-------------
+``admin.columnActions``
+
+Column Actions are specific actions that are performed when displaying field data from a feature.
+
+The only action Opensphere currently supports is the ``UrlColumnAction``.  When displaying feature information, this action will scan column names and values via regular expression to create a clickable link.
+
+Example:
+
+.. code-block:: json
+  {
+    "admin": {
+      "columnActions": {
+        "googleMapsAction": {
+          "type": "url",
+          "description": "Create a link to a location on Google Maps.",
+          "regex": {
+            "col": "^DD_LAT_LON$",
+            "val": "[\-\d]\d+\.\d+",
+            "search": "\w",
+            "replace": ","
+          },
+          "action": "https://www.google.com/maps/@%s"
+        }
+      }
+    }
+  }
+
+One of ``"col"`` or ``"val"`` is required. ``"search"`` and ``"replace"`` can be used to transform the text before substituting into the URL, but are entirely optional.

--- a/src/os/ui/feature/featureinfocell.js
+++ b/src/os/ui/feature/featureinfocell.js
@@ -105,12 +105,6 @@ os.ui.feature.FeatureInfoCellCtrl.prototype.init_ = function() {
     this.scope_['actions'] =
         os.ui.columnactions.ColumnActionManager.getInstance().getActions(null, this.scope_['ca'], value);
 
-    // make all string cells copyable
-    if (typeof value === 'string') {
-      this.copyValue_ = value;
-      this.element_.parent().dblclick(this.onDblClick_.bind(this));
-    }
-
     if (property['field'] == os.Fields.PROPERTIES && typeof value === 'object') {
       // add the View Properties link
       this.scope_['type'] = 'prop';
@@ -126,9 +120,12 @@ os.ui.feature.FeatureInfoCellCtrl.prototype.init_ = function() {
       this.scope_['type'] = 'desc';
     } else {
       // default case, just show it
+      this.copyValue_ = this.scope_['property']['value'];
       this.scope_['property']['value'] =
-          // We want Angular to trust the HTML we generate. We do NOT trust the value, and it is sanitized elsewhere.
+          // We want Angular to trust the HTML we generate. We do NOT trust the value, and it is sanitized
+          // elsewhere.
           this.sce_.trustAsHtml('<span>' + os.ui.formatter.urlNewTabFormatter(value) + '</span>');
+      this.element_.parent().dblclick(this.onDblClick_.bind(this));
     }
   }
 };

--- a/src/os/ui/feature/featureinfocell.js
+++ b/src/os/ui/feature/featureinfocell.js
@@ -105,6 +105,12 @@ os.ui.feature.FeatureInfoCellCtrl.prototype.init_ = function() {
     this.scope_['actions'] =
         os.ui.columnactions.ColumnActionManager.getInstance().getActions(null, this.scope_['ca'], value);
 
+    // make all string cells copyable
+    if (typeof value === 'string') {
+      this.copyValue_ = value;
+      this.element_.parent().dblclick(this.onDblClick_.bind(this));
+    }
+
     if (property['field'] == os.Fields.PROPERTIES && typeof value === 'object') {
       // add the View Properties link
       this.scope_['type'] = 'prop';
@@ -120,12 +126,9 @@ os.ui.feature.FeatureInfoCellCtrl.prototype.init_ = function() {
       this.scope_['type'] = 'desc';
     } else {
       // default case, just show it
-      this.copyValue_ = this.scope_['property']['value'];
       this.scope_['property']['value'] =
-          // We want Angular to trust the HTML we generate. We do NOT trust the value, and it is sanitized
-          // elsewhere.
+          // We want Angular to trust the HTML we generate. We do NOT trust the value, and it is sanitized elsewhere.
           this.sce_.trustAsHtml('<span>' + os.ui.formatter.urlNewTabFormatter(value) + '</span>');
-      this.element_.parent().dblclick(this.onDblClick_.bind(this));
     }
   }
 };


### PR DESCRIPTION
I was looking at `featureinfocell.js` and trying to figure out how column actions worked, and didn't see that there was any documentation available.