### PR TITLE
fix(track): ensure places node list will update when track name changes

### DIFF
--- a/src/plugin/track/track.js
+++ b/src/plugin/track/track.js
@@ -466,6 +466,7 @@ plugin.track.updateTrackZIndex = os.track.updateTrackZIndex;
  *
  * @param {!os.track.CreateOptions} options The options object for the track.
  * @return {os.track.TrackFeatureLike|undefined} The track feature.
+ * @suppress {accessControls} for onFeatureChange access
  */
 plugin.track.createAndAdd = function(options) {
   var track = os.track.createTrack(options);
@@ -479,6 +480,7 @@ plugin.track.createAndAdd = function(options) {
   var trackNode = plugin.file.kml.ui.updatePlacemark({
     'feature': track
   });
+  ol.events.listen(track, goog.events.EventType.PROPERTYCHANGE, trackNode.onFeatureChange, trackNode);
 
   var rootNode = plugin.places.PlacesManager.getInstance().getPlacesRoot();
   if (rootNode) {


### PR DESCRIPTION
Resolves #842

The scenario is when the track is created off initial data (e.g. an aircraft ADS-B track using the ICAO code), and a later update provides the call sign. The track creator does something like:
`track.values_.name = newName;`
which updates the track label on the map, but the places node list keeps the old name

The caller updating the track name (or other values) still has to call
`track.dispatchEvent(new os.events.PropertyChangeEvent(os.annotation.EventType.UPDATE_PLACEMARK));`

This doesn't seem great, in that I had to override the access control. If there is a better way, would appreciate advice.