### PR TITLE
docs: add jsdoc for deprecated menu references

### DIFF
--- a/src/os/ui/menu/mapmenu.js
+++ b/src/os/ui/menu/mapmenu.js
@@ -12,7 +12,7 @@ goog.require('os.ui.window.confirmColorDirective');
 
 /**
  * @type {os.ui.menu.Menu<ol.Coordinate>|undefined}
- * @deprecated
+ * @deprecated use os.ui.menu.map.MENU instead
  */
 os.ui.menu.MAP = undefined;
 

--- a/src/os/ui/menu/spatialmenu.js
+++ b/src/os/ui/menu/spatialmenu.js
@@ -101,7 +101,7 @@ os.ui.menu.spatial.MENU = undefined;
 /**
  * Old reference, maintained for compatibility.
  * @type {os.ui.menu.SpatialMenu|undefined}
- * @deprecated
+ * @deprecated use os.ui.menu.spatial.MENU instead
  */
 os.ui.menu.SPATIAL = undefined;
 


### PR DESCRIPTION
Minor documentation to provide guidance for external plugins.