### PR TITLE
docs: expand WMS terrain provider documentation

### DIFF
--- a/docs/guides/settings_guide.rst
+++ b/docs/guides/settings_guide.rst
@@ -304,6 +304,11 @@ WMS Tiles
               "baseType": "wms",
               "options": {
                 "url": "<server url>"
+                "layers": [{
+                  "layerName": "<elevation layer>",
+                  "minLevel": <level number>,
+                  "maxLevel": <level number>
+                }]
               },
             }
           }
@@ -311,6 +316,9 @@ WMS Tiles
       }
     }
   }
+
+Where the `<server url>` would be something like `https://yourgeoserver:8080/geoserver/ows` 
+and the `layers` entries have corresponding layer names and resolution ranges.
 
 Cesium World Terrain
 ********************


### PR DESCRIPTION
Existing documentation suggested just the URL, which (to me) looked like it would have to be some kind of template (e.g. as we have for the other map providers, using XYZ style). Hopefully this makes it a bit clearer as to what goes where.