### PR TITLE
fix(grid): fixes behavior of copying data in grids, code cleanup

### DIFF
--- a/src/os/ui/feature/featureinfocell.js
+++ b/src/os/ui/feature/featureinfocell.js
@@ -99,7 +99,11 @@ os.ui.feature.FeatureInfoCellCtrl.prototype.destroy_ = function() {
 os.ui.feature.FeatureInfoCellCtrl.prototype.init_ = function() {
   var property = this.scope_['property'];
   var value = property['value'];
+
+  this.element_.parent().dblclick(this.onDblClick_.bind(this));
+  this.copyValue_ = value;
   this.scope_['type'] = '';
+
   if (value) {
     this.scope_['ca'] = new os.ui.columnactions.SimpleColumnActionModel(property['field']);
     this.scope_['actions'] =
@@ -107,6 +111,13 @@ os.ui.feature.FeatureInfoCellCtrl.prototype.init_ = function() {
 
     if (property['field'] == os.Fields.PROPERTIES && typeof value === 'object') {
       // add the View Properties link
+      try {
+        this.copyValue_ = JSON.stringify(value);
+      } catch (e) {
+        // not serializable, womp womp
+        this.copyValue_ = '';
+      }
+
       this.scope_['type'] = 'prop';
     } else if (this.scope_['actions'].length > 0) {
       // we have column actions, use those
@@ -120,12 +131,9 @@ os.ui.feature.FeatureInfoCellCtrl.prototype.init_ = function() {
       this.scope_['type'] = 'desc';
     } else {
       // default case, just show it
-      this.copyValue_ = this.scope_['property']['value'];
-      this.scope_['property']['value'] =
-          // We want Angular to trust the HTML we generate. We do NOT trust the value, and it is sanitized
-          // elsewhere.
-          this.sce_.trustAsHtml('<span>' + os.ui.formatter.urlNewTabFormatter(value) + '</span>');
-      this.element_.parent().dblclick(this.onDblClick_.bind(this));
+      // We want Angular to trust the HTML we generate. We do NOT trust the value, and it is sanitized
+      // elsewhere.
+      property['value'] = this.sce_.trustAsHtml('<span>' + os.ui.formatter.urlNewTabFormatter(value) + '</span>');
     }
   }
 };

--- a/src/os/ui/slick/slickgrid.js
+++ b/src/os/ui/slick/slickgrid.js
@@ -1643,6 +1643,9 @@ os.ui.slick.SlickGridCtrl.prototype.onDblClick = function(e, args) {
   if (!this.inEvent) {
     this.inEvent = true;
     var value = angular.element(this.grid.getCellNode(args['row'], args['cell'])).text();
+    if (value) {
+      value = value.trim();
+    }
     os.ui.text.copy(value);
     this.inEvent = false;
   }

--- a/views/feature/featureinfocell.html
+++ b/views/feature/featureinfocell.html
@@ -1,7 +1,7 @@
 <span ng-switch="type">
   <span ng-switch-when="cx" ng-click="cell.viewCxReport()">Launch Report</span>
   <span ng-switch-when="prop" ng-click="cell.viewProperties()">Show Properties</span>
-  <span ng-switch-when="desc" ng-click="cell.showDescription()">Show Description</span>
+  <a href="" ng-switch-when="desc" ng-click="cell.showDescription()">Show Description</a>
   <span ng-switch-when="ca">
     <span>{{property.value}} </span>
     <span ng-if="actions.length == 1" data-colvalue="property.value">


### PR DESCRIPTION
- Ensures that there's always a double click handler that does something in the feature info window.
- Trims copy text in slickgrids.
- Linkifies the "Show Description" text used for opening the description tab in the feature info window.