### PR TITLE
Modify interaction

### DIFF
--- a/src/os/action/eventtype.js
+++ b/src/os/action/eventtype.js
@@ -65,6 +65,7 @@ os.action.EventType = {
   RESTORE_FEATURE: 'spatial:restoreFeature',
   EXCLUDE: 'exclude',
   ADD_EXCLUDE: 'add_exclude',
+  MODIFY_GEOMETRY: 'spatial:modifyGeometry',
 
   // feature
   FEATURE_INFO: 'featureInfo',

--- a/src/os/interaction/interaction.js
+++ b/src/os/interaction/interaction.js
@@ -9,6 +9,16 @@ goog.requireType('ol.render.Feature');
 
 
 /**
+ * Event types for the modify interaction.
+ * @enum {string}
+ */
+os.interaction.ModifyEventType = {
+  COMPLETE: 'modify:complete',
+  CANCEL: 'modify:cancel'
+};
+
+
+/**
  * Rotation delta, in radians.
  * @type {number}
  * @const

--- a/src/os/interaction/modifyinteraction.js
+++ b/src/os/interaction/modifyinteraction.js
@@ -5,10 +5,11 @@ const I3DSupport = goog.require('os.I3DSupport');
 const KeyCodes = goog.require('goog.events.KeyCodes');
 const KeyHandler = goog.require('goog.events.KeyHandler');
 const OLModify = goog.require('ol.interaction.Modify');
+const PayloadEvent = goog.require('os.events.PayloadEvent');
 const osImplements = goog.require('os.implements');
 const {MODAL_SELECTOR} = goog.require('os.ui');
+const {ModifyEventType} = goog.require('os.interaction');
 const {notifyStyleChange} = goog.require('os.style');
-const PayloadEvent = goog.require('os.events.PayloadEvent');
 
 const KeyEvent = goog.requireType('goog.events.KeyEvent');
 
@@ -61,18 +62,18 @@ class Modify extends OLModify {
     if (!document.querySelector(MODAL_SELECTOR)) {
       switch (event.keyCode) {
         case KeyCodes.ESC:
-          this.dispatchEvent(new PayloadEvent('cancel', this.features_));
+          this.dispatchEvent(new PayloadEvent(ModifyEventType.CANCEL, this.features_));
           this.setActive(false);
-          this.dispose();
           break;
         case KeyCodes.ENTER:
-          this.dispatchEvent(new PayloadEvent('complete', this.features_));
+          this.dispatchEvent(new PayloadEvent(ModifyEventType.COMPLETE, this.features_));
           this.setActive(false);
-          this.dispose();
           break;
         default:
           break;
       }
+
+      notifyStyleChange(this.overlay_, [this.features_.getArray()[0]]);
     }
   }
 

--- a/src/os/interaction/modifyinteraction.js
+++ b/src/os/interaction/modifyinteraction.js
@@ -192,7 +192,7 @@ class Modify extends OLModify {
       feature.changed();
     }
 
-    notifyStyleChange(this.overlay_, [feature, this.features_.getArray()[0]]);
+    notifyStyleChange(this.overlay_, [feature]);
 
     return feature;
   }

--- a/src/os/interaction/modifyinteraction.js
+++ b/src/os/interaction/modifyinteraction.js
@@ -1,17 +1,27 @@
 goog.module('os.interaction.Modify');
 goog.module.declareLegacyNamespace();
 
+const Circle = goog.require('ol.style.Circle');
+const Feature = goog.require('ol.Feature');
+const Fill = goog.require('ol.style.Fill');
 const I3DSupport = goog.require('os.I3DSupport');
 const KeyCodes = goog.require('goog.events.KeyCodes');
 const KeyHandler = goog.require('goog.events.KeyHandler');
 const OLModify = goog.require('ol.interaction.Modify');
 const PayloadEvent = goog.require('os.events.PayloadEvent');
+const Point = goog.require('ol.geom.Point');
+const RecordField = goog.require('os.data.RecordField');
+const Stroke = goog.require('ol.style.Stroke');
+const Style = goog.require('ol.style.Style');
 const osImplements = goog.require('os.implements');
 const {MODAL_SELECTOR} = goog.require('os.ui');
 const {ModifyEventType} = goog.require('os.interaction');
 const {notifyStyleChange} = goog.require('os.style');
+const osWindow = goog.require('os.ui.window');
+const windowSelector = goog.require('os.ui.windowSelector');
 
 const KeyEvent = goog.requireType('goog.events.KeyEvent');
+const OSMap = goog.requireType('os.Map');
 
 
 /**
@@ -23,10 +33,13 @@ class Modify extends OLModify {
   /**
    * Constructor.
    * @param {olx.interaction.ModifyOptions=} opt_options Options.
+   *
+   * @suppress {accessControls}
    */
   constructor(opt_options) {
-    opt_options = opt_options || {};
-    super(opt_options);
+    const options = opt_options || {};
+
+    super(options);
 
     /**
      * @type {KeyHandler}
@@ -35,6 +48,16 @@ class Modify extends OLModify {
     this.keyHandler = new KeyHandler(document, true);
 
     this.keyHandler.listen(KeyHandler.EventType.KEY, this.handleKeyEvent, true, this);
+
+    // jank alert: the functions that are called when the interaction starts and ends are hard to override, so instead
+    // listen to our own events and toggle the map movement on and off
+    ol.events.listen(this, ol.interaction.ModifyEventType.MODIFYSTART, this.handleStart, this);
+    ol.events.listen(this, ol.interaction.ModifyEventType.MODIFYEND, this.handleEnd, this);
+
+    // use the drawing layer as the overlay layer so that geometries are synced to WebGL automatically
+    this.overlay_ = os.map.mapContainer.getDrawingLayer();
+
+    this.showControls();
   }
 
   /**
@@ -42,6 +65,11 @@ class Modify extends OLModify {
    */
   disposeInternal() {
     goog.dispose(this.keyHandler);
+
+    ol.events.unlisten(this, ol.interaction.ModifyEventType.MODIFYSTART, this.handleStart, this);
+    ol.events.unlisten(this, ol.interaction.ModifyEventType.MODIFYEND, this.handleEnd, this);
+
+    this.removeControls();
   }
 
   /**
@@ -49,6 +77,24 @@ class Modify extends OLModify {
    */
   is3DSupported() {
     return true;
+  }
+
+  /**
+   * Handles modify start events by disabling map movement.
+   * @param {OLModify.Event} event The event.
+   * @protected
+   */
+  handleStart(event) {
+    /** @type {OSMap} */ (this.getMap()).toggleMovement(false);
+  }
+
+  /**
+   * Handles modify end events by enabling map movement.
+   * @param {OLModify.Event} event The event.
+   * @protected
+   */
+  handleEnd(event) {
+    /** @type {OSMap} */ (this.getMap()).toggleMovement(true);
   }
 
   /**
@@ -78,16 +124,124 @@ class Modify extends OLModify {
   }
 
   /**
+   * Shows control information for this interaction.
+   */
+  showControls() {
+    const injector = angular.element(windowSelector.CONTAINER).injector();
+    const scope = injector.get('$rootScope').$new();
+    const controls = [
+      {
+        'text': 'Remove Vertex',
+        'keys': [KeyCodes.ALT, '+'],
+        'other': [os.ui.help.Controls.MOUSE.LEFT_MOUSE]
+      },
+      {
+        'text': 'Save Changes',
+        'keys': [KeyCodes.ENTER]
+      },
+      {
+        'text': 'Cancel',
+        'keys': [KeyCodes.ESC]
+      }
+    ];
+
+    const scopeOptions = {
+      'controls': controls
+    };
+
+    const windowOptions = {
+      'id': WIN_ID,
+      'label': 'Modify Geometry Controls',
+      'x': 'center',
+      'y': 1100,
+      'width': 290,
+      'height': 'auto',
+      'show-close': true
+    };
+
+    const template = '<controlblock class="u-bg-body-offset" controls="controls"></controlblock>';
+    osWindow.create(windowOptions, template, undefined, scope, undefined, scopeOptions);
+  }
+
+  /**
+   * Remove the controls element.
+   */
+  removeControls() {
+    const win = osWindow.getById(WIN_ID);
+    osWindow.close(win);
+  }
+
+  /**
    * @inheritDoc
    *
    * @suppress {accessControls}
    */
   createOrUpdateVertexFeature_(coordinates) {
-    const feature = super.createOrUpdateVertexFeature_(coordinates);
-    notifyStyleChange(this.overlay_, [feature]);
+    let feature = this.vertexFeature_;
+    if (!feature) {
+      feature = new Feature(new Point(coordinates));
+      // feature.set(RecordField.SOURCE_ID, os.map.mapContainer.DRAW_ID);
+      feature.set(RecordField.DRAWING_LAYER_NODE, false);
+      feature.setStyle(VERTEX_STYLE);
+
+      this.vertexFeature_ = feature;
+      os.map.mapContainer.addFeature(feature);
+    } else {
+      var geometry = /** @type {Point} */ (feature.getGeometry());
+      geometry.setCoordinates(coordinates);
+      feature.changed();
+    }
+
+    notifyStyleChange(this.overlay_, [feature, this.features_.getArray()[0]]);
+
     return feature;
   }
 }
+
+
+/**
+ * Style for the feature being modified.
+ * @type {Array<Style>}
+ * @const
+ */
+Modify.STYLE = [
+  new Style({
+    stroke: new Stroke({
+      color: [0, 153, 255, 1],
+      width: 3
+    })
+  })
+];
+
+
+/**
+ * Style for the vertex feature.
+ * @type {Array<Style>}
+ * @const
+ */
+const VERTEX_STYLE = [
+  new Style({
+    image: new Circle({
+      radius: 6,
+      fill: new Fill({
+        color: [0, 153, 255, 1]
+      }),
+      stroke: new Stroke({
+        color: [255, 255, 255, 1],
+        width: 2
+      })
+    }),
+    zIndex: Infinity
+  })
+];
+
+
+/**
+ * ID for the control window.
+ * @type {string}
+ * @const
+ */
+const WIN_ID = 'modifyControls';
 
 osImplements(Modify, I3DSupport.ID);
 

--- a/src/os/interaction/modifyinteraction.js
+++ b/src/os/interaction/modifyinteraction.js
@@ -180,7 +180,6 @@ class Modify extends OLModify {
     let feature = this.vertexFeature_;
     if (!feature) {
       feature = new Feature(new Point(coordinates));
-      // feature.set(RecordField.SOURCE_ID, os.map.mapContainer.DRAW_ID);
       feature.set(RecordField.DRAWING_LAYER_NODE, false);
       feature.setStyle(VERTEX_STYLE);
 
@@ -209,7 +208,18 @@ Modify.STYLE = [
     stroke: new Stroke({
       color: [0, 153, 255, 1],
       width: 3
-    })
+    }),
+    image: new Circle({
+      radius: 6,
+      fill: new Fill({
+        color: [0, 153, 255, 1]
+      }),
+      stroke: new Stroke({
+        color: [255, 255, 255, 1],
+        width: 2
+      })
+    }),
+    zIndex: Infinity
   })
 ];
 

--- a/src/os/interaction/modifyinteraction.js
+++ b/src/os/interaction/modifyinteraction.js
@@ -1,0 +1,93 @@
+goog.module('os.interaction.Modify');
+goog.module.declareLegacyNamespace();
+
+const I3DSupport = goog.require('os.I3DSupport');
+const KeyCodes = goog.require('goog.events.KeyCodes');
+const KeyHandler = goog.require('goog.events.KeyHandler');
+const OLModify = goog.require('ol.interaction.Modify');
+const osImplements = goog.require('os.implements');
+const {MODAL_SELECTOR} = goog.require('os.ui');
+const {notifyStyleChange} = goog.require('os.style');
+const PayloadEvent = goog.require('os.events.PayloadEvent');
+
+const KeyEvent = goog.requireType('goog.events.KeyEvent');
+
+
+/**
+ * Allows the user to modify geometries on the map directly.
+ *
+ * @implements {I3DSupport}
+ */
+class Modify extends OLModify {
+  /**
+   * Constructor.
+   * @param {olx.interaction.ModifyOptions=} opt_options Options.
+   */
+  constructor(opt_options) {
+    opt_options = opt_options || {};
+    super(opt_options);
+
+    /**
+     * @type {KeyHandler}
+     * @protected
+     */
+    this.keyHandler = new KeyHandler(document, true);
+
+    this.keyHandler.listen(KeyHandler.EventType.KEY, this.handleKeyEvent, true, this);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    goog.dispose(this.keyHandler);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  is3DSupported() {
+    return true;
+  }
+
+  /**
+   * Handles keydown events for stopping the interaction.
+   * @param {KeyEvent} event The key event.
+   * @protected
+   *
+   * @suppress {accessControls}
+   */
+  handleKeyEvent(event) {
+    if (!document.querySelector(MODAL_SELECTOR)) {
+      switch (event.keyCode) {
+        case KeyCodes.ESC:
+          this.dispatchEvent(new PayloadEvent('cancel', this.features_));
+          this.setActive(false);
+          this.dispose();
+          break;
+        case KeyCodes.ENTER:
+          this.dispatchEvent(new PayloadEvent('complete', this.features_));
+          this.setActive(false);
+          this.dispose();
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @suppress {accessControls}
+   */
+  createOrUpdateVertexFeature_(coordinates) {
+    const feature = super.createOrUpdateVertexFeature_(coordinates);
+    notifyStyleChange(this.overlay_, [feature]);
+    return feature;
+  }
+}
+
+osImplements(Modify, I3DSupport.ID);
+
+exports = Modify;

--- a/src/os/mixin/mixin.js
+++ b/src/os/mixin/mixin.js
@@ -199,7 +199,7 @@ ol.interaction.Modify.handleDragEvent_ = function(evt) {
 
     if (coordinates) {
       this.setGeometryCoordinates_(geometry, coordinates);
-      os.style.notifyStyleChange(os.feature.getLayer(segmentData.feature), segmentData.feature);
+      os.style.notifyStyleChange(os.feature.getLayer(segmentData.feature), [segmentData.feature]);
     }
   }
   this.createOrUpdateVertexFeature_(vertex);

--- a/src/os/mixin/mixin.js
+++ b/src/os/mixin/mixin.js
@@ -8,6 +8,7 @@ goog.require('goog.math');
 goog.require('ol.View');
 goog.require('ol.color');
 goog.require('ol.extent');
+goog.require('ol.interaction.Modify');
 goog.require('ol.math');
 goog.require('ol.renderer.canvas.Map');
 goog.require('ol.renderer.canvas.VectorLayer');
@@ -125,3 +126,81 @@ ol.renderer.canvas.VectorLayer.prototype.forEachFeatureAtCoordinate = function(c
     originalRenderFrame.call(this, frameState);
   };
 })();
+
+
+/**
+ * @param {ol.MapBrowserPointerEvent} evt Event.
+ * @this {ol.interaction.Modify}
+ * @suppress {accessControls}
+ */
+ol.interaction.Modify.handleDragEvent_ = function(evt) {
+  this.ignoreNextSingleClick_ = false;
+  this.willModifyFeatures_(evt);
+
+  var vertex = evt.coordinate;
+  for (var i = 0, ii = this.dragSegments_.length; i < ii; ++i) {
+    var dragSegment = this.dragSegments_[i];
+    var segmentData = dragSegment[0];
+    var depth = segmentData.depth;
+    var geometry = segmentData.geometry;
+    var coordinates;
+    var segment = segmentData.segment;
+    var index = dragSegment[1];
+
+    while (vertex.length < geometry.getStride()) {
+      vertex.push(segment[index][vertex.length]);
+    }
+
+    switch (geometry.getType()) {
+      case ol.geom.GeometryType.POINT:
+        coordinates = vertex;
+        segment[0] = segment[1] = vertex;
+        break;
+      case ol.geom.GeometryType.MULTI_POINT:
+        coordinates = geometry.getCoordinates();
+        coordinates[segmentData.index] = vertex;
+        segment[0] = segment[1] = vertex;
+        break;
+      case ol.geom.GeometryType.LINE_STRING:
+        coordinates = geometry.getCoordinates();
+        coordinates[segmentData.index + index] = vertex;
+        segment[index] = vertex;
+        break;
+      case ol.geom.GeometryType.MULTI_LINE_STRING:
+        coordinates = geometry.getCoordinates();
+        coordinates[depth[0]][segmentData.index + index] = vertex;
+        segment[index] = vertex;
+        break;
+      case ol.geom.GeometryType.POLYGON:
+        coordinates = geometry.getCoordinates();
+        coordinates[depth[0]][segmentData.index + index] = vertex;
+        segment[index] = vertex;
+        break;
+      case ol.geom.GeometryType.MULTI_POLYGON:
+        coordinates = geometry.getCoordinates();
+        coordinates[depth[1]][depth[0]][segmentData.index + index] = vertex;
+        segment[index] = vertex;
+        break;
+      case ol.geom.GeometryType.CIRCLE:
+        segment[0] = segment[1] = vertex;
+        if (segmentData.index === ol.interaction.Modify.MODIFY_SEGMENT_CIRCLE_CENTER_INDEX) {
+          this.changingFeature_ = true;
+          geometry.setCenter(vertex);
+          this.changingFeature_ = false;
+        } else { // We're dragging the circle's circumference:
+          this.changingFeature_ = true;
+          geometry.setRadius(ol.coordinate.distance(geometry.getCenter(), vertex));
+          this.changingFeature_ = false;
+        }
+        break;
+      default:
+        // pass
+    }
+
+    if (coordinates) {
+      this.setGeometryCoordinates_(geometry, coordinates);
+      os.style.notifyStyleChange(os.feature.getLayer(segmentData.feature), segmentData.feature);
+    }
+  }
+  this.createOrUpdateVertexFeature_(vertex);
+};

--- a/src/os/source/imodifiablesource.js
+++ b/src/os/source/imodifiablesource.js
@@ -1,0 +1,33 @@
+goog.module('os.source.IModifiableSource');
+goog.module.declareLegacyNamespace();
+
+const Feature = goog.requireType('ol.Feature');
+
+
+/**
+ * @interface
+ */
+class IModifiableSource {
+  /**
+   * Get whether the source supports modify.
+   * @return {boolean}
+   */
+  supportsModify() {}
+
+  /**
+   * Get the modify function used to handle the feature update.
+   * @return {function(Feature, Feature)} Function that takes the feature to update as the first argument and the
+   *                                      feature that was modified by the interaction as the second argument.
+   */
+  getModifyFunction() {}
+}
+
+
+/**
+ * Identifier used with os.implements.
+ * @type {string}
+ */
+IModifiableSource.ID = 'os.source.IModifiableSource';
+
+
+exports = IModifiableSource;

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -3730,7 +3730,6 @@ os.source.Vector.prototype.persist = function(opt_to) {
   options['timeEnabled'] = this.getTimeEnabled();
   options['altitudeMode'] = this.getAltitudeMode();
   options['refreshInterval'] = this.refreshInterval;
-  options['supportsModify'] = this.canModify;
 
   if (this.uniqueId_) {
     options['uniqueId'] = this.uniqueId_.persist();

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -40,6 +40,7 @@ goog.require('os.mixin.rbush');
 goog.require('os.ogc');
 goog.require('os.registerClass');
 goog.require('os.source');
+goog.require('os.source.IModifiableSource');
 goog.require('os.source.ISource');
 goog.require('os.source.PropertyChange');
 goog.require('os.source.column');
@@ -58,6 +59,7 @@ goog.require('os.webgl');
  * @extends {ol.source.Vector}
  * @implements {os.source.ISource}
  * @implements {os.hist.IHistogramProvider}
+ * @implements {os.source.IModifiableSource}
  * @param {olx.source.VectorOptions=} opt_options OpenLayers vector source options.
  * @constructor
  */
@@ -400,6 +402,13 @@ os.source.Vector = function(opt_options) {
    */
   this.detectColumnTypes_ = false;
 
+  /**
+   * Flag for what this source supports modify
+   * @type {boolean}
+   * @protected
+   */
+  this.canModify = true;
+
   if (!options['disableAreaSelection']) {
     os.dispatcher.listen(os.action.EventType.SELECT, this.onFeatureAction_, false, this);
     os.dispatcher.listen(os.action.EventType.SELECT_EXCLUSIVE, this.onFeatureAction_, false, this);
@@ -416,6 +425,7 @@ os.source.Vector = function(opt_options) {
 goog.inherits(os.source.Vector, ol.source.Vector);
 os.implements(os.source.Vector, os.hist.IHistogramProvider.ID);
 os.implements(os.source.Vector, os.source.ISource.ID);
+os.implements(os.source.Vector, os.source.IModifiableSource.ID);
 
 
 /**
@@ -2597,7 +2607,7 @@ os.source.Vector.prototype.updateAnimationOverlay = function() {
 
       // notify data consumers if dynamic data has changed
       if (hasDynamic) {
-        this.dispatchEvent(new os.events.PropertyChangeEvent(os.source.PropertyChange.DATA));
+        this.notifyDataChange();
       }
     } else {
       this.animationOverlay.setFeatures(undefined);
@@ -2797,7 +2807,7 @@ os.source.Vector.prototype.disposeDynamicAnimation = function() {
 
   if (hasDynamic) {
     // notify data consumers that the dynamic data has changed
-    this.dispatchEvent(new os.events.PropertyChangeEvent(os.source.PropertyChange.DATA));
+    this.notifyDataChange();
   }
 };
 
@@ -3683,6 +3693,34 @@ os.source.Vector.prototype.setUniqueId = function(value) {
 
 
 /**
+ * Fire a data change notify event.
+ */
+os.source.Vector.prototype.notifyDataChange = function() {
+  this.dispatchEvent(new os.events.PropertyChangeEvent(os.source.PropertyChange.DATA));
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.source.Vector.prototype.supportsModify = function() {
+  return this.canModify;
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.source.Vector.prototype.getModifyFunction = function() {
+  return (originalFeature, modifiedFeature) => {
+    originalFeature.setGeometry(modifiedFeature.getGeometry());
+    os.feature.createEllipse(originalFeature, true);
+    this.notifyDataChange();
+  };
+};
+
+
+/**
  * @inheritDoc
  */
 os.source.Vector.prototype.persist = function(opt_to) {
@@ -3692,6 +3730,7 @@ os.source.Vector.prototype.persist = function(opt_to) {
   options['timeEnabled'] = this.getTimeEnabled();
   options['altitudeMode'] = this.getAltitudeMode();
   options['refreshInterval'] = this.refreshInterval;
+  options['supportsModify'] = this.canModify;
 
   if (this.uniqueId_) {
     options['uniqueId'] = this.uniqueId_.persist();
@@ -3748,5 +3787,9 @@ os.source.Vector.prototype.restore = function(config) {
 
   if (config['detectColumnTypes']) {
     this.setDetectColumnTypes(config['detectColumnTypes']);
+  }
+
+  if (config['supportsModify'] != null) {
+    this.canModify = /** @type {boolean} */ (config['supportsModify']);
   }
 };

--- a/src/os/ui/help/controlblock.js
+++ b/src/os/ui/help/controlblock.js
@@ -32,6 +32,16 @@ Module.directive('controlblock', [directive]);
 
 
 /**
+ * Map of keycodes to their OSX equivalents.
+ * @type {Object<KeyCodes<number>, string>}
+ */
+const osxKeyCodeMap = {
+  [KeyCodes.META]: 'Command',
+  [KeyCodes.ALT]: 'Option'
+};
+
+
+/**
  * Controller function for the controlblock directive
  * @unrestricted
  */
@@ -71,8 +81,8 @@ class Controller {
    * @export
    */
   getKey(key) {
-    if (key === KeyCodes.META && isOSX()) {
-      return 'Command';
+    if (isOSX() && key in osxKeyCodeMap) {
+      return osxKeyCodeMap[key];
     }
 
     return toTitleCase(KeyNames[key]);

--- a/src/os/ui/help/controlblock.js
+++ b/src/os/ui/help/controlblock.js
@@ -85,7 +85,7 @@ class Controller {
    * @export
    */
   getMouse(other) {
-    // TODO: os.ui.help.Controls is a mess that needs to be decomposed to clean up this global reference
+    // TODO: requiring os.ui.help.Controls creates a circular dependency, so file class needs to be decomposed
     var mouse = os.ui.help.Controls.MOUSE_IMAGE[other];
     if (mouse) {
       return mouse;

--- a/src/os/ui/help/controlblock.js
+++ b/src/os/ui/help/controlblock.js
@@ -1,0 +1,129 @@
+goog.module('os.ui.help.ControlBlockUI');
+goog.module.declareLegacyNamespace();
+
+const Module = goog.require('os.ui.Module');
+const OSWindow = goog.require('os.ui.window');
+const {ROOT, isOSX} = goog.require('os');
+const KeyCodes = goog.require('goog.events.KeyCodes');
+const KeyNames = goog.require('goog.events.KeyNames');
+const {toTitleCase} = goog.require('goog.string');
+
+
+/**
+ * The controlblock directive
+ * @return {angular.Directive}
+ */
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  scope: {
+    'controls': '='
+  },
+  templateUrl: ROOT + 'views/help/controlblock.html',
+  controller: Controller,
+  controllerAs: 'controlBlock'
+});
+
+
+/**
+ * Add the directive to the module.
+ */
+Module.directive('controlblock', [directive]);
+
+
+/**
+ * Controller function for the controlblock directive
+ * @unrestricted
+ */
+class Controller {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    /**
+     * @type {?angular.JQLite}
+     * @private
+     */
+    this.element_ = $element;
+  }
+
+  /**
+   * Clean up.
+   * @protected
+   */
+  $onDestroy() {}
+
+  /**
+   * Close the window.
+   * @export
+   */
+  cancel() {
+    OSWindow.close(this.element_);
+  }
+
+  /**
+   * Get the key text
+   * @param {KeyCodes} key
+   * @return {string}
+   * @export
+   */
+  getKey(key) {
+    if (key === KeyCodes.META && isOSX()) {
+      return 'Command';
+    }
+
+    return toTitleCase(KeyNames[key]);
+  }
+
+  /**
+   * Get the key text
+   * @param {string} other
+   * @return {?string}
+   * @export
+   */
+  getMouse(other) {
+    // TODO: os.ui.help.Controls is a mess that needs to be decomposed to clean up this global reference
+    var mouse = os.ui.help.Controls.MOUSE_IMAGE[other];
+    if (mouse) {
+      return mouse;
+    }
+    return null;
+  }
+
+  /**
+   * Get the key text
+   * @param {string} other
+   * @return {?string}
+   * @export
+   */
+  getFont(other) {
+    var font = os.ui.help.Controls.FONT_CLASS[other];
+    if (font) {
+      return os.ui.help.Controls.FONT_CLASS[other]['font'];
+    }
+    return null;
+  }
+
+  /**
+   * Get the key text
+   * @param {string} other
+   * @return {?string}
+   * @export
+   */
+  getFontClass(other) {
+    var font = os.ui.help.Controls.FONT_CLASS[other];
+    if (font) {
+      return os.ui.help.Controls.FONT_CLASS[other]['class'];
+    }
+    return null;
+  }
+}
+
+
+exports = {
+  Controller,
+  directive
+};

--- a/src/os/ui/help/controls.js
+++ b/src/os/ui/help/controls.js
@@ -7,6 +7,7 @@ goog.require('goog.events.KeyNames');
 goog.require('ol.array');
 goog.require('os.ui');
 goog.require('os.ui.Module');
+goog.require('os.ui.help.ControlBlockUI');
 goog.require('os.ui.window');
 
 
@@ -85,71 +86,6 @@ os.ui.help.ControlsCtrl.launch = function() {
     }, 'controlshelp');
   }
 };
-
-
-/**
- * Get the key text
- *
- * @param {goog.events.KeyCodes} key
- * @return {string}
- * @export
- */
-os.ui.help.ControlsCtrl.prototype.getKey = function(key) {
-  if (key === goog.events.KeyCodes.META && os.isOSX()) {
-    return 'Command';
-  }
-
-  return goog.string.toTitleCase(goog.events.KeyNames[key]);
-};
-
-
-/**
- * Get the key text
- *
- * @param {string} other
- * @return {?string}
- * @export
- */
-os.ui.help.ControlsCtrl.prototype.getMouse = function(other) {
-  var mouse = os.ui.help.Controls.MOUSE_IMAGE[other];
-  if (mouse) {
-    return mouse;
-  }
-  return null;
-};
-
-
-/**
- * Get the key text
- *
- * @param {string} other
- * @return {?string}
- * @export
- */
-os.ui.help.ControlsCtrl.prototype.getFont = function(other) {
-  var font = os.ui.help.Controls.FONT_CLASS[other];
-  if (font) {
-    return os.ui.help.Controls.FONT_CLASS[other]['font'];
-  }
-  return null;
-};
-
-
-/**
- * Get the key text
- *
- * @param {string} other
- * @return {?string}
- * @export
- */
-os.ui.help.ControlsCtrl.prototype.getFontClass = function(other) {
-  var font = os.ui.help.Controls.FONT_CLASS[other];
-  if (font) {
-    return os.ui.help.Controls.FONT_CLASS[other]['class'];
-  }
-  return null;
-};
-
 
 
 /**

--- a/src/os/ui/menu/spatialmenu.js
+++ b/src/os/ui/menu/spatialmenu.js
@@ -598,9 +598,13 @@ os.ui.menu.spatial.visibleIfCanModifyGeometry = function(context) {
 
   if (features.length == 1) {
     const feature = features[0];
-    const source = os.feature.getSource(feature);
-    if (os.implements(source, os.source.IModifiableSource.ID)) {
-      supportsModify = /** @type {os.source.IModifiableSource} */ (source).supportsModify();
+    if (feature) {
+      const source = os.feature.getSource(feature);
+      const geometry = /** @type {!ol.geom.Geometry} */ (feature.get(os.interpolate.ORIGINAL_GEOM_FIELD) ||
+          feature.getGeometry());
+      if (geometry && os.implements(source, os.source.IModifiableSource.ID)) {
+        supportsModify = /** @type {os.source.IModifiableSource} */ (source).supportsModify();
+      }
     }
   }
 
@@ -747,7 +751,8 @@ os.ui.menu.spatial.onMenuEvent = function(event, opt_layerIds) {
             const clone = new os.feature.DynamicFeature();
 
             // use the original geom, interpolated coordinates make for a weird UX
-            const originalGeom = /** @type {ol.geom.Geometry} */ (feature.get(os.interpolate.ORIGINAL_GEOM_FIELD));
+            const originalGeom = /** @type {!ol.geom.Geometry} */ (feature.get(os.interpolate.ORIGINAL_GEOM_FIELD) ||
+                feature.getGeometry());
             clone.setGeometry(originalGeom.clone());
             clone.setStyle(os.interaction.Modify.STYLE);
             clone.set(os.data.RecordField.DRAWING_LAYER_NODE, false);

--- a/src/os/ui/menu/spatialmenu.js
+++ b/src/os/ui/menu/spatialmenu.js
@@ -747,6 +747,7 @@ os.ui.menu.spatial.onMenuEvent = function(event, opt_layerIds) {
             os.ui.query.launchModifyArea(conf);
             break;
           case os.action.EventType.MODIFY_GEOMETRY:
+            const mc = os.MapContainer.getInstance();
             // start by cloning the feature so we don't modify the existing geom
             const clone = new os.feature.DynamicFeature();
 
@@ -758,13 +759,14 @@ os.ui.menu.spatial.onMenuEvent = function(event, opt_layerIds) {
             clone.set(os.data.RecordField.DRAWING_LAYER_NODE, false);
             clone.set(os.interpolate.METHOD_FIELD, os.interpolate.Method.NONE);
             clone.setId(goog.string.getRandomString());
-            os.MapContainer.getInstance().addFeature(clone);
+            mc.addFeature(clone);
 
             const interaction = new os.interaction.Modify({
               features: new ol.Collection([clone])
             });
+            interaction.setOverlay(/** @type {ol.layer.Vector} */ (mc.getDrawingLayer()));
 
-            os.MapContainer.getInstance().getMap().addInteraction(interaction);
+            mc.getMap().addInteraction(interaction);
             interaction.setActive(true);
 
             /**

--- a/src/os/ui/menu/spatialmenu.js
+++ b/src/os/ui/menu/spatialmenu.js
@@ -744,17 +744,12 @@ os.ui.menu.spatial.onMenuEvent = function(event, opt_layerIds) {
             break;
           case os.action.EventType.MODIFY_GEOMETRY:
             // start by cloning the feature so we don't modify the existing geom
-            const clone = feature.clone();
+            const clone = new os.feature.DynamicFeature();
 
             // use the original geom, interpolated coordinates make for a weird UX
             const originalGeom = /** @type {ol.geom.Geometry} */ (feature.get(os.interpolate.ORIGINAL_GEOM_FIELD));
-            clone.setGeometry(originalGeom);
-
-            // style it and add it to the drawing layer to modify
-            const editStyles = ol.style.Style.createDefaultEditing();
-            const style = editStyles[ol.geom.GeometryType.LINE_STRING]
-                .concat(editStyles[ol.geom.GeometryType.POLYGON]);
-            clone.setStyle(style);
+            clone.setGeometry(originalGeom.clone());
+            clone.setStyle(os.interaction.Modify.STYLE);
             clone.set(os.data.RecordField.DRAWING_LAYER_NODE, false);
             clone.set(os.interpolate.METHOD_FIELD, os.interpolate.Method.NONE);
             clone.setId(goog.string.getRandomString());

--- a/src/plugin/cesium/interaction/cesiuminteraction.js
+++ b/src/plugin/cesium/interaction/cesiuminteraction.js
@@ -1,5 +1,10 @@
 goog.provide('plugin.cesium.interaction');
 
+goog.require('os.interaction.DragBox');
+goog.require('os.interaction.DragCircle');
+goog.require('os.interaction.DrawPolygon');
+goog.require('os.interaction.Measure');
+goog.require('os.interaction.Modify');
 goog.require('os.map');
 goog.require('plugin.cesium.interaction.dragbox');
 goog.require('plugin.cesium.interaction.dragcircle');

--- a/src/plugin/cesium/sync/converter.js
+++ b/src/plugin/cesium/sync/converter.js
@@ -1,11 +1,11 @@
 goog.module('plugin.cesium.sync.converter');
 
 const DynamicFeature = goog.require('os.feature.DynamicFeature');
-const GeometryType = goog.require('ol.geom.GeometryType');
 const DynamicLineStringConverter = goog.require('plugin.cesium.sync.DynamicLineStringConverter');
 const Ellipse = goog.require('os.geom.Ellipse');
 const EllipseConverter = goog.require('plugin.cesium.sync.EllipseConverter');
 const GeometryCollectionConverter = goog.require('plugin.cesium.sync.GeometryCollectionConverter');
+const GeometryType = goog.require('ol.geom.GeometryType');
 const LabelConverter = goog.require('plugin.cesium.sync.LabelConverter');
 const LineStringConverter = goog.require('plugin.cesium.sync.LineStringConverter');
 const MultiDynamicLineStringConverter = goog.require('plugin.cesium.sync.MultiDynamicLineStringConverter');
@@ -63,7 +63,9 @@ GeometryCollectionConverter.setConvertFunction(convertGeometry);
  */
 const dynamicConverters = {
   [GeometryType.LINE_STRING]: new DynamicLineStringConverter,
-  [GeometryType.MULTI_LINE_STRING]: new MultiDynamicLineStringConverter
+  [GeometryType.MULTI_LINE_STRING]: new MultiDynamicLineStringConverter,
+  [GeometryType.POLYGON]: new DynamicLineStringConverter,
+  [GeometryType.MULTI_POLYGON]: new MultiDynamicLineStringConverter
 };
 
 

--- a/src/plugin/cesium/sync/converter.js
+++ b/src/plugin/cesium/sync/converter.js
@@ -2,6 +2,8 @@ goog.module('plugin.cesium.sync.converter');
 
 const DynamicFeature = goog.require('os.feature.DynamicFeature');
 const DynamicLineStringConverter = goog.require('plugin.cesium.sync.DynamicLineStringConverter');
+const DynamicMultiPolygonConverter = goog.require('plugin.cesium.sync.DynamicMultiPolygonConverter');
+const DynamicPolygonConverter = goog.require('plugin.cesium.sync.DynamicPolygonConverter');
 const Ellipse = goog.require('os.geom.Ellipse');
 const EllipseConverter = goog.require('plugin.cesium.sync.EllipseConverter');
 const GeometryCollectionConverter = goog.require('plugin.cesium.sync.GeometryCollectionConverter');
@@ -64,8 +66,8 @@ GeometryCollectionConverter.setConvertFunction(convertGeometry);
 const dynamicConverters = {
   [GeometryType.LINE_STRING]: new DynamicLineStringConverter,
   [GeometryType.MULTI_LINE_STRING]: new MultiDynamicLineStringConverter,
-  [GeometryType.POLYGON]: new DynamicLineStringConverter,
-  [GeometryType.MULTI_POLYGON]: new MultiDynamicLineStringConverter
+  [GeometryType.POLYGON]: new DynamicPolygonConverter,
+  [GeometryType.MULTI_POLYGON]: new DynamicMultiPolygonConverter
 };
 
 

--- a/src/plugin/cesium/sync/dynamicmultipolygonconverter.js
+++ b/src/plugin/cesium/sync/dynamicmultipolygonconverter.js
@@ -1,0 +1,57 @@
+goog.module('plugin.cesium.sync.DynamicMultiPolygonConverter');
+
+const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
+const {createOrUpdateSegment} = goog.require('plugin.cesium.sync.DynamicLineString');
+
+const Feature = goog.requireType('ol.Feature');
+const MultiPolygon = goog.requireType('ol.geom.MultiPolygon');
+const Style = goog.requireType('ol.style.Style');
+const VectorContext = goog.requireType('plugin.cesium.VectorContext');
+
+
+/**
+ * Converter for DynamicFeature MultiPolygons.
+ * @extends {BaseConverter<(MultiPolygon), (Cesium.Polyline|Cesium.PolylineOptions)>}
+ */
+class DynamicMultiPolygonConverter extends BaseConverter {
+  /**
+   * @inheritDoc
+   */
+  create(feature, geometry, style, context) {
+    createOrUpdateMultiPolygon(feature, geometry, style, context);
+    return true;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  update(feature, geometry, style, context, primitive) {
+    createOrUpdateMultiPolygon(feature, geometry, style, context, Array.isArray(primitive) ? primitive : [primitive]);
+    return true;
+  }
+}
+
+
+/**
+ * Creates or updates a MultiPolygon geometry as a Cesium.Polyline.
+ * @param {!Feature} feature
+ * @param {!MultiPolygon} multipolygon
+ * @param {!Style} style
+ * @param {!VectorContext} context
+ * @param {Array<!Cesium.Polyline>=} opt_primitives
+ */
+const createOrUpdateMultiPolygon = (feature, multipolygon, style, context, opt_primitives) => {
+  const flatCoords = multipolygon.getFlatCoordinates();
+  const endss = multipolygon.getEndss();
+  let offset = 0;
+
+  endss.forEach((ends) => {
+    ends.forEach((end, i) => {
+      createOrUpdateSegment(i, feature, multipolygon, style, context, flatCoords, offset, end, opt_primitives);
+      offset = end;
+    });
+  });
+};
+
+
+exports = DynamicMultiPolygonConverter;

--- a/src/plugin/cesium/sync/dynamicpolygonconverter.js
+++ b/src/plugin/cesium/sync/dynamicpolygonconverter.js
@@ -1,23 +1,13 @@
 goog.module('plugin.cesium.sync.DynamicPolygonConverter');
 
 const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
-const getTransformFunction = goog.require('plugin.cesium.sync.getTransformFunction');
-const olcsCore = goog.require('olcs.core');
-const {GeometryInstanceId} = goog.require('plugin.cesium');
-const {createColoredPrimitive, createGeometryInstance} = goog.require('plugin.cesium.primitive');
-const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
-const {getDashPattern, getLineStringPositions} = goog.require('plugin.cesium.sync.linestring');
-const {getHeightReference} = goog.require('plugin.cesium.sync.HeightReference');
+const {createOrUpdateSegment} = goog.require('plugin.cesium.sync.DynamicLineString');
 
 const Polygon = goog.requireType('ol.geom.Polygon');
 const Feature = goog.requireType('ol.Feature');
 const Geometry = goog.requireType('ol.geom.Geometry');
-const MultiPolygon = goog.requireType('ol.geom.MultiPolygon');
 const Style = goog.requireType('ol.style.Style');
 const VectorContext = goog.requireType('plugin.cesium.VectorContext');
-const LineString = goog.requireType('ol.geom.LineString');
-const MultiLineString = goog.requireType('ol.geom.MultiLineString');
-const Ellipse = goog.requireType('os.geom.Ellipse');
 
 
 /**
@@ -29,13 +19,7 @@ class DynamicPolygonConverter extends BaseConverter {
    * @inheritDoc
    */
   create(feature, geometry, style, context) {
-    const polylines = createPolygonAsPolyline(feature, geometry, style, context, []);
-    polylines.forEach((polyline) => {
-      context.addPrimitive(polyline, feature, geometry);
-    });
-
-    const polylineOptions = createPolyline(feature, geometry, style, context);
-    context.addPolyline(polylineOptions, feature, geometry);
+    createOrUpdatePolygon(feature, geometry, style, context);
     return true;
   }
 
@@ -43,250 +27,30 @@ class DynamicPolygonConverter extends BaseConverter {
    * @inheritDoc
    */
   update(feature, geometry, style, context, primitive) {
-    updatePolyline(feature, geometry, style, context, primitive);
+    createOrUpdatePolygon(feature, geometry, style, context, Array.isArray(primitive) ? primitive : [primitive]);
     return true;
   }
 }
 
 
 /**
- * @param {!Feature} feature Ol3 feature..
- * @param {!(LineString|Ellipse|MultiLineString)} geometry Ol3 line string geometry.
+ * Creates or updates a polygon geometry as a Cesium.Polyline.
+ * @param {!Feature} feature
+ * @param {!Polygon} polygon
  * @param {!Style} style
  * @param {!VectorContext} context
- * @param {Array<number>=} opt_flatCoords The flat coordinates from a multiline
- * @param {number=} opt_offset
- * @param {number=} opt_end
- * @return {!Cesium.PolylineOptions}
+ * @param {!Array<!Cesium.Polyline>=} opt_primitives
  */
-const createPolyline = (feature, geometry, style, context, opt_flatCoords, opt_offset, opt_end) => {
-  const polylineOptions = /** @type {Cesium.PolylineOptions} */ ({});
-  updatePolyline(feature, geometry, style, context, polylineOptions, opt_flatCoords, opt_offset, opt_end);
-  return polylineOptions;
-};
+const createOrUpdatePolygon = (feature, polygon, style, context, opt_primitives) => {
+  const flatCoords = polygon.getFlatCoordinates();
+  const ends = polygon.getEnds();
+  let offset = 0;
 
-
-/**
- * @param {!Feature} feature Ol3 feature..
- * @param {!(LineString|Ellipse|MultiLineString)} geometry Ol3 line string geometry.
- * @param {!Style} style
- * @param {!VectorContext} context
- * @param {!(Cesium.Polyline|Cesium.PolylineOptions)} polyline The polyline, for updates.
- * @param {Array<number>=} opt_flatCoords The flat coordinates from a multiline
- * @param {number=} opt_offset
- * @param {number=} opt_end
- */
-const updatePolyline = (feature, geometry, style, context, polyline, opt_flatCoords, opt_offset, opt_end) => {
-  const geomRevision = geometry.getRevision();
-  if (polyline.geomRevision != geomRevision) {
-    polyline.positions = getLineStringPositions(geometry, opt_flatCoords, opt_offset, opt_end);
-    polyline.geomRevision = geomRevision;
-  }
-
-  const width = getLineWidthFromStyle(style);
-  const color = getColor(style, context, GeometryInstanceId.GEOM_OUTLINE);
-  const dashPattern = getDashPattern(style);
-
-  const materialOptions = {
-    color: color,
-    dashPattern: dashPattern
-  };
-
-  const materialType = dashPattern != null ? Cesium.Material.PolylineDashType : Cesium.Material.ColorType;
-  const material = polyline.material;
-  if (!material || material.type != materialType) {
-    polyline.material = Cesium.Material.fromType(materialType, materialOptions);
-  } else {
-    if (!material.uniforms.color.equals(color)) {
-      material.uniforms.color = color;
-    }
-    if (materialType === Cesium.Material.PolylineDashType && material.uniforms.dashPattern != dashPattern) {
-      material.uniforms.dashPattern = dashPattern;
-    }
-  }
-
-  polyline.width = width;
-
-  if (polyline instanceof Cesium.Polyline) {
-    // mark as updated so it isn't deleted
-    polyline.dirty = false;
-  }
-};
-
-
-/**
- * @param {!Feature} feature Ol3 feature..
- * @param {!(Polygon|MultiPolygon)} geometry Ol3 polygon geometry.
- * @param {!Style} style
- * @param {!VectorContext} context
- * @param {!Array<!Cesium.PrimitiveLike>} result
- * @param {Array<number>=} opt_polyFlats
- * @param {number=} opt_offset
- * @param {Array<number>=} opt_ringEnds
- * @param {boolean=} opt_extrude
- * @param {number=} opt_index
- * @return {Array<!Cesium.PrimitiveLike>|null}
- */
-const createPolygonAsPolyline = (feature, geometry, style, context, result, opt_polyFlats, opt_offset, opt_ringEnds,
-    opt_extrude, opt_index) => {
-  const hierarchy = createPolygonHierarchy(geometry, opt_polyFlats, opt_offset, opt_ringEnds, opt_extrude);
-  if (!hierarchy) {
-    return null;
-  }
-
-  const csRings = [hierarchy.positions];
-  if (hierarchy.holes) {
-    hierarchy.holes.forEach(function(hole) {
-      csRings.push(hole.positions);
-    });
-  }
-
-  goog.asserts.assert(csRings.length > 0);
-
-  const width = getLineWidthFromStyle(style);
-  const lineDash = getDashPattern(style);
-  const outlineColor = getColor(style, context, GeometryInstanceId.GEOM_OUTLINE);
-
-  const appearance = lineDash ? new Cesium.PolylineMaterialAppearance({
-    material: Cesium.Material.fromType(Cesium.Material.PolylineDashType, {
-      color: outlineColor,
-      dashPattern: lineDash
-    })
-  }) : new Cesium.PolylineColorAppearance();
-
-  // Cesium doesn't make line width accessible once the primitive is loaded to the GPU, so we need to save it. also
-  // save if the outline needs to be displayed, so we know to recreate the primitive if that changes.
-  const heightReference = getHeightReference(context.layer, feature, geometry, opt_index);
-  const primitiveType = heightReference === Cesium.HeightReference.CLAMP_TO_GROUND ? Cesium.GroundPolylinePrimitive :
-    Cesium.Primitive;
-  const geometryType = heightReference === Cesium.HeightReference.CLAMP_TO_GROUND ? Cesium.GroundPolylineGeometry :
-    Cesium.PolylineGeometry;
-
-  // always create outlines even if the style doesn't have a stroke. this allows updating the primitive if a stroke
-  // is added without recreating it.
-  for (let i = 0; i < csRings.length; ++i) {
-    // Handle both color and width
-    const polylineGeometry = new geometryType({
-      positions: csRings[i],
-      vertexFormat: appearance.vertexFormat,
-      width: width
-    });
-
-    const instance = createGeometryInstance(GeometryInstanceId.GEOM_OUTLINE, polylineGeometry, outlineColor);
-    const outlinePrimitive = new primitiveType({
-      geometryInstances: instance,
-      appearance: appearance
-    });
-
-    outlinePrimitive['olLineWidth'] = width;
-    result.push(outlinePrimitive);
-  }
-
-  if (style.getFill()) {
-    const fillColor = getColor(style, context, GeometryInstanceId.GEOM);
-
-    if (fillColor.alpha > 0) {
-      const fillGeometry = new Cesium.PolygonGeometry({
-        polygonHierarchy: hierarchy,
-        perPositionHeight: true
-      });
-
-      const p = createColoredPrimitive(fillGeometry, fillColor, undefined, undefined,
-          heightReference === Cesium.HeightReference.CLAMP_TO_GROUND ? Cesium.GroundPrimitive : Cesium.Primitive);
-      result.push(p);
-    }
-  }
-
-  return result;
-};
-
-
-/**
- * @type {!ol.Coordinate}
- */
-const scratchCoord1 = [];
-
-
-/**
- * @type {!ol.Coordinate}
- */
-const scratchCoord2 = [];
-
-
-/**
- * @type {!ol.Extent}
- */
-const scratchExtent1 = [Infinity, Infinity, -Infinity, -Infinity];
-
-
-/**
- * Creates a Cesium.PolygonHierarchy from an ol.geom.Polygon.
- *
- * @param {!(Polygon|MultiPolygon)} geometry The OL polygon
- * @param {Array<number>=} opt_flats
- * @param {number=} opt_offset
- * @param {Array<number>=} opt_ringEnds
- * @param {boolean=} opt_extrude
- * @return {Cesium.PolygonHierarchy}
- */
-const createPolygonHierarchy = (geometry, opt_flats, opt_offset, opt_ringEnds, opt_extrude) => {
-  const transform = getTransformFunction();
-
-  const flats = opt_flats || geometry.getFlatCoordinates();
-  let offset = opt_offset || 0;
-  const ends = opt_ringEnds || geometry.getEnds();
-  // let extrude = opt_extrude != undefined ? opt_extrude : !!geometry.get('extrude');
-  const stride = geometry.getStride();
-  const coord = scratchCoord1;
-  const transformedCoord = scratchCoord2;
-  coord.length = stride;
-  transformedCoord.length = stride;
-
-  const extent = scratchExtent1;
-
-  // reset extent
-  extent[0] = Infinity;
-  extent[1] = Infinity;
-  extent[2] = -Infinity;
-  extent[3] = -Infinity;
-
-  let positions;
-  let holes;
-
-  for (let r = 0, rr = ends.length; r < rr; r++) {
-    const end = ends[r];
-    const csPos = new Array((end - offset) / stride);
-
-    let count = 0;
-    for (let i = offset; i < end; i += stride) {
-      for (let j = 0; j < stride; j++) {
-        coord[j] = flats[i + j];
-        transformedCoord[j] = coord[j];
-      }
-
-      if (transform) {
-        transform(coord, transformedCoord, coord.length);
-      }
-
-      csPos[count] = olcsCore.ol4326CoordinateToCesiumCartesian(transformedCoord);
-      count++;
-    }
-
-    // if a ring is empty, just ignore it
-    if (csPos && csPos.length) {
-      if (r == 0) {
-        positions = csPos;
-      } else {
-        holes = holes || [];
-        holes.push(new Cesium.PolygonHierarchy(csPos));
-      }
-    }
-
+  ends.forEach((end, i) => {
+    createOrUpdateSegment(i, feature, polygon, style, context, flatCoords, offset, end, opt_primitives);
     offset = end;
-  }
-
-  // don't create a polygon if we don't have an outer ring
-  return positions ? new Cesium.PolygonHierarchy(positions, holes) : null;
+  });
 };
+
 
 exports = DynamicPolygonConverter;

--- a/src/plugin/cesium/sync/dynamicpolygonconverter.js
+++ b/src/plugin/cesium/sync/dynamicpolygonconverter.js
@@ -1,0 +1,292 @@
+goog.module('plugin.cesium.sync.DynamicPolygonConverter');
+
+const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
+const getTransformFunction = goog.require('plugin.cesium.sync.getTransformFunction');
+const olcsCore = goog.require('olcs.core');
+const {GeometryInstanceId} = goog.require('plugin.cesium');
+const {createColoredPrimitive, createGeometryInstance} = goog.require('plugin.cesium.primitive');
+const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
+const {getDashPattern, getLineStringPositions} = goog.require('plugin.cesium.sync.linestring');
+const {getHeightReference} = goog.require('plugin.cesium.sync.HeightReference');
+
+const Polygon = goog.requireType('ol.geom.Polygon');
+const Feature = goog.requireType('ol.Feature');
+const Geometry = goog.requireType('ol.geom.Geometry');
+const MultiPolygon = goog.requireType('ol.geom.MultiPolygon');
+const Style = goog.requireType('ol.style.Style');
+const VectorContext = goog.requireType('plugin.cesium.VectorContext');
+const LineString = goog.requireType('ol.geom.LineString');
+const MultiLineString = goog.requireType('ol.geom.MultiLineString');
+const Ellipse = goog.requireType('os.geom.Ellipse');
+
+
+/**
+ * Converter for DynamicFeature polygons.
+ * @extends {BaseConverter<(Polygon), (Cesium.Polyline|Cesium.PolylineOptions)>}
+ */
+class DynamicPolygonConverter extends BaseConverter {
+  /**
+   * @inheritDoc
+   */
+  create(feature, geometry, style, context) {
+    const polylines = createPolygonAsPolyline(feature, geometry, style, context, []);
+    polylines.forEach((polyline) => {
+      context.addPrimitive(polyline, feature, geometry);
+    });
+
+    const polylineOptions = createPolyline(feature, geometry, style, context);
+    context.addPolyline(polylineOptions, feature, geometry);
+    return true;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  update(feature, geometry, style, context, primitive) {
+    updatePolyline(feature, geometry, style, context, primitive);
+    return true;
+  }
+}
+
+
+/**
+ * @param {!Feature} feature Ol3 feature..
+ * @param {!(LineString|Ellipse|MultiLineString)} geometry Ol3 line string geometry.
+ * @param {!Style} style
+ * @param {!VectorContext} context
+ * @param {Array<number>=} opt_flatCoords The flat coordinates from a multiline
+ * @param {number=} opt_offset
+ * @param {number=} opt_end
+ * @return {!Cesium.PolylineOptions}
+ */
+const createPolyline = (feature, geometry, style, context, opt_flatCoords, opt_offset, opt_end) => {
+  const polylineOptions = /** @type {Cesium.PolylineOptions} */ ({});
+  updatePolyline(feature, geometry, style, context, polylineOptions, opt_flatCoords, opt_offset, opt_end);
+  return polylineOptions;
+};
+
+
+/**
+ * @param {!Feature} feature Ol3 feature..
+ * @param {!(LineString|Ellipse|MultiLineString)} geometry Ol3 line string geometry.
+ * @param {!Style} style
+ * @param {!VectorContext} context
+ * @param {!(Cesium.Polyline|Cesium.PolylineOptions)} polyline The polyline, for updates.
+ * @param {Array<number>=} opt_flatCoords The flat coordinates from a multiline
+ * @param {number=} opt_offset
+ * @param {number=} opt_end
+ */
+const updatePolyline = (feature, geometry, style, context, polyline, opt_flatCoords, opt_offset, opt_end) => {
+  const geomRevision = geometry.getRevision();
+  if (polyline.geomRevision != geomRevision) {
+    polyline.positions = getLineStringPositions(geometry, opt_flatCoords, opt_offset, opt_end);
+    polyline.geomRevision = geomRevision;
+  }
+
+  const width = getLineWidthFromStyle(style);
+  const color = getColor(style, context, GeometryInstanceId.GEOM_OUTLINE);
+  const dashPattern = getDashPattern(style);
+
+  const materialOptions = {
+    color: color,
+    dashPattern: dashPattern
+  };
+
+  const materialType = dashPattern != null ? Cesium.Material.PolylineDashType : Cesium.Material.ColorType;
+  const material = polyline.material;
+  if (!material || material.type != materialType) {
+    polyline.material = Cesium.Material.fromType(materialType, materialOptions);
+  } else {
+    if (!material.uniforms.color.equals(color)) {
+      material.uniforms.color = color;
+    }
+    if (materialType === Cesium.Material.PolylineDashType && material.uniforms.dashPattern != dashPattern) {
+      material.uniforms.dashPattern = dashPattern;
+    }
+  }
+
+  polyline.width = width;
+
+  if (polyline instanceof Cesium.Polyline) {
+    // mark as updated so it isn't deleted
+    polyline.dirty = false;
+  }
+};
+
+
+/**
+ * @param {!Feature} feature Ol3 feature..
+ * @param {!(Polygon|MultiPolygon)} geometry Ol3 polygon geometry.
+ * @param {!Style} style
+ * @param {!VectorContext} context
+ * @param {!Array<!Cesium.PrimitiveLike>} result
+ * @param {Array<number>=} opt_polyFlats
+ * @param {number=} opt_offset
+ * @param {Array<number>=} opt_ringEnds
+ * @param {boolean=} opt_extrude
+ * @param {number=} opt_index
+ * @return {Array<!Cesium.PrimitiveLike>|null}
+ */
+const createPolygonAsPolyline = (feature, geometry, style, context, result, opt_polyFlats, opt_offset, opt_ringEnds,
+    opt_extrude, opt_index) => {
+  const hierarchy = createPolygonHierarchy(geometry, opt_polyFlats, opt_offset, opt_ringEnds, opt_extrude);
+  if (!hierarchy) {
+    return null;
+  }
+
+  const csRings = [hierarchy.positions];
+  if (hierarchy.holes) {
+    hierarchy.holes.forEach(function(hole) {
+      csRings.push(hole.positions);
+    });
+  }
+
+  goog.asserts.assert(csRings.length > 0);
+
+  const width = getLineWidthFromStyle(style);
+  const lineDash = getDashPattern(style);
+  const outlineColor = getColor(style, context, GeometryInstanceId.GEOM_OUTLINE);
+
+  const appearance = lineDash ? new Cesium.PolylineMaterialAppearance({
+    material: Cesium.Material.fromType(Cesium.Material.PolylineDashType, {
+      color: outlineColor,
+      dashPattern: lineDash
+    })
+  }) : new Cesium.PolylineColorAppearance();
+
+  // Cesium doesn't make line width accessible once the primitive is loaded to the GPU, so we need to save it. also
+  // save if the outline needs to be displayed, so we know to recreate the primitive if that changes.
+  const heightReference = getHeightReference(context.layer, feature, geometry, opt_index);
+  const primitiveType = heightReference === Cesium.HeightReference.CLAMP_TO_GROUND ? Cesium.GroundPolylinePrimitive :
+    Cesium.Primitive;
+  const geometryType = heightReference === Cesium.HeightReference.CLAMP_TO_GROUND ? Cesium.GroundPolylineGeometry :
+    Cesium.PolylineGeometry;
+
+  // always create outlines even if the style doesn't have a stroke. this allows updating the primitive if a stroke
+  // is added without recreating it.
+  for (let i = 0; i < csRings.length; ++i) {
+    // Handle both color and width
+    const polylineGeometry = new geometryType({
+      positions: csRings[i],
+      vertexFormat: appearance.vertexFormat,
+      width: width
+    });
+
+    const instance = createGeometryInstance(GeometryInstanceId.GEOM_OUTLINE, polylineGeometry, outlineColor);
+    const outlinePrimitive = new primitiveType({
+      geometryInstances: instance,
+      appearance: appearance
+    });
+
+    outlinePrimitive['olLineWidth'] = width;
+    result.push(outlinePrimitive);
+  }
+
+  if (style.getFill()) {
+    const fillColor = getColor(style, context, GeometryInstanceId.GEOM);
+
+    if (fillColor.alpha > 0) {
+      const fillGeometry = new Cesium.PolygonGeometry({
+        polygonHierarchy: hierarchy,
+        perPositionHeight: true
+      });
+
+      const p = createColoredPrimitive(fillGeometry, fillColor, undefined, undefined,
+          heightReference === Cesium.HeightReference.CLAMP_TO_GROUND ? Cesium.GroundPrimitive : Cesium.Primitive);
+      result.push(p);
+    }
+  }
+
+  return result;
+};
+
+
+/**
+ * @type {!ol.Coordinate}
+ */
+const scratchCoord1 = [];
+
+
+/**
+ * @type {!ol.Coordinate}
+ */
+const scratchCoord2 = [];
+
+
+/**
+ * @type {!ol.Extent}
+ */
+const scratchExtent1 = [Infinity, Infinity, -Infinity, -Infinity];
+
+
+/**
+ * Creates a Cesium.PolygonHierarchy from an ol.geom.Polygon.
+ *
+ * @param {!(Polygon|MultiPolygon)} geometry The OL polygon
+ * @param {Array<number>=} opt_flats
+ * @param {number=} opt_offset
+ * @param {Array<number>=} opt_ringEnds
+ * @param {boolean=} opt_extrude
+ * @return {Cesium.PolygonHierarchy}
+ */
+const createPolygonHierarchy = (geometry, opt_flats, opt_offset, opt_ringEnds, opt_extrude) => {
+  const transform = getTransformFunction();
+
+  const flats = opt_flats || geometry.getFlatCoordinates();
+  let offset = opt_offset || 0;
+  const ends = opt_ringEnds || geometry.getEnds();
+  // let extrude = opt_extrude != undefined ? opt_extrude : !!geometry.get('extrude');
+  const stride = geometry.getStride();
+  const coord = scratchCoord1;
+  const transformedCoord = scratchCoord2;
+  coord.length = stride;
+  transformedCoord.length = stride;
+
+  const extent = scratchExtent1;
+
+  // reset extent
+  extent[0] = Infinity;
+  extent[1] = Infinity;
+  extent[2] = -Infinity;
+  extent[3] = -Infinity;
+
+  let positions;
+  let holes;
+
+  for (let r = 0, rr = ends.length; r < rr; r++) {
+    const end = ends[r];
+    const csPos = new Array((end - offset) / stride);
+
+    let count = 0;
+    for (let i = offset; i < end; i += stride) {
+      for (let j = 0; j < stride; j++) {
+        coord[j] = flats[i + j];
+        transformedCoord[j] = coord[j];
+      }
+
+      if (transform) {
+        transform(coord, transformedCoord, coord.length);
+      }
+
+      csPos[count] = olcsCore.ol4326CoordinateToCesiumCartesian(transformedCoord);
+      count++;
+    }
+
+    // if a ring is empty, just ignore it
+    if (csPos && csPos.length) {
+      if (r == 0) {
+        positions = csPos;
+      } else {
+        holes = holes || [];
+        holes.push(new Cesium.PolygonHierarchy(csPos));
+      }
+    }
+
+    offset = end;
+  }
+
+  // don't create a polygon if we don't have an outer ring
+  return positions ? new Cesium.PolygonHierarchy(positions, holes) : null;
+};
+
+exports = DynamicPolygonConverter;

--- a/src/plugin/cesium/sync/multidynamiclinestringconverter.js
+++ b/src/plugin/cesium/sync/multidynamiclinestringconverter.js
@@ -1,7 +1,7 @@
 goog.module('plugin.cesium.sync.MultiDynamicLineStringConverter');
 
 const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
-const {createPolyline, updatePolyline} = goog.require('plugin.cesium.sync.DynamicLineString');
+const {createOrUpdateSegment} = goog.require('plugin.cesium.sync.DynamicLineString');
 
 const Feature = goog.requireType('ol.Feature');
 const MultiLineString = goog.requireType('ol.geom.MultiLineString');
@@ -45,26 +45,10 @@ const createOrUpdateDynamicMultiLineString = (feature, multiLine, style, context
 
   let offset = 0;
 
-  for (let i = 0, ii = lineEnds.length; i < ii; i++) {
-    const lineEnd = lineEnds[i];
-
-    let line;
-    if (opt_primitives && i < opt_primitives.length) {
-      line = opt_primitives[i];
-    }
-
-    if (!line) {
-      line = createPolyline(feature, multiLine, style, context, lineFlats, offset, lineEnd);
-
-      if (line) {
-        context.addPolyline(line, feature, multiLine);
-      }
-    } else {
-      updatePolyline(feature, multiLine, style, context, line, lineFlats, offset, lineEnd);
-    }
-
-    offset = lineEnd;
-  }
+  lineEnds.forEach((end, i) => {
+    createOrUpdateSegment(i, feature, multiLine, style, context, lineFlats, offset, end, opt_primitives);
+    offset = end;
+  });
 };
 
 

--- a/src/plugin/cesium/sync/polygon.js
+++ b/src/plugin/cesium/sync/polygon.js
@@ -341,5 +341,6 @@ const createPolygonHierarchy = (geometry, opt_flats, opt_offset, opt_ringEnds, o
 
 exports = {
   createAndAddPolygon,
-  createPolygon
+  createPolygon,
+  createPolygonHierarchy
 };

--- a/src/plugin/places/placessource.js
+++ b/src/plugin/places/placessource.js
@@ -1,5 +1,6 @@
 goog.provide('plugin.places.PlacesSource');
 
+goog.require('os.feature');
 goog.require('os.geom.GeometryField');
 goog.require('os.source.IModifiableSource');
 goog.require('os.track');
@@ -48,6 +49,7 @@ plugin.places.PlacesSource.prototype.getModifyFunction = function() {
       };
 
       plugin.file.kml.ui.updatePlacemark(options);
+      os.feature.createEllipse(originalFeature, true);
       os.style.notifyStyleChange(plugin.places.PlacesManager.getInstance().getPlacesLayer());
     }
   };

--- a/src/plugin/places/placessource.js
+++ b/src/plugin/places/placessource.js
@@ -2,7 +2,6 @@ goog.provide('plugin.places.PlacesSource');
 
 goog.require('os.feature');
 goog.require('os.geom.GeometryField');
-goog.require('os.source.IModifiableSource');
 goog.require('os.track');
 goog.require('plugin.file.kml.KMLSource');
 goog.require('plugin.file.kml.ui.KMLNode');
@@ -12,7 +11,6 @@ goog.require('plugin.file.kml.ui.KMLNode');
 /**
  * Vector source to manage places created in the application. Also adds specialized handling for tracks.
  * @param {olx.source.VectorOptions=} opt_options OpenLayers vector source options.
- * @implements {os.source.IModifiableSource}
  * @extends {plugin.file.kml.KMLSource}
  * @constructor
  */
@@ -50,7 +48,7 @@ plugin.places.PlacesSource.prototype.getModifyFunction = function() {
 
       plugin.file.kml.ui.updatePlacemark(options);
       os.feature.createEllipse(originalFeature, true);
-      os.style.notifyStyleChange(plugin.places.PlacesManager.getInstance().getPlacesLayer());
+      this.notifyDataChange();
     }
   };
 };

--- a/test/plugin/cesium/sync/converter.test.js
+++ b/test/plugin/cesium/sync/converter.test.js
@@ -9,6 +9,8 @@ goog.require('os.map');
 goog.require('os.proj');
 goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.sync.DynamicLineStringConverter');
+goog.require('plugin.cesium.sync.DynamicMultiPolygonConverter');
+goog.require('plugin.cesium.sync.DynamicPolygonConverter');
 goog.require('plugin.cesium.sync.EllipseConverter');
 goog.require('plugin.cesium.sync.GeometryCollectionConverter');
 goog.require('plugin.cesium.sync.LabelConverter');
@@ -40,6 +42,8 @@ describe('plugin.cesium.sync.converter', () => {
   const PointConverter = goog.module.get('plugin.cesium.sync.PointConverter');
   const PolygonConverter = goog.module.get('plugin.cesium.sync.PolygonConverter');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
+  const DynamicPolygonConverter = goog.module.get('plugin.cesium.sync.DynamicPolygonConverter');
+  const DynamicMultiPolygonConverter = goog.module.get('plugin.cesium.sync.DynamicMultiPolygonConverter');
 
   let feature;
   let geometry;
@@ -112,9 +116,9 @@ describe('plugin.cesium.sync.converter', () => {
         [GeometryType.LINE_STRING]: DynamicLineStringConverter,
         [GeometryType.MULTI_LINE_STRING]: MultiDynamicLineStringConverter,
         [GeometryType.MULTI_POINT]: MultiPointConverter,
-        [GeometryType.MULTI_POLYGON]: MultiPolygonConverter,
+        [GeometryType.MULTI_POLYGON]: DynamicMultiPolygonConverter,
         [GeometryType.POINT]: PointConverter,
-        [GeometryType.POLYGON]: PolygonConverter
+        [GeometryType.POLYGON]: DynamicPolygonConverter
       });
     });
 

--- a/test/plugin/cesium/sync/dynamicmultipolygonconverter.test.js
+++ b/test/plugin/cesium/sync/dynamicmultipolygonconverter.test.js
@@ -1,0 +1,87 @@
+goog.require('ol.geom.MultiPolygon');
+goog.require('ol.proj');
+goog.require('ol.style.Style');
+goog.require('os.feature.DynamicFeature');
+goog.require('os.layer.Vector');
+goog.require('os.map');
+goog.require('os.proj');
+goog.require('plugin.cesium.VectorContext');
+goog.require('plugin.cesium.sync.DynamicMultiPolygonConverter');
+goog.require('test.plugin.cesium.scene');
+
+describe('plugin.cesium.sync.DynamicMultiPolygonConverter', () => {
+  const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
+  const VectorContext = goog.module.get('plugin.cesium.VectorContext');
+  const DynamicMultiPolygonConverter = goog.module.get('plugin.cesium.sync.DynamicMultiPolygonConverter');
+  const converter = new DynamicMultiPolygonConverter();
+
+  let feature;
+  let geometry;
+  let style;
+  let context;
+
+  beforeEach(() => {
+    const coords = [
+      [
+        [[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]]
+      ],
+      [
+        [[10, 10], [10, 20], [20, 20], [20, 10], [10, 10]]
+      ]
+    ];
+    geometry = new ol.geom.MultiPolygon(coords);
+    feature = new os.feature.DynamicFeature(geometry);
+    style = new ol.style.Style();
+    layer = new os.layer.Vector();
+    scene = getFakeScene();
+    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+  });
+
+  const originalProjection = os.map.PROJECTION;
+  afterEach(() => {
+    os.map.PROJECTION = originalProjection;
+  });
+
+  const blue = 'rgba(0,0,255,1)';
+
+  describe('create', () => {
+    it('should create multipolygons', () => {
+      expect(converter.create(feature, geometry, style, context)).toBe(true);
+      expect(context.polylines.length).toBe(2);
+    });
+
+    it('should create multipolygons with holes', () => {
+      const coords = [
+        [
+          [[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]],
+          [[1, 1], [1, 4], [4, 4], [4, 1], [1, 1]]
+        ],
+        [
+          [[10, 10], [10, 20], [20, 20], [20, 10], [10, 10]],
+          [[12, 12], [12, 18], [18, 18], [18, 12], [12, 12]]
+        ]
+      ];
+      geometry = new ol.geom.MultiPolygon(coords);
+      feature = new os.feature.DynamicFeature(geometry);
+
+      expect(converter.create(feature, geometry, style, context)).toBe(true);
+      expect(context.polylines.length).toBe(4);
+    });
+  });
+
+  describe('update', () => {
+    it('should update multipolygons', () => {
+      expect(converter.create(feature, geometry, style, context)).toBe(true);
+      const primitives = converter.retrieve(feature, geometry, style, context);
+      expect(context.polylines.length).toBe(2);
+
+      style.setStroke(new ol.style.Stroke({
+        color: blue,
+        width: 2
+      }));
+
+      expect(converter.update(feature, geometry, style, context, primitives)).toBe(true);
+      expect(context.polylines.length).toBe(2);
+    });
+  });
+});

--- a/test/plugin/cesium/sync/dynamicpolygonconverter.test.js
+++ b/test/plugin/cesium/sync/dynamicpolygonconverter.test.js
@@ -1,0 +1,168 @@
+goog.require('ol.Feature');
+goog.require('ol.geom.Polygon');
+goog.require('ol.proj');
+goog.require('ol.style.Circle');
+goog.require('ol.style.Fill');
+goog.require('ol.style.Image');
+goog.require('ol.style.Style');
+goog.require('plugin.cesium.VectorContext');
+goog.require('plugin.cesium.sync.DynamicPolygonConverter');
+goog.require('test.plugin.cesium.scene');
+goog.require('test.plugin.cesium.sync.dynamiclinestring');
+
+describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
+  const VectorContext = goog.module.get('plugin.cesium.VectorContext');
+  const {testLine} = goog.module.get('test.plugin.cesium.sync.dynamiclinestring');
+  const {getRealScene, renderScene} = goog.module.get('test.plugin.cesium.scene');
+  const DynamicPolygonConverter = goog.module.get('plugin.cesium.sync.DynamicPolygonConverter');
+  const polygonConverter = new DynamicPolygonConverter();
+
+  let feature;
+  let geometry;
+  let style;
+  let context;
+
+  beforeEach(() => {
+    enableWebGLMock();
+    geometry = new ol.geom.Polygon([[[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]]]);
+    feature = new ol.Feature(geometry);
+    style = new ol.style.Style();
+    layer = new os.layer.Vector();
+    scene = getRealScene();
+    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+  });
+
+  const originalProjection = os.map.PROJECTION;
+  afterEach(() => {
+    disableWebGLMock();
+    os.map.PROJECTION = originalProjection;
+  });
+
+  const bluish = 'rgba(20,50,255,1)';
+  const greenish = 'rgba(10,255,10,1)';
+
+  describe('create', () => {
+    it('should create a polygon as a polyline', () => {
+      const result = polygonConverter.create(feature, geometry, style, context);
+      expect(result).toBe(true);
+      expect(context.polylines.length).toBe(1);
+      testLine(context.polylines.get(0));
+    });
+
+    it('should create a polygon with a given stroke style', () => {
+      style.setStroke(new ol.style.Stroke({
+        color: greenish,
+        width: 4
+      }));
+
+      const result = polygonConverter.create(feature, geometry, style, context);
+      expect(result).toBe(true);
+      testLine(context.polylines.get(0), {color: greenish, width: 4});
+    });
+
+    it('should create a dashed polygon if the stroke contains a dash', () => {
+      const stroke = new ol.style.Stroke({
+        color: greenish,
+        width: 1
+      });
+      stroke.setLineDash([12, 4]);
+      style.setStroke(stroke);
+
+      const result = polygonConverter.create(feature, geometry, style, context);
+      expect(result).toBe(true);
+      testLine(context.polylines.get(0), {
+        color: greenish,
+        dashPattern: parseInt('1111111111110000', 2),
+        width: 1
+      });
+    });
+
+    it('should create a polygon with holes as multiple polylines', () => {
+      const holeCoords = [
+        [[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]],
+        [[1, 1], [1, 4], [4, 4], [4, 1], [1, 1]]
+      ];
+      geometry = new ol.geom.Polygon(holeCoords);
+      feature = new ol.Feature(geometry);
+
+      const result = polygonConverter.create(feature, geometry, style, context);
+      expect(result).toBe(true);
+      expect(context.polylines.length).toBe(2);
+      testLine(context.polylines.get(0));
+      testLine(context.polylines.get(1));
+    });
+  });
+
+  describe('update', () => {
+    it('should update changing line widths', () => {
+      style.setStroke(new ol.style.Stroke({
+        color: bluish,
+        width: 3
+      }));
+
+      polygonConverter.create(feature, geometry, style, context);
+
+      const polygon = context.polylines.get(0);
+
+      style.setStroke(new ol.style.Stroke({
+        color: greenish,
+        width: 4
+      }));
+
+      const result = polygonConverter.update(feature, geometry, style, context, polygon);
+      expect(result).toBe(true);
+    });
+
+    it('should update changing dash patterns', () => {
+      const stroke = new ol.style.Stroke({
+        color: greenish,
+        width: 1
+      });
+      stroke.setLineDash([12, 4]);
+      style.setStroke(stroke);
+
+      polygonConverter.create(feature, geometry, style, context);
+
+      const polygon = context.polylines.get(0);
+      stroke.setLineDash([8, 8]);
+
+      const result = polygonConverter.update(feature, geometry, style, context, polygon);
+      expect(result).toBe(true);
+    });
+
+    it('should update lines with new colors', () => {
+      style.setStroke(new ol.style.Stroke({
+        color: greenish,
+        width: 4
+      }));
+
+      let result = polygonConverter.create(feature, geometry, style, context);
+      expect(result).toBe(true);
+
+      const polygon = context.polylines.get(0);
+      polygon._asynchronous = false;
+      renderScene(scene);
+
+      testLine(polygon, {
+        color: greenish,
+        width: 4,
+        cleanedGeometryInstances: true
+      });
+
+      style.getStroke().setColor(bluish);
+
+      polygon.dirty = true;
+      result = polygonConverter.update(feature, geometry, style, context, polygon);
+      expect(result).toBe(true);
+
+      testLine(polygon, {
+        color: bluish,
+        width: 4,
+        cleanedGeometryInstances: true
+      });
+
+      expect(polygon.dirty).toBe(false);
+    });
+  });
+});
+

--- a/views/help/controlblock.html
+++ b/views/help/controlblock.html
@@ -1,0 +1,25 @@
+<div class="card-body">
+  <div ng-repeat="ctrl in controls" class="row align-items-center mb-1">
+    <div class="text-right col-5 col-form-label">{{ctrl.text}} </div>
+    <div class="col-7">
+      <span ng-repeat="keyCode in ctrl.keys track by $index">
+        <span ng-if="$even" class="d-inline-block px-2 bg-secondary u-bg-secondary-text rounded border border-secondary">
+          <span class="text-monospace">
+            {{controlBlock.getKey(keyCode)}}
+          </span>
+        </span>
+        <span ng-if="$odd"> {{keyCode}} </span>
+      </span>
+      <span ng-repeat="otherText in ctrl.other track by $index">
+        <span ng-if="$even">
+          <img ng-if="controlBlock.getMouse(otherText)" ng-src="{{controlBlock.getMouse(otherText)}}">
+          <span ng-if="controlBlock.getFont(otherText)" class="d-inline-block px-1 bg-secondary u-bg-secondary-text rounded border border-secondary" ng-class="controlBlock.getFontClass(otherText)">
+            <i ng-class="controlBlock.getFont(otherText)"></i>
+          </span>
+          <span ng-if="!controlBlock.getMouse(otherText) && !controlBlock.getFont(otherText)" class="d-inline-block px-2 bg-secondary u-bg-secondary-text rounded border border-secondary">{{otherText}}</span>
+        </span>
+        <span ng-if="$odd"> {{otherText}} </span>
+      </span>
+    </div>
+  </div>
+</div>

--- a/views/help/controls.html
+++ b/views/help/controls.html
@@ -5,31 +5,7 @@
         <div class="card-header">
           <h4 class="m-0">{{control.section}}</h4>
         </div>
-        <div class="card-body">
-          <div ng-repeat="ctrl in control.controls" class="row align-items-center mb-1">
-            <div class="text-right col-5 col-form-label">{{ctrl.text}} </div>
-            <div class="col-7">
-              <span ng-repeat="keyCode in ctrl.keys track by $index">
-                <span ng-if="$even" class="d-inline-block px-2 bg-secondary u-bg-secondary-text rounded border border-secondary">
-                  <span class="text-monospace">
-                    {{controlsHelp.getKey(keyCode)}}
-                  </span>
-                </span>
-                <span ng-if="$odd"> {{keyCode}} </span>
-              </span>
-              <span ng-repeat="otherText in ctrl.other track by $index">
-                <span ng-if="$even">
-                  <img ng-if="controlsHelp.getMouse(otherText)" ng-src="{{controlsHelp.getMouse(otherText)}}">
-                  <span ng-if="controlsHelp.getFont(otherText)" class="d-inline-block px-1 bg-secondary u-bg-secondary-text rounded border border-secondary" ng-class="controlsHelp.getFontClass(otherText)">
-                    <i ng-class="controlsHelp.getFont(otherText)"></i>
-                  </span>
-                  <span ng-if="!controlsHelp.getMouse(otherText) && !controlsHelp.getFont(otherText)" class="d-inline-block px-2 bg-secondary u-bg-secondary-text rounded border border-secondary">{{otherText}}</span>
-                </span>
-                <span ng-if="$odd"> {{otherText}} </span>
-              </span>
-            </div>
-          </div>
-        </div>
+        <controlblock controls="control.controls"></controlblock>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Adds an adapted version of the Modify Interaction provided by Openlayers. This interaction allows for dynamically updating geometries on the map with clicking and dragging. The 3D sync of the interaction is accomplished through the Drawing Layer and new dynamic synchronizers rather than the traditional method used for other pointer interactions (which set update/cleanup functions). This pattern should be cleaner and generally more easily adaptable to other use cases.

There are a few little quirks I still need to iron out:
- The vertex feature gets stuck sometimes in 2D.
- The alt-click interaction is a little funky and doesn't seem to work sometimes when it should. Might be an OL issue.
- Interpolated geometries don't modify as expected due to the intermediate coordinates. This is an underlying issue that might not be fixable in this issue.