### PR TITLE
build(lint): disable the text-content rule

### DIFF
--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -16,7 +16,8 @@
     "wcag/h30": "warn",
     "wcag/h32": "off",
     "wcag/h37": "off",
-    "prefer-native-element": "warn"
+    "prefer-native-element": "warn",
+    "text-content": "off"
   }
 }
 


### PR DESCRIPTION
This is a new recommended rule in [`html-validate@4.3.0`](https://gitlab.com/html-validate/html-validate/-/releases/v4.3.0), which should have been a breaking change/major release.

https://html-validate.org/rules/text-content.html