### PR TITLE
feat(slicktreestyle): improve interface for styling slickTree

### DIFF
--- a/src/os/ui/nodetoggle.js
+++ b/src/os/ui/nodetoggle.js
@@ -14,7 +14,7 @@ os.ui.nodeToggleDirective = function() {
     restrict: 'AE',
     replace: true,
     template: '<i class="js-node-toggle c-node-toggle fa fa-fw" ' +
-        'ng-class="{\'fa-caret-right\': item.collapsed, \'fa-caret-down\': !item.collapsed}"></i>',
+        'ng-class="{\'{{collapsedIcon}}\': item.collapsed, \'{{expandedIcon}}\': !item.collapsed}"></i>',
     controller: os.ui.NodeToggleCtrl,
     controllerAs: 'toggle'
   };
@@ -49,15 +49,38 @@ os.ui.NodeToggleCtrl = function($scope, $element) {
    */
   this.element_ = $element;
 
+  /**
+   * @type {string}
+   */
+  this.scope_['expandedIcon'] = os.ui.NodeToggleCtrl.DEFAULT_EXPANDED;
+
+  /**
+   * @type {string}
+   */
+  this.scope_['collapsedIcon'] = os.ui.NodeToggleCtrl.DEFAULT_COLLAPSED;
+
   if (this.scope_['item'] instanceof os.ui.slick.SlickTreeNode) {
     var item = /** @type {os.ui.slick.SlickTreeNode} */ (this.scope_['item']);
     item.listen(goog.events.EventType.PROPERTYCHANGE, this.onPropertyChange, false, this);
-
+    this.updateIcons_();
     this.updateOpacity();
   }
 
   this.scope_.$on('$destroy', this.onDestroy_.bind(this));
 };
+
+
+/**
+ * The default expanded icon content.
+ * @type {string}
+ */
+os.ui.NodeToggleCtrl.DEFAULT_EXPANDED = 'fa-caret-down';
+
+/**
+ * The default collapsed icon content.
+ * @type {string}
+ */
+os.ui.NodeToggleCtrl.DEFAULT_COLLAPSED = 'fa-caret-right';
 
 
 /**
@@ -88,6 +111,9 @@ os.ui.NodeToggleCtrl.prototype.onPropertyChange = function(e) {
   if (p == 'children') {
     this.updateOpacity();
   }
+  if (p == 'icons') {
+    this.updateIcons_();
+  }
 };
 
 
@@ -98,4 +124,21 @@ os.ui.NodeToggleCtrl.prototype.updateOpacity = function() {
   var item = /** @type {os.ui.slick.SlickTreeNode} */ (this.scope_['item']);
   var children = item.getChildren();
   this.element_.css('opacity', children && children.length > 0 ? '1' : '0');
+};
+
+
+/**
+ * Updates the icons displayed by the directive.
+ *
+ * @private
+ */
+os.ui.NodeToggleCtrl.prototype.updateIcons_ = function() {
+  var item = /** @type {os.ui.slick.SlickTreeNode} */ (this.scope_['item']);
+  var icons = item.getToggleIcons();
+  if (icons) {
+    this.scope_['collapsedIcon'] = icons['collapsed'] || os.ui.NodeToggleCtrl.DEFAULT_COLLAPSED;
+    this.scope_['expandedIcon'] = icons['expanded'] || os.ui.NodeToggleCtrl.DEFAULT_EXPANDED;
+  }
+
+  os.ui.apply(this.scope_);
 };

--- a/src/os/ui/slick/slickgrid.js
+++ b/src/os/ui/slick/slickgrid.js
@@ -663,9 +663,8 @@ os.ui.slick.SlickGridCtrl.prototype.onRowCountChanged = function(e, args) {
 
 /**
  * Resizes the grid
- * @param {Object} dimensions
  */
-os.ui.slick.SlickGridCtrl.prototype.resize = function(dimensions) {
+os.ui.slick.SlickGridCtrl.prototype.resize = function() {
   this.resizeDelay.start();
 };
 

--- a/src/os/ui/slick/slickgrid.js
+++ b/src/os/ui/slick/slickgrid.js
@@ -663,8 +663,9 @@ os.ui.slick.SlickGridCtrl.prototype.onRowCountChanged = function(e, args) {
 
 /**
  * Resizes the grid
+ * @param {Object} dimensions
  */
-os.ui.slick.SlickGridCtrl.prototype.resize = function() {
+os.ui.slick.SlickGridCtrl.prototype.resize = function(dimensions) {
   this.resizeDelay.start();
 };
 

--- a/src/os/ui/slick/slicktree.js
+++ b/src/os/ui/slick/slicktree.js
@@ -96,6 +96,16 @@ os.ui.slick.slickTreeDirective = function() {
       'winLauncherClass': '@',
 
       /**
+       * Whether to show a border
+       */
+      'showBorder': '=?',
+
+      /**
+       * Options Override
+       */
+      'options': '=?',
+
+      /**
        * Whether or not there is a root node. This fixes the case where you dont want to show the root
        * And you also want slicktree to create the root
        */
@@ -134,6 +144,14 @@ os.ui.slick.SlickTreeCtrl = function($scope, $element, $compile) {
    * @protected
    */
   this.multiSelect = $scope['multiSelect'] == 'true';
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.showBorder_ = $scope['showBorder'] || false;
+
+  $scope['getItemMetadata'] = (this.showBorder_) ? (this.getRowStyleBorder) : (this.getRowStyle);
 
   os.ui.slick.SlickTreeCtrl.base(this, 'constructor', $scope, $element, $compile);
 
@@ -254,7 +272,7 @@ os.ui.slick.SlickTreeCtrl.prototype.disposeRoot_ = function() {
  */
 os.ui.slick.SlickTreeCtrl.prototype.getOptions = function() {
   var selectable = this.scope['disableSelection'] != 'true';
-  return {
+  var defaults = {
     // prevent the slick index behavior when selection is disabled, not very useful in our trees - THIN-6977
     'enableCellNavigation': selectable,
     'fullWidthRows': true,
@@ -264,6 +282,10 @@ os.ui.slick.SlickTreeCtrl.prototype.getOptions = function() {
     'headerRowHeight': 0,
     'rowHeight': 21
   };
+  if (this.scope['options']) {
+    return Object.assign(defaults, this.scope['options']);
+  }
+  return defaults;
 };
 
 
@@ -278,6 +300,37 @@ os.ui.slick.SlickTreeCtrl.prototype.getColumns = function() {
     'sortable': false,
     'formatter': this.treeFormatter.bind(this)
   }];
+};
+
+
+/**
+ * @param {Object} dimensions
+ * @override
+ */
+os.ui.slick.SlickTreeCtrl.prototype.resize = function(dimensions) {
+  this.grid.resizeCanvas();
+
+  if (this.showBorder_) {
+    $(this.grid.getCanvasNode()).css('width', (dimensions['width'] - 3) + 'px');
+  }
+};
+
+
+/**
+ * @param {number} row
+ * @return {Object}
+ */
+os.ui.slick.SlickTreeCtrl.prototype.getRowStyleBorder = function(row) {
+  return {'cssClasses': 'border'};
+};
+
+
+/**
+ * @param {number} row
+ * @return {Object}
+ */
+os.ui.slick.SlickTreeCtrl.prototype.getRowStyle = function(row) {
+  return {};
 };
 
 

--- a/src/os/ui/slick/slicktree.js
+++ b/src/os/ui/slick/slicktree.js
@@ -96,11 +96,6 @@ os.ui.slick.slickTreeDirective = function() {
       'winLauncherClass': '@',
 
       /**
-       * Whether to show a border
-       */
-      'showBorder': '=?',
-
-      /**
        * Options Override
        */
       'options': '=?',
@@ -144,14 +139,6 @@ os.ui.slick.SlickTreeCtrl = function($scope, $element, $compile) {
    * @protected
    */
   this.multiSelect = $scope['multiSelect'] == 'true';
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  this.showBorder_ = $scope['showBorder'] || false;
-
-  $scope['getItemMetadata'] = (this.showBorder_) ? (this.getRowStyleBorder) : (this.getRowStyle);
 
   os.ui.slick.SlickTreeCtrl.base(this, 'constructor', $scope, $element, $compile);
 
@@ -300,37 +287,6 @@ os.ui.slick.SlickTreeCtrl.prototype.getColumns = function() {
     'sortable': false,
     'formatter': this.treeFormatter.bind(this)
   }];
-};
-
-
-/**
- * @param {Object} dimensions
- * @override
- */
-os.ui.slick.SlickTreeCtrl.prototype.resize = function(dimensions) {
-  this.grid.resizeCanvas();
-
-  if (this.showBorder_) {
-    $(this.grid.getCanvasNode()).css('width', (dimensions['width'] - 3) + 'px');
-  }
-};
-
-
-/**
- * @param {number} row
- * @return {Object}
- */
-os.ui.slick.SlickTreeCtrl.prototype.getRowStyleBorder = function(row) {
-  return {'cssClasses': 'border'};
-};
-
-
-/**
- * @param {number} row
- * @return {Object}
- */
-os.ui.slick.SlickTreeCtrl.prototype.getRowStyle = function(row) {
-  return {};
 };
 
 

--- a/src/os/ui/slick/slicktreenode.js
+++ b/src/os/ui/slick/slicktreenode.js
@@ -473,6 +473,7 @@ os.ui.slick.SlickTreeNode.prototype.performAction = function(type) {
 os.ui.slick.SlickTreeNode.prototype.updateFrom = function(other) {
   var node = /** @type {os.ui.slick.SlickTreeNode} */ (other);
 
+  this.nodeUI = node.nodeUI;
   this.collapsed = node.collapsed;
   this.setToolTip(node.getToolTip());
   this.setCheckboxVisible(node.getCheckboxVisible());

--- a/src/os/ui/slick/slicktreenode.js
+++ b/src/os/ui/slick/slicktreenode.js
@@ -113,6 +113,14 @@ os.ui.slick.SlickTreeNode = function() {
   this.bold = true;
 
   /**
+   * @type {Object}
+   */
+  this.icons = {
+    'collapsed': os.ui.NodeToggleCtrl.DEFAULT_COLLAPSED,
+    'expanded': os.ui.NodeToggleCtrl.DEFAULT_EXPANDED
+  };
+
+  /**
    * @type {boolean}
    * @private
    */
@@ -395,6 +403,30 @@ os.ui.slick.SlickTreeNode.prototype.getIcons = function() {
  */
 os.ui.slick.SlickTreeNode.prototype.formatIcons = function() {
   return '&nbsp;';
+};
+
+
+/**
+ * API call to get the HTML for the toggle icons
+ * Toggle Icons can be: classIcon
+ * @return {Object<string, string>} The toggle icons HTML
+ * @export
+ */
+os.ui.slick.SlickTreeNode.prototype.getToggleIcons = function() {
+  return this.icons;
+};
+
+
+/**
+ * API call to get the HTML for the toggle icons
+ * Toggle Icons can be: classIcon
+ * @param {string} collapsed
+ * @param {string} expanded
+ * @export
+ */
+os.ui.slick.SlickTreeNode.prototype.setToggleIcons = function(collapsed, expanded) {
+  this.icons['collapsed'] = collapsed;
+  this.icons['expanded'] = expanded;
 };
 
 


### PR DESCRIPTION
Needed for a client ticket adding Object Type Counts to all Object Type Trees.

- Improve interface for styling SlickTree for typesTree in bits-internal.

- Adds extension to slicktreenode for Object Type Tree nodes. Most of the style interface changes are made in slicktreenode for accessibility to other instances but can be moved to the new objecttypenode.js.