### PR TITLE
feat(electron): test release url to authenticate and set cookies

### DIFF
--- a/externs/electron.externs.js
+++ b/externs/electron.externs.js
@@ -55,6 +55,12 @@ let ElectronOS;
 
 
 /**
+ * Notify the main process that it should check for updates.
+ */
+ElectronOS.checkForUpdates = function() {};
+
+
+/**
  * Register a certificate request handler with Electron.
  * @param {Electron.CertificateRequestFn|undefined} handler The handler.
  */

--- a/src/plugin/electron/electron.js
+++ b/src/plugin/electron/electron.js
@@ -9,6 +9,15 @@ const ID = 'electron';
 
 
 /**
+ * Electron settings keys.
+ * @enum {string}
+ */
+const SettingKey = {
+  RELEASE_URL: 'plugin.electron.releaseUrl'
+};
+
+
+/**
  * If the app is running within Electron.
  * @return {boolean}
  */
@@ -17,4 +26,4 @@ const isElectron = () => {
 };
 
 
-exports = {ID, isElectron};
+exports = {ID, SettingKey, isElectron};


### PR DESCRIPTION
Request `latest.yml` from the Electron release URL, if configured. This will ensure the update file exists prior to checking for updates, and will also authenticate with the URL using the selected client certificate so appropriate session cookies will be saved. These cookies are used by ngageoint/opensphere-electron/pull/36 to ensure authentication works properly when checking for updates.