### PR TITLE
fix(presets): default colors correctly set

### DIFF
--- a/src/os/layer/preset/layerpresetmanager.js
+++ b/src/os/layer/preset/layerpresetmanager.js
@@ -218,6 +218,9 @@ class LayerPresetManager extends Disposable {
           // add a "Basic" preset to the list if there are user-defined ones OR the user is an admin
           if (presets.length > 0 || this.isAdmin()) {
             OsLayerPreset.addDefault(presets, id, filterKey || undefined);
+            OsLayerPreset.updateDefault(/** @type {ILayer} */ (layer), presets.find((preset) => {
+              return preset.id == OsLayerPreset.DEFAULT_PRESET_ID;
+            }));
           }
 
           // return the list to any .then() bindings


### PR DESCRIPTION
Makes sure that the default presets get the correct color rather than loading in with a white fill. 