### PR TITLE
refactor(electron): rework certificate selection ui

### DIFF
--- a/externs/electron.externs.js
+++ b/externs/electron.externs.js
@@ -20,7 +20,9 @@ let Electron;
  *   subject: Electron.CertificatePrincipal,
  *   subjectName: string,
  *   serialNumber: string,
- *   fingerprint: string
+ *   fingerprint: string,
+ *   validExpiry: number,
+ *   validStart: number
  * }}
  */
 Electron.Certificate;

--- a/scss/opensphere.scss
+++ b/scss/opensphere.scss
@@ -23,6 +23,7 @@
 @import 'os/draganddropicon';
 @import 'os/dragdrop';
 @import 'os/duration';
+@import 'os/electron';
 @import 'os/formatter';
 @import 'os/glyph';
 @import 'os/iconpicker';

--- a/scss/os/_electron.scss
+++ b/scss/os/_electron.scss
@@ -1,0 +1,14 @@
+.c-electron-confirm-cert {
+  .card {
+    background-color: $secondary;
+
+    &.active {
+      background-color: $primary;
+    }
+
+    &:hover {
+      background-color: darken($primary, 10%);
+      color: $white;
+    }
+  }
+}

--- a/src/plugin/electron/electronconfirmcert.js
+++ b/src/plugin/electron/electronconfirmcert.js
@@ -68,7 +68,6 @@ class Controller {
     if (this.scope) {
       const certs = /** @type {Array<!Electron.Certificate>} */ (this.scope['certs']);
       if (certs) {
-        certs.sort(sortCerts);
         this['cert'] = certs[0];
       }
 
@@ -77,29 +76,20 @@ class Controller {
   }
 
   /**
-   * Get the user-facing name for a certificate.
+   * Format the certificate expiry to a date string.
    * @param {Electron.Certificate} cert The certificate.
-   * @return {string} The name.
+   * @return {string} The formatted expiry.
    * @export
    */
-  getName(cert) {
-    return cert ? `${cert.subjectName} (${cert.issuerName})` : 'Unknown Certificate';
+  formatExpiry(cert) {
+    let expiry = 'Unknown';
+    if (cert && cert.validExpiry > 0) {
+      expiry = moment(cert.validExpiry * 1000).format('dddd, MMMM D, YYYY');
+    }
+
+    return expiry;
   }
 }
-
-
-/**
- * Sort client certificates by subject/issuer name.
- * @param {Electron.Certificate} a First certificate.
- * @param {Electron.Certificate} b Second certificate.
- * @return {number} The sort value.
- */
-const sortCerts = (a, b) => {
-  // Sort by subject name, then issuer name.
-  return a.subjectName === b.subjectName ?
-      (a.issuerName > b.issuerName ? 1 : a.issuerName === b.issuerName ? 0 : -1) :
-      (a.subjectName > b.subjectName ? 1 : -1);
-};
 
 
 /**
@@ -133,13 +123,15 @@ const launchConfirmCert = (url, certs) => {
       prompt: '<electronconfirmcert></electronconfirmcert>',
       windowOptions: /** @type {!osx.window.WindowOptions} */ ({
         label: 'Select a Certificate',
+        icon: 'fa fa-key',
         height: 'auto',
+        width: 450,
         modal: true,
         parent: windowSelector.APP
       })
     }), {
       'certs': certs,
-      'prompt': `Select a certificate to authenticate yourself to ${url}`
+      'prompt': `Please select a certificate to authenticate yourself to <span class="text-monospace">${url}</span>.`
     });
   });
 };

--- a/src/plugin/electron/electronconfirmcert.js
+++ b/src/plugin/electron/electronconfirmcert.js
@@ -84,7 +84,7 @@ class Controller {
   formatExpiry(cert) {
     let expiry = 'Unknown';
     if (cert && cert.validExpiry > 0) {
-      expiry = moment(cert.validExpiry * 1000).format('dddd, MMMM D, YYYY');
+      expiry = moment(cert.validExpiry * 1000).format('YYYY MMM D');
     }
 
     return expiry;

--- a/views/plugin/electron/electronconfirmcert.html
+++ b/views/plugin/electron/electronconfirmcert.html
@@ -1,7 +1,20 @@
-<div>
-  <div class="form-group">{{prompt}}</div>
+<div class="c-electron-confirm-cert px-1">
+  <div class="form-group" ng-bind-html="prompt"></div>
   <div class="form-group">
-    <select class="custom-select" placeholder="Select certificate..." ng-model="ctrl.cert" required
-        ng-options="cert as ctrl.getName(cert) for cert in certs"></select>
+    <div class="card mt-2 user-select-none"
+        ng-class="ctrl.cert === cert && 'active'"
+        ng-click="ctrl.cert = cert"
+        ng-repeat="cert in certs">
+      <div class="card-body d-flex align-items-center">
+        <div class="flex-fill">
+          <div class="font-weight-bold">{{ cert.subjectName }}</div>
+          <div>Issued By: {{ cert.issuerName }}</div>
+          <div>Expires: {{ ctrl.formatExpiry(cert) }}</div>
+        </div>
+        <div ng-if="ctrl.cert === cert">
+          <i class="fa fa-check"></i>
+        </div>
+      </div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
The existing Electron certificate selection UI lacks in a few areas:

- If the default cert isn't the one you want, it takes three clicks to change it (open dropdown, select cert, OK).
- The dropdown doesn't show enough information about the cert until opened, and questionably not then either.

To address these issues, each certificate is now displayed as a card with clearly displayed cert details.

Old UI:
![Old UI](https://user-images.githubusercontent.com/5685437/105912953-69ae9580-5fe9-11eb-99ef-62aac27a0ed4.png)

New UI:
![New UI](https://user-images.githubusercontent.com/5685437/105912977-703d0d00-5fe9-11eb-90ac-003b1aa49ef2.png)
