### PR TITLE
fix: heatmap export items no longer removed from scope

### DIFF
--- a/src/os/ui/file/exportdialog.js
+++ b/src/os/ui/file/exportdialog.js
@@ -87,10 +87,6 @@ os.ui.file.ExportDialogCtrl = function($scope, $element, $compile) {
     }
   }
 
-  if (this.options.additionalOptions) {
-    this['additionalOptions'] = this.options.additionalOptions;
-  }
-
   /**
    * @type {Object.<string, os.ex.IPersistenceMethod>}
    */
@@ -124,9 +120,12 @@ os.ui.file.ExportDialogCtrl = function($scope, $element, $compile) {
   $scope.$watch('persister', this.onPersisterChange.bind(this));
   $scope.$on('$destroy', this.destroy.bind(this));
 
-  $scope.$on('addexportoptions.updateitem', goog.bind(function(event, items) {
-    this.options.items = items || [];
-  }, this));
+  // Only listen to this scope change if additional options exist
+  if (this.options.additionalOptions) {
+    $scope.$on('addexportoptions.updateitem', goog.bind(function(event, items) {
+      this.options.items = items || [];
+    }, this));
+  }
 };
 
 

--- a/src/os/ui/file/exportdialog.js
+++ b/src/os/ui/file/exportdialog.js
@@ -105,6 +105,11 @@ os.ui.file.ExportDialogCtrl = function($scope, $element, $compile) {
     }
   }
 
+  /**
+   * @type {boolean}
+   */
+  this['additionalOptions'] = this.options.additionalOptions || false;
+
   // add application-specific UI
   var customContainer = this.element.find('.js-custom-ui');
   var customOptions = this.getCustomOptions();

--- a/src/plugin/file/kml/ui/kmltreeexportui.js
+++ b/src/plugin/file/kml/ui/kmltreeexportui.js
@@ -131,9 +131,13 @@ plugin.file.kml.ui.KMLTreeExportCtrl = function($scope, $element) {
   }
 
   $scope.$on('$destroy', this.destroy.bind(this));
-  $scope.$on('addexportoptions.updateitem', goog.bind(function(event, items) {
-    this.scope['exportData'] = items;
-  }, this));
+
+  // Don't listen for this if we don't have additional options
+  if (this['additionalOptions']) {
+    $scope.$on('addexportoptions.updateitem', goog.bind(function(event, items) {
+      this.scope['exportData'] = items || [];
+    }, this));
+  }
 
   // fire auto height event
   setTimeout(function() {

--- a/views/file/exportdialog.html
+++ b/views/file/exportdialog.html
@@ -24,10 +24,8 @@
         </div>
       </div>
 
-      <div class="" ng-if="options.additionalOptions">
-        <div class="js-additional-ui__container">
-          <addexportoptions options="options"></addexportoptions>
-        </div>
+      <div class="js-additional-ui__container" ng-if="exportdialog.additionalOptions">
+        <addexportoptions options="options"></addexportoptions>
       </div>
 
       <div class="js-export-ui__wrapper" ng-show="exporter && exportdialog.getExporterUI()">

--- a/views/file/exportdialog.html
+++ b/views/file/exportdialog.html
@@ -24,7 +24,7 @@
         </div>
       </div>
 
-      <div class="" ng-show="exportdialog.additionalOptions">
+      <div class="" ng-if="options.additionalOptions">
         <div class="js-additional-ui__container">
           <addexportoptions options="options"></addexportoptions>
         </div>

--- a/views/plugin/kml/kmltreeexport.html
+++ b/views/plugin/kml/kmltreeexport.html
@@ -19,7 +19,7 @@
       </div>
 
       <div>
-        <div class="js-additional-ui__container" ng-show="treeExport.additionalOptions">
+        <div class="js-additional-ui__container" ng-if="treeExport.additionalOptions">
           <addexportoptions options="options" showcount="true"></addexportoptions>
         </div>
       </div>

--- a/views/plugin/kml/kmltreeexport.html
+++ b/views/plugin/kml/kmltreeexport.html
@@ -18,10 +18,8 @@
         </div>
       </div>
 
-      <div>
-        <div class="js-additional-ui__container" ng-if="treeExport.additionalOptions">
-          <addexportoptions options="options" showcount="true"></addexportoptions>
-        </div>
+      <div class="js-additional-ui__container" ng-if="treeExport.additionalOptions">
+        <addexportoptions options="options" showcount="true"></addexportoptions>
       </div>
 
       <h5 class="mt-3 text-center">KML Options</h5>


### PR DESCRIPTION
The UI will no longer state that there are no items when attempting to export a heatmap.

The additional export options directive will no longer be loaded if there are no additional options.