### PR TITLE
Add support for Arc ImageServer and better FeatureServer support

### DIFF
--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -1393,6 +1393,15 @@ Cesium.Cartesian3.fromDegrees = function(lon, lat, opt_alt, opt_ellipsoid, opt_r
 
 
 /**
+ * @param {Array<number>} coordinates The coordinates in degrees
+ * @param {Cesium.Ellipsoid=} opt_ellipsoid The ellipsoid.
+ * @param {Array<Cesium.Cartesian3>=} opt_result Altitude in meters
+ * @return {!Array<Cesium.Cartesian3>}
+ */
+Cesium.Cartesian3.fromDegreesArray = function(coordinates, opt_ellipsoid, opt_result) {};
+
+
+/**
  * @param {Cesium.Cartesian3} right
  * @return {boolean}
  */

--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -1670,7 +1670,7 @@ Cesium.Polygon.prototype.material;
  * @typedef {{
  *   color: (Cesium.Color|undefined),
  *   horizontal: (boolean|undefined),
- *   image: (string|undefined),
+ *   image: (string|HTMLCanvasElement|HTMLVideoElement|Image|undefined),
  *   repeat: (number|undefined),
  *   evenColor: (Cesium.Color|undefined),
  *   oddColor: (Cesium.Color|undefined),

--- a/src/os/layer/image.js
+++ b/src/os/layer/image.js
@@ -123,6 +123,11 @@ os.layer.Image = function(options) {
    */
   this.hidden_ = true;
 
+  var source = this.getSource();
+  if (source) {
+    ol.events.listen(source, goog.events.EventType.PROPERTYCHANGE, this.onSourcePropertyChange_, this);
+  }
+
   this.setZIndex(999);
 };
 goog.inherits(os.layer.Image, ol.layer.Image);
@@ -549,6 +554,22 @@ os.layer.Image.prototype.callAction = function(type) {
         break;
       default:
         break;
+    }
+  }
+};
+
+
+/**
+ * Handler for source change events.
+ *
+ * @param {os.events.PropertyChangeEvent} event
+ * @private
+ */
+os.layer.Image.prototype.onSourcePropertyChange_ = function(event) {
+  if (event instanceof os.events.PropertyChangeEvent) {
+    var p = event.getProperty();
+    if (p == os.source.PropertyChange.LOADING) {
+      this.setLoading(/** @type {boolean} */ (event.getNewValue()));
     }
   }
 };

--- a/src/os/mixin/imagesourcemixin.js
+++ b/src/os/mixin/imagesourcemixin.js
@@ -1,0 +1,171 @@
+goog.provide('os.mixin.ImageSource');
+
+goog.require('goog.Uri');
+goog.require('goog.async.Delay');
+goog.require('goog.events');
+goog.require('ol.events.Event');
+goog.require('ol.source.Image');
+goog.require('os.events.PropertyChangeEvent');
+goog.require('os.implements');
+goog.require('os.ol.source.ILoadingSource');
+
+
+/*
+ * Adds ILoadingSource functionality to the base Openlayers Image source class. This allows for the loading
+ * spinner on the layer to be displayed.
+ */
+os.implements(ol.source.Image, os.ol.source.ILoadingSource.ID);
+
+
+/**
+ * Loading flag for the image layer.
+ * @type {boolean}
+ * @private
+ */
+ol.source.Image.prototype.loading_ = false;
+
+
+/**
+ * Counter for the number of loading images.
+ * @type {number}
+ * @private
+ */
+ol.source.Image.prototype.numLoadingImages_ = 0;
+
+
+/**
+ * Delay to prevent rapid firing loading events.
+ * @type {?goog.async.Delay}
+ * @private
+ */
+ol.source.Image.prototype.loadingDelay_ = null;
+
+
+/**
+ * @inheritDoc
+ */
+ol.source.Image.prototype.disposeInternal = function() {
+  ol.source.Image.prototype.disposeInternal.call(this);
+
+  if (this.loadingDelay_) {
+    this.loadingDelay_.dispose();
+    this.loadingDelay_ = null;
+  }
+};
+
+
+/**
+ * Gets a loading delay for preventing the spinner from bouncing in and out of the view.
+ * @return {?goog.async.Delay}
+ * @protected
+ */
+ol.source.Image.prototype.getLoadingDelay = function() {
+  if (!this.loadingDelay_ && !this.isDisposed()) {
+    this.loadingDelay_ = new goog.async.Delay(this.fireLoadingEvent_, 500, this);
+  }
+
+  return this.loadingDelay_;
+};
+
+
+/**
+ * Fires an event to indicate a loading change.
+ * @private
+ */
+ol.source.Image.prototype.fireLoadingEvent_ = function() {
+  if (!this.isDisposed()) {
+    this.dispatchEvent(new os.events.PropertyChangeEvent('loading', this.loading_, !this.loading_));
+  }
+};
+
+
+/**
+ * @return {boolean}
+ */
+ol.source.Image.prototype.isLoading = function() {
+  return this.loading_;
+};
+
+
+/**
+ * @param {boolean} value
+ */
+ol.source.Image.prototype.setLoading = function(value) {
+  if (this.loading_ !== value) {
+    this.loading_ = value;
+    var delay = this.getLoadingDelay();
+
+    if (delay) {
+      if (this.loading_) {
+        // always notify the UI when the layer starts loading
+        delay.fire();
+      } else {
+        // add a delay when notifying the UI loading is complete in case it starts loading again soon. this prevents
+        // flickering of the loading state, particularly when using Cesium.
+        delay.start();
+        this.numLoadingImages_ = 0;
+      }
+    }
+  }
+};
+
+
+/**
+ * Decrements the loading counter.
+ */
+ol.source.Image.prototype.decrementLoading = function() {
+  this.numLoadingImages_--;
+
+  if (this.numLoadingImages_ === 0) {
+    this.setLoading(false);
+  }
+};
+
+
+/**
+ * Increments the loading counter.
+ */
+ol.source.Image.prototype.incrementLoading = function() {
+  this.numLoadingImages_++;
+
+  if (this.numLoadingImages_ === 1) {
+    this.setLoading(true);
+  }
+};
+
+
+/**
+ * Handle image change events.
+ * @param {ol.events.Event} event Event.
+ * @protected
+ *
+ * @suppress {accessControls}
+ */
+ol.source.Image.prototype.originalHandleImageChange = ol.source.Image.prototype.handleImageChange;
+
+
+/**
+ * Handle image change events.
+ * @param {ol.events.Event} event Event.
+ * @protected
+ *
+ * @suppress {duplicate}
+ */
+ol.source.Image.prototype.handleImageChange = function(event) {
+  const image = /** @type {ol.Image} */ (event.target);
+  switch (image.getState()) {
+    case ol.ImageState.LOADING:
+      this.incrementLoading();
+      break;
+    case ol.ImageState.LOADED:
+      this.decrementLoading();
+      break;
+    case ol.ImageState.ERROR:
+      this.decrementLoading();
+      break;
+    default:
+      // pass
+  }
+
+  this.originalHandleImageChange(event);
+};

--- a/src/os/mixin/mixin.js
+++ b/src/os/mixin/mixin.js
@@ -12,6 +12,7 @@ goog.require('ol.interaction.Modify');
 goog.require('ol.math');
 goog.require('ol.renderer.canvas.Map');
 goog.require('ol.renderer.canvas.VectorLayer');
+goog.require('os.mixin.ImageSource');
 goog.require('os.mixin.ResolutionConstraint');
 goog.require('os.mixin.TileImage');
 goog.require('os.mixin.UrlTileSource');

--- a/src/plugin/arc/arc.js
+++ b/src/plugin/arc/arc.js
@@ -26,6 +26,17 @@ plugin.arc.MAP_SERVER = 'MapServer';
 
 
 /**
+ * Enum of supported server types.
+ * @enum {string}
+ */
+plugin.arc.ServerType = {
+  MAP_SERVER: 'MapServer',
+  IMAGE_SERVER: 'ImageServer',
+  FEATURE_SERVER: 'FeatureServer'
+};
+
+
+/**
  * @type {string}
  * @const
  */

--- a/src/plugin/arc/arcloader.js
+++ b/src/plugin/arc/arcloader.js
@@ -214,15 +214,39 @@ plugin.arc.ArcLoader.prototype.onLoad = function(event) {
     if (services && goog.isArray(services)) {
       for (var j = 0, jj = services.length; j < jj; j++) {
         var service = services[j];
-        var type = service['type'];
-        if (type === plugin.arc.MAP_SERVER) {
-          var name = /** @type {string} */ (service['name']);
-          name = name.substring(name.lastIndexOf('/') + 1);
-          var serviceNode = new plugin.arc.node.ArcServiceNode(this.server_);
+        var type = /** @type {string} */ (service['type']);
+        var name = /** @type {string} */ (service['name']);
+        name = name.substring(name.lastIndexOf('/') + 1);
+        var url = this.url_ + '/' + name + '/' + type;
+        var serviceNode;
+
+        if (type === plugin.arc.ServerType.MAP_SERVER) {
+          serviceNode = new plugin.arc.node.ArcServiceNode(this.server_);
+          serviceNode.setServiceType(plugin.arc.ServerType.MAP_SERVER);
           serviceNode.setLabel(name);
           serviceNode.listen(goog.net.EventType.SUCCESS, this.onChildLoad, false, this);
           serviceNode.listen(goog.net.EventType.ERROR, this.onChildLoad, false, this);
-          serviceNode.load(this.url_ + '/' + name);
+          serviceNode.load(url);
+          this.toLoad_.push(serviceNode);
+        }
+
+        if (type === plugin.arc.ServerType.FEATURE_SERVER) {
+          serviceNode = new plugin.arc.node.ArcServiceNode(this.server_);
+          serviceNode.setLabel(name);
+          serviceNode.setServiceType(plugin.arc.ServerType.FEATURE_SERVER);
+          serviceNode.listen(goog.net.EventType.SUCCESS, this.onChildLoad, false, this);
+          serviceNode.listen(goog.net.EventType.ERROR, this.onChildLoad, false, this);
+          serviceNode.load(url);
+          this.toLoad_.push(serviceNode);
+        }
+
+        if (type === plugin.arc.ServerType.IMAGE_SERVER) {
+          serviceNode = new plugin.arc.node.ArcServiceNode(this.server_);
+          serviceNode.setLabel(name);
+          serviceNode.setServiceType(plugin.arc.ServerType.IMAGE_SERVER);
+          serviceNode.listen(goog.net.EventType.SUCCESS, this.onChildLoad, false, this);
+          serviceNode.listen(goog.net.EventType.ERROR, this.onChildLoad, false, this);
+          serviceNode.load(url);
           this.toLoad_.push(serviceNode);
         }
       }
@@ -234,6 +258,9 @@ plugin.arc.ArcLoader.prototype.onLoad = function(event) {
       var lastIdx = this.url_.lastIndexOf('/MapServer');
       if (lastIdx == -1) {
         lastIdx = this.url_.lastIndexOf('/FeatureServer');
+      }
+      if (lastIdx == -1) {
+        lastIdx = this.url_.lastIndexOf('/ImageServer');
       }
 
       if (lastIdx != -1) {

--- a/src/plugin/arc/arcplugin.js
+++ b/src/plugin/arc/arcplugin.js
@@ -8,6 +8,7 @@ goog.require('plugin.arc');
 goog.require('plugin.arc.ArcServer');
 goog.require('plugin.arc.arcImportDirective');
 goog.require('plugin.arc.layer.ArcFeatureLayerConfig');
+goog.require('plugin.arc.layer.ArcImageLayerConfig');
 goog.require('plugin.arc.layer.ArcLayerDescriptor');
 goog.require('plugin.arc.layer.ArcTileLayerConfig');
 goog.require('plugin.arc.mime');
@@ -42,6 +43,7 @@ plugin.arc.ArcPlugin.prototype.init = function() {
   var lcm = os.layer.config.LayerConfigManager.getInstance();
   lcm.registerLayerConfig(plugin.arc.layer.ArcFeatureLayerConfig.ID, plugin.arc.layer.ArcFeatureLayerConfig);
   lcm.registerLayerConfig(plugin.arc.layer.ArcTileLayerConfig.ID, plugin.arc.layer.ArcTileLayerConfig);
+  lcm.registerLayerConfig(plugin.arc.layer.ArcImageLayerConfig.ID, plugin.arc.layer.ArcImageLayerConfig);
 
   var im = os.ui.im.ImportManager.getInstance();
   im.registerImportUI(this.id, new os.ui.ProviderImportUI('<arcserver></arcserver>'));

--- a/src/plugin/arc/layer/arcimagelayerconfig.js
+++ b/src/plugin/arc/layer/arcimagelayerconfig.js
@@ -1,0 +1,110 @@
+goog.provide('plugin.arc.layer.ArcImageLayerConfig');
+
+goog.require('ol.proj.Projection');
+goog.require('ol.source.ImageArcGISRest');
+goog.require('os.layer.Image');
+goog.require('os.layer.config.AbstractLayerConfig');
+goog.require('os.net');
+goog.require('os.net.CrossOrigin');
+goog.require('os.proj');
+goog.require('plugin.arc.layer.AnimatedArcTile');
+goog.require('plugin.arc.source.ArcTileSource');
+
+
+
+/**
+ * Layer config for Arc image layers.
+ *
+ * @extends {os.layer.config.AbstractLayerConfig}
+ * @constructor
+ */
+plugin.arc.layer.ArcImageLayerConfig = function() {
+  plugin.arc.layer.ArcImageLayerConfig.base(this, 'constructor');
+
+  /**
+   * @type {ol.proj.Projection}
+   * @protected
+   */
+  this.projection = null;
+
+  /**
+   * @type {?os.net.CrossOrigin}
+   * @protected
+   */
+  this.crossOrigin = null;
+};
+goog.inherits(plugin.arc.layer.ArcImageLayerConfig, os.layer.config.AbstractLayerConfig);
+
+
+/**
+ * Arc image layer config ID.
+ * @type {string}
+ */
+plugin.arc.layer.ArcImageLayerConfig.ID = 'arcimage';
+
+
+/**
+ * @inheritDoc
+ */
+plugin.arc.layer.ArcImageLayerConfig.prototype.initializeConfig = function(options) {
+  plugin.arc.layer.ArcImageLayerConfig.base(this, 'initializeConfig', options);
+
+  var projection = os.proj.getBestSupportedProjection(options);
+  if (!projection) {
+    throw new Error('No projections supported by the layer are defined!');
+  }
+  this.projection = projection;
+
+  // cross origin
+  if (!os.net.isValidCrossOrigin(options['crossOrigin'])) {
+    this.crossOrigin = /** @type {os.net.CrossOrigin} */ (os.net.getCrossOrigin(this.url));
+  } else {
+    this.crossOrigin = /** @type {os.net.CrossOrigin} */ (options['crossOrigin']);
+
+    // register the cross origin value by URL pattern so that our Cesium.loadImage mixin can find it
+    os.net.registerCrossOrigin(new RegExp('^' + this.url), this.crossOrigin);
+  }
+
+  // the correct none equivalent for crossOrigin in OL3 is null
+  if (this.crossOrigin === os.net.CrossOrigin.NONE) {
+    this.crossOrigin = null;
+    options['crossOrigin'] = null;
+  }
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.arc.layer.ArcImageLayerConfig.prototype.createLayer = function(options) {
+  this.initializeConfig(options);
+
+  var source = this.getSource(options);
+  var imageOptions = /** @type {olx.layer.ImageOptions} */ ({
+    source: source
+  });
+  var imageLayer = new os.layer.Image(imageOptions);
+
+  // image layers are hidden by default, we want this one to show
+  imageLayer.setHidden(false);
+  imageLayer.restore(options);
+  return imageLayer;
+};
+
+
+/**
+ * Creates a configured Arc Image source.
+ * @param {Object<string, *>} options
+ * @return {ol.source.ImageArcGISRest}
+ * @protected
+ */
+plugin.arc.layer.ArcImageLayerConfig.prototype.getSource = function(options) {
+  var arcOptions = /** @type {olx.source.ImageArcGISRestOptions} */ ({
+    url: this.url,
+    ratio: 1, // this ratio value defaults to 1.5 for some reason, which blows up Cesium, set it to 1
+    projection: this.projection,
+    crossOrigin: this.crossOrigin
+  });
+
+  return new ol.source.ImageArcGISRest(arcOptions);
+};

--- a/src/plugin/arc/layer/arcimagelayerconfig.js
+++ b/src/plugin/arc/layer/arcimagelayerconfig.js
@@ -1,110 +1,112 @@
-goog.provide('plugin.arc.layer.ArcImageLayerConfig');
+goog.module('plugin.arc.layer.ArcImageLayerConfig');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.proj.Projection');
-goog.require('ol.source.ImageArcGISRest');
-goog.require('os.layer.Image');
-goog.require('os.layer.config.AbstractLayerConfig');
-goog.require('os.net');
-goog.require('os.net.CrossOrigin');
-goog.require('os.proj');
-goog.require('plugin.arc.layer.AnimatedArcTile');
-goog.require('plugin.arc.source.ArcTileSource');
+goog.require('os.mixin.ImageSource');
 
+const ImageArcGISRest = goog.require('ol.source.ImageArcGISRest');
+const Image = goog.require('os.layer.Image');
+const AbstractLayerConfig = goog.require('os.layer.config.AbstractLayerConfig');
+const net = goog.require('os.net');
+const CrossOrigin = goog.require('os.net.CrossOrigin');
+const proj = goog.require('os.proj');
+
+const Projection = goog.requireType('ol.proj.Projection');
 
 
 /**
  * Layer config for Arc image layers.
- *
- * @extends {os.layer.config.AbstractLayerConfig}
- * @constructor
  */
-plugin.arc.layer.ArcImageLayerConfig = function() {
-  plugin.arc.layer.ArcImageLayerConfig.base(this, 'constructor');
+class ArcImageLayerConfig extends AbstractLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    /**
+     * @type {Projection}
+     * @protected
+     */
+    this.projection = null;
+
+    /**
+     * @type {?CrossOrigin}
+     * @protected
+     */
+    this.crossOrigin = null;
+  }
 
   /**
-   * @type {ol.proj.Projection}
-   * @protected
+   * @inheritDoc
    */
-  this.projection = null;
+  initializeConfig(options) {
+    super.initializeConfig(options);
+
+    var projection = proj.getBestSupportedProjection(options);
+    if (!projection) {
+      throw new Error('No projections supported by the layer are defined!');
+    }
+    this.projection = projection;
+
+    // cross origin
+    if (!net.isValidCrossOrigin(options['crossOrigin'])) {
+      this.crossOrigin = /** @type {CrossOrigin} */ (net.getCrossOrigin(this.url));
+    } else {
+      this.crossOrigin = /** @type {CrossOrigin} */ (options['crossOrigin']);
+
+      // register the cross origin value by URL pattern so that our Cesium.loadImage mixin can find it
+      net.registerCrossOrigin(new RegExp('^' + this.url), this.crossOrigin);
+    }
+
+    // the correct none equivalent for crossOrigin in OL3 is null
+    if (this.crossOrigin === CrossOrigin.NONE) {
+      this.crossOrigin = null;
+      options['crossOrigin'] = null;
+    }
+  }
 
   /**
-   * @type {?os.net.CrossOrigin}
+   * @inheritDoc
+   */
+  createLayer(options) {
+    this.initializeConfig(options);
+
+    var source = this.getSource(options);
+    var imageOptions = /** @type {olx.layer.ImageOptions} */ ({
+      source: source
+    });
+    var imageLayer = new Image(imageOptions);
+
+    // image layers are hidden by default, we want this one to show
+    imageLayer.setHidden(false);
+    imageLayer.restore(options);
+    return imageLayer;
+  }
+
+  /**
+   * Creates a configured Arc Image source.
+   * @param {Object<string, *>} options
+   * @return {ImageArcGISRest}
    * @protected
    */
-  this.crossOrigin = null;
-};
-goog.inherits(plugin.arc.layer.ArcImageLayerConfig, os.layer.config.AbstractLayerConfig);
+  getSource(options) {
+    var arcOptions = /** @type {olx.source.ImageArcGISRestOptions} */ ({
+      url: this.url,
+      ratio: 1, // this ratio value defaults to 1.5 for some reason, which blows up Cesium, set it to 1
+      projection: this.projection,
+      crossOrigin: this.crossOrigin
+    });
+
+    return new ImageArcGISRest(arcOptions);
+  }
+}
 
 
 /**
  * Arc image layer config ID.
  * @type {string}
  */
-plugin.arc.layer.ArcImageLayerConfig.ID = 'arcimage';
+ArcImageLayerConfig.ID = 'arcimage';
 
 
-/**
- * @inheritDoc
- */
-plugin.arc.layer.ArcImageLayerConfig.prototype.initializeConfig = function(options) {
-  plugin.arc.layer.ArcImageLayerConfig.base(this, 'initializeConfig', options);
-
-  var projection = os.proj.getBestSupportedProjection(options);
-  if (!projection) {
-    throw new Error('No projections supported by the layer are defined!');
-  }
-  this.projection = projection;
-
-  // cross origin
-  if (!os.net.isValidCrossOrigin(options['crossOrigin'])) {
-    this.crossOrigin = /** @type {os.net.CrossOrigin} */ (os.net.getCrossOrigin(this.url));
-  } else {
-    this.crossOrigin = /** @type {os.net.CrossOrigin} */ (options['crossOrigin']);
-
-    // register the cross origin value by URL pattern so that our Cesium.loadImage mixin can find it
-    os.net.registerCrossOrigin(new RegExp('^' + this.url), this.crossOrigin);
-  }
-
-  // the correct none equivalent for crossOrigin in OL3 is null
-  if (this.crossOrigin === os.net.CrossOrigin.NONE) {
-    this.crossOrigin = null;
-    options['crossOrigin'] = null;
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.arc.layer.ArcImageLayerConfig.prototype.createLayer = function(options) {
-  this.initializeConfig(options);
-
-  var source = this.getSource(options);
-  var imageOptions = /** @type {olx.layer.ImageOptions} */ ({
-    source: source
-  });
-  var imageLayer = new os.layer.Image(imageOptions);
-
-  // image layers are hidden by default, we want this one to show
-  imageLayer.setHidden(false);
-  imageLayer.restore(options);
-  return imageLayer;
-};
-
-
-/**
- * Creates a configured Arc Image source.
- * @param {Object<string, *>} options
- * @return {ol.source.ImageArcGISRest}
- * @protected
- */
-plugin.arc.layer.ArcImageLayerConfig.prototype.getSource = function(options) {
-  var arcOptions = /** @type {olx.source.ImageArcGISRestOptions} */ ({
-    url: this.url,
-    ratio: 1, // this ratio value defaults to 1.5 for some reason, which blows up Cesium, set it to 1
-    projection: this.projection,
-    crossOrigin: this.crossOrigin
-  });
-
-  return new ol.source.ImageArcGISRest(arcOptions);
-};
+exports = ArcImageLayerConfig;

--- a/src/plugin/arc/layer/arclayerdescriptor.js
+++ b/src/plugin/arc/layer/arclayerdescriptor.js
@@ -314,8 +314,8 @@ plugin.arc.layer.ArcLayerDescriptor.prototype.configureDescriptor = function(con
   var capabilities = /** @type {string} */ (config['capabilities']);
   if (capabilities) {
     var capsArr = capabilities.split(/\s*,\s*/);
-    this.setTilesEnabled(ol.array.includes(capsArr, 'Map'));
-    this.setFeaturesEnabled(ol.array.includes(capsArr, 'Data'));
+    this.setTilesEnabled(capsArr.includes('Map'));
+    this.setFeaturesEnabled(capsArr.includes('Data') || capsArr.includes('Query'));
   } else {
     this.setTilesEnabled(true);
     this.setFeaturesEnabled(true);

--- a/src/plugin/arc/node/arcservicenode.js
+++ b/src/plugin/arc/node/arcservicenode.js
@@ -190,6 +190,7 @@ plugin.arc.node.ArcServiceNode.prototype.addLayer_ = function(layer) {
 plugin.arc.node.ArcServiceNode.prototype.addImageLayer_ = function(json) {
   const id = this.server_.getId() + os.ui.data.BaseProvider.ID_DELIMITER + /** @type {string} */ (json['name']);
   const extent = /** @type {Object<string, number>} */ (json['extent']);
+  const wkid = /** @type {number} */ (extent['spatialReference']['latestWkid']);
   const config = {
     'id': id,
     'url': this.url_,
@@ -198,7 +199,7 @@ plugin.arc.node.ArcServiceNode.prototype.addImageLayer_ = function(json) {
     'provider': this.server_.getLabel(),
     'title': json['name'],
     'extent': [extent['xmin'], extent['ymin'], extent['xmax'], extent['ymax']],
-    'extentProjection': 'EPSG:3857',
+    'extentProjection': wkid === 3857 ? 'EPSG:3857' : 'EPSG:4326',
     'layerType': os.layer.LayerType.TILES,
     'icons': os.ui.Icons.TILES
   };

--- a/src/plugin/cesium/mixin/cesiummixin.js
+++ b/src/plugin/cesium/mixin/cesiummixin.js
@@ -53,7 +53,7 @@ plugin.cesium.mixin.loadCesiumMixins = function() {
     let url = options.url || '';
     if (crossOrigin) {
       const osCrossOrigin = os.net.getCrossOrigin(url);
-      if (osCrossOrigin != os.net.CrossOrigin.NONE) {
+      if (osCrossOrigin == os.net.CrossOrigin.USE_CREDENTIALS) {
         url = new URL(url);
         Cesium.TrustedServers.add(url.hostname, getPort(url));
       }

--- a/src/plugin/cesium/sync/imagesynchronizer.js
+++ b/src/plugin/cesium/sync/imagesynchronizer.js
@@ -206,9 +206,6 @@ plugin.cesium.sync.ImageSynchronizer.prototype.syncInternal = function(opt_force
     this.lastExtent_ = extent.slice();
 
     if (url && extent) {
-      // clamp the extent or Cesium will complain about the rectangle
-      // extent = os.extent.clamp(extent, os.map.PROJECTION.getWorldExtent());
-
       if (changed) {
         var primitive = new Cesium.Primitive({
           geometryInstances: new Cesium.GeometryInstance({

--- a/src/plugin/cesium/sync/imagesynchronizer.js
+++ b/src/plugin/cesium/sync/imagesynchronizer.js
@@ -168,6 +168,11 @@ plugin.cesium.sync.ImageSynchronizer.prototype.syncInternal = function(opt_force
             ol.events.listen(img, ol.events.EventType.CHANGE, this.onSyncChange, this);
           }
 
+          if (imageState == ol.ImageState.ERROR) {
+            // don't do anything, leave the old image rendered
+            return;
+          }
+
           if (imageState == ol.ImageState.IDLE) {
             img.load();
           }
@@ -207,10 +212,18 @@ plugin.cesium.sync.ImageSynchronizer.prototype.syncInternal = function(opt_force
 
     if (url && extent) {
       if (changed) {
-        var primitive = new Cesium.Primitive({
+        var minX = viewExtent[0];
+        var minY = viewExtent[1];
+        var maxX = viewExtent[2] - os.geo.EPSILON;
+        var maxY = viewExtent[3] - os.geo.EPSILON;
+        var flatCoordinates = [minX, minY, minX, maxY, maxX, maxY, maxX, minY, minX, minY];
+
+        var primitive = new Cesium.GroundPrimitive({
           geometryInstances: new Cesium.GeometryInstance({
-            geometry: new Cesium.RectangleGeometry({
-              rectangle: Cesium.Rectangle.fromDegrees(viewExtent[0], viewExtent[1], viewExtent[2], viewExtent[3])
+            geometry: new Cesium.PolygonGeometry({
+              polygonHierarchy: new Cesium.PolygonHierarchy(Cesium.Cartesian3.fromDegreesArray(flatCoordinates)),
+              height: 5000,
+              arcType: Cesium.ArcType.RHUMB
             }),
             id: this.layer.getId() + '.' + (this.nextId_++)
           }),

--- a/src/plugin/cesium/sync/imagesynchronizer.js
+++ b/src/plugin/cesium/sync/imagesynchronizer.js
@@ -75,6 +75,13 @@ plugin.cesium.sync.ImageSynchronizer = function(layer, map, scene) {
    */
   this.lastUrl_;
 
+  /**
+   * Flag for fixing a bug with the first render loop pass.
+   * @type {boolean}
+   * @private
+   */
+  this.firstLoopFixed_ = false;
+
   this.onPrimitiveReady_ = this.onPrimitiveReadyInternal.bind(this);
   this.scene.primitives.add(this.collection_);
 
@@ -108,12 +115,13 @@ plugin.cesium.sync.ImageSynchronizer.prototype.synchronize = function() {
   this.syncInternal();
 };
 
+
 /**
  * @param {boolean=} opt_force Force an update regardless of the current source revision
  * @protected
  */
 plugin.cesium.sync.ImageSynchronizer.prototype.syncInternal = function(opt_force) {
-  if (this.lastRevision_ !== this.source_.getRevision() || opt_force) {
+  if (this.source_ && (this.lastRevision_ !== this.source_.getRevision() || opt_force)) {
     this.lastRevision_ = this.source_.getRevision();
 
     if (this.activePrimitive_) {
@@ -122,33 +130,55 @@ plugin.cesium.sync.ImageSynchronizer.prototype.syncInternal = function(opt_force
 
     var map = /** @type {os.Map} */ (os.map.mapContainer.getMap());
     var viewExtent = map.getExtent();
+    if (ol.extent.containsExtent(viewExtent, os.map.PROJECTION.getWorldExtent())) {
+      // never allow an extent larger than the world to be requested
+      return;
+    }
+
+    // normalize the extent across the antimeridian
+    viewExtent = os.extent.normalize(viewExtent, -360, 0);
 
     if (!viewExtent) {
       this.removeImmediate_();
       return;
     }
 
-    var pixelExtent = map.getPixelFromCoordinate(ol.extent.getBottomLeft(viewExtent)).concat(
-        map.getPixelFromCoordinate(ol.extent.getTopRight(viewExtent)));
-
-    var resolution = ol.extent.getWidth(viewExtent) / Math.abs(ol.extent.getWidth(pixelExtent));
-    if (isNaN(resolution)) {
-      return;
-    }
-
-    var img = this.source_.getImage(viewExtent, resolution, window.devicePixelRatio, os.map.PROJECTION);
-    if (img) {
-      if (img !== this.image_) {
-        if (this.image_) {
-          ol.events.unlisten(this.image_, ol.events.EventType.CHANGE, this.onSyncChange, this);
-        }
-
-        this.image_ = img;
-        ol.events.listen(this.image_, ol.events.EventType.CHANGE, this.onSyncChange, this);
+    var resolution = map.getView().getResolution();
+    let img;
+    if (!isNaN(resolution) && resolution != null) {
+      if (!this.firstLoopFixed_) {
+        // HACK ALERT: when initially loading into Cesium, the image for this layer has already been created and loaded
+        // by a single render call on the 2D map. The extent for this request is incompatible with 3D since it's
+        // often wider than the world extent. OL also caches the bad image, so this tiny change to the resolution
+        // is designed to defeat that cache.
+        resolution += os.geo.EPSILON;
+        this.firstLoopFixed_ = true;
       }
-    } else {
-      this.removeImmediate_();
-      return;
+
+      img = this.source_.getImage(viewExtent, resolution, window.devicePixelRatio, os.map.PROJECTION);
+
+      if (img) {
+        if (img !== this.image_) {
+          if (this.image_) {
+            ol.events.unlisten(this.image_, ol.events.EventType.CHANGE, this.onSyncChange, this);
+          }
+
+          var imageState = img.getState();
+          if (imageState != ol.ImageState.LOADED && imageState != ol.ImageState.ERROR) {
+            ol.events.listen(img, ol.events.EventType.CHANGE, this.onSyncChange, this);
+          }
+
+          if (imageState == ol.ImageState.IDLE) {
+            img.load();
+          }
+
+          this.image_ = img;
+          return;
+        }
+      } else {
+        this.removeImmediate_();
+        return;
+      }
     }
 
     var url;
@@ -175,19 +205,21 @@ plugin.cesium.sync.ImageSynchronizer.prototype.syncInternal = function(opt_force
     }
     this.lastExtent_ = extent.slice();
 
-
     if (url && extent) {
+      // clamp the extent or Cesium will complain about the rectangle
+      // extent = os.extent.clamp(extent, os.map.PROJECTION.getWorldExtent());
+
       if (changed) {
         var primitive = new Cesium.Primitive({
           geometryInstances: new Cesium.GeometryInstance({
             geometry: new Cesium.RectangleGeometry({
-              rectangle: Cesium.Rectangle.fromDegrees(extent[0], extent[1], extent[2], extent[3])
+              rectangle: Cesium.Rectangle.fromDegrees(viewExtent[0], viewExtent[1], viewExtent[2], viewExtent[3])
             }),
             id: this.layer.getId() + '.' + (this.nextId_++)
           }),
           appearance: new Cesium.MaterialAppearance({
             material: Cesium.Material.fromType('Image', {
-              image: url
+              image: el
             })
           }),
           show: this.layer.getVisible()
@@ -195,6 +227,7 @@ plugin.cesium.sync.ImageSynchronizer.prototype.syncInternal = function(opt_force
 
         primitive.readyPromise.then(this.onPrimitiveReady_);
         this.collection_.add(primitive);
+        os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
       }
     } else {
       this.removeImmediate_();
@@ -209,7 +242,9 @@ plugin.cesium.sync.ImageSynchronizer.prototype.syncInternal = function(opt_force
  */
 plugin.cesium.sync.ImageSynchronizer.prototype.onPrimitiveReadyInternal = function(primitive) {
   this.activePrimitive_ = primitive;
-  for (var i = this.collection_.length - 1; i; i--) {
+
+  let i = this.collection_.length;
+  while (i--) {
     var item = this.collection_.get(i);
 
     if (item !== this.activePrimitive_) {

--- a/src/plugin/cesium/sync/polygon.js
+++ b/src/plugin/cesium/sync/polygon.js
@@ -1,4 +1,5 @@
 goog.module('plugin.cesium.sync.polygon');
+goog.module.declareLegacyNamespace();
 
 const olcsCore = goog.require('olcs.core');
 const {GeometryInstanceId} = goog.require('plugin.cesium');

--- a/test/plugin/arc/node/arcservicenode.test.js
+++ b/test/plugin/arc/node/arcservicenode.test.js
@@ -50,7 +50,8 @@ describe('plugin.arc.node.ArcServiceNode', function() {
     };
 
     var node = new plugin.arc.node.ArcServiceNode(server);
-    node.addLayer_(layerConfig, server);
+    node.setUrl(server.getUrl());
+    node.addLayer_(layerConfig);
 
     expect(node.getChildren().length).toBe(1);
     var dNode = node.getChildren()[0];


### PR DESCRIPTION
This PR includes updates to allow for loading an Arc FeatureServer that has no corresponding MapServer as well as adding support for the Arc ImageServer service. This works very easily in 2D mode through Openlayers' included `ImageArcGISRest` source, but had some hitches in 3D, some of which still need addressing. I have been unable to solve these two issues:

1. The images sometimes get clipped by the globe.
2. There is occasional flickering when swapping out the primitive with a new one on a fresh image loading.