### PR TITLE
feat(electron): make release channel configurable

### DIFF
--- a/src/plugin/electron/electron.js
+++ b/src/plugin/electron/electron.js
@@ -13,6 +13,9 @@ const ID = 'electron';
  * @enum {string}
  */
 const SettingKey = {
+  // publish.channel from the electron-builder config
+  RELEASE_CHANNEL: 'plugin.electron.releaseChannel',
+  // electron.releaseUrl from the app settings
   RELEASE_URL: 'plugin.electron.releaseUrl'
 };
 

--- a/src/plugin/electron/electronplugin.js
+++ b/src/plugin/electron/electronplugin.js
@@ -3,6 +3,7 @@ goog.module.declareLegacyNamespace();
 
 goog.require('plugin.electron.ElectronMemoryConfigUI');
 
+const Settings = goog.require('os.config.Settings');
 const Request = goog.require('os.net.Request');
 const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
 const {ID, SettingKey, isElectron} = goog.require('plugin.electron');
@@ -25,9 +26,11 @@ const onCertificateRequest = (url, certs) => {
  * @protected
  */
 const checkForUpdates = () => {
-  const releaseUrl = os.settings.get(SettingKey.RELEASE_URL, '');
+  const settings = Settings.getInstance();
+  const releaseUrl = settings.get(SettingKey.RELEASE_URL, '');
   if (releaseUrl) {
-    const request = new Request(`${releaseUrl}/latest.yml`);
+    const releaseChannel = /** @type {string} */ (settings.get(SettingKey.RELEASE_CHANNEL, 'latest'));
+    const request = new Request(`${releaseUrl}/${releaseChannel}.yml`);
     request.getPromise().then((response) => {
       if (response) {
         // Update file exists, notify the main process to check it.


### PR DESCRIPTION
The release channel for Electron is determined by the `publish.channel` value in the `electron-builder` config. It defaults to `latest`, but may be set to the branch in CI builds. This PR allows the channel to be configured within OpenSphere, so the Electron process and OpenSphere will use the same value.