### PR TITLE
fix(image): properly call parent class dispose

### DIFF
--- a/src/os/mixin/imagesourcemixin.js
+++ b/src/os/mixin/imagesourcemixin.js
@@ -45,7 +45,7 @@ ol.source.Image.prototype.loadingDelay_ = null;
  * @inheritDoc
  */
 ol.source.Image.prototype.disposeInternal = function() {
-  ol.source.Image.prototype.disposeInternal.call(this);
+  ol.source.Source.prototype.disposeInternal.call(this);
 
   if (this.loadingDelay_) {
     this.loadingDelay_.dispose();


### PR DESCRIPTION
Had the call in there wrong creating a loop and call stack overflow. Fixed to call the parent class one correctly.