### PR TITLE
refactor(cesium): convert goog.module to es6 modules

### DIFF
--- a/docs/guides/es6_transition_guide.rst
+++ b/docs/guides/es6_transition_guide.rst
@@ -13,6 +13,7 @@ As a step toward modernizing our codebase, OpenSphere plans to migrate all code 
   :caption: Guides
 
   goog_module_guide/index
+  goog_module_to_es6_guide/index
   es6_class_guide/index
   angular_module_guide/index
   unit_test_module_guide/index

--- a/docs/guides/goog_module_to_es6_guide/index.rst
+++ b/docs/guides/goog_module_to_es6_guide/index.rst
@@ -1,0 +1,97 @@
+Migrating from goog.modules to ES6 modules
+==========================================
+
+The primary difference between a ``goog.module`` and an ES6 module is how imports/exports are defined. With ``goog.module``, we solely use ``goog.require`` to import dependencies and use the ``exports`` keyword to assign either a single default export or an object listing named exports. ES6 modules use the ``import`` and ``export`` keywords, which are part of the JavaScript specification. MDN's JavaScript guide has an excellent reference on `JavaScript modules`_ with details on how these keywords work.
+
+.. _JavaScript modules: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules
+.. _Migrating from goog.modules to ES6 modules: https://github.com/google/closure-compiler/wiki/Migrating-from-goog.modules-to-ES6-modules
+
+Transform Script
+****************
+
+To convert ``goog.module`` files to ES6 modules, we'll use the ``moduletoes6.js`` transform in `opensphere-jscodeshift`_. This transform is based on the Closure Compiler's `Migrating from goog.modules to ES6 modules`_ guide.
+
+.. _opensphere-jscodeshift: https://github.com/schmidtk/opensphere-jscodeshift/
+
+To run the transform, clone ``opensphere-jscodeshift`` to your workspace and ``yarn upgrade``. Then run the transform on a ``goog.module`` file:
+
+.. code-block:: none
+
+    $ cd /path/to/opensphere-jscodeshift
+    $ yarn run shift -t src/transforms/es6/moduletoes6.js <target file or directory>
+
+The transform can be run against a single file or a directory. In the case of a directory, it will recursively run against any ``.js`` files it finds under the base path. The transform will make the following changes:
+
+- Replace the ``goog.module`` expression with ``goog.declareModuleId``.
+- Replace ``exports`` with inline ``export`` and ``export default`` declarations.
+- If ``export default`` is used, creates a ``<filename>.shim.js`` file to maintain backwards compatibility with ``const TheDefaultExport = goog.require(<module name>)``.
+- Remove the ``goog.module.declareLegacyNamespace`` statement, if present.
+
+goog.declareModuleId
+********************
+
+To make ES6 modules accessible to ``goog.module`` or ``goog.provide`` files, the Closure Library provides the ``goog.declareModuleId`` function to declare a Closure module ID. This is analagous to ``goog.module``, and makes the ES6 module's exports available via ``goog.require`` or ``goog.module.get``.
+
+.. warning:: Until OpenSphere has been completely migrated to ES6 modules (including tests), ``goog.declareModuleId`` **should be included in all new modules**. Once modules can be entirely referenced via ``import`` we can script removal of these calls from all files.
+
+Referencing ES6 Modules
+***********************
+
+The code used to reference an ES6 module varies based on the file type referencing the module. For these examples, assume we have the following ES6 modules in OpenSphere.
+
+.. literalinclude:: src/os/index.js
+  :caption: An index module with named exports at ``src/os/index.js``.
+  :linenos:
+  :language: javascript
+
+.. literalinclude:: src/os/myclass.js
+  :caption: A class with a default export at ``src/os/myclass.js``.
+  :linenos:
+  :language: javascript
+
+From an ES6 Module
+++++++++++++++++++
+
+To import these files from another ES6 module, use ``import`` statements with a path to the file. Within OpenSphere, use a relative path. From external projects, use a Node path. The file's ``.js`` extension is not required in the path, and for ``index.js`` files the path can end at the containing directory.
+
+.. code-block:: javascript
+
+  // From OpenSphere
+  import {MY_CONSTANT} from '../path/to/os';
+  import MyClass from '../path/to/os/myclass';
+
+  // From another project
+  import {MY_CONSTANT} from 'opensphere/src/os';
+  import MyClass from 'opensphere/src/os/myclass';
+
+From a Goog Module
+++++++++++++++++++
+
+To import these files from a ``goog.module``, use ``goog.require`` assignments.
+
+.. code-block:: javascript
+
+  const {MY_CONSTANT} = goog.require('os');
+  const {default: MyClass} = goog.require('os.MyClass');
+
+.. note:: The default export from an ES6 module will be assigned to the ``default`` property on the object returned by ``goog.require``. This is why the transform script creates a shim file, so existing references to the module do not need to be updated. You do not need to create this shim for new files, simply use the above syntax to reference the default export properly.
+
+From Legacy Files/Tests
++++++++++++++++++++++++
+
+To import the modules from a legacy file using ``goog.provide`` or from tests, use a combination of ``goog.require`` to add the dependency and ``goog.module.get`` to reference the module.
+
+.. code-block:: javascript
+
+  // Add a dependency on the module
+  goog.require('os');
+  goog.require('os.MyClass');
+
+  // Load the module
+  const {MY_CONSTANT} = goog.module.get('os');
+  const {default: MyClass} = goog.module.get('os.MyClass');
+
+Legacy Namespaces
+*****************
+
+With ``goog.module`` files, the ``goog.module.declareLegacyNamespace`` function is called to export the module's namespace to the global ``window`` object. This function cannot be used in an ES6 module because it violates a core principle of modules, that they do not pollute the global scope. The transform script will remove this function from converted files, so prior to running the transform please ensure the module is no longer referenced using the global namespace.

--- a/docs/guides/goog_module_to_es6_guide/src/os/index.js
+++ b/docs/guides/goog_module_to_es6_guide/src/os/index.js
@@ -1,0 +1,7 @@
+goog.declareModuleId('os');
+
+/**
+ * A named export.
+ * @type {number}
+ */
+export const MY_CONSTANT = 42;

--- a/docs/guides/goog_module_to_es6_guide/src/os/myclass.js
+++ b/docs/guides/goog_module_to_es6_guide/src/os/myclass.js
@@ -1,0 +1,6 @@
+goog.declareModuleId('os.MyClass');
+
+/**
+ * A default export.
+ */
+export default class MyClass {}

--- a/docs/guides/settings_guide.rst
+++ b/docs/guides/settings_guide.rst
@@ -306,10 +306,10 @@ WMS Tiles
                 "url": "<server url>"
                 "layers": [{
                   "layerName": "<elevation layer>",
-                  "minLevel": <level number>,
-                  "maxLevel": <level number>
+                  "minLevel": 0,
+                  "maxLevel": 10
                 }]
-              },
+              }
             }
           }
         }
@@ -317,7 +317,7 @@ WMS Tiles
     }
   }
 
-Where the `<server url>` would be something like `https://yourgeoserver:8080/geoserver/ows` 
+Where the `<server url>` would be something like `https://yourgeoserver:8080/geoserver/ows`
 and the `layers` entries have corresponding layer names and resolution ranges.
 
 Cesium World Terrain
@@ -369,6 +369,7 @@ The value of the matched field will be substituted for ``%s`` in the ``"action"`
 Example:
 
 .. code-block:: json
+
   {
     "admin": {
       "columnActions": {

--- a/src/plugin/cesium/primitive.js
+++ b/src/plugin/cesium/primitive.js
@@ -8,7 +8,6 @@ const styleUtils = goog.require('plugin.cesium.sync.style');
 
 const Feature = goog.requireType('ol.Feature');
 const Geometry = goog.requireType('ol.geom.Geometry');
-const IConverter = goog.requireType('plugin.cesium.sync.IConverter');
 const Style = goog.requireType('ol.style.Style');
 const VectorContext = goog.requireType('plugin.cesium.VectorContext');
 

--- a/src/plugin/cesium/sync/baseconverter.js
+++ b/src/plugin/cesium/sync/baseconverter.js
@@ -1,6 +1,6 @@
-goog.module('plugin.cesium.sync.BaseConverter');
+goog.declareModuleId('plugin.cesium.sync.BaseConverterTemp');
 
-const {getPrimitive, deletePrimitive} = goog.require('plugin.cesium.primitive');
+import {getPrimitive, deletePrimitive} from '../primitive';
 
 const IConverter = goog.requireType('plugin.cesium.sync.IConverter');
 
@@ -22,4 +22,4 @@ BaseConverter.prototype.retrieve = getPrimitive;
  */
 BaseConverter.prototype.delete = deletePrimitive;
 
-exports = BaseConverter;
+export default BaseConverter;

--- a/src/plugin/cesium/sync/baseconverter.shim.js
+++ b/src/plugin/cesium/sync/baseconverter.shim.js
@@ -1,0 +1,7 @@
+goog.module('plugin.cesium.sync.BaseConverter');
+
+const {
+  default: BaseConverter
+} = goog.require('plugin.cesium.sync.BaseConverterTemp');
+
+exports = BaseConverter;

--- a/src/plugin/cesium/sync/iconverter.js
+++ b/src/plugin/cesium/sync/iconverter.js
@@ -1,8 +1,9 @@
-goog.module('plugin.cesium.sync.IConverter');
+goog.declareModuleId('plugin.cesium.sync.IConverterTemp');
 
 const Feature = goog.requireType('ol.Feature');
 const Style = goog.requireType('ol.style.Style');
 const VectorContext = goog.requireType('plugin.cesium.VectorContext');
+
 
 /**
  * @interface
@@ -48,4 +49,4 @@ class IConverter {
   delete(feature, geometry, style, context, primitive) {}
 }
 
-exports = IConverter;
+export default IConverter;

--- a/src/plugin/cesium/sync/iconverter.shim.js
+++ b/src/plugin/cesium/sync/iconverter.shim.js
@@ -1,0 +1,7 @@
+goog.module('plugin.cesium.sync.IConverter');
+
+const {
+  default: IConverter
+} = goog.require('plugin.cesium.sync.IConverterTemp');
+
+exports = IConverter;

--- a/src/plugin/cesium/sync/runconverter.js
+++ b/src/plugin/cesium/sync/runconverter.js
@@ -1,4 +1,4 @@
-goog.module('plugin.cesium.sync.runConverter');
+goog.declareModuleId('plugin.cesium.sync.runConverter');
 
 const Feature = goog.requireType('ol.Feature');
 const Geometry = goog.requireType('ol.geom.Geometry');
@@ -14,7 +14,7 @@ const IConverter = goog.requireType('plugin.cesium.sync.IConverter');
  * @param {!Style} style
  * @param {!VectorContext} context
  */
-const runConverter = (converter, feature, geometry, style, context) => {
+export const runConverter = (converter, feature, geometry, style, context) => {
   const primitive = converter.retrieve(feature, geometry, style, context);
   if (primitive) {
     const updateSuccessful = converter.update(feature, geometry, style, context, primitive);
@@ -26,9 +26,4 @@ const runConverter = (converter, feature, geometry, style, context) => {
   }
 
   converter.create(feature, geometry, style, context);
-};
-
-
-exports = {
-  runConverter
 };


### PR DESCRIPTION
This PR is intended as an example to show how `goog.module` files can be converted to ES6 modules. The approach to default exports is described in Closure's documentation here:

[Migrating from goog.modules to ES6 modules](https://github.com/google/closure-compiler/wiki/Migrating-from-goog.modules-to-ES6-modules)

In short, if you `goog.require` an ES6 module with `goog.declareModuleId` and a default export, the returned object will have a `default` property for the default export. To maintain backward compatibility, we will create temporary shim files that expose the original namespace by re-exporting the temporary ES6 module namespace. As files referencing the dependency are converted to ES6, they can `import` the original file and eventually the shim can be deleted.