### PR TITLE
fix(capture): avoid hard coding timeline fill

### DIFF
--- a/src/os/ui/capture/timelinerenderer.js
+++ b/src/os/ui/capture/timelinerenderer.js
@@ -17,12 +17,6 @@ os.ui.capture.TimelineRenderer = function(opt_options) {
   this.title = 'Timeline';
 
   /**
-   * @type {string}
-   * @private
-   */
-  this.fill_ = options['fill'] || '#fff';
-
-  /**
    * @type {boolean}
    * @private
    */
@@ -35,7 +29,7 @@ goog.inherits(os.ui.capture.TimelineRenderer, os.ui.capture.SvgRenderer);
  * @inheritDoc
  */
 os.ui.capture.TimelineRenderer.prototype.getFill = function() {
-  return this.fill_;
+  return window.getComputedStyle(this.getRenderElement())['fill'];
 };
 
 

--- a/src/plugin/capture/captureplugin.js
+++ b/src/plugin/capture/captureplugin.js
@@ -119,9 +119,7 @@ plugin.capture.CapturePlugin.prototype.initRenderers = function() {
   ];
 
   if (!goog.userAgent.IE) {
-    renderers.push(new os.ui.capture.TimelineRenderer({
-      'fill': '#888'
-    }));
+    renderers.push(new os.ui.capture.TimelineRenderer());
   }
 
   return renderers;


### PR DESCRIPTION
Resolves #1063.

Testing will require generating and viewing the GIF recording with a couple of different themes to verify correct rendering.