### PR TITLE
feat(kml): utilizes mirror for kml icon exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "copy:resources": "xargs -n 2 cp -r < .build/resources-copy-files",
     "copy": "npm-run-all -s copy:files copy:images copy:onboarding copy:views copy:config copy:resources",
     "rename": "find dist -type f | xargs perl -pi -e \"s#{APP}#$(json -a admin.brand.opensphere admin.about.application -d '\\n'< .build/settings.json | sed '/^$/d' | head -n 1)#g\"",
-    "build": "npm-run-all -s init -p lint genlibs -s compile copy build:index rename",
+    "build": "npm-run-all -s init -p lint genlibs -s compile copy build:index rename symlink",
     "build:nolint": "npm run init && npm run genlibs && npm run compile && npm run copy && npm run build:index && npm run rename",
     "build:index": "xargs -n 1 os-index < .build/resources-pages",
     "dev": "npm-run-all -s init genlibs compile:vendor-min compile:resolve gen:deps -p compile:debugcss build:webpack-dev build:devindex",
@@ -148,7 +148,9 @@
     "start-server": "http-server ../../ -a localhost -p 8282 -c-1 -o -U -s &",
     "stop-server": "run-script-os",
     "stop-server:darwin:linux": "pkill -f http-server",
-    "stop-server:windows": "taskkill -F -PID $(netstat -ano | findstr 0.0.0.0:8282 | awk '{print $5}')"
+    "stop-server:windows": "taskkill -F -PID $(netstat -ano | findstr 0.0.0.0:8282 | awk '{print $5}')",
+    "symlink": "run-script-os",
+    "symlink:nix": "./tasks/symlink.sh"
   },
   "keywords": [
     "geospatial",

--- a/src/os/ui/file/kml/abstractkmlexporter.js
+++ b/src/os/ui/file/kml/abstractkmlexporter.js
@@ -123,7 +123,7 @@ os.ui.file.kml.AbstractKMLExporter = function() {
    * @type {os.ui.file.kml.Icon}
    * @private
    */
-  this.defaultIcon_ = /** @type {os.ui.file.kml.Icon} */ (goog.object.clone(os.ui.file.kml.DEFAULT_ICON));
+  this.defaultIcon_ = /** @type {os.ui.file.kml.Icon} */ ({});
 
   /**
    * The icon to use for placemarks.
@@ -166,6 +166,12 @@ os.ui.file.kml.AbstractKMLExporter = function() {
    * @protected
    */
   this.useCenterPoint = false;
+
+  // initial setup
+  this.setDefaultIcon(
+      os.ui.file.kml.DEFAULT_ICON.href,
+      os.ui.file.kml.DEFAULT_ICON.scale,
+      os.ui.file.kml.DEFAULT_ICON.options);
 };
 goog.inherits(os.ui.file.kml.AbstractKMLExporter, os.ex.ZipExporter);
 

--- a/src/plugin/file/kml/kmlplugin.js
+++ b/src/plugin/file/kml/kmlplugin.js
@@ -46,6 +46,13 @@ plugin.file.kml.KMLPlugin.TYPE = 'KML Layers';
 
 
 /**
+ * @type {string}
+ * @const
+ */
+plugin.file.kml.KMLPlugin.ICON_MIRROR = 'plugin.file.kml.icon.mirror';
+
+
+/**
  * @inheritDoc
  */
 plugin.file.kml.KMLPlugin.prototype.init = function() {
@@ -79,8 +86,14 @@ plugin.file.kml.KMLPlugin.prototype.init = function() {
   // set up actions
   plugin.file.kml.menu.treeSetup();
 
+  // try to load the first google earth icon; if it fails, set the mirror and flag
   return new os.net.Request(os.ui.file.kml.GOOGLE_EARTH_ICON_SET[0].path).getPromise()
       .then(goog.nullFunction, () => {
+        const settings = os.config.Settings.getInstance();
+        const mirror = /** @type {string|null} */ (settings.get(plugin.file.kml.KMLPlugin.ICON_MIRROR));
+        if (mirror) {
+          os.ui.file.kml.mirror = mirror;
+        }
         os.ui.file.kml.isGoogleMapsAccessible = false;
       });
 };

--- a/src/plugin/file/kml/ui/kmlexportui.js
+++ b/src/plugin/file/kml/ui/kmlexportui.js
@@ -137,7 +137,7 @@ plugin.file.kml.ui.KMLExportCtrl.prototype.updateExporter_ = function() {
     this.exporter_.setUseCenterPoint(this['useCenterPoint']);
     if (this['icon']) {
       var kmlIcon = {// osx.icon.Icon to os.ui.file.kml.Icon
-        'href': this['icon']['path'],
+        'href': os.ui.file.kml.exportableIconUri(this['icon']['path']),
         'options': this['icon']['options']
       };
       this.exporter_.setIcon(kmlIcon);

--- a/tasks/symlink.sh
+++ b/tasks/symlink.sh
@@ -1,4 +1,4 @@
-pushd "dist/opensphere"
+cd dist/opensphere/
 if [ -L images ]; then
   rm images;
 fi
@@ -6,4 +6,4 @@ fi
 ls -tr | grep '^v1' | head -n -1 | xargs rm -rf --
 
 find ./v1* -maxdepth 0 -type d -exec ln -s {}/images images \;
-popd
+cd ../..

--- a/tasks/symlink.sh
+++ b/tasks/symlink.sh
@@ -1,0 +1,9 @@
+pushd "dist/opensphere"
+if [ -L images ]; then
+  rm images;
+fi
+
+ls -tr | grep '^v1' | head -n -1 | xargs rm -rf --
+
+find ./v1* -maxdepth 0 -type d -exec ln -s {}/images images \;
+popd


### PR DESCRIPTION
When the primary Google icon source is unavailable, KMLExport will switch the icon source to either 
1) the fully-Location-resolved internal `/images/icons/kml` folder (e.g. https://my.url/images/icons/kml/...), or
2) a mirror website, as configured in `settings.json`.