### PR TITLE
fix(href): add href to a tags so hyperlinks appear correctly

### DIFF
--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -8,6 +8,7 @@
   },
 
   "rules": {
+    "attribute-allowed-values": "warn",
     "element-name": "off",
     "element-required-attributes": "off",
     "no-inline-style": "warn",

--- a/views/filter/editfilters.html
+++ b/views/filter/editfilters.html
@@ -15,8 +15,8 @@
         </div>
       </div>
       <ul class="nav nav-tabs flex-shrink-0">
-        <li class="nav-item"><a class="nav-link" ng-class="{active: tab == 'basic'}" ng-click="filters.setTab('basic')">Basic</a></li>
-        <li class="nav-item"><a class="nav-link" ng-class="{active: tab == 'advanced'}" ng-click="filters.setTab('advanced')">Advanced</a></li>
+        <li class="nav-item"><a href class="nav-link" ng-class="{active: tab == 'basic'}" ng-click="filters.setTab('basic')">Basic</a></li>
+        <li class="nav-item"><a href class="nav-link" ng-class="{active: tab == 'advanced'}" ng-click="filters.setTab('advanced')">Advanced</a></li>
       </ul>
       <div ng-if="tab == 'basic'" class="flex-column d-flex flex-fill">
         <basicfilterbuilder root="filters.root" columns="columns" is-complex="filters.isComplex"></basicfilterbuilder>

--- a/views/icon/iconselector.html
+++ b/views/icon/iconselector.html
@@ -4,7 +4,7 @@
       <div>
         <ul class="nav nav-tabs flex-shrink-0" ng-show="showtabs">
           <li class="nav-item" ng-repeat="tab in tabs">
-            <a class="nav-link" ng-click="selector.setTab(tab.name)" ng-class="{active: activeTab == tab.name}">{{tab.name}}</a>
+            <a href class="nav-link" ng-click="selector.setTab(tab.name)" ng-class="{active: activeTab == tab.name}">{{tab.name}}</a>
           </li>
         </ul>
       </div>

--- a/views/plugin/featureaction/editfeatureaction.html
+++ b/views/plugin/featureaction/editfeatureaction.html
@@ -24,8 +24,8 @@
       <h5 class="mt-1">For data matching the filter...</h5>
 
       <ul class="nav nav-tabs flex-shrink-0">
-        <li class="nav-item"><a class="nav-link" ng-click="ctrl.setTab('basic')" ng-class="{active: tab == 'basic'}">Basic</a></li>
-        <li class="nav-item"><a class="nav-link" ng-class="{active: tab == 'advanced'}" ng-click="ctrl.setTab('advanced')">Advanced</a></li>
+        <li class="nav-item"><a href class="nav-link" ng-click="ctrl.setTab('basic')" ng-class="{active: tab == 'basic'}">Basic</a></li>
+        <li class="nav-item"><a href class="nav-link" ng-class="{active: tab == 'advanced'}" ng-click="ctrl.setTab('advanced')">Advanced</a></li>
       </ul>
       <div class="flex-column d-flex flex-fill">
         <div class="flex-column d-flex flex-fill">


### PR DESCRIPTION
After JQuery update it was discovered that <a> tags without href don't appear correctly. This ticket fixes those issues, but for now we must change "attribute-allowed-values" errors to be warnings.