### PR TITLE
fix(shapefile): fix shapefile import dialog in electron

### DIFF
--- a/src/plugin/file/shp/ui/shpfilesstep.js
+++ b/src/plugin/file/shp/ui/shpfilesstep.js
@@ -208,8 +208,14 @@ plugin.file.shp.ui.SHPFilesStepCtrl.prototype.onFileChange_ = function(event) {
   if (inputEl.files && inputEl.files.length > 0) {
     this['loading'] = true;
 
-    var reader = os.file.createFromFile(inputEl.files[0]);
-    reader.addCallbacks(goog.partial(this.handleResult_, type), goog.partial(this.handleError_, type), this);
+    const file = inputEl.files[0];
+    if (file.path && os.file.FILE_URL_ENABLED) {
+      this[type + 'Name'] = os.file.getFileUrl(file.path);
+      this.loadUrl(type);
+    } else {
+      var reader = os.file.createFromFile(file);
+      reader.addCallbacks(goog.partial(this.handleResult_, type), goog.partial(this.handleError_, type), this);
+    }
   } else {
     this.onClear(type);
   }


### PR DESCRIPTION
Currently is if user tried to import a shapefile within electron the shapefile import dialog would pop up asking for the other file dbf or shp.  The user would be allowed to browse for a file and select it but it would never populate the import dialog and never allow the user to import a shapefile.  This fix now allows the user to import the shapefile.