### PR TITLE
fix(scaleline): ensure menu closes on toggle action

### DIFF
--- a/src/os/ui/menu/menu.js
+++ b/src/os/ui/menu/menu.js
@@ -328,5 +328,9 @@ os.ui.menu.Menu.prototype.dispatchEvent = function(evt) {
  * @return {boolean}
  */
 os.ui.menu.Menu.supportsToggle = function(el) {
-  return !!el && (el.nodeName.toLowerCase() == 'button' || goog.dom.classlist.contains(el, 'btn-group'));
+  return !!el
+    && (el.nodeName.toLowerCase() == 'button'
+      || goog.dom.classlist.contains(el, 'btn-group')
+      || goog.dom.classlist.contains(el, 'js-menu__toggle')
+    );
 };

--- a/src/os/ui/scaleline.js
+++ b/src/os/ui/scaleline.js
@@ -33,8 +33,9 @@ const directive = function() {
     restrict: 'E',
     replace: true,
     scope: true,
-    template: '<li class="pointer" id="scale-line" ng-click="ctrl.openMenu()" ng-right-click="ctrl.openMenu()">' +
-        '<div class="unit-group"></div></li>',
+    template: '<li class="pointer js-menu__toggle" id="scale-line" ' +
+      'ng-click="ctrl.openMenu()" ng-right-click="ctrl.openMenu()">' +
+      '<div class="unit-group"></div></li>',
     controller: Controller,
     controllerAs: 'ctrl'
   };


### PR DESCRIPTION
The report (#746) says Units doesn't close. It looks like it doesn't, but what is really happening
is the menu closes (on "click outside" processing), and then opens again (in response the click).

There is existing logic in the menu code to properly handle toggle actions, but it only works for
buttons (based on nodeName like 'button' or 'btn-group' in the classes). Changing that could have
unintended consequences outside of OpenSphere, so the approach is the allow subclasses to specify
that they can be toggled.