### PR TITLE
Fix issues with source modify functions

### DIFF
--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -3713,8 +3713,14 @@ os.source.Vector.prototype.supportsModify = function() {
  */
 os.source.Vector.prototype.getModifyFunction = function() {
   return (originalFeature, modifiedFeature) => {
+    // Replace the geometry on the feature and interpolate the new geometry.
     originalFeature.setGeometry(modifiedFeature.getGeometry());
+    originalFeature.unset(os.interpolate.ORIGINAL_GEOM_FIELD, true);
+    os.interpolate.interpolateFeature(originalFeature);
+
+    // Update the ellipse, if needed.
     os.feature.createEllipse(originalFeature, true);
+
     this.notifyDataChange();
   };
 };

--- a/src/os/ui/menu/spatialmenu.js
+++ b/src/os/ui/menu/spatialmenu.js
@@ -220,10 +220,10 @@ os.ui.menu.spatial.setup = function() {
           icons: ['<i class="fa fa-fw fa-edit"></i>'],
           beforeRender: os.ui.menu.spatial.visibleIfCanModify
         }, {
-          label: 'Modify Geometry...',
+          label: 'Modify Freeform...',
           eventType: os.action.EventType.MODIFY_GEOMETRY,
-          tooltip: 'Modify the the geometry',
-          icons: ['<i class="fa fa-fw fa-edit"></i>'],
+          tooltip: 'Modify the geometry with a click-and-drag interaction',
+          icons: ['<i class="fa fa-fw fa-hand-pointer-o"></i>'],
           handler: os.ui.menu.spatial.onMenuEvent,
           beforeRender: os.ui.menu.spatial.visibleIfCanModifyGeometry
         }]

--- a/src/plugin/places/placessource.js
+++ b/src/plugin/places/placessource.js
@@ -2,6 +2,7 @@ goog.provide('plugin.places.PlacesSource');
 
 goog.require('os.feature');
 goog.require('os.geom.GeometryField');
+goog.require('os.interpolate');
 goog.require('os.track');
 goog.require('plugin.file.kml.KMLSource');
 goog.require('plugin.file.kml.ui.KMLNode');
@@ -41,6 +42,9 @@ plugin.places.PlacesSource.prototype.getModifyFunction = function() {
 
     if (node) {
       originalFeature.setGeometry(modifiedFeature.getGeometry());
+      originalFeature.unset(os.interpolate.ORIGINAL_GEOM_FIELD, true);
+      os.interpolate.interpolateFeature(originalFeature);
+
       const options = {
         'node': node,
         'feature': originalFeature


### PR DESCRIPTION
The modify functions for the modify interaction were not updating the original geometry on the feature, causing subsequent modify operations to use the wrong geometry. This fixes the issue, and changes the modify menu option name/icon to distinguish it more from Modify Area. In the future, those two menu options will likely be combined to further ease confusion.