### PR TITLE
feat(styles): preset dropdown follows selection

### DIFF
--- a/scss/os/_overrides_bootstrap.scss
+++ b/scss/os/_overrides_bootstrap.scss
@@ -170,3 +170,7 @@ input:-webkit-autofill {
   -webkit-animation-fill-mode: both;
   -webkit-animation-name: autofill;
 }
+
+.mb-1px {
+  margin-bottom: 1px;
+}

--- a/src/os/data/registry.js
+++ b/src/os/data/registry.js
@@ -144,6 +144,14 @@ class Registry extends EventTarget {
         case RegistryPropertyChange.REMOVE:
           onRemove.call(opt_this, event.newVal_);
           break;
+        case RegistryPropertyChange.CLEAR:
+          const keys = event.newVal_;
+          if (keys && keys.length > 0) {
+            keys.forEach((key) => {
+              onRemove.call(opt_this, key);
+            });
+          }
+          break;
         default:
           break;
       }
@@ -187,9 +195,8 @@ class Registry extends EventTarget {
    * Empty out the Registry
    */
   clear() {
-    this.keys().forEach((key) => {
-      this.remove(key);
-    });
+    this.dispatchEvent(new PropertyChangeEvent(RegistryPropertyChange.CLEAR, this.keys()));
+    this.map_ = /** @type {!Object<string, T>} */ ({});
   }
 }
 

--- a/src/os/data/registry.js
+++ b/src/os/data/registry.js
@@ -182,6 +182,15 @@ class Registry extends EventTarget {
     }
     return false;
   }
+
+  /**
+   * Empty out the Registry
+   */
+  clear() {
+    this.keys().forEach((key) => {
+      this.remove(key);
+    });
+  }
 }
 
 exports = Registry;

--- a/src/os/data/registryproperychange.js
+++ b/src/os/data/registryproperychange.js
@@ -6,6 +6,7 @@ goog.module('os.data.RegistryPropertyChange');
  */
 const PropertyChange = {
   ADD: 'registry:add',
+  CLEAR: 'registry:clear',
   REMOVE: 'registry:remove',
   UPDATE: 'registry:update'
 };

--- a/src/os/im/action/importactionmanager.js
+++ b/src/os/im/action/importactionmanager.js
@@ -658,13 +658,15 @@ os.im.action.ImportActionManager.prototype.hasActiveActions = function(id) {
  * @private
  */
 os.im.action.ImportActionManager.prototype.getActiveActionEntryIds_ = function(type, entries) {
-  let ids = [];
-  (entries || []).forEach((entry) => {
-    if (entry.enabled && entry.type == type) {
-      ids.push(entry.getId());
-    }
-    ids = ids.concat(this.getActiveActionEntryIds_(type, entry.getChildren()));
-  });
+  const ids = [];
+  if (entries) {
+    entries.forEach((entry) => {
+      if (entry.enabled && entry.type == type) {
+        ids.push(entry.getId());
+      }
+      ids.push(...this.getActiveActionEntryIds_(type, entry.getChildren()));
+    });
+  }
   return ids;
 };
 
@@ -695,15 +697,11 @@ os.im.action.ImportActionManager.prototype.getRootActiveActionEntries_ = functio
     isActive = true;
   } else if (entry) {
     const entries = entry.getChildren();
-    const len = entries ? entries.length : 0;
 
-    // use a for loop so it can be broken out of
-    for (let i = 0; i < len; i++) {
-      const e = entries[i];
-      if (this.getRootActiveActionEntries_(type, e)) {
-        isActive = true;
-        break;
-      }
+    if (entries) {
+      isActive = entries.some((e) => {
+        return this.getRootActiveActionEntries_(type, e);
+      });
     }
   }
   return isActive;

--- a/src/os/layer/preset/layerpresetmanager.js
+++ b/src/os/layer/preset/layerpresetmanager.js
@@ -106,7 +106,7 @@ class LayerPresetManager extends Disposable {
   }
 
   /**
-   * Handle layer removed the map.
+   * Handle when layer removed from the map.
    * @param {!LayerEvent} event The layer event.
    * @protected
    */

--- a/src/os/layer/preset/layerpresetmanager.js
+++ b/src/os/layer/preset/layerpresetmanager.js
@@ -1,21 +1,40 @@
 goog.module('os.layer.preset.LayerPresetManager');
 goog.module.declareLegacyNamespace();
 
-const settings = goog.require('os.config.Settings');
-const Disposable = goog.require('goog.Disposable');
-const Promise = goog.require('goog.Promise');
+const Debouncer = goog.require('goog.async.Debouncer');
 const Dispatcher = goog.require('os.Dispatcher');
-const VectorLayerPreset = goog.require('os.command.VectorLayerPreset');
-const Registry = goog.require('os.data.Registry');
-const LayerEventType = goog.require('os.events.LayerEventType');
-const osImplements = goog.require('os.implements');
-const ILayer = goog.require('os.layer.ILayer');
-const OsLayerPreset = goog.require('os.layer.preset');
-const SettingsPresetService = goog.require('os.layer.preset.SettingsPresetService');
+const Disposable = goog.require('goog.Disposable');
+const GoogEventType = goog.require('goog.events.EventType');
 const IFilterable = goog.require('os.filter.IFilterable');
+const ILayer = goog.require('os.layer.ILayer');
+const ImportActionManager = goog.require('os.im.action.ImportActionManager');
+const LayerEventType = goog.require('os.events.LayerEventType');
+const OsLayerPreset = goog.require('os.layer.preset');
+const OsStyle = goog.require('os.style');
+const Promise = goog.require('goog.Promise');
+const Registry = goog.require('os.data.Registry');
+const SettingsPresetService = goog.require('os.layer.preset.SettingsPresetService');
+const VectorLayerPreset = goog.require('os.command.VectorLayerPreset');
+
+const settings = goog.require('os.config.Settings');
+const olEvents = goog.require('ol.events');
+const osImplements = goog.require('os.implements');
 
 const IPresetService = goog.requireType('os.layer.preset.IPresetService');
+const LayerEvent = goog.requireType('os.events.LayerEvent');
+const {EventsKey: OlEventsKey} = goog.requireType('ol');
+const OlLayer = goog.requireType('ol.layer.Layer');
+const PropertyChangeEvent = goog.requireType('os.events.PropertyChangeEvent');
 
+
+/**
+ * @typedef {{
+ *   debouncer: (!Debouncer),
+ *   listener: (OlEventsKey|null),
+ *   selected: (osx.layer.Preset|null)
+ * }}
+ */
+let LayerPresetsMetaData;
 
 /**
  * Manager for keeping track of available layer presets. These presets consist of a layer options object and a
@@ -35,6 +54,7 @@ class LayerPresetManager extends Disposable {
     this.admin_ = false;
 
     /**
+     * The available service(s) which can get Presets for a LayerId
      * @type {!Registry<IPresetService>}
      * @private
      */
@@ -42,16 +62,17 @@ class LayerPresetManager extends Disposable {
 
     /**
      * The available layer presets.
-     * @type {Object<string, Promise<Array<osx.layer.Preset>>>}
+     * @type {!Registry<Promise<Array<osx.layer.Preset>>>}
      * @private
      */
-    this.presets_ = {};
+    this.presets_ = new Registry();
 
     // add the basic PresetService; not an admin
     this.registerService(SettingsPresetService.ID, new SettingsPresetService(), false);
 
     // listen for new layers
     Dispatcher.getInstance().listen(LayerEventType.ADD, this.onLayerAdded, false, this);
+    Dispatcher.getInstance().listen(LayerEventType.REMOVE, this.onLayerRemoved, false, this);
   }
 
   /**
@@ -59,13 +80,17 @@ class LayerPresetManager extends Disposable {
    */
   disposeInternal() {
     super.disposeInternal();
+
+    this.clearLayerPresets();
     this.services_.dispose();
+
     Dispatcher.getInstance().unlisten(LayerEventType.ADD, this.onLayerAdded, false, this);
+    Dispatcher.getInstance().unlisten(LayerEventType.REMOVE, this.onLayerRemoved, false, this);
   }
 
   /**
    * Handle layer added to the map.
-   * @param {!os.events.LayerEvent} event The layer event.
+   * @param {!LayerEvent} event The layer event.
    * @protected
    */
   onLayerAdded(event) {
@@ -75,14 +100,155 @@ class LayerPresetManager extends Disposable {
     if (layer) {
       const layerId = layer.getId();
       if (layerId) {
-        const promise = this.getPresets(layerId);
-        if (promise) {
-          promise.then((presets) => {
-            this.applyDefaults(layerId, presets);
-          });
-        }
+        this.getPresets(layerId, true);
       }
     }
+  }
+
+  /**
+   * Handle layer removed the map.
+   * @param {!LayerEvent} event The layer event.
+   * @protected
+   */
+  onLayerRemoved(event) {
+    const layer = osImplements(event.layer, ILayer.ID) ?
+        /** @type {ILayer} */ (event.layer) : undefined;
+
+    if (layer) {
+      const layerId = layer.getId();
+      this.clearLayerPreset(layerId);
+    }
+  }
+
+  /**
+   *
+   * @param {!string} layerId
+   * @param {!osx.layer.Preset} preset
+   */
+  listenToLayerStyleChange(layerId, preset) {
+    const layer = this.getLayer_(layerId);
+    let [,, meta] = /** @type {!Array<*>} */ (this.presets_.entry(layerId));
+    meta = /** @type {!LayerPresetsMetaData} */ (meta);
+
+    // only have one listener at a time
+    if (layer && meta && !meta.listener) {
+      meta.selected = preset;
+      meta.listener = olEvents.listen(
+          layer,
+          GoogEventType.PROPERTYCHANGE,
+          this.onLayerStyleChanged.bind(this, layerId, layer, false),
+          this);
+    }
+  }
+
+  /**
+   * Handle layer style changed debouncer.
+   * @param {!string} layerId The layer id.
+   * @param {!OlLayer} layer The layer.
+   * @param {!boolean} check True if the current style needs to be tested extensively against the Preset style
+   * @param {!PropertyChangeEvent} event The layer event.
+   * @protected
+   */
+  onLayerStyleChanged(layerId, layer, check, event) {
+    let [,, meta] = /** @type {!Array<*>} */ (this.presets_.entry(layerId));
+    meta = /** @type {!LayerPresetsMetaData} */ (meta);
+
+    // get the debouncer for this layerId
+    if (meta && !meta.debouncer.isDisposed()) {
+      meta.debouncer.fire(check, event);
+    }
+  }
+
+  /**
+   * Handle layer style changed.
+   * @param {!string} layerId The layer id.
+   * @param {!OlLayer} layer The layer.
+   * @param {!boolean} check True if the current style needs to be tested extensively against the Preset style
+   * @param {!PropertyChangeEvent} event The layer event.
+   * @private
+   */
+  onLayerStyleChanged_(layerId, layer, check, event) {
+    // check that the style does/doesn't match the Preset. If not, set the clean over to false and stop listening
+    if (layer && event['getProperty'] && event.getProperty() == 'style') {
+      if (this.isLayerStyleDirty_(layerId, layer, check, event)) {
+        let [,, meta] = /** @type {!Array<*>} */ (this.presets_.entry(layerId));
+        meta = /** @type {!LayerPresetsMetaData} */ (meta);
+
+        const key = /** @type {OlEventsKey} */ (meta.listener);
+        if (key && layer) {
+          olEvents.unlistenByKey(key);
+          meta.listener = null;
+        }
+
+        OsLayerPreset.setSavedPresetClean(layerId, false);
+        OsStyle.notifyStyleChange(layer);
+      }
+    }
+  }
+
+  /**
+   * Handle layer style changed.
+   * @param {!string} layerId The layer id.
+   * @param {!OlLayer} layer The layer.
+   * @param {!boolean} check True if the current style needs to be tested extensively against the Preset style
+   * @param {!PropertyChangeEvent} event The layer event.
+   * @return {boolean} true if the style is what the preset says it should be
+   * @private
+   */
+  isLayerStyleDirty_(layerId, layer, check, event) {
+    let dirty = false;
+    let [,, meta] = /** @type {!Array<*>} */ (this.presets_.entry(layerId));
+    meta = /** @type {!LayerPresetsMetaData} */ (meta);
+
+    if (meta && meta.selected) {
+      // check the layer configs
+      const config1 = meta.selected.layerConfig;
+      const config2 = /** @type {ILayer} */ (layer).persist();
+      dirty = (JSON.stringify(config1) != JSON.stringify(config2));
+
+      // check the active Feature Actions if not dirty yet
+      if (!dirty && meta.selected.featureActions && meta.selected.featureActions.length > 0) {
+        const ids1 = meta.selected.featureActions;
+        const ids2 = ImportActionManager.getInstance().getActiveActionEntryIds(layerId);
+        dirty = (ids1.join('') != ids2.join(''));
+      }
+    }
+    return dirty;
+  }
+
+  /**
+   * Clean up the memory for the listener, debouncer, and presets promise for a Layer
+   * @param {!string} layerId The layer id.
+   */
+  clearLayerPreset(layerId) {
+    const entry = this.presets_.entry(layerId);
+    if (entry) {
+      this.clearLayerPresets([entry]);
+    }
+  }
+
+  /**
+   * Clean up all the listeners, debouncers, and presets
+   *
+   * @param {Array<Array<*>>=} opt_entries
+   */
+  clearLayerPresets(opt_entries = this.presets_.entries()) {
+    // first, loop and remove the listeners and debouncers
+    opt_entries.forEach(([id, , meta]) => {
+      id = /** @type {!string} */ (id);
+      meta = /** @type {!LayerPresetsMetaData} */ (meta);
+
+      const key = /** @type {OlEventsKey} */ (meta.listener);
+      const layer = this.getLayer_(id);
+      if (key && layer) {
+        olEvents.unlistenByKey(key);
+      }
+      meta.listener = null;
+      meta.debouncer.dispose();
+    });
+
+    // then, wipe the promises too
+    this.presets_.clear();
   }
 
   /**
@@ -118,8 +284,7 @@ class LayerPresetManager extends Disposable {
    * @return {boolean} true if prior value overwritten
    */
   registerService(key, service, ...opt) {
-    this.presets_ = {}; // set presets to reload every layer
-
+    this.clearLayerPresets(); // set presets to reload every layer
     return this.services_.register(...[key, service].concat(opt));
   }
 
@@ -128,8 +293,20 @@ class LayerPresetManager extends Disposable {
    * @return {boolean} true if prior value dropped
    */
   unregisterService(key) {
-    this.presets_ = {}; // set presets to reload every layer
+    this.clearLayerPresets(); // set presets to reload every layer
     return this.services_.remove(key);
+  }
+
+  /**
+   * Helper function
+   * @param {!string} layerId
+   * @return {?OlLayer}
+   * @private
+   */
+  getLayer_(layerId) {
+    // HACK: doing goog.require('os.MapContainer') properly creates a circular dependency somewhere in
+    // the os.layer chain. TODO Fix it when there's time
+    return (os.map.mapContainer) ? os.map.mapContainer.getLayer(layerId) : null;
   }
 
   /**
@@ -140,13 +317,13 @@ class LayerPresetManager extends Disposable {
    * @return {Promise<Array<osx.layer.Preset>>|undefined}
    */
   getPresets(id, opt_applyDefault) {
-    var promise = this.presets_[id];
+    var promise = this.presets_.get(id);
 
     if (!promise) {
       // Do NOT pass opt_applyDefault down to initPreset; applyDefaults() is called on-demand below, possibly
       // on an already-resolved promise
       this.initPreset(id);
-      promise = this.presets_[id];
+      promise = this.presets_.get(id);
     }
 
     // handle this separately from the initPreset so future calls to getPresets can try to applyDefaults()
@@ -168,10 +345,7 @@ class LayerPresetManager extends Disposable {
   initPreset(id, opt_applyDefault) {
     // use the filter key to pull the value from settings
     var filterKey;
-
-    // HACK: doing goog.require('os.MapContainer') properly creates a circular dependency somewhere in
-    // the os.layer chain. TODO Fix it when there's time
-    var layer = (os.map.mapContainer) ? os.map.mapContainer.getLayer(id) : null;
+    var layer = this.getLayer_(id);
 
     if (!layer) return; // extra check; can't do presets without a working layer to which to add them
 
@@ -236,9 +410,42 @@ class LayerPresetManager extends Disposable {
       promise.then((presets) => {
         this.applyDefaults(id, presets);
       });
+    } else {
+      promise.then((presets) => {
+        this.applyNone(id, presets);
+      });
     }
 
-    this.presets_[id] = promise;
+    const meta = /** @type {LayerPresetsMetaData} */ ({
+      listener: null,
+      debouncer: new Debouncer(this.onLayerStyleChanged_.bind(this, id, layer), 250, this)
+    });
+
+    this.presets_.register(id, promise, meta);
+  }
+
+  /**
+   * Checks if Style matches the last-set Preset and initializes listeners if so.
+   *
+   * @param {string} id The layer ID.
+   * @param {Array<osx.layer.Preset>} presets The presets.
+   * @protected
+   */
+  applyNone(id, presets) {
+    if (presets && presets.length) {
+      const isCleanPreset = OsLayerPreset.getSavedPresetClean(id);
+
+      // don't set up the listener if it's already dirty
+      if (isCleanPreset) {
+        const presetId = OsLayerPreset.getSavedPresetId(id);
+        const preset = presets.find((p) => {
+          return p.id == presetId;
+        });
+        if (preset) {
+          this.listenToLayerStyleChange(id, preset);
+        }
+      }
+    }
   }
 
   /**
@@ -259,19 +466,43 @@ class LayerPresetManager extends Disposable {
         });
 
         if (preset) {
-          var cmd = new VectorLayerPreset(id, preset);
-          cmd.execute();
+          this.applyPreset(id, preset);
         }
 
         // apply the Default style for a layer only once as long as the settings remain intact
         applied[id] = true;
         settings.getInstance().set(OsLayerPreset.SettingKey.APPLIED_DEFAULTS, applied);
+      } else {
+        this.applyNone(id, presets);
       }
     }
+  }
+
+  /**
+   *
+   * @param {!string} id The layer ID.
+   * @param {!osx.layer.Preset} preset The preset.
+   */
+  applyPreset(id, preset) {
+    let [,, meta] = /** @type {!Array<*>} */ (this.presets_.entry(id));
+    meta = /** @type {!LayerPresetsMetaData} */ (meta);
+    meta.selected = preset;
+
+    OsLayerPreset.setSavedPresetId(id, preset.id || null);
+    OsLayerPreset.setSavedPresetClean(id, true);
+
+    this.listenToLayerStyleChange(id, preset);
+
+    // TODO move the work of the command into LPM
+    var cmd = new VectorLayerPreset(id, preset);
+    cmd.execute();
   }
 }
 
 goog.addSingletonGetter(LayerPresetManager);
+
+// export it so it's used
+LayerPresetManager.LayerPresetsMetaData = LayerPresetsMetaData;
 
 
 exports = LayerPresetManager;

--- a/src/os/layer/preset/layerpresetmanager.js
+++ b/src/os/layer/preset/layerpresetmanager.js
@@ -204,6 +204,37 @@ class LayerPresetManager extends Disposable {
       // check the layer configs
       const config1 = meta.selected.layerConfig;
       const config2 = /** @type {ILayer} */ (layer).persist();
+
+      // "basic" preset doesn't have all the details of a real layer
+      if (meta.selected.id == OsLayerPreset.DEFAULT_PRESET_ID) {
+        config2['icon'] = null;
+        delete config2['colorModel'];
+        delete config2['replaceStyle'];
+        delete config2['showRotation'];
+      }
+
+      // TODO remove this after fixing the "layer.restore()" to treat -no value- as a "clear"
+      // if not applying a new "border" style or "unique identifier", ignore the current one
+      if (!config1['lineDash']) {
+        delete config2['lineDash'];
+      }
+      if (!config1['uniqueId']) {
+        delete config2['uniqueId'];
+      }
+      if (!config1['threshold'] && config2['threshold']) {
+        delete config2['ageOffActive'];
+        delete config2['ageOffTime'];
+        delete config2['lateData'];
+        delete config2['lateDataMillis'];
+        delete config2['play'];
+        delete config2['sound'];
+        delete config2['streamBinCreateTracks'];
+        delete config2['streamBins'];
+        delete config2['streamBinsActive'];
+        delete config2['streamBinSize'];
+        delete config2['threshold'];
+      }
+
       dirty = (JSON.stringify(config1) != JSON.stringify(config2));
 
       // check the active Feature Actions if not dirty yet

--- a/src/os/layer/preset/preset.js
+++ b/src/os/layer/preset/preset.js
@@ -4,6 +4,9 @@ goog.module.declareLegacyNamespace();
 const object = goog.require('goog.object');
 const style = goog.require('os.style');
 const OsLayer = goog.require('os.layer');
+const Settings = goog.require('os.config.Settings');
+
+const FilterActionEntry = goog.requireType('os.im.action.FilterActionEntry');
 
 
 /**
@@ -42,7 +45,9 @@ const PresetServiceAction = {
  */
 const SettingKey = {
   APPLIED_DEFAULTS: BASE_KEY + 'appliedDefaults',
-  PRESETS: BASE_KEY + 'presets'
+  PRESETS: BASE_KEY + 'presets',
+  SAVED_PRESET_IDS: BASE_KEY + 'saved.presetIds',
+  SAVED_PRESET_CLEANS: BASE_KEY + 'saved.presetCleans'
 };
 
 /**
@@ -93,6 +98,56 @@ const addDefault = function(presets, opt_layerId, opt_layerFilterKey) {
 };
 
 /**
+ * Get the selected Preset ID from saved Settings for the desired Layer
+ *
+ * @param {string} id The layer ID
+ * @return {!boolean}
+ */
+const getSavedPresetClean = function(id) {
+  var lookup = /** @type {!Object<string, boolean>} */
+      (Settings.getInstance().get(SettingKey.SAVED_PRESET_CLEANS, {}));
+  return (lookup[id] === false) ? false : true;
+};
+
+/**
+ * Get the selected Preset ID from saved Settings for the desired Layer
+ *
+ * @param {string} id The layer ID
+ * @return {?string}
+ */
+const getSavedPresetId = function(id) {
+  var lookup = /** @type {!Object<string, ?string>} */
+      (Settings.getInstance().get(SettingKey.SAVED_PRESET_IDS, {}));
+  return lookup[id];
+};
+
+/**
+ * Get the selected Preset ID from saved Settings for the desired Layer
+ *
+ * @param {string} id The layer ID
+ * @param {boolean} clean Is clean
+ */
+const setSavedPresetClean = function(id, clean) {
+  var lookup = /** @type {!Object<string, boolean>} */
+      (Settings.getInstance().get(SettingKey.SAVED_PRESET_CLEANS, {}));
+  lookup[id] = clean;
+  Settings.getInstance().set(SettingKey.SAVED_PRESET_CLEANS, lookup);
+};
+
+/**
+ * Get the selected Preset ID from saved Settings for the desired Layer
+ *
+ * @param {string} id The layer ID
+ * @param {?string=} opt_presetId
+ */
+const setSavedPresetId = function(id, opt_presetId) {
+  var lookup = /** @type {!Object<string, ?string>} */
+      (Settings.getInstance().get(SettingKey.SAVED_PRESET_IDS, {}));
+  lookup[id] = opt_presetId || null;
+  Settings.getInstance().set(SettingKey.SAVED_PRESET_IDS, lookup);
+};
+
+/**
  * Update the default preset for a layer.
  * @param {os.layer.ILayer} layer The layer.
  * @param {osx.layer.Preset} preset The default preset.
@@ -110,11 +165,16 @@ const updateDefault = function(layer, preset) {
   }
 };
 
+
 exports = {
   BASE_KEY,
   DEFAULT_PRESET_ID,
   PresetServiceAction,
   SettingKey,
   addDefault,
+  getSavedPresetClean,
+  getSavedPresetId,
+  setSavedPresetClean,
+  setSavedPresetId,
   updateDefault
 };

--- a/src/os/layer/preset/presetmenubutton.js
+++ b/src/os/layer/preset/presetmenubutton.js
@@ -505,7 +505,7 @@ const directive = () => ({
       ng-click="ctrl.openMenu()"
       ng-class="{active: menu}"
       ng-disabled="ctrl.thinking">
-    <i class="fa" ng-class="ctrl.thinking && 'fa-spin fa-spinner'"></i>
+    <i class="fa fa-spin fa-spinner" ng-if="ctrl.thinking"></i>
   </button>
 </div>
 `

--- a/src/os/layer/preset/presetmenubutton.js
+++ b/src/os/layer/preset/presetmenubutton.js
@@ -175,57 +175,11 @@ class Controller extends MenuButtonCtrl {
 
     const iam = ImportActionManager.getInstance();
 
-    /**
-     * Depth-first traversal of tree; returns ID's of active FeatureActions
-     * @param {string|undefined} type
-     * @param {Array<FilterActionEntry>=} entries
-     * @return {!Array<string>}
-     */
-    const traverse = function(type, entries) {
-      let ids = [];
-      (entries || []).forEach((entry) => {
-        if (entry.enabled && entry.type == type) {
-          ids.push(entry.getId());
-        }
-        ids = ids.concat(traverse(type, entry.getChildren()));
-      });
-      return ids;
-    };
-
     // get the currently active FeatureAction ID's as a list
-    const ids = traverse(clone.layerId, iam.getActionEntries());
-
-    /**
-     * Get simplified list of active FeatureActions (no repeats via children)
-     * @param {string|undefined} type
-     * @param {FilterActionEntry=} entry
-     * @return {!boolean}
-     */
-    const active = function(type, entry) {
-      let isActive = false;
-
-      if (entry && entry.enabled && entry.type == type) {
-        isActive = true;
-      } else if (entry) {
-        const entries = entry.getChildren();
-        const len = entries ? entries.length : 0;
-
-        // use a for loop so it can be broken out of
-        for (let i = 0; i < len; i++) {
-          const e = entries[i];
-          if (active(type, e)) {
-            isActive = true;
-            break;
-          }
-        }
-      }
-      return isActive;
-    };
+    const ids = iam.getActiveActionEntryIds(clone.layerId);
 
     // only return top-level feature actions, not specific sub-entries
-    const entries = iam.getActionEntries().filter((entry) => {
-      return active(clone.layerId, entry);
-    });
+    const entries = iam.getRootActiveActionEntries(clone.layerId);
 
     if (entries && entries.length > 0 && ids && ids.length > 0) {
       clone.featureActions = ids;

--- a/src/os/ui/layer/vectorlayerui.js
+++ b/src/os/ui/layer/vectorlayerui.js
@@ -382,7 +382,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.loadPresets = function() {
               }, this);
             }
 
-            // set the current selection, with priority as current > settings > first
+            // set the current selection for the UI
             this['preset'] = settingsPreset || currentPreset || presets[0];
 
             var isCleanPreset = os.layer.preset.getSavedPresetClean(id);

--- a/src/os/ui/layer/vectorlayerui.js
+++ b/src/os/ui/layer/vectorlayerui.js
@@ -16,7 +16,6 @@ goog.require('os.command.VectorLayerLabel');
 goog.require('os.command.VectorLayerLabelColor');
 goog.require('os.command.VectorLayerLabelSize');
 goog.require('os.command.VectorLayerLineDash');
-goog.require('os.command.VectorLayerPreset');
 goog.require('os.command.VectorLayerReplaceStyle');
 goog.require('os.command.VectorLayerRotation');
 goog.require('os.command.VectorLayerShape');
@@ -27,6 +26,7 @@ goog.require('os.command.VectorUniqueIdCmd');
 goog.require('os.command.style');
 goog.require('os.data.OSDataManager');
 goog.require('os.defines');
+goog.require('os.layer.preset');
 goog.require('os.layer.preset.LayerPresetManager');
 goog.require('os.layer.preset.PresetMenuButton');
 goog.require('os.style');
@@ -132,6 +132,12 @@ os.ui.layer.VectorLayerUICtrl = function($scope, $element, $timeout) {
    * @type {boolean}
    */
   this['showAltitudeModes'] = false;
+
+  /**
+   * If the Styles are "dirty" or equal to a Preset
+   * @type {boolean}
+   */
+  this['showPresetsDropdown'] = true;
 
   /**
    * The unique identifier for the layer.
@@ -360,14 +366,6 @@ os.ui.layer.VectorLayerUICtrl.prototype.loadPresets = function() {
       if (promise) {
         promise.then(function(presets) {
           if (presets && presets.length) {
-            var basicPreset = presets.find(function(p) {
-              return p.id === os.layer.preset.DEFAULT_PRESET_ID;
-            });
-            // tweak the colors to match the layer
-            if (basicPreset) {
-              os.layer.preset.updateDefault(layer, basicPreset);
-            }
-
             this['presets'] = presets;
 
             // the preset objects may change, so resolve the current selection by id
@@ -375,8 +373,20 @@ os.ui.layer.VectorLayerUICtrl.prototype.loadPresets = function() {
               return p && p.id == this['preset'].id;
             }, this) : undefined;
 
-            // set the current selection, with priority as current > default > first
-            this['preset'] = currentPreset || basicPreset || presets[0];
+            // the preset might be saved in settings
+            var settingsPreset = null;
+            var settingsPresetId = os.layer.preset.getSavedPresetId(id);
+            if (settingsPresetId) {
+              settingsPreset = presets.find(function(p) {
+                return p && p.id == settingsPresetId;
+              }, this);
+            }
+
+            // set the current selection, with priority as current > settings > first
+            this['preset'] = settingsPreset || currentPreset || presets[0];
+
+            var isCleanPreset = os.layer.preset.getSavedPresetClean(id);
+            this['showPresetsDropdown'] = isCleanPreset;
 
             // tell the directive to re-render now that we have a new list of presets
             os.ui.apply(this.scope);
@@ -396,14 +406,13 @@ os.ui.layer.VectorLayerUICtrl.prototype.applyPreset = function() {
   var items = /** @type {Array} */ (this.scope['items']);
   if (items && items.length > 0) {
     var value = this['preset'];
-    var fn =
-        /**
-         * @param {os.layer.ILayer} layer
-         * @return {os.command.ICommand}
-         */
-        (layer) => new os.command.VectorLayerPreset(layer.getId(), value);
+    var layer = items[0].getLayer();
 
-    this.createCommand(fn);
+    // flag the UI is clean
+    this['showPresetsDropdown'] = true;
+
+    // call lpm to get all the benefits
+    os.layer.preset.LayerPresetManager.getInstance().applyPreset(layer.getId(), value);
   }
 };
 

--- a/views/layer/vector.html
+++ b/views/layer/vector.html
@@ -6,17 +6,21 @@
       Style
     </div>
     <div id="layer-style" class="card-body collapse" data-parent="#layerControls">
-      <div class="form-group row" ng-if="vector.presets && vector.presets.length" title="Choose a layer style preset.">
+      <div class="form-group row" ng-if="vector.presets && vector.presets.length" title="Quickly sets Styles, Labels, and Feature Action(s).">
         <div class="col-3">
-          Preset
+          Presets
         </div>
-        <div class="d-flex col">
-            <select class="custom-select col-7" ng-model="vector.preset"
+        <div class="d-flex col" ng-show="!vector.showPresetsDropdown">
+            <span><i>Customized</i>&nbsp;</span>
+            <button class="btn btn-link text-muted" ng-click="vector.showPresetsDropdown = true;">
+              Apply a Preset <i class="fa fa-fw fa-arrow-right"></i>
+            </button>
+        </div>
+        <div class="d-flex col" ng-show="vector.showPresetsDropdown">
+          <select class="custom-select col-7" ng-model="vector.preset"
               ng-options="((preset.published === true ? '' : '*') + preset.label + (preset.default === true ? ' (default)' : '')) for preset in vector.presets track by preset.id+preset.layerId">
-            </select>
-            <div class="col-5">
-                <presetmenubutton preset="vector.preset"></presetmenubutton>
-            </div>
+          </select>
+          <presetmenubutton preset="vector.preset"></presetmenubutton>
         </div>
       </div>
 

--- a/views/layer/vector.html
+++ b/views/layer/vector.html
@@ -10,14 +10,14 @@
         <div class="col-3">
           Presets
         </div>
-        <div class="d-flex col" ng-show="!vector.showPresetsDropdown">
-            <span><i>Customized</i>&nbsp;</span>
-            <button class="btn btn-link text-muted" ng-click="vector.showPresetsDropdown = true;">
-              Apply a Preset <i class="fa fa-fw fa-arrow-right"></i>
-            </button>
+        <div class="d-flex col mb-1px" ng-show="!vector.showPresetsDropdown">
+          <span class="btn disabled"><i>Customized</i>&nbsp;</span>
+          <button class="btn btn-link text-muted" ng-click="vector.showPresetsDropdown = true;">
+            Apply a Preset <i class="fa fa-fw fa-arrow-right"></i>
+          </button>
         </div>
         <div class="d-flex col" ng-show="vector.showPresetsDropdown">
-          <select class="custom-select col-7" ng-model="vector.preset"
+          <select class="custom-select col" ng-model="vector.preset"
               ng-options="((preset.published === true ? '' : '*') + preset.label + (preset.default === true ? ' (default)' : '')) for preset in vector.presets track by preset.id+preset.layerId">
           </select>
           <presetmenubutton preset="vector.preset"></presetmenubutton>

--- a/views/layer/vectorstylecontrols.html
+++ b/views/layer/vectorstylecontrols.html
@@ -53,7 +53,7 @@
   <div class="form-group row flex-shrink-0" title="Sets the style of the line">
     <label class="col-3 col-form-label">Border</label>
     <div class="col my-auto">
-      <select class="w-25 js-line-dash" ng-model="lineDashOption" ng-change="ctrl.onLineDashChange()"
+      <select class="w-50 js-line-dash" ng-model="lineDashOption" ng-change="ctrl.onLineDashChange()"
           ng-options="option as option.name for option in lineDashOptions track by option.pattern">
       </select>
     </div>


### PR DESCRIPTION
"Presets" dropdown now follows the selected value instead of being simply a list from which Presets can be chosen/applied.

When the current style does not match the previously set Preset (or default), then the dropdown will be replaced with "Customized" and a link-button to view the dropdown and return to a Preset style.