### PR TITLE
style(btn): remove btn-link override in place of ad-hoc adjustments

### DIFF
--- a/scss/standard/_bootswatch.scss
+++ b/scss/standard/_bootswatch.scss
@@ -20,10 +20,3 @@
 .pagination {
   margin: .5rem;
 }
-
-.btn.btn-link {
-  border: 0;
-  font-size: inherit;
-  padding: 0;
-  vertical-align: baseline;
-}

--- a/src/os/ui/alert/alertlinkfilter.js
+++ b/src/os/ui/alert/alertlinkfilter.js
@@ -16,7 +16,8 @@ os.ui.alert.alertLinkFilter = function($sce) {
     if (typeof text == 'string') {
       text = os.ui.sanitize(text);
       text = text.replace(/\[([^|]+)\|([^\]]+)\]/g,
-          '<button onclick="$(this).scope().$emit(\'dispatch\',\'$2\')" class="btn btn-link" type="button">$1</button>'
+          '<button onclick="$(this).scope().$emit(\'dispatch\',\'$2\')" class="btn btn-link border-0 p-0" ' +
+          'type="button">$1</button>'
       );
       return $sce.trustAsHtml(text);
     }


### PR DESCRIPTION
The `.btn-link` override causes any button with this class to differ in size from other buttons. This causes unwanted UI layout issues, so it is being removed. Instead, local style overrides should be used when things like border/padding need to be removed.