### PR TITLE
feat(vector): add custom select color

### DIFF
--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -3399,7 +3399,8 @@ os.source.Vector.prototype.select = function(feature) {
         feature.id_ != null && this.idIndex_[feature.id_] && this.shownRecordMap[feature.id_]) {
       goog.array.binaryInsert(this.selected_, feature, os.feature.idCompare);
       this.selectedById_[id] = true;
-      feature.set(os.style.StyleType.SELECT, os.style.DEFAULT_SELECT_CONFIG);
+      var selectCfg = feature.get(os.style.StyleType.CUSTOM_SELECT) || os.style.DEFAULT_SELECT_CONFIG;
+      feature.set(os.style.StyleType.SELECT, selectCfg);
       return true;
     }
   }

--- a/src/os/style/styletype.js
+++ b/src/os/style/styletype.js
@@ -8,6 +8,7 @@ goog.provide('os.style.StyleType');
 os.style.StyleType = {
   FEATURE: '_style',
   SELECT: '_selectStyle',
+  CUSTOM_SELECT: '_customSelectStyle',
   HIGHLIGHT: '_highlightStyle',
   CUSTOM_HIGHLIGHT: '_customHighlightStyle',
   LABEL: '_labelStyle'


### PR DESCRIPTION
feat(vector): add custom select color

Add CUSTOM_SELECT `styletype.js` and changed` vectorSource.js` to check for a set custom select style and apply it it, or use the default select style type if it was not set. This allows a feature item to have a custom color style set for the Select option and to avoid conflicts with set feature colors. 

Not tickets or breaking issues attached to this commit.