### PR TITLE
fix(folder): prevent error for empty wms folders

### DIFF
--- a/src/os/ui/ogc/ogcserver.js
+++ b/src/os/ui/ogc/ogcserver.js
@@ -1616,7 +1616,7 @@ os.ui.ogc.OGCServer.prototype.parseLayer = function(node, version, crsList, opt_
       }
     }
 
-    if (isFolder) {
+    if (layer && isFolder) {
       var children = layer.getChildren();
       if (!children || children.length === 0) {
         return null;


### PR DESCRIPTION
WMS Folders with no WMS Layers no longer throw null JS error