### PR TITLE
fix(drawcontrols): missing config assignments in base draw controls

### DIFF
--- a/src/os/ui/draw/basedrawcontrols.js
+++ b/src/os/ui/draw/basedrawcontrols.js
@@ -1,7 +1,6 @@
 goog.provide('os.ui.draw.BaseDrawControlsCtrl');
 goog.provide('os.ui.draw.baseDrawControlsDirective');
 
-goog.require('goog.Disposable');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
 goog.require('ol.Feature');
@@ -54,7 +53,6 @@ os.ui.Module.directive('drawControls', [os.ui.draw.baseDrawControlsDirective]);
  *
  * @param {!angular.Scope} $scope
  * @param {!angular.JQLite} $element
- * @extends {goog.Disposable}
  * @constructor
  * @ngInject
  */
@@ -127,7 +125,6 @@ os.ui.draw.BaseDrawControlsCtrl = function($scope, $element) {
    */
   this['controlMenu'] = os.ui.menu.draw.MENU;
 };
-goog.inherits(os.ui.draw.BaseDrawControlsCtrl, goog.Disposable);
 
 
 /**
@@ -140,7 +137,7 @@ os.ui.draw.BaseDrawControlsCtrl.LOGGER_ = goog.log.getLogger('os.ui.draw.BaseDra
 
 
 /**
- * Angular initialization hook. Sets up event listening and our controls menu.
+ * Angular initialization lifecycle function. Sets up event listening and our controls menu.
  */
 os.ui.draw.BaseDrawControlsCtrl.prototype.$onInit = function() {
   this.initControlMenu();
@@ -160,19 +157,9 @@ os.ui.draw.BaseDrawControlsCtrl.prototype.$onInit = function() {
 
 
 /**
- * Angular destruction hook.
+ * Angular destruction lifecycle function. Stop event listening.
  */
 os.ui.draw.BaseDrawControlsCtrl.prototype.$onDestroy = function() {
-  this.dispose();
-};
-
-
-/**
- * @inheritDoc
- */
-os.ui.draw.BaseDrawControlsCtrl.prototype.disposeInternal = function() {
-  os.ui.draw.BaseDrawControlsCtrl.base(this, 'disposeInternal');
-
   os.dispatcher.unlisten(os.ui.draw.DrawEventType.DRAWSTART, this.apply, false, this);
   os.dispatcher.unlisten(os.ui.draw.DrawEventType.DRAWEND, this.onDrawEnd, false, this);
   os.dispatcher.unlisten(os.ui.draw.DrawEventType.DRAWCANCEL, this.apply, false, this);

--- a/src/os/ui/draw/basedrawcontrols.js
+++ b/src/os/ui/draw/basedrawcontrols.js
@@ -114,7 +114,13 @@ os.ui.draw.BaseDrawControlsCtrl = function($scope, $element) {
    * If the line control is supported.
    * @type {boolean}
    */
-  this['supportsLines'] = this['supportsLines'] || false;
+  this['supportsLines'] = $scope['supportsLines'] || false;
+
+  /**
+   * If extra controls should be hidden.
+   * @type {boolean}
+   */
+  this['hideExtraControls'] = $scope['hideExtraControls'] || false;
 
   /**
    * @type {os.ui.menu.Menu|undefined}

--- a/src/os/ui/draw/basedrawcontrols.js
+++ b/src/os/ui/draw/basedrawcontrols.js
@@ -57,8 +57,6 @@ os.ui.Module.directive('drawControls', [os.ui.draw.baseDrawControlsDirective]);
  * @ngInject
  */
 os.ui.draw.BaseDrawControlsCtrl = function($scope, $element) {
-  os.ui.draw.BaseDrawControlsCtrl.base(this, 'constructor');
-
   /**
    * @type {?angular.Scope}
    * @private

--- a/src/os/ui/draw/basedrawcontrols.js
+++ b/src/os/ui/draw/basedrawcontrols.js
@@ -114,18 +114,35 @@ os.ui.draw.BaseDrawControlsCtrl = function($scope, $element) {
    * If the line control is supported.
    * @type {boolean}
    */
-  this['supportsLines'] = $scope['supportsLines'] || false;
+  this['supportsLines'] = false;
 
   /**
    * If extra controls should be hidden.
    * @type {boolean}
    */
-  this['hideExtraControls'] = $scope['hideExtraControls'] || false;
+  this['hideExtraControls'] = false;
 
   /**
    * @type {os.ui.menu.Menu|undefined}
    */
   this['controlMenu'] = os.ui.menu.draw.MENU;
+};
+goog.inherits(os.ui.draw.BaseDrawControlsCtrl, goog.Disposable);
+
+
+/**
+ * The logger.
+ * @const
+ * @type {goog.log.Logger}
+ * @private
+ */
+os.ui.draw.BaseDrawControlsCtrl.LOGGER_ = goog.log.getLogger('os.ui.draw.BaseDrawControlsCtrl');
+
+
+/**
+ * Angular initialization hook. Sets up event listening and our controls menu.
+ */
+os.ui.draw.BaseDrawControlsCtrl.prototype.$onInit = function() {
   this.initControlMenu();
 
   os.dispatcher.listen(os.ui.draw.DrawEventType.DRAWSTART, this.apply, false, this);
@@ -139,19 +156,15 @@ os.ui.draw.BaseDrawControlsCtrl = function($scope, $element) {
 
   var selected = /** @type {string} */ (os.settings.get('drawType', os.ui.ol.interaction.DragBox.TYPE));
   this.setSelectedControl(selected);
-
-  $scope.$on('$destroy', this.dispose.bind(this));
 };
-goog.inherits(os.ui.draw.BaseDrawControlsCtrl, goog.Disposable);
 
 
 /**
- * The logger.
- * @const
- * @type {goog.log.Logger}
- * @private
+ * Angular destruction hook.
  */
-os.ui.draw.BaseDrawControlsCtrl.LOGGER_ = goog.log.getLogger('os.ui.draw.BaseDrawControlsCtrl');
+os.ui.draw.BaseDrawControlsCtrl.prototype.$onDestroy = function() {
+  this.dispose();
+};
 
 
 /**

--- a/src/os/ui/draw/drawcontrols.js
+++ b/src/os/ui/draw/drawcontrols.js
@@ -69,8 +69,8 @@ os.ui.draw.DrawControlsCtrl.LOGGER_ = goog.log.getLogger('os.ui.draw.DrawControl
 /**
  * @inheritDoc
  */
-os.ui.draw.DrawControlsCtrl.prototype.disposeInternal = function() {
-  os.ui.draw.DrawControlsCtrl.base(this, 'disposeInternal');
+os.ui.draw.DrawControlsCtrl.prototype.$onDestroy = function() {
+  os.ui.draw.DrawControlsCtrl.base(this, '$onDestroy');
   goog.events.unlisten(os.MapContainer.getInstance(), os.MapEvent.MAP_READY, this.onMapReady, false, this);
 };
 

--- a/src/os/ui/draw/drawcontrols.js
+++ b/src/os/ui/draw/drawcontrols.js
@@ -47,7 +47,11 @@ os.ui.Module.directive('osDrawControls', [os.ui.draw.drawControlsDirective]);
  * @ngInject
  */
 os.ui.draw.DrawControlsCtrl = function($scope, $element) {
-  this['supportsLines'] = true;
+  // If we haven't set supportsLines on scope, it should be 'true'
+  if ($scope['supportsLines'] == null) {
+    $scope['supportsLines'] = true;
+  }
+
   os.ui.draw.DrawControlsCtrl.base(this, 'constructor', $scope, $element);
   this.log = os.ui.draw.DrawControlsCtrl.LOGGER_;
 };

--- a/src/os/ui/draw/drawcontrols.js
+++ b/src/os/ui/draw/drawcontrols.js
@@ -47,12 +47,11 @@ os.ui.Module.directive('osDrawControls', [os.ui.draw.drawControlsDirective]);
  * @ngInject
  */
 os.ui.draw.DrawControlsCtrl = function($scope, $element) {
-  // If we haven't set supportsLines on scope, it should be 'true'
-  if ($scope['supportsLines'] == null) {
-    $scope['supportsLines'] = true;
-  }
-
   os.ui.draw.DrawControlsCtrl.base(this, 'constructor', $scope, $element);
+
+  // Base draw controller doesn't support lines as a default.
+  this['supportsLines'] = true;
+
   this.log = os.ui.draw.DrawControlsCtrl.LOGGER_;
 };
 goog.inherits(os.ui.draw.DrawControlsCtrl, os.ui.draw.BaseDrawControlsCtrl);


### PR DESCRIPTION
`hidesExtraControls` is accessed in `initControlMenu` called from the constructor. For any es6 subclasses, where `this` may not be called before `super()`, extra controls will always be visible even if that is not desired.

`supportsLines` was also being assigned to itself which is probably not the correct behavior.