### PR TITLE
refactor: add requireType for types in jsdoc

### DIFF
--- a/src/os/im/action/filteractionentry.js
+++ b/src/os/im/action/filteractionentry.js
@@ -6,6 +6,8 @@ goog.require('os.filter.FilterEntry');
 goog.require('os.im.action.ImportActionCallbackConfig');
 goog.require('os.ui.filter.fn');
 
+goog.requireType('os.im.action.IImportAction');
+
 
 
 /**

--- a/src/os/im/action/importaction.js
+++ b/src/os/im/action/importaction.js
@@ -1,6 +1,8 @@
 goog.provide('os.im.action');
 goog.provide('os.im.action.TagName');
 
+goog.requireType('os.im.action.IImportAction');
+
 
 /**
  * Identifier for import action components.

--- a/src/os/im/action/importactionmanager.js
+++ b/src/os/im/action/importactionmanager.js
@@ -13,6 +13,8 @@ goog.require('os.im.action.default');
 goog.require('os.plugin.PluginManager');
 goog.require('os.ui.filter');
 
+goog.requireType('os.im.action.IImportAction');
+
 
 /**
  * Manager for import actions.

--- a/src/os/layer/animatedtile.js
+++ b/src/os/layer/animatedtile.js
@@ -1,4 +1,5 @@
 goog.provide('os.layer.AnimatedTile');
+
 goog.require('goog.async.Delay');
 goog.require('os.events.PropertyChangeEvent');
 goog.require('os.layer.PropertyChange');
@@ -9,6 +10,9 @@ goog.require('os.time.TimelineController');
 goog.require('os.ui.Icons');
 goog.require('os.ui.IconsSVG');
 goog.require('os.ui.ScreenOverlayCtrl');
+
+goog.requireType('ol.source.TileArcGISRest');
+goog.requireType('ol.source.TileWMS');
 
 
 

--- a/src/os/os.js
+++ b/src/os/os.js
@@ -9,6 +9,8 @@ goog.require('ol.typedefs');
 goog.require('os.mixin.closure');
 goog.require('os.ol.license');
 
+goog.requireType('os.debug.FancierWindow');
+
 
 /**
  * TODO after running the ES6 conversion on a lot of the files, bring this deprecated to life; it'd add

--- a/src/os/webgl/abstractrootsynchronizer.js
+++ b/src/os/webgl/abstractrootsynchronizer.js
@@ -11,6 +11,8 @@ goog.require('os.layer.Image');
 goog.require('os.layer.Tile');
 goog.require('os.webgl.SynchronizerManager');
 
+goog.requireType('os.webgl.AbstractWebGLSynchronizer');
+
 
 /**
  * An abstract root synchronizer for a WebGL renderer.

--- a/src/os/webgl/abstractwebglrenderer.js
+++ b/src/os/webgl/abstractwebglrenderer.js
@@ -7,6 +7,8 @@ goog.require('os.config.DisplaySetting');
 goog.require('os.map.terrain');
 goog.require('os.webgl.IWebGLRenderer');
 
+goog.requireType('os.webgl.AbstractRootSynchronizer');
+
 
 /**
  * Abstract WebGL renderer implementation.

--- a/src/os/webgl/synchronizermanager.js
+++ b/src/os/webgl/synchronizermanager.js
@@ -2,6 +2,8 @@ goog.provide('os.webgl.SynchronizerManager');
 
 goog.require('os.layer.SynchronizerType');
 
+goog.requireType('os.webgl.AbstractWebGLSynchronizer');
+
 
 
 /**


### PR DESCRIPTION
Added several `goog.requireType` statements for types referenced in JSDoc only.