### PR TITLE
Adds user-created folders to the layers window

### DIFF
--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -256,8 +256,8 @@ osx.layer.PresetSearch;
  * @typedef {{
  *   id: !string,
  *   name: !string,
- *   parentId: (string|undefined),
- *   children: (Array<(string|osx.layer.FolderOptions)>|undefined),
+ *   parentId: !string,
+ *   children: !Array<(string|osx.layer.FolderOptions)>,
  *   collapsed: (boolean|undefined)
  * }}
  */

--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -255,9 +255,10 @@ osx.layer.PresetSearch;
 /**
  * @typedef {{
  *   id: !string,
- *   name: !string,
+ *   type: !string,
  *   parentId: !string,
- *   children: !Array<(string|osx.layer.FolderOptions)>,
+ *   name: (string|undefined),
+ *   children: (Array<(osx.layer.FolderOptions)>|undefined),
  *   collapsed: (boolean|undefined)
  * }}
  */

--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -253,6 +253,17 @@ osx.layer.PresetSearch;
 
 
 /**
+ * @typedef {{
+ *   id: !string,
+ *   name: !string,
+ *   children: (Array<(string|osx.layer.FolderOptions)>|undefined),
+ *   collapsed: (boolean|undefined)
+ * }}
+ */
+osx.layer.FolderOptions;
+
+
+/**
  * Namespace.
  * @type {Object}
  */

--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -256,6 +256,7 @@ osx.layer.PresetSearch;
  * @typedef {{
  *   id: !string,
  *   name: !string,
+ *   parentId: (string|undefined),
  *   children: (Array<(string|osx.layer.FolderOptions)>|undefined),
  *   collapsed: (boolean|undefined)
  * }}

--- a/src/os/data/foldernode.js
+++ b/src/os/data/foldernode.js
@@ -1,0 +1,36 @@
+goog.module('os.data.FolderNode');
+goog.module.declareLegacyNamespace();
+
+const Feature = goog.requireType('ol.Feature');
+const SlickTreeNode = goog.require('os.ui.slick.SlickTreeNode');
+const Vector = goog.requireType('os.layer.Vector');
+
+
+/**
+ * Tree node representing a layer folder.
+ */
+class FolderNode extends SlickTreeNode {
+  /**
+   */
+  constructor() {
+    super();
+    this.nodeUI = '<foldernodeui></foldernodeui>';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  formatIcons() {
+    const open = this.hasChildren() && !this.collapsed;
+    return '<i class="fa fa-folder' + (open ? '-open' : '') + ' fa-fw"></i>';
+  }
+}
+
+exports = FolderNode;

--- a/src/os/data/foldernode.js
+++ b/src/os/data/foldernode.js
@@ -42,7 +42,7 @@ class FolderNode extends SlickTreeNode {
   setOptions(options) {
     this.options = options;
     this.setId(options.id);
-    this.setLabel(options.name);
+    this.setLabel(options.name || 'New Folder');
     this.collapsed = options.collapsed || false;
   }
 

--- a/src/os/data/foldernode.js
+++ b/src/os/data/foldernode.js
@@ -11,10 +11,21 @@ const Vector = goog.requireType('os.layer.Vector');
  */
 class FolderNode extends SlickTreeNode {
   /**
+   * @param {osx.layer.FolderOptions} options
    */
-  constructor() {
+  constructor(options) {
     super();
+
     this.nodeUI = '<foldernodeui></foldernodeui>';
+
+    /**
+     * The folder options.
+     * @type {osx.layer.FolderOptions}
+     * @protected
+     */
+    this.options = null;
+
+    this.setOptions(options);
   }
 
   /**
@@ -22,6 +33,25 @@ class FolderNode extends SlickTreeNode {
    */
   disposeInternal() {
     super.disposeInternal();
+  }
+
+  /**
+   * Get the folder options.
+   * @return {osx.layer.FolderOptions}
+   */
+  getOptions() {
+    return this.options;
+  }
+
+  /**
+   * Set the folder options.
+   * @param {osx.layer.FolderOptions} options
+   */
+  setOptions(options) {
+    this.options = options;
+    this.setId(options.id);
+    this.setLabel(options.name);
+    this.collapsed = options.collapsed || false;
   }
 
   /**

--- a/src/os/data/foldernode.js
+++ b/src/os/data/foldernode.js
@@ -28,13 +28,6 @@ class FolderNode extends SlickTreeNode {
   }
 
   /**
-   * @inheritDoc
-   */
-  disposeInternal() {
-    super.disposeInternal();
-  }
-
-  /**
    * Get the folder options.
    * @return {osx.layer.FolderOptions}
    */
@@ -58,7 +51,7 @@ class FolderNode extends SlickTreeNode {
    */
   formatIcons() {
     const open = this.hasChildren() && !this.collapsed;
-    return '<i class="fa fa-folder' + (open ? '-open' : '') + ' fa-fw"></i>';
+    return `<i class="fa fa-folder${open ? '-open' : ''} fa-fw"></i>`;
   }
 }
 

--- a/src/os/data/foldernode.js
+++ b/src/os/data/foldernode.js
@@ -15,7 +15,6 @@ class FolderNode extends SlickTreeNode {
    */
   constructor(options) {
     super();
-
     this.nodeUI = '<foldernodeui></foldernodeui>';
 
     /**
@@ -23,7 +22,7 @@ class FolderNode extends SlickTreeNode {
      * @type {osx.layer.FolderOptions}
      * @protected
      */
-    this.options = null;
+    this.options;
 
     this.setOptions(options);
   }

--- a/src/os/data/foldernode.js
+++ b/src/os/data/foldernode.js
@@ -1,7 +1,6 @@
 goog.module('os.data.FolderNode');
 goog.module.declareLegacyNamespace();
 
-const Feature = goog.requireType('ol.Feature');
 const SlickTreeNode = goog.require('os.ui.slick.SlickTreeNode');
 const Vector = goog.requireType('os.layer.Vector');
 

--- a/src/os/data/layertreesearch.js
+++ b/src/os/data/layertreesearch.js
@@ -79,9 +79,15 @@ os.data.LayerTreeSearch.prototype.setupNode = function(item) {
  * @override
  */
 os.data.LayerTreeSearch.prototype.finalizeSearch = function(groupBy, results) {
-  var i = results.length;
-  while (i--) {
-    this.makeGroups_(results[i].getChildren(), /** @type {!os.ui.slick.SlickTreeNode} */ (results[i]));
+  if (groupBy) {
+    var i = results.length;
+    while (i--) {
+      this.makeGroups_(results[i].getChildren(), /** @type {!os.ui.slick.SlickTreeNode} */ (results[i]));
+    }
+  } else {
+    var layerNodes = results.slice();
+    results.length = 0;
+    this.createResults(results, layerNodes);
   }
 };
 
@@ -121,99 +127,7 @@ os.data.LayerTreeSearch.prototype.fillListFromSearch = function(list) {
       layerNodes.push(node);
     }
 
-    const optionsArray = os.layer.FolderManager.getInstance().getItems();
-    const folderNodeMap = {};
-
-    if (optionsArray.length > 0) {
-      /**
-       * Recursively build the tree from the folder options saved in FolderManager.
-       * @param {osx.layer.FolderOptions} options
-       * @param {number} i
-       * @param {Array<(osx.layer.FolderOptions|string)>} arr
-       */
-      var builder = (options, i, arr) => {
-        if (options.type == 'folder') {
-          const folderNode = new os.data.FolderNode(options);
-          folderNodeMap[options.id] = folderNode;
-
-          if (folderNodeMap[options.parentId]) {
-            folderNodeMap[options.parentId].addChild(folderNode);
-          } else {
-            list.push(folderNode);
-          }
-
-          if (options.children) {
-            options.children.forEach(builder);
-          }
-        } else {
-          var layerNode = layerNodes.find((node) => node.getId() === options.id);
-          if (layerNode) {
-            if (folderNodeMap[options.parentId]) {
-              folderNodeMap[options.parentId].addChild(layerNode);
-            } else {
-              list.push(layerNode);
-            }
-          }
-        }
-      };
-
-      optionsArray.forEach(builder);
-      list;
-    }
-
-    // const foldersArr = os.layer.FolderManager.getInstance().getItems().filter((item) => item.type == 'folder');
-
-    // if (foldersArr.length > 0) {
-    //   const folderNodeMap = {};
-    //   const resultsClone = list.slice();
-
-    // /**
-    //  * Recursively build the tree from the folder options saved in FolderManager.
-    //  * @param {(osx.layer.FolderOptions|string)} folder
-    //  * @param {number} i
-    //  * @param {Array<(osx.layer.FolderOptions|string)>} arr
-    //  */
-    // var fn = (folder, i, arr) => {
-    //   if (folder.type == 'folder') {
-    //     const folderNode = new os.data.FolderNode(folder);
-    //     folderNodeMap[folderNode.getId()] = folderNode;
-
-    //     const parentNode = folderNodeMap[folder.parentId];
-    //     if (parentNode) {
-    //       parentNode.addChild(folderNode);
-    //     } else {
-    //       list.push(folderNode);
-    //       // parent.addChild(folderNode, undefined, i);
-    //     }
-
-    //     if (folder.children) {
-    //       folder.children.forEach((child) => {
-    //         if (child.type == 'layer') {
-    //           folderNodeMap[child.id] = folderNode;
-    //         }
-    //       });
-    //     }
-    //   } else {
-    //     const childId = folder.id;
-    //     const child = resultsClone.find((layerNode) => layerNode.getId() === childId);
-
-    //     if (child) {
-    //       const parentNode = folderNodeMap[child.getId()];
-
-    //       if (parentNode) {
-    //         parentNode.addChild(child);
-    //         goog.array.remove(list, child);
-    //       }
-    //     }
-    //   }
-
-    //   if (folder.children) {
-    //     folder.children.forEach(fn);
-    //   }
-    // };
-
-    //   foldersArr.forEach(fn);
-    // }
+    this.createResults(list, layerNodes);
   } else {
     this.addNoResult(list);
   }
@@ -229,107 +143,53 @@ os.data.LayerTreeSearch.prototype.fillListFromSearch = function(list) {
  */
 os.data.LayerTreeSearch.prototype.makeGroups_ = function(results, parent) {
   if (results && results.length > 0) {
-    const foldersArr = [];
-    const count = results.length;
+    // if there are no user-created folders, fall back to grouping them automatically
+    var idBuckets = /** @type {!Object<string, !Array<!os.structs.ITreeNode>>} */
+        (goog.array.bucket(results, this.getNodeGroup.bind(this)));
+    results.length = 0;
 
-    if (foldersArr.length > 0) {
-      // const folderNodeMap = {};
-      // const resultsClone = results.slice();
+    for (var id in idBuckets) {
+      var bucket = idBuckets[id];
 
-      // /**
-      //  * Recursively build the tree from the folder options saved in FolderManager.
-      //  * @param {(osx.layer.FolderOptions|string)} folder
-      //  * @param {number} i
-      //  * @param {Array<(osx.layer.FolderOptions|string)>} arr
-      //  */
-      // var fn = (folder, i, arr) => {
-      //   if (typeof folder == 'object') {
-      //     const folderNode = new os.data.FolderNode(folder);
-      //     folderNodeMap[folderNode.getId()] = folderNode;
+      if (bucket.length > 1) {
+        var min = Number.MAX_VALUE;
+        var title = 'Unknown';
 
-      //     const parentNode = folderNodeMap[folder.parentId];
-      //     if (parentNode) {
-      //       parentNode.addChild(folderNode);
-      //     } else {
-      //       parent.addChild(folderNode, undefined, i);
-      //     }
+        // pick the shortest title as the label for the group
+        for (var i = 0, n = bucket.length; i < n; i++) {
+          var node = /** @type {os.data.LayerNode} */ (bucket[i]);
+          var layer = node.getLayer();
+          var t = os.implements(layer, os.IGroupable.ID) ?
+            /** @type {os.IGroupable} */ (layer).getGroupLabel() : layer.getTitle();
 
-      //     if (folder.children) {
-      //       folder.children.forEach((child) => {
-      //         if (typeof child == 'string') {
-      //           folderNodeMap[child] = folderNode;
-      //         }
-      //       });
-      //     }
-      //   } else {
-      //     const childId = folder;
-      //     const child = resultsClone.find((layerNode) => layerNode.getId() === childId);
-
-      //     if (child) {
-      //       const parentNode = folderNodeMap[child.getId()];
-
-      //       if (parent) {
-      //         parentNode.addChild(child);
-      //         goog.array.remove(results, child);
-      //       }
-      //     }
-      //   }
-
-      //   if (folder.children) {
-      //     folder.children.forEach(fn);
-      //   }
-      // };
-
-      // foldersArr.forEach(fn);
-    } else {
-      // if there are no user-created folders, fall back to grouping them automatically
-      var idBuckets = /** @type {!Object<string, !Array<!os.structs.ITreeNode>>} */
-          (goog.array.bucket(results, this.getNodeGroup.bind(this)));
-      results.length = 0;
-
-      for (var id in idBuckets) {
-        var bucket = idBuckets[id];
-
-        if (bucket.length > 1) {
-          var min = Number.MAX_VALUE;
-          var title = 'Unknown';
-
-          // pick the shortest title as the label for the group
-          for (var i = 0, n = bucket.length; i < n; i++) {
-            var node = /** @type {os.data.LayerNode} */ (bucket[i]);
-            var layer = node.getLayer();
-            var t = os.implements(layer, os.IGroupable.ID) ?
-              /** @type {os.IGroupable} */ (layer).getGroupLabel() : layer.getTitle();
-
-            if (t.length < min) {
-              title = t;
-              min = t.length;
-            }
+          if (t.length < min) {
+            title = t;
+            min = t.length;
           }
-
-          var groupLayer = new os.layer.LayerGroup();
-          groupLayer.setId(id + os.ui.data.BaseProvider.ID_DELIMITER + '_group');
-          groupLayer.setTitle(title);
-
-          var groupNode = new os.data.LayerNode();
-
-          for (i = 0, n = bucket.length; i < n; i++) {
-            var node = bucket[i];
-            if (node) {
-              var layer = node.getLayer();
-              if (layer) {
-                groupLayer.addLayer(layer);
-              }
-
-              groupNode.addChild(node);
-            }
-          }
-
-          groupNode.setLayer(groupLayer);
-          results.push(groupNode);
-        } else if (bucket.length == 1) {
-          results.push(bucket[0]);
         }
+
+        var groupLayer = new os.layer.LayerGroup();
+        groupLayer.setId(id + os.ui.data.BaseProvider.ID_DELIMITER + '_group');
+        groupLayer.setTitle(title);
+
+        var groupNode = new os.data.LayerNode();
+
+        for (i = 0, n = bucket.length; i < n; i++) {
+          var node = bucket[i];
+          if (node) {
+            var layer = node.getLayer();
+            if (layer) {
+              groupLayer.addLayer(layer);
+            }
+
+            groupNode.addChild(node);
+          }
+        }
+
+        groupNode.setLayer(groupLayer);
+        results.push(groupNode);
+      } else if (bucket.length == 1) {
+        results.push(bucket[0]);
       }
     }
 
@@ -337,6 +197,7 @@ os.data.LayerTreeSearch.prototype.makeGroups_ = function(results, parent) {
     // Essentially this takes the "(1)" or "(1 of 2)" portion and applies the difference in count to both numbers.
     var label = parent.getLabel();
     var i = label.indexOf('(');
+    var count = results.length;
 
     /**
      * @type {Array<string|number>}
@@ -362,6 +223,59 @@ os.data.LayerTreeSearch.prototype.makeGroups_ = function(results, parent) {
     }
 
     parent.setLabel(label + '(' + counts[0] + (counts.length > 1 ? ' of ' + counts[1] : '') + ')');
+  }
+};
+
+
+/**
+ * Creates the final results.
+ *
+ * @param {!Array<!os.structs.ITreeNode>} results
+ * @param {!Array<!os.structs.ITreeNode>} layerNodes
+ * @private
+ */
+os.data.LayerTreeSearch.prototype.createResults = function(results, layerNodes) {
+  const items = os.layer.FolderManager.getInstance().getItems();
+  const folderNodeMap = {};
+
+  if (items.length > 0) {
+    /**
+     * Recursively build the tree from the folder options saved in FolderManager.
+     * @param {osx.layer.FolderOptions} options
+     * @param {number} i
+     * @param {Array<(osx.layer.FolderOptions|string)>} arr
+     */
+    var builder = (options, i, arr) => {
+      if (options.type == 'folder') {
+        const folderNode = new os.data.FolderNode(options);
+        folderNodeMap[options.id] = folderNode;
+
+        if (folderNodeMap[options.parentId]) {
+          folderNodeMap[options.parentId].addChild(folderNode);
+        } else {
+          results.push(folderNode);
+        }
+
+        if (options.children) {
+          options.children.forEach(builder);
+        }
+      } else {
+        var layerNode = layerNodes.find((node) => node.getId() === options.id);
+        if (layerNode) {
+          if (folderNodeMap[options.parentId]) {
+            folderNodeMap[options.parentId].addChild(layerNode);
+          } else {
+            results.push(layerNode);
+          }
+        }
+      }
+    };
+
+    items.forEach(builder);
+  } else {
+    // just use all of the layer nodes
+    results.splice(0, 0, ...layerNodes);
+    results.sort(os.ui.slick.TreeSearch.labelCompare);
   }
 };
 

--- a/src/os/data/layertreesearch.js
+++ b/src/os/data/layertreesearch.js
@@ -6,7 +6,6 @@ goog.require('os.data.groupby.LayerZOrderGroupBy');
 goog.require('os.layer.FolderManager');
 goog.require('os.layer.ILayer');
 goog.require('os.layer.LayerGroup');
-goog.require('os.menu.folder');
 goog.require('os.structs.ITreeNodeSupplier');
 goog.require('os.ui.data.BaseProvider');
 goog.require('os.ui.node.FolderNodeUI');
@@ -27,7 +26,6 @@ goog.require('os.ui.slick.TreeSearch');
  */
 os.data.LayerTreeSearch = function(setAs, onObj, opt_noResultLabel) {
   os.data.LayerTreeSearch.base(this, 'constructor', [], setAs, onObj, opt_noResultLabel);
-  os.menu.folder.setup();
 };
 goog.inherits(os.data.LayerTreeSearch, os.ui.slick.AbstractGroupByTreeSearch);
 

--- a/src/os/data/zorder.js
+++ b/src/os/data/zorder.js
@@ -2,6 +2,7 @@ goog.provide('os.data.ZOrder');
 goog.provide('os.data.ZOrderEntry');
 goog.provide('os.data.ZOrderEventType');
 
+goog.require('goog.events.EventTarget');
 goog.require('ol.array');
 goog.require('os.config.Settings');
 
@@ -24,9 +25,12 @@ os.data.ZOrderEntry;
 /**
  * Maintains Z-Order for layers between sessions
  *
+ * @extends {goog.events.EventTarget}
  * @constructor
  */
 os.data.ZOrder = function() {
+  os.data.ZOrder.base(this, 'constructor');
+
   /**
    * @type {?ol.Map}
    * @private
@@ -39,6 +43,7 @@ os.data.ZOrder = function() {
    */
   this.groups_ = null;
 };
+goog.inherits(os.data.ZOrder, goog.events.EventTarget);
 goog.addSingletonGetter(os.data.ZOrder);
 
 
@@ -102,6 +107,30 @@ os.data.ZOrder.prototype.getZType = function(id) {
   }
 
   return null;
+};
+
+
+/**
+ * Gets the Z-order index for a layer's ID.
+ * @param {string} id
+ * @return {number} The Z-Order group type
+ */
+os.data.ZOrder.prototype.getIndex = function(id) {
+  if (!this.groups_ || !id) {
+    return -1;
+  }
+
+  for (var type in this.groups_) {
+    var list = /** @type {Array.<os.data.ZOrderEntry>} */ (this.groups_[type] || []);
+
+    for (var i = 0, n = list.length; i < n; i++) {
+      if (list[i].id == id) {
+        return i;
+      }
+    }
+  }
+
+  return -1;
 };
 
 
@@ -201,6 +230,8 @@ os.data.ZOrder.prototype.update = function() {
       }
     }
   }
+
+  this.dispatchEvent('zOrder:update');
 };
 
 

--- a/src/os/layer/folder.js
+++ b/src/os/layer/folder.js
@@ -62,9 +62,36 @@ const launchRemoveFolder = (options, callback, opt_removeChildren) => {
 };
 
 
+/**
+ * Flag for keeping track of whether the folder menu items should appear.
+ * @type {boolean}
+ */
+let folderMenuEnabled = true;
+
+
+/**
+ * Set whether the folder menu is enabled.
+ * @param {boolean} value
+ */
+const setFolderMenuEnabled = (value) => {
+  folderMenuEnabled = value;
+};
+
+
+/**
+ * Get whether the folder menu is abled
+ * @return {boolean}
+ */
+const getFolderMenuEnabled = () => {
+  return folderMenuEnabled;
+};
+
+
 exports = {
   FolderEventType,
   MetricKey,
   SettingsKey,
-  launchRemoveFolder
+  launchRemoveFolder,
+  setFolderMenuEnabled,
+  getFolderMenuEnabled
 };

--- a/src/os/layer/folder.js
+++ b/src/os/layer/folder.js
@@ -1,6 +1,8 @@
 goog.module('os.layer.folder');
 goog.module.declareLegacyNamespace();
 
+const ConfirmUI = goog.require('os.ui.window.ConfirmUI');
+
 
 /**
  * Enum of folder event types.
@@ -10,12 +12,20 @@ const FolderEventType = {
   // menu events
   CREATE_FOLDER: 'createFolder',
   REMOVE_FOLDER: 'removeFolder',
+  UNFOLDER: 'unfolder',
 
   // manager events
   FOLDER_CREATED: 'folderCreated',
   FOLDER_UPDATED: 'folderUpdated',
   FOLDER_REMOVED: 'folderRemoved',
   FOLDERS_CLEARED: 'foldersCleared'
+};
+
+
+const MetricKey = {
+  CREATE_FOLDER: 'os.layer.folder.folderCreated',
+  REMOVE_FOLDER: 'os.layer.folder.folderUpdated',
+  UNFOLDER: 'os.layer.folder.foldersCleared'
 };
 
 
@@ -28,7 +38,33 @@ const SettingsKey = {
 };
 
 
+/**
+ * Launches the remove folder dialog
+ * @param {osx.layer.FolderOptions} options
+ * @param {Function} callback
+ * @param {boolean=} opt_removeChildren
+ */
+const launchRemoveFolder = (options, callback, opt_removeChildren) => {
+  let prompt = 'Are you sure you want to remove the folder?';
+
+  if (opt_removeChildren) {
+    prompt += ' This will remove all child layers as well.';
+  }
+
+  ConfirmUI.launchConfirm(/** @type {!osx.window.ConfirmOptions} */ ({
+    confirm: callback,
+    prompt: prompt,
+    windowOptions: /** @type {!osx.window.WindowOptions} */ ({
+      icon: 'fa fa-trash-o',
+      label: 'Remove ' + options.name
+    })
+  }));
+};
+
+
 exports = {
   FolderEventType,
-  SettingsKey
+  MetricKey,
+  SettingsKey,
+  launchRemoveFolder
 };

--- a/src/os/layer/folder.js
+++ b/src/os/layer/folder.js
@@ -1,6 +1,8 @@
 goog.module('os.layer.folder');
 goog.module.declareLegacyNamespace();
 
+goog.require('os.ui.window.confirmTextDirective');
+
 const ConfirmUI = goog.require('os.ui.window.ConfirmUI');
 
 
@@ -63,6 +65,30 @@ const launchRemoveFolder = (options, callback, opt_removeChildren) => {
 
 
 /**
+ * Create or e edit a folder.
+ * @param {osx.layer.FolderOptions} options
+ * @param {Function} callback
+ * @param {boolean=} opt_isEdit
+ */
+const createOrEditFolder = (options, callback, opt_isEdit = false) => {
+  const label = opt_isEdit ? options.name : 'New Folder';
+  const winLabel = (opt_isEdit ? 'Edit' : 'Add') + ' Folder';
+
+  const confirmOptions = /** @type {!osx.window.ConfirmTextOptions} */ ({
+    confirm: callback,
+    defaultValue: label,
+    prompt: 'Please choose a label for the folder:',
+    windowOptions: /** @type {!osx.window.WindowOptions} */ ({
+      icon: 'fa fa-folder',
+      label: winLabel
+    })
+  });
+
+  os.ui.window.launchConfirmText(confirmOptions);
+};
+
+
+/**
  * Flag for keeping track of whether the folder menu items should appear.
  * @type {boolean}
  */
@@ -92,6 +118,7 @@ exports = {
   MetricKey,
   SettingsKey,
   launchRemoveFolder,
+  createOrEditFolder,
   setFolderMenuEnabled,
   getFolderMenuEnabled
 };

--- a/src/os/layer/folder.js
+++ b/src/os/layer/folder.js
@@ -7,14 +7,28 @@ goog.module.declareLegacyNamespace();
  * @enum {string}
  */
 const FolderEventType = {
+  // menu events
   CREATE_FOLDER: 'createFolder',
   REMOVE_FOLDER: 'removeFolder',
+
+  // manager events
   FOLDER_CREATED: 'folderCreated',
   FOLDER_UPDATED: 'folderUpdated',
-  FOLDER_REMOVED: 'folderRemoved'
+  FOLDER_REMOVED: 'folderRemoved',
+  FOLDERS_CLEARED: 'foldersCleared'
+};
+
+
+/**
+ * Enum of folder settings keys.
+ * @enum {string}
+ */
+const SettingsKey = {
+  FOLDERS: 'layers.folders'
 };
 
 
 exports = {
-  FolderEventType
+  FolderEventType,
+  SettingsKey
 };

--- a/src/os/layer/folder.js
+++ b/src/os/layer/folder.js
@@ -1,0 +1,20 @@
+goog.module('os.layer.folder');
+goog.module.declareLegacyNamespace();
+
+
+/**
+ * Enum of folder event types.
+ * @enum {string}
+ */
+const FolderEventType = {
+  CREATE_FOLDER: 'createFolder',
+  REMOVE_FOLDER: 'removeFolder',
+  FOLDER_CREATED: 'folderCreated',
+  FOLDER_UPDATED: 'folderUpdated',
+  FOLDER_REMOVED: 'folderRemoved'
+};
+
+
+exports = {
+  FolderEventType
+};

--- a/src/os/layer/foldermanager.js
+++ b/src/os/layer/foldermanager.js
@@ -94,6 +94,11 @@ class FolderManager extends EventTarget {
       const parent = this.getFolder(folder.parentId);
       if (parent) {
         removed = remove(parent.children, folder);
+
+        if (folder.children) {
+          parent.children.push(...folder.children);
+          this.updateZOrder();
+        }
       } else {
         removed = remove(this.folders, folder);
       }

--- a/src/os/layer/foldermanager.js
+++ b/src/os/layer/foldermanager.js
@@ -201,8 +201,9 @@ class FolderManager extends EventTarget {
    * @param {string} id The ID of the item to move.
    * @param {string} targetId The ID of the target item.
    * @param {boolean=} opt_after True if the item should be moved after the target item.
+   * @param {boolean=} opt_sibling True for the case of dropping a node above a target folder.
    */
-  move(id, targetId, opt_after) {
+  move(id, targetId, opt_after = false, opt_sibling = false) {
     if (id === targetId) {
       return;
     }
@@ -220,10 +221,16 @@ class FolderManager extends EventTarget {
     let targetIndex;
 
     if (targetItem && targetItem.type === 'folder') {
-      // dropped directly on a folder, so use its children and put the item in the 0th position
-      targetParent = targetItem;
-      targetList = targetItem.children;
-      targetIndex = 0;
+      if (opt_sibling) {
+        targetParent = this.getItem(targetItem.parentId);
+        targetList = targetParent ? targetParent.children : this.items;
+        targetIndex = targetList.indexOf(targetItem);
+      } else {
+        // dropped directly on a folder, so use its children and put the item in the 0th position
+        targetParent = targetItem;
+        targetList = targetItem.children;
+        targetIndex = 0;
+      }
     } else {
       // locate the correct parent list and target index
       targetParent = this.getItem(targetItem.parentId);

--- a/src/os/layer/foldermanager.js
+++ b/src/os/layer/foldermanager.js
@@ -1,0 +1,167 @@
+goog.module('os.layer.FolderManager');
+goog.module.declareLegacyNamespace();
+
+const {FolderEventType} = goog.require('os.layer.folder');
+const EventTarget = goog.require('goog.events.EventTarget');
+const Settings = goog.require('os.config.Settings');
+
+
+/**
+ * Global folder manager instance.
+ * @type {FolderManager}
+ */
+let instance;
+
+
+/**
+ * Manager class for layer folders. Maintains a map of what folders exist and what layers belong to them.
+ */
+class FolderManager extends EventTarget {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    /**
+     * Map for tracking existing folders.
+     * @type {Object<string, osx.layer.FolderOptions>}
+     * @protected
+     */
+    this.folderMap = {};
+
+    this.restore();
+  }
+
+  /**
+   * Get the global folder manager instance.
+   * @return {FolderManager}
+   */
+  static getInstance() {
+    if (!instance) {
+      instance = new FolderManager();
+    }
+
+    return instance;
+  }
+
+  /**
+   * Set the global folder manager instance.
+   * @param {!FolderManager} value The FolderManager instance to set.
+   */
+  static setInstance(value) {
+    instance = value;
+  }
+
+  /**
+   * Create a new folder.
+   * @param {osx.layer.FolderOptions} options The folder options
+   * @param {string=} opt_parentId Optional parent to add the folder options to.
+   */
+  createFolder(options, opt_parentId) {
+    if (opt_parentId) {
+      var parentFolder = this.getFolder(opt_parentId);
+      if (parentFolder) {
+        parentFolder.children.unshift(options);
+        options.children.forEach((child) => {
+          goog.array.remove(parentFolder.children, child);
+        });
+      }
+    } else {
+      this.folderMap[options.id] = options;
+    }
+
+    this.dispatchEvent(FolderEventType.FOLDER_CREATED);
+    this.persist();
+  }
+
+  /**
+   * Remove a folder.
+   * @param {string} id The folder ID to remove
+   */
+  removeFolder(id) {
+    delete this.folderMap[id];
+    this.dispatchEvent(FolderEventType.FOLDER_REMOVED);
+    this.persist();
+  }
+
+  /**
+   * Gets the folder map.
+   * @return {Object<string, osx.layer.FolderOptions>}
+   */
+  getFolders() {
+    return this.folderMap;
+  }
+
+  /**
+   * Gets the folder map.
+   * @param {string} id The folder ID to find.
+   * @return {Object<string, osx.layer.FolderOptions>}
+   */
+  getFolder(id) {
+    var folder = this.folderMap[id];
+
+    if (!folder) {
+      for (var key in this.folderMap) {
+        var options = this.folderMap[key];
+        folder = options.children.find((child) => child == id);
+      }
+    }
+
+    return folder;
+  }
+
+  /**
+   * Callback for folder name.
+   * @param {!osx.layer.FolderOptions} options The folder options.
+   * @param {string} parentId
+   * @param {string} name The chosen folder name.
+   * @protected
+   */
+  onFolderName(options, parentId, name) {
+    this.removeFolder(options.id);
+    options.name = name;
+    this.createFolder(options, parentId);
+  }
+
+  /**
+   * Create or e edit a folder.
+   * @param {osx.layer.FolderOptions} options
+   * @param {string=} opt_parentId
+   */
+  createOrEditFolder(options, opt_parentId) {
+    var node = options['node'];
+    var label = node ? node.getLabel() : 'New Folder';
+    var winLabel = (node ? 'Edit' : 'Add') + ' Folder';
+    var parentId = opt_parentId || '';
+
+    var confirmOptions = /** @type {!osx.window.ConfirmTextOptions} */ ({
+      confirm: this.onFolderName.bind(this, options, parentId),
+      defaultValue: label,
+      prompt: 'Please choose a label for the folder:',
+      windowOptions: /** @type {!osx.window.WindowOptions} */ ({
+        icon: 'fa fa-folder',
+        label: winLabel
+      })
+    });
+
+    os.ui.window.launchConfirmText(confirmOptions);
+  }
+
+  /**
+   * Saves the folders to settings.
+   */
+  persist() {
+    Settings.getInstance().set('layers.folders', this.folderMap);
+  }
+
+  /**
+   * Restores the settings.
+   */
+  restore() {
+    this.folderMap = /** @type {Object<string, osx.layer.FolderOptions>} */
+        (Settings.getInstance().get('layers.folders', {}));
+  }
+}
+
+exports = FolderManager;

--- a/src/os/layer/foldermanager.js
+++ b/src/os/layer/foldermanager.js
@@ -258,41 +258,6 @@ class FolderManager extends EventTarget {
   }
 
   /**
-   * Callback for folder name.
-   * @param {!osx.layer.FolderOptions} options The folder options.
-   * @param {string} name The chosen folder name.
-   * @protected
-   */
-  onFolderName(options, name) {
-    this.removeFolder(options.id);
-    options.name = name;
-    this.createFolder(options);
-  }
-
-  /**
-   * Create or e edit a folder.
-   * @param {osx.layer.FolderOptions} options
-   * @param {string=} opt_parentId
-   */
-  createOrEditFolder(options, opt_parentId) {
-    const existing = this.getItem(options.id);
-    const label = existing ? existing.name : 'New Folder';
-    const winLabel = (existing ? 'Edit' : 'Add') + ' Folder';
-
-    const confirmOptions = /** @type {!osx.window.ConfirmTextOptions} */ ({
-      confirm: this.onFolderName.bind(this, options),
-      defaultValue: label,
-      prompt: 'Please choose a label for the folder:',
-      windowOptions: /** @type {!osx.window.WindowOptions} */ ({
-        icon: 'fa fa-folder',
-        label: winLabel
-      })
-    });
-
-    os.ui.window.launchConfirmText(confirmOptions);
-  }
-
-  /**
    * Clears the manager.
    */
   clear() {

--- a/src/os/layer/foldermenu.js
+++ b/src/os/layer/foldermenu.js
@@ -75,29 +75,6 @@ const onUnfolder = (id) => {
 
 
 /**
- * Removes a folder.
- * @param {MenuEvent<Context>} event
- */
-const removeFolder = function(event) {
-  const context = event.getContext()[0];
-
-  if (context instanceof FolderNode) {
-    launchRemoveFolder(context.getOptions(), onRemoveFolder.bind(undefined, context), true);
-  }
-};
-
-
-/**
- * Handle removing a folder and its child layers.
- * @param {!FolderNode} folderNode The folder node to remove.
- * @protected
- */
-const onRemoveFolder = (folderNode) => {
-  FolderManager.getInstance().removeFolder(folderNode.getId());
-};
-
-
-/**
  * Show a menu item if the context supports creating a folder.
  * @param {Context} context The menu context.
  * @this {MenuItem}
@@ -108,24 +85,6 @@ const showCreateFolder = function(context) {
   if (context && context.length > 0) {
     var layers = os.ui.menu.layer.getLayersFromContext(context);
     this.visible = layers.length == context.length;
-  }
-};
-
-
-/**
- * Show a menu item if the context supports removing a folder.
- * @param {Context} context The menu context.
- * @this {MenuItem}
- */
-const showRemoveFolder = function(context) {
-  this.visible = false;
-
-  if (context && context.length == 1) {
-    const folder = /** @type {FolderNode} */ (context[0]);
-
-    if (folder instanceof FolderNode) {
-      this.visible = folder.hasChildren();
-    }
   }
 };
 
@@ -164,17 +123,6 @@ const setup = function() {
       beforeRender: showCreateFolder,
       handler: createFolder,
       sort: 0
-    });
-
-    group.addChild({
-      label: 'Remove Folder and Children',
-      eventType: FolderEventType.REMOVE_FOLDER,
-      tooltip: 'Removes the folder and its children.',
-      icons: ['<i class="fa fa-fw fa-times"></i>'],
-      metricKey: 'os.layer.removeFolder',
-      beforeRender: showRemoveFolder,
-      handler: removeFolder,
-      sort: 20
     });
 
     group.addChild({

--- a/src/os/layer/foldermenu.js
+++ b/src/os/layer/foldermenu.js
@@ -32,6 +32,17 @@ const createFolder = function(event) {
   let layerOptions = [];
 
   if (layers) {
+    let parentItems = fm.getParent(layers[0].getId());
+    parentItems = Array.isArray(parentItems) ? parentItems : parentItems.children;
+
+    // the order of the layers returned from the context depends on the selection order
+    // we want the order to match the view, so sort against the map
+    layers.sort((layerA, layerB) => {
+      const indexA = parentItems.findIndex((item) => item.id === layerA.getId());
+      const indexB = parentItems.findIndex((item) => item.id === layerB.getId());
+
+      return indexA - indexB;
+    });
     layerOptions = layers.map((l) => fm.getItem(l.getId()));
 
     // determine if we need to assign them to a parent
@@ -39,16 +50,16 @@ const createFolder = function(event) {
     if (parent) {
       parentId = parent.getId();
     }
-  }
 
-  fm.createOrEditFolder({
-    id: getRandomString(),
-    type: 'folder',
-    children: layerOptions,
-    name: 'New Folder',
-    parentId: parentId,
-    collapsed: false
-  });
+    fm.createOrEditFolder({
+      id: getRandomString(),
+      type: 'folder',
+      children: layerOptions,
+      name: 'New Folder',
+      parentId: parentId,
+      collapsed: false
+    });
+  }
 };
 
 

--- a/src/os/layer/foldermenu.js
+++ b/src/os/layer/foldermenu.js
@@ -4,7 +4,7 @@ goog.module.declareLegacyNamespace();
 const FolderManager = goog.require('os.layer.FolderManager');
 const FolderNode = goog.require('os.data.FolderNode');
 const layerMenu = goog.require('os.ui.menu.layer');
-const {FolderEventType, launchRemoveFolder} = goog.require('os.layer.folder');
+const {FolderEventType, launchRemoveFolder, getFolderMenuEnabled} = goog.require('os.layer.folder');
 const {getLayersFromContext} = goog.require('os.ui.menu.layer');
 const {getRandomString} = goog.require('goog.string');
 
@@ -94,8 +94,8 @@ const onUnfolder = (id) => {
 const showCreateFolder = function(context) {
   this.visible = false;
 
-  if (context && context.length > 0) {
-    var layers = os.ui.menu.layer.getLayersFromContext(context);
+  if (getFolderMenuEnabled() && context && context.length > 0) {
+    var layers = layerMenu.getLayersFromContext(context);
     this.visible = layers.length == context.length;
   }
 };
@@ -109,7 +109,7 @@ const showCreateFolder = function(context) {
 const showUnfolder = function(context) {
   this.visible = false;
 
-  if (context && context.length == 1) {
+  if (getFolderMenuEnabled() && context && context.length == 1) {
     this.visible = context[0] instanceof FolderNode;
   }
 };

--- a/src/os/layer/foldermenu.js
+++ b/src/os/layer/foldermenu.js
@@ -36,12 +36,12 @@ const createFolder = function(event) {
 
     // determine if we need to assign them to a parent
     const parent = nodes[0].getParent();
-    if (parent instanceof FolderNode) {
+    if (parent) {
       parentId = parent.getId();
-      const sharedParent = nodes.every((n) => n.getParent().getId() == parentId);
-      if (!sharedParent) {
-        parentId = undefined;
-      }
+      // const sharedParent = nodes.every((n) => n.getParent().getId() == parentId);
+      // if (!sharedParent) {
+      //   parentId = undefined;
+      // }
     }
   }
 
@@ -49,8 +49,9 @@ const createFolder = function(event) {
     id: getRandomString(),
     children: layerIds,
     name: 'New Folder',
+    parentId: parentId,
     collapsed: false
-  }, parentId);
+  });
 };
 
 

--- a/src/os/layer/foldermenu.js
+++ b/src/os/layer/foldermenu.js
@@ -1,0 +1,138 @@
+goog.module('os.menu.folder');
+goog.module.declareLegacyNamespace();
+
+const FolderManager = goog.require('os.layer.FolderManager');
+const FolderNode = goog.require('os.data.FolderNode');
+const layerMenu = goog.require('os.ui.menu.layer');
+const {FolderEventType} = goog.require('os.layer.folder');
+const {getLayersFromContext} = goog.require('os.ui.menu.layer');
+const {getRandomString} = goog.require('goog.string');
+
+const MenuEvent = goog.requireType('os.ui.menu.MenuEvent');
+const MenuItem = goog.requireType('os.ui.menu.MenuItem');
+const {Context} = goog.requireType('os.ui.menu.layer');
+
+
+/**
+ * Whether the folder menu has been initialized.
+ * @type {boolean}
+ */
+let initialized = false;
+
+
+/**
+ * Creates a folder.
+ * @param {MenuEvent<Context>} event
+ */
+const createFolder = function(event) {
+  const nodes = event.getContext();
+  const layers = getLayersFromContext(nodes);
+  const fm = FolderManager.getInstance();
+  let layerIds;
+  let parentId;
+
+  if (layers) {
+    layerIds = layers.map((l) => l.getId());
+
+    // determine if we need to assign them to a parent
+    const parent = nodes[0].getParent();
+    if (parent instanceof FolderNode) {
+      parentId = parent.getId();
+      const sharedParent = nodes.every((n) => n.getParent().getId() == parentId);
+      if (!sharedParent) {
+        parentId = undefined;
+      }
+    }
+  }
+
+  fm.createOrEditFolder({
+    id: getRandomString(),
+    children: layerIds,
+    name: 'New Folder',
+    collapsed: false
+  }, parentId);
+};
+
+
+/**
+ * Removes a folder.
+ * @param {MenuEvent<Context>} event
+ */
+const removeFolder = function(event) {
+  const context = event.getContext();
+  const fm = FolderManager.getInstance();
+
+  if (context.id) {
+    fm.removeFolder(context.id);
+  }
+};
+
+
+/**
+ * Show a menu item if the context supports creating a folder.
+ * @param {Context} context The menu context.
+ * @this {MenuItem}
+ */
+const showCreateFolder = function(context) {
+  this.visible = false;
+
+  if (context && context.length > 0) {
+    var layers = os.ui.menu.layer.getLayersFromContext(context);
+    this.visible = layers.length == context.length;
+  }
+};
+
+
+/**
+ * Show a menu item if the context supports removing a folder.
+ * @param {Context} context The menu context.
+ * @this {MenuItem}
+ */
+const showRemoveFolder = function(context) {
+  this.visible = false;
+
+  if (context && context.length == 1) {
+    this.visible = context[0] instanceof FolderNode;
+  }
+};
+
+
+/**
+ * Sets up analyze actions
+ */
+const setup = function() {
+  layerMenu.setup();
+  const menu = layerMenu.MENU;
+
+  if (!initialized && menu) {
+    var group = menu.getRoot().find(layerMenu.GroupLabel.LAYER);
+    initialized = true;
+
+    group.addChild({
+      label: 'Create Folder',
+      eventType: FolderEventType.CREATE_FOLDER,
+      tooltip: 'Creates a folder for layers.',
+      icons: ['<i class="fa fa-fw fa-folder"></i>'],
+      metricKey: 'os.layer.createFolder',
+      beforeRender: showCreateFolder,
+      handler: createFolder,
+      sort: 0
+    });
+
+    group.addChild({
+      label: 'Remove Folder',
+      eventType: FolderEventType.REMOVE_FOLDER,
+      tooltip: 'Remove the folder.',
+      icons: ['<i class="fa fa-fw fa-folder"></i>'],
+      metricKey: 'os.layer.removeFolder',
+      beforeRender: showRemoveFolder,
+      handler: removeFolder,
+      sort: 0
+    });
+  }
+};
+
+
+exports = {
+  setup
+};

--- a/src/os/layer/foldermenu.js
+++ b/src/os/layer/foldermenu.js
@@ -4,7 +4,7 @@ goog.module.declareLegacyNamespace();
 const FolderManager = goog.require('os.layer.FolderManager');
 const FolderNode = goog.require('os.data.FolderNode');
 const layerMenu = goog.require('os.ui.menu.layer');
-const {FolderEventType, launchRemoveFolder, getFolderMenuEnabled} = goog.require('os.layer.folder');
+const {FolderEventType, launchRemoveFolder, createOrEditFolder, getFolderMenuEnabled} = goog.require('os.layer.folder');
 const {getLayersFromContext} = goog.require('os.ui.menu.layer');
 const {getRandomString} = goog.require('goog.string');
 
@@ -51,15 +51,29 @@ const createFolder = function(event) {
       parentId = parent.getId();
     }
 
-    fm.createOrEditFolder({
+    const createOptions = {
       id: getRandomString(),
       type: 'folder',
       children: layerOptions,
       name: 'New Folder',
       parentId: parentId,
       collapsed: false
-    });
+    };
+
+    createOrEditFolder(createOptions, onCreateFolder.bind(undefined, createOptions));
   }
+};
+
+
+/**
+ * Handle creating a folder.
+ * @param {osx.layer.FolderOptions} createOptions The ID to remove.
+ * @param {string} name The chosen folder name.
+ * @protected
+ */
+const onCreateFolder = (createOptions, name) => {
+  createOptions.name = name;
+  FolderManager.getInstance().createFolder(createOptions);
 };
 
 

--- a/src/os/layer/foldermenu.js
+++ b/src/os/layer/foldermenu.js
@@ -28,8 +28,8 @@ const createFolder = function(event) {
   const nodes = event.getContext();
   const layers = getLayersFromContext(nodes);
   const fm = FolderManager.getInstance();
-  let layerIds;
-  let parentId;
+  let parentId = '';
+  let layerIds = [];
 
   if (layers) {
     layerIds = layers.map((l) => l.getId());
@@ -38,10 +38,6 @@ const createFolder = function(event) {
     const parent = nodes[0].getParent();
     if (parent) {
       parentId = parent.getId();
-      // const sharedParent = nodes.every((n) => n.getParent().getId() == parentId);
-      // if (!sharedParent) {
-      //   parentId = undefined;
-      // }
     }
   }
 

--- a/src/os/layer/foldermenu.js
+++ b/src/os/layer/foldermenu.js
@@ -29,10 +29,10 @@ const createFolder = function(event) {
   const layers = getLayersFromContext(nodes);
   const fm = FolderManager.getInstance();
   let parentId = '';
-  let layerIds = [];
+  let layerOptions = [];
 
   if (layers) {
-    layerIds = layers.map((l) => l.getId());
+    layerOptions = layers.map((l) => fm.getItem(l.getId()));
 
     // determine if we need to assign them to a parent
     const parent = nodes[0].getParent();
@@ -43,7 +43,8 @@ const createFolder = function(event) {
 
   fm.createOrEditFolder({
     id: getRandomString(),
-    children: layerIds,
+    type: 'folder',
+    children: layerOptions,
     name: 'New Folder',
     parentId: parentId,
     collapsed: false

--- a/src/os/mainctrl.js
+++ b/src/os/mainctrl.js
@@ -65,6 +65,7 @@ goog.require('os.layer.config.StaticLayerConfig');
 goog.require('os.load.LoadingManager');
 goog.require('os.map');
 goog.require('os.map.interaction');
+goog.require('os.menu.folder');
 goog.require('os.metrics.AddDataMetrics');
 goog.require('os.metrics.FiltersMetrics');
 goog.require('os.metrics.LayersMetrics');
@@ -305,6 +306,7 @@ os.MainCtrl = function($scope, $element, $compile, $timeout, $injector) {
   os.ui.state.menu.setup();
   os.ui.menu.buffer.setup();
   os.ui.menu.windows.default.setup();
+  os.menu.folder.setup();
 
   // assign the spatial menu
   os.ui.draw.MENU = os.ui.menu.spatial.MENU;

--- a/src/os/ui/layer/vectorlayerui.js
+++ b/src/os/ui/layer/vectorlayerui.js
@@ -863,7 +863,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.onShowLabelsChange = function(event, val
  * @protected
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getColor = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
+  var items = this.getLayerNodes();
 
   if (items) {
     for (var i = 0, n = items.length; i < n; i++) {
@@ -890,7 +890,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getColor = function() {
  * @protected
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getFillColor = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
+  var items = this.getLayerNodes();
 
   if (items) {
     for (var i = 0, n = items.length; i < n; i++) {
@@ -919,7 +919,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getFillColor = function() {
  * @protected
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getFillOpacity = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
+  var items = this.getLayerNodes();
   var opacity = os.style.DEFAULT_FILL_ALPHA;
 
   if (items) {
@@ -952,7 +952,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getFillOpacity = function() {
  * @return {number} The size
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getSize = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
+  var items = this.getLayerNodes();
   var size;
 
   if (items) {
@@ -979,7 +979,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getSize = function() {
  * @return {Array<number>|undefined} The line
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getLineDash = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
+  var items = this.getLayerNodes();
   var lineDash;
 
   if (items) {
@@ -1006,7 +1006,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getLineDash = function() {
  * @return {?osx.icon.Icon} The icon
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getIcon = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
+  var items = this.getLayerNodes();
   var icon = null;
 
   if (items && items.length > 0) {
@@ -1027,7 +1027,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getIcon = function() {
  * @return {?osx.icon.Icon} The icon.
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getCenterIcon = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
+  var items = this.getLayerNodes();
   var icon = null;
 
   if (items && items.length > 0) {
@@ -1048,7 +1048,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getCenterIcon = function() {
  * @return {string} The shape
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getShape = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
+  var items = this.getLayerNodes();
   var shape;
 
   if (items && items.length > 0) {
@@ -1068,7 +1068,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getShape = function() {
  * @return {Array<string>} The available shape options
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getShapes = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
+  var items = this.getLayerNodes();
   var shapes = goog.object.getKeys(os.style.SHAPES);
 
   if (items && items.length > 0) {
@@ -1090,7 +1090,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getShapes = function() {
  * @return {string} The shape
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getCenterShape = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
+  var items = this.getLayerNodes();
   var shape;
 
   if (items && items.length > 0) {
@@ -1113,7 +1113,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getCenterShape = function() {
  * @return {Array<string>} The available shape options
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getCenterShapes = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
+  var items = this.getLayerNodes();
   var shapes = goog.object.getKeys(os.style.SHAPES);
 
   if (items && items.length > 0) {
@@ -1353,7 +1353,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.onUniqueIdChange = function() {
  * @return {string}
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getRotationColumn = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
+  var items = this.getLayerNodes();
   if (items && items.length > 0) {
     var config = os.style.StyleManager.getInstance().getLayerConfig(items[0].getId());
     if (config) {
@@ -1371,7 +1371,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getRotationColumn = function() {
  * @return {boolean}
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getShowRotation = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
+  var items = this.getLayerNodes();
   if (items && items.length > 0) {
     var config = os.style.StyleManager.getInstance().getLayerConfig(items[0].getId());
     if (config) {

--- a/src/os/ui/layer/vectorlayerui.js
+++ b/src/os/ui/layer/vectorlayerui.js
@@ -1448,6 +1448,8 @@ os.ui.layer.VectorLayerUICtrl.prototype.onMapView3DChange_ = function(event) {
  */
 os.ui.layer.VectorLayerUICtrl.prototype.disposeInternal = function() {
   os.map.mapContainer.unlisten(goog.events.EventType.PROPERTYCHANGE, this.onMapView3DChange_, false, this);
+  goog.dispose(this.labelSizeChangeDelay);
+
   os.ui.layer.VectorLayerUICtrl.base(this, 'disposeInternal');
 };
 

--- a/src/os/ui/layer/vectorlayerui.js
+++ b/src/os/ui/layer/vectorlayerui.js
@@ -863,7 +863,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.onShowLabelsChange = function(event, val
  * @protected
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getColor = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
 
   if (items) {
     for (var i = 0, n = items.length; i < n; i++) {
@@ -890,7 +890,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getColor = function() {
  * @protected
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getFillColor = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
 
   if (items) {
     for (var i = 0, n = items.length; i < n; i++) {
@@ -919,7 +919,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getFillColor = function() {
  * @protected
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getFillOpacity = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
   var opacity = os.style.DEFAULT_FILL_ALPHA;
 
   if (items) {
@@ -952,7 +952,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getFillOpacity = function() {
  * @return {number} The size
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getSize = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
   var size;
 
   if (items) {
@@ -979,7 +979,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getSize = function() {
  * @return {Array<number>|undefined} The line
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getLineDash = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
   var lineDash;
 
   if (items) {
@@ -1006,7 +1006,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getLineDash = function() {
  * @return {?osx.icon.Icon} The icon
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getIcon = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
   var icon = null;
 
   if (items && items.length > 0) {
@@ -1027,7 +1027,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getIcon = function() {
  * @return {?osx.icon.Icon} The icon.
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getCenterIcon = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
   var icon = null;
 
   if (items && items.length > 0) {
@@ -1048,7 +1048,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getCenterIcon = function() {
  * @return {string} The shape
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getShape = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
   var shape;
 
   if (items && items.length > 0) {
@@ -1068,7 +1068,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getShape = function() {
  * @return {Array<string>} The available shape options
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getShapes = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
   var shapes = goog.object.getKeys(os.style.SHAPES);
 
   if (items && items.length > 0) {
@@ -1090,7 +1090,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getShapes = function() {
  * @return {string} The shape
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getCenterShape = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
   var shape;
 
   if (items && items.length > 0) {
@@ -1113,7 +1113,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getCenterShape = function() {
  * @return {Array<string>} The available shape options
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getCenterShapes = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
   var shapes = goog.object.getKeys(os.style.SHAPES);
 
   if (items && items.length > 0) {
@@ -1353,7 +1353,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.onUniqueIdChange = function() {
  * @return {string}
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getRotationColumn = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
   if (items && items.length > 0) {
     var config = os.style.StyleManager.getInstance().getLayerConfig(items[0].getId());
     if (config) {
@@ -1371,7 +1371,7 @@ os.ui.layer.VectorLayerUICtrl.prototype.getRotationColumn = function() {
  * @return {boolean}
  */
 os.ui.layer.VectorLayerUICtrl.prototype.getShowRotation = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+  var items = /** @type {Array<!os.data.LayerNode>} */ (this.getLayerNodes());
   if (items && items.length > 0) {
     var config = os.style.StyleManager.getInstance().getLayerConfig(items[0].getId());
     if (config) {

--- a/src/os/ui/layers.js
+++ b/src/os/ui/layers.js
@@ -155,7 +155,8 @@ os.ui.LayersCtrl.VIEWS = {
   'Source': new os.data.groupby.LayerProviderGroupBy(),
   'Tag': new os.ui.data.groupby.TagGroupBy(true),
   'Type': new os.data.groupby.LayerTypeGroupBy(),
-  'Z-Order': new os.data.groupby.LayerZOrderGroupBy()
+  'Z-Order': new os.data.groupby.LayerZOrderGroupBy(),
+  'Folder': -1
 };
 
 

--- a/src/os/ui/layers.js
+++ b/src/os/ui/layers.js
@@ -156,7 +156,7 @@ os.ui.LayersCtrl.VIEWS = {
   'Tag': new os.ui.data.groupby.TagGroupBy(true),
   'Type': new os.data.groupby.LayerTypeGroupBy(),
   'Z-Order': new os.data.groupby.LayerZOrderGroupBy(),
-  'Folder': -1
+  'Folder': null
 };
 
 

--- a/src/os/ui/layers.js
+++ b/src/os/ui/layers.js
@@ -99,7 +99,7 @@ os.ui.LayersCtrl = function($scope, $element) {
   }
 
   this.scope['views'] = os.ui.LayersCtrl.VIEWS;
-  this.viewDefault = 'Z-Order';
+  this.viewDefault = /** @type {string} */ (os.settings.get('layers.viewDefault', 'Z-Order'));
 
   /**
    * @type {?os.data.LayerTreeSearch}

--- a/src/os/ui/layers.js
+++ b/src/os/ui/layers.js
@@ -16,6 +16,7 @@ goog.require('os.data.groupby.LayerZOrderGroupBy');
 goog.require('os.defines');
 goog.require('os.events.LayerEventType');
 goog.require('os.layer.FolderManager');
+goog.require('os.layer.folder');
 goog.require('os.metrics.Metrics');
 goog.require('os.metrics.keys');
 goog.require('os.object');
@@ -135,6 +136,8 @@ os.ui.LayersCtrl = function($scope, $element) {
   this.scope['featuresBtnIcon'] = os.ROOT + 'images/features-base.png';
 
   this.init();
+
+  os.layer.folder.setFolderMenuEnabled(!this.scope['view']);
 };
 goog.inherits(os.ui.LayersCtrl, os.ui.slick.AbstractGroupByTreeSearchCtrl);
 
@@ -151,12 +154,12 @@ os.ui.LayersCtrl.SKIP_TOGGLE_FUNCS = [];
  * @type {!Object<string, os.data.groupby.INodeGroupBy>}
  */
 os.ui.LayersCtrl.VIEWS = {
+  'Folder': null,
   'Recently Updated': new os.data.groupby.DateGroupBy(true),
   'Source': new os.data.groupby.LayerProviderGroupBy(),
   'Tag': new os.ui.data.groupby.TagGroupBy(true),
   'Type': new os.data.groupby.LayerTypeGroupBy(),
-  'Z-Order': new os.data.groupby.LayerZOrderGroupBy(),
-  'Folder': null
+  'Z-Order': new os.data.groupby.LayerZOrderGroupBy()
 };
 
 
@@ -196,6 +199,7 @@ os.ui.LayersCtrl.prototype.close = function() {
  */
 os.ui.LayersCtrl.prototype.onGroupByChanged = function() {
   os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.AddData.GROUP_BY, 1);
+  os.layer.folder.setFolderMenuEnabled(!this.scope['view']);
   this.search();
 };
 

--- a/src/os/ui/layers.js
+++ b/src/os/ui/layers.js
@@ -15,6 +15,7 @@ goog.require('os.data.groupby.LayerTypeGroupBy');
 goog.require('os.data.groupby.LayerZOrderGroupBy');
 goog.require('os.defines');
 goog.require('os.events.LayerEventType');
+goog.require('os.layer.FolderManager');
 goog.require('os.metrics.Metrics');
 goog.require('os.metrics.keys');
 goog.require('os.object');
@@ -119,6 +120,10 @@ os.ui.LayersCtrl = function($scope, $element) {
   map.listen(os.events.LayerEventType.REMOVE, this.search, false, this);
   map.listen(os.events.LayerEventType.CHANGE, this.search, false, this);
 
+  var fm = os.layer.FolderManager.getInstance();
+  fm.listen(os.layer.folder.FolderEventType.FOLDER_CREATED, this.search, false, this);
+  fm.listen(os.layer.folder.FolderEventType.FOLDER_REMOVED, this.search, false, this);
+
   // refresh on changed favorites
   os.settings.listen(os.user.settings.FavoriteManager.KEY, this.search, false, this);
 
@@ -160,6 +165,10 @@ os.ui.LayersCtrl.prototype.disposeInternal = function() {
   map.unlisten(os.events.LayerEventType.ADD, this.search, false, this);
   map.unlisten(os.events.LayerEventType.REMOVE, this.search, false, this);
   map.unlisten(os.events.LayerEventType.CHANGE, this.search, false, this);
+
+  var fm = os.layer.FolderManager.getInstance();
+  fm.unlisten(os.layer.folder.FolderEventType.FOLDER_CREATED, this.search, false, this);
+  fm.unlisten(os.layer.folder.FolderEventType.FOLDER_REMOVED, this.search, false, this);
 
   os.settings.unlisten(os.user.settings.FavoriteManager.KEY, this.search, false, this);
 

--- a/src/os/ui/layers.js
+++ b/src/os/ui/layers.js
@@ -123,6 +123,8 @@ os.ui.LayersCtrl = function($scope, $element) {
   var fm = os.layer.FolderManager.getInstance();
   fm.listen(os.layer.folder.FolderEventType.FOLDER_CREATED, this.search, false, this);
   fm.listen(os.layer.folder.FolderEventType.FOLDER_REMOVED, this.search, false, this);
+  fm.listen(os.layer.folder.FolderEventType.FOLDER_UPDATED, this.search, false, this);
+  fm.listen(os.layer.folder.FolderEventType.FOLDERS_CLEARED, this.search, false, this);
 
   // refresh on changed favorites
   os.settings.listen(os.user.settings.FavoriteManager.KEY, this.search, false, this);
@@ -169,6 +171,8 @@ os.ui.LayersCtrl.prototype.disposeInternal = function() {
   var fm = os.layer.FolderManager.getInstance();
   fm.unlisten(os.layer.folder.FolderEventType.FOLDER_CREATED, this.search, false, this);
   fm.unlisten(os.layer.folder.FolderEventType.FOLDER_REMOVED, this.search, false, this);
+  fm.unlisten(os.layer.folder.FolderEventType.FOLDER_UPDATED, this.search, false, this);
+  fm.unlisten(os.layer.folder.FolderEventType.FOLDERS_CLEARED, this.search, false, this);
 
   os.settings.unlisten(os.user.settings.FavoriteManager.KEY, this.search, false, this);
 

--- a/src/os/ui/layertree.js
+++ b/src/os/ui/layertree.js
@@ -248,8 +248,13 @@ os.ui.LayerTreeCtrl.prototype.doMove = function(rows, insertBefore) {
                 // use !after since the tree is sorted by descending z-index
                 z.move(moveIds[j], targetIds[k], !after);
               } else {
+                // This covers the case of dropping a layer into the space above a folder. This case is nasty
+                // because the target ID is the folder in both cases, so we need to know if we're making it a child
+                // to that folder or a sibling to that folder
+                const sibling = this.moveMode != os.ui.slick.SlickTreeNode.MOVE_MODE.REPARENT;
+
                 // update the folder manager
-                fm.move(moveIds[j], targetIds[k], after);
+                fm.move(moveIds[j], targetIds[k], after, sibling);
                 fm.persist();
               }
             }

--- a/src/os/ui/layertree.js
+++ b/src/os/ui/layertree.js
@@ -160,7 +160,7 @@ os.ui.LayerTreeCtrl.prototype.canDragMove = function(rows, insertBefore) {
         // layers cannot be dragged to a different Z-Order group
         var z = os.data.ZOrder.getInstance();
         var differentZ = z.getZType(item.getId()) !== z.getZType(beforeItem.getId());
-        if (differentZ && item instanceof os.data.LayerNode && beforeItem instanceof os.data.LayerNode) {
+        if (differentZ) {
           return false;
         }
       } else {
@@ -222,7 +222,10 @@ os.ui.LayerTreeCtrl.prototype.doMove = function(rows, insertBefore) {
         targetIds = [layer.getId()];
       } else if (targetNode instanceof os.data.FolderNode) {
         targetIds = [targetNode.getId()];
-      } else if (layer instanceof os.layer.LayerGroup) {
+      }
+
+      if (layer instanceof os.layer.LayerGroup) {
+        // use all of the IDs in the group for the target IDs
         targetIds = /** @type {os.layer.LayerGroup} */ (layer).getLayers().map(os.layer.mapLayersToIds);
       }
 
@@ -230,14 +233,16 @@ os.ui.LayerTreeCtrl.prototype.doMove = function(rows, insertBefore) {
         var moveNode = /** @type {(os.data.LayerNode|os.data.FolderNode)} */ (this.grid.getDataItem(rows[i]));
 
         if (moveNode) {
+          layer = moveNode instanceof os.data.LayerNode ? moveNode.getLayer() : null;
           var moveIds = [];
 
           if (moveNode instanceof os.data.LayerNode) {
-            layer = moveNode.getLayer();
             moveIds = [layer.getId()];
           } else if (moveNode instanceof os.data.FolderNode) {
             moveIds = [moveNode.getId()];
-          } else if (layer instanceof os.layer.LayerGroup) {
+          }
+
+          if (layer instanceof os.layer.LayerGroup) {
             // move all the layer group's children in the z-order
             moveIds = /** @type {os.layer.LayerGroup} */ (layer).getLayers().map(os.layer.mapLayersToIds);
           }

--- a/src/os/ui/node/foldernodeui.js
+++ b/src/os/ui/node/foldernodeui.js
@@ -56,7 +56,7 @@ class Controller extends AbstractNodeUICtrl {
     var node = /** @type {os.data.FolderNode} */ (this.scope['item']);
     if (node) {
       FolderManager.getInstance().createOrEditFolder(
-          /** @type {!osx.layer.FolderOptions} */ ({id: goog.string.getRandomString()}), node.getId());
+          /** @type {!osx.layer.FolderOptions} */ ({id: goog.string.getRandomString(), parentId: node.getId()}));
     }
   }
 
@@ -67,7 +67,6 @@ class Controller extends AbstractNodeUICtrl {
   tryRemove() {
     var node = /** @type {FolderNode} */ (this.scope['item']);
     if (node) {
-      // FolderManager.getInstance().tryRemove(node.getId());
       if (node.hasChildren()) {
         var label = node.getLabel();
         var prompt = 'Are you sure you want to remove the folder? This will remove all its descendants.';
@@ -102,10 +101,7 @@ class Controller extends AbstractNodeUICtrl {
   edit() {
     var node = /** @type {FolderNode} */ (this.scope['item']);
     if (node) {
-      const options = {
-        id: node.getId(),
-        name: node.getLabel() || 'New Folder'
-      };
+      const options = node.getOptions();
       FolderManager.getInstance().createOrEditFolder(options);
     }
   }

--- a/src/os/ui/node/foldernodeui.js
+++ b/src/os/ui/node/foldernodeui.js
@@ -2,9 +2,9 @@ goog.module('os.ui.node.FolderNodeUI');
 goog.module.declareLegacyNamespace();
 
 const AbstractNodeUICtrl = goog.require('os.ui.slick.AbstractNodeUICtrl');
-const ConfirmUI = goog.require('os.ui.window.ConfirmUI');
 const FolderManager = goog.require('os.layer.FolderManager');
 const Module = goog.require('os.ui.Module');
+const {launchRemoveFolder} = goog.require('os.layer.folder');
 
 const FolderNode = goog.requireType('os.data.FolderNode');
 
@@ -20,7 +20,7 @@ const directive = () => ({
   template: `<span ng-if="nodeUi.show()" class="d-flex flex-shrink-0">
       <span ng-click="nodeUi.addFolder()"><i class="fa fa-folder fa-fw c-glyph" title="Create a new folder"></i></span>
       <span ng-click="nodeUi.edit()"><i class="fa fa-pencil fa-fw c-glyph" title="Edit the folder"></i></span>
-      <span ng-click="nodeUi.tryRemove()"><i class="fa fa-times fa-fw c-glyph" title="Remove the folder"></i></span>
+      <span ng-click="nodeUi.tryRemove()"><i class="fa fa-times fa-fw c-glyph" title="Unfolder"></i></span>
       </span>`.trim(),
   controller: Controller,
   controllerAs: 'nodeUi'
@@ -73,17 +73,7 @@ class Controller extends AbstractNodeUICtrl {
     var node = /** @type {FolderNode} */ (this.scope['item']);
     if (node) {
       if (node.hasChildren()) {
-        var label = node.getLabel();
-        var prompt = 'Are you sure you want to remove the folder? This will remove all its descendants.';
-
-        ConfirmUI.launchConfirm(/** @type {!osx.window.ConfirmOptions} */ ({
-          confirm: this.removeNodeInternal.bind(this, node),
-          prompt: prompt,
-          windowOptions: /** @type {!osx.window.WindowOptions} */ ({
-            icon: 'fa fa-trash-o',
-            label: 'Remove ' + label
-          })
-        }));
+        launchRemoveFolder(node.getOptions(), this.removeNodeInternal.bind(this, node));
       } else {
         this.removeNodeInternal(node);
       }

--- a/src/os/ui/node/foldernodeui.js
+++ b/src/os/ui/node/foldernodeui.js
@@ -4,7 +4,7 @@ goog.module.declareLegacyNamespace();
 const AbstractNodeUICtrl = goog.require('os.ui.slick.AbstractNodeUICtrl');
 const FolderManager = goog.require('os.layer.FolderManager');
 const Module = goog.require('os.ui.Module');
-const {launchRemoveFolder} = goog.require('os.layer.folder');
+const {launchRemoveFolder, createOrEditFolder} = goog.require('os.layer.folder');
 
 const FolderNode = goog.requireType('os.data.FolderNode');
 
@@ -55,15 +55,26 @@ class Controller extends AbstractNodeUICtrl {
   addFolder() {
     var node = /** @type {os.data.FolderNode} */ (this.scope['item']);
     if (node) {
-      const folder = {
+      const options = {
         name: 'New Folder',
         type: 'folder',
         id: goog.string.getRandomString(),
         parentId: node.getId(),
         children: []
       };
-      FolderManager.getInstance().createOrEditFolder(folder);
+
+      createOrEditFolder(options, this.onCreateFolder.bind(this, options));
     }
+  }
+
+  /**
+   * Handles creating a new folder.
+   * @param {!osx.layer.FolderOptions} options The folder options.
+   * @param {string} name The chosen folder name.
+   */
+  onCreateFolder(options, name) {
+    options.name = name;
+    FolderManager.getInstance().createFolder(options);
   }
 
   /**
@@ -98,8 +109,20 @@ class Controller extends AbstractNodeUICtrl {
     var node = /** @type {FolderNode} */ (this.scope['item']);
     if (node) {
       const options = node.getOptions();
-      FolderManager.getInstance().createOrEditFolder(options);
+      createOrEditFolder(options, this.onEditFolder.bind(this, options), true);
     }
+  }
+
+  /**
+   * Handles editing a folder.
+   * @param {osx.layer.FolderOptions} options The folder options.
+   * @param {string} name The chosen folder name.
+   */
+  onEditFolder(options, name) {
+    const fm = FolderManager.getInstance();
+    fm.removeFolder(options.id);
+    options.name = name;
+    fm.createFolder(options);
   }
 }
 

--- a/src/os/ui/node/foldernodeui.js
+++ b/src/os/ui/node/foldernodeui.js
@@ -55,8 +55,13 @@ class Controller extends AbstractNodeUICtrl {
   addFolder() {
     var node = /** @type {os.data.FolderNode} */ (this.scope['item']);
     if (node) {
-      FolderManager.getInstance().createOrEditFolder(
-          /** @type {!osx.layer.FolderOptions} */ ({id: goog.string.getRandomString(), parentId: node.getId()}));
+      const folder = {
+        name: 'New Folder',
+        id: goog.string.getRandomString(),
+        parentId: node.getId(),
+        children: []
+      };
+      FolderManager.getInstance().createOrEditFolder(folder);
     }
   }
 

--- a/src/os/ui/node/foldernodeui.js
+++ b/src/os/ui/node/foldernodeui.js
@@ -57,6 +57,7 @@ class Controller extends AbstractNodeUICtrl {
     if (node) {
       const folder = {
         name: 'New Folder',
+        type: 'folder',
         id: goog.string.getRandomString(),
         parentId: node.getId(),
         children: []

--- a/src/os/ui/node/foldernodeui.js
+++ b/src/os/ui/node/foldernodeui.js
@@ -1,0 +1,118 @@
+goog.module('os.ui.node.FolderNodeUI');
+goog.module.declareLegacyNamespace();
+
+const AbstractNodeUICtrl = goog.require('os.ui.slick.AbstractNodeUICtrl');
+const ConfirmUI = goog.require('os.ui.window.ConfirmUI');
+const FolderManager = goog.require('os.layer.FolderManager');
+const Module = goog.require('os.ui.Module');
+
+const FolderNode = goog.requireType('os.data.FolderNode');
+
+
+/**
+ * The foldernodeui directive.
+ *
+ * @return {angular.Directive}
+ */
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  template: `<span ng-if="nodeUi.show()" class="d-flex flex-shrink-0">
+      <span ng-click="nodeUi.addFolder()"><i class="fa fa-folder fa-fw c-glyph" title="Create a new folder"></i></span>
+      <span ng-click="nodeUi.edit()"><i class="fa fa-pencil fa-fw c-glyph" title="Edit the folder"></i></span>
+      <span ng-click="nodeUi.tryRemove()"><i class="fa fa-times fa-fw c-glyph" title="Remove the folder"></i></span>
+      </span>`.trim(),
+  controller: Controller,
+  controllerAs: 'nodeUi'
+});
+
+
+/**
+ * Add the directive to the Angular module
+ */
+Module.directive('foldernodeui', [directive]);
+
+
+/**
+ * Controller for the folder node UI.
+ * @unrestricted
+ */
+class Controller extends AbstractNodeUICtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    super($scope, $element);
+  }
+
+  /**
+   * Add a new folder.
+   * @export
+   */
+  addFolder() {
+    var node = /** @type {os.data.FolderNode} */ (this.scope['item']);
+    if (node) {
+      FolderManager.getInstance().createOrEditFolder(
+          /** @type {!osx.layer.FolderOptions} */ ({id: goog.string.getRandomString()}), node.getId());
+    }
+  }
+
+  /**
+   * Prompt the user to remove the node from the tree.
+   * @export
+   */
+  tryRemove() {
+    var node = /** @type {FolderNode} */ (this.scope['item']);
+    if (node) {
+      // FolderManager.getInstance().tryRemove(node.getId());
+      if (node.hasChildren()) {
+        var label = node.getLabel();
+        var prompt = 'Are you sure you want to remove the folder? This will remove all its descendants.';
+
+        ConfirmUI.launchConfirm(/** @type {!osx.window.ConfirmOptions} */ ({
+          confirm: this.removeNodeInternal.bind(this, node),
+          prompt: prompt,
+          windowOptions: /** @type {!osx.window.WindowOptions} */ ({
+            icon: 'fa fa-trash-o',
+            label: 'Remove ' + label
+          })
+        }));
+      } else {
+        this.removeNodeInternal(node);
+      }
+    }
+  }
+
+  /**
+   * Removes the node from the tree.
+   * @param {!FolderNode} node The node
+   * @protected
+   */
+  removeNodeInternal(node) {
+    FolderManager.getInstance().removeFolder(node.getId());
+  }
+
+  /**
+   * Edits the folder title.
+   * @export
+   */
+  edit() {
+    var node = /** @type {FolderNode} */ (this.scope['item']);
+    if (node) {
+      const options = {
+        id: node.getId(),
+        name: node.getLabel() || 'New Folder'
+      };
+      FolderManager.getInstance().createOrEditFolder(options);
+    }
+  }
+}
+
+
+exports = {
+  Controller,
+  directive
+};

--- a/src/os/ui/slick/abstractgroupbytreesearch.js
+++ b/src/os/ui/slick/abstractgroupbytreesearch.js
@@ -79,7 +79,7 @@ os.ui.slick.AbstractGroupByTreeSearch.prototype.searchNodes = function(exp, resu
     }
   }
 
-  this.finalizeSearch(groupBy, results);
+  // this.finalizeSearch(groupBy, results);
 };
 
 

--- a/src/os/ui/slick/abstractgroupbytreesearch.js
+++ b/src/os/ui/slick/abstractgroupbytreesearch.js
@@ -78,8 +78,6 @@ os.ui.slick.AbstractGroupByTreeSearch.prototype.searchNodes = function(exp, resu
       }
     }
   }
-
-  // this.finalizeSearch(groupBy, results);
 };
 
 

--- a/test/os/data/foldernode.test.js
+++ b/test/os/data/foldernode.test.js
@@ -1,0 +1,53 @@
+goog.require('os.data.FolderNode');
+goog.require('os.ui.slick.SlickTreeNode');
+
+
+describe('os.data.FolderNode', () => {
+  const FolderNode = goog.module.get('os.data.FolderNode');
+  const SlickTreeNode = goog.module.get('os.ui.slick.SlickTreeNode');
+  const folder = {
+    id: 'folder0',
+    name: 'My Folder',
+    parentId: 'Feature Layers',
+    children: ['layer0', 'layer1'],
+    collapsed: true
+  };
+
+  it('should instantiate correctly from folder options', () => {
+    const folderNode = new FolderNode(folder);
+    expect(folderNode.getOptions()).toBe(folder);
+    expect(folderNode.getId()).toBe(folder.id);
+    expect(folderNode.getLabel()).toBe(folder.name);
+    expect(folderNode.collapsed).toBe(true);
+  });
+
+  it('should update from new folder options', () => {
+    const folderNode = new FolderNode(folder);
+    const newFolder = {
+      id: 'newFolderId',
+      name: 'Another Folder',
+      parentId: 'Feature Layers',
+      children: ['otherChild'],
+      collapsed: false
+    };
+    folderNode.setOptions(newFolder);
+
+    expect(folderNode.getOptions()).toBe(newFolder);
+    expect(folderNode.getId()).toBe(newFolder.id);
+    expect(folderNode.getLabel()).toBe(newFolder.name);
+    expect(folderNode.collapsed).toBe(false);
+  });
+
+  it('should format icons properly', () => {
+    const folderNode = new FolderNode(folder);
+    folderNode.collapsed = false;
+    let iconStr = folderNode.formatIcons();
+
+    expect(iconStr).toBe(`<i class="fa fa-folder fa-fw"></i>`);
+
+    folderNode.addChild(new SlickTreeNode());
+    iconStr = folderNode.formatIcons();
+
+    expect(iconStr).toBe(`<i class="fa fa-folder-open fa-fw"></i>`);
+  });
+});

--- a/test/os/data/zorder.test.js
+++ b/test/os/data/zorder.test.js
@@ -101,6 +101,22 @@ describe('os.data.ZOrder', function() {
     expect(z.groups_['Feature Layers'][1].id).toBe('vectorLayer1');
   });
 
+  it('should get the z-order type for a layer ID', () => {
+    let type = z.getZType('tileLayer3');
+    expect(type).toBe('Tile Layers');
+
+    type = z.getZType('vectorLayer2');
+    expect(type).toBe('Feature Layers');
+  });
+
+  it('should get the z-order index for a layer ID', () => {
+    let index = z.getIndex('tileLayer3');
+    expect(index).toBe(0);
+
+    index = z.getIndex('vectorLayer1');
+    expect(index).toBe(1);
+  });
+
   it('should update the map from the z-order data', function() {
     var groups = z.getMap().getLayers().getArray();
     groups.forEach(function(group) {

--- a/test/os/layer/folder.test.js
+++ b/test/os/layer/folder.test.js
@@ -1,0 +1,41 @@
+goog.require('os.MapContainer');
+goog.require('os.data.ZOrder');
+goog.require('os.layer.FolderManager');
+goog.require('os.layer.folder');
+goog.require('os.mock');
+goog.require('os.ui.window');
+
+
+describe('os.layer.FolderManager', () => {
+  const FolderManager = goog.module.get('os.layer.FolderManager');
+  const {createOrEditFolder} = goog.module.get('os.layer.folder');
+
+  let folder;
+
+  beforeEach(() => {
+    // clean up the global instance before each
+    FolderManager.getInstance().clear();
+
+    folder = {
+      id: 'folder0',
+      type: 'folder',
+      name: 'My Folder',
+      parentId: 'Feature Layers',
+      children: [],
+      collapsed: true
+    };
+  });
+
+  it('should launch the create window UI', () => {
+    let calledOptions;
+    const mockLaunch = (options) => {
+      calledOptions = options;
+    };
+    spyOn(os.ui.window, 'launchConfirmText').andCallFake(mockLaunch);
+
+    createOrEditFolder(folder);
+
+    expect(calledOptions.defaultValue).toBe('New Folder');
+    expect(calledOptions.windowOptions.label).toBe('Add Folder');
+  });
+});

--- a/test/os/layer/foldermanager.test.js
+++ b/test/os/layer/foldermanager.test.js
@@ -6,7 +6,6 @@ goog.require('os.layer.config.MockTileLayerConfig');
 goog.require('os.layer.config.MockVectorLayerConfig');
 goog.require('os.layer.folder');
 goog.require('os.mock');
-goog.require('os.ui.window');
 
 
 describe('os.layer.FolderManager', () => {
@@ -368,20 +367,6 @@ describe('os.layer.FolderManager', () => {
     expect(folder0.children[0].id).toBe('layer0');
     expect(folder0.children[1].id).toBe('moveLayer4');
     expect(folder0.children[2].id).toBe('childFolder');
-  });
-
-  it('should launch the create window UI', () => {
-    let calledOptions;
-    const mockLaunch = (options) => {
-      calledOptions = options;
-    };
-    spyOn(os.ui.window, 'launchConfirmText').andCallFake(mockLaunch);
-
-    const fm = FolderManager.getInstance();
-    fm.createOrEditFolder(folder);
-
-    expect(calledOptions.defaultValue).toBe('New Folder');
-    expect(calledOptions.windowOptions.label).toBe('Add Folder');
   });
 
   it('should fire change events', () => {

--- a/test/os/layer/foldermanager.test.js
+++ b/test/os/layer/foldermanager.test.js
@@ -1,6 +1,9 @@
 goog.require('os.MapContainer');
 goog.require('os.data.ZOrder');
 goog.require('os.layer.FolderManager');
+goog.require('os.layer.config.LayerConfigManager');
+goog.require('os.layer.config.MockTileLayerConfig');
+goog.require('os.layer.config.MockVectorLayerConfig');
 goog.require('os.layer.folder');
 goog.require('os.mock');
 goog.require('os.ui.window');
@@ -11,6 +14,9 @@ describe('os.layer.FolderManager', () => {
   const Settings = goog.module.get('os.config.Settings');
   const {FolderEventType, SettingsKey} = goog.module.get('os.layer.folder');
   const MapContainer = goog.module.get('os.MapContainer');
+  const LayerConfigManager = goog.module.get('os.layer.config.LayerConfigManager');
+  const MockTileLayerConfig = goog.module.get('os.layer.config.MockTileLayerConfig');
+  const MockVectorLayerConfig = goog.module.get('os.layer.config.MockVectorLayerConfig');
 
   let folder;
   let childFolder;
@@ -45,15 +51,6 @@ describe('os.layer.FolderManager', () => {
     };
 
     // reset the test folder objects
-    folder = {
-      id: 'folder0',
-      type: 'folder',
-      name: 'My Folder',
-      parentId: 'Feature Layers',
-      children: [childFolder, layer0, layer1],
-      collapsed: true
-    };
-
     childFolder = {
       id: 'childFolder',
       type: 'folder',
@@ -62,6 +59,42 @@ describe('os.layer.FolderManager', () => {
       children: [childLayer0],
       collapsed: false
     };
+
+    folder = {
+      id: 'folder0',
+      type: 'folder',
+      name: 'My Folder',
+      parentId: 'Feature Layers',
+      children: [childFolder, layer0, layer1],
+      collapsed: true
+    };
+  });
+
+  it('merge layer items from the map', () => {
+    const fm = FolderManager.getInstance();
+    expect(fm.items.length).toBe(0);
+
+    const map = MapContainer.getInstance();
+    const lcm = LayerConfigManager.getInstance();
+    const tlc = lcm.getLayerConfig(MockTileLayerConfig.TYPE);
+    map.addLayer(tlc.createLayer({id: 'tileLayer1'}));
+    map.addLayer(tlc.createLayer({id: 'tileLayer2'}));
+    map.addLayer(tlc.createLayer({id: 'tileLayer3'}));
+
+    const vlc = lcm.getLayerConfig(MockVectorLayerConfig.TYPE);
+    map.addLayer(vlc.createLayer({id: 'vectorLayer1'}));
+    map.addLayer(vlc.createLayer({id: 'vectorLayer2'}));
+
+    fm.mergeFromMap();
+
+    // we should have a drawing layer and the rest of the layers in the order they are added to the map
+    expect(fm.items.length).toBe(6);
+    expect(fm.items[0].id).toBe('draw');
+    expect(fm.items[1].id).toBe('tileLayer1');
+    expect(fm.items[2].id).toBe('tileLayer2');
+    expect(fm.items[3].id).toBe('tileLayer3');
+    expect(fm.items[4].id).toBe('vectorLayer1');
+    expect(fm.items[5].id).toBe('vectorLayer2');
   });
 
   it('should restore from settings on instantiation', () => {
@@ -132,6 +165,7 @@ describe('os.layer.FolderManager', () => {
 
   it('should create and add child folders to other folders', () => {
     const fm = FolderManager.getInstance();
+    folder.children = [layer0, layer1];
     fm.createFolder(folder);
     fm.createFolder(childFolder);
 
@@ -190,10 +224,150 @@ describe('os.layer.FolderManager', () => {
   it('should get folders that are children to other folders by ID', () => {
     const fm = FolderManager.getInstance();
     fm.createFolder(folder);
-    fm.createFolder(childFolder);
 
     const result = fm.getItem('childFolder');
     expect(result).toEqual(childFolder);
+  });
+
+  it('should get parents to items', () => {
+    const fm = FolderManager.getInstance();
+    fm.createFolder(folder);
+
+    let parent = fm.getParent('layer0');
+    expect(parent).toEqual(folder);
+
+    parent = fm.getParent('folder0');
+    expect(parent).toBe(fm.getItems());
+  });
+
+  it('should move items around at the root level', () => {
+    const fm = FolderManager.getInstance();
+    fm.createFolder(folder);
+
+    // insert some layers to move around
+    for (let i = 0; i < 5; i++) {
+      fm.items.push({
+        id: 'moveLayer' + i,
+        type: 'layer',
+        parentId: ''
+      });
+    }
+
+    expect(fm.items[0].id).toBe('folder0');
+    expect(fm.items[1].id).toBe('draw');
+    expect(fm.items[2].id).toBe('moveLayer0');
+    expect(fm.items[3].id).toBe('moveLayer1');
+    expect(fm.items[4].id).toBe('moveLayer2');
+    expect(fm.items[5].id).toBe('moveLayer3');
+    expect(fm.items[6].id).toBe('moveLayer4');
+
+    // test moving a layer before another layer
+    fm.move('moveLayer0', 'moveLayer3');
+
+    expect(fm.items[0].id).toBe('folder0');
+    expect(fm.items[1].id).toBe('draw');
+    expect(fm.items[2].id).toBe('moveLayer1');
+    expect(fm.items[3].id).toBe('moveLayer2');
+    expect(fm.items[4].id).toBe('moveLayer0');
+    expect(fm.items[5].id).toBe('moveLayer3');
+    expect(fm.items[6].id).toBe('moveLayer4');
+
+    // test moving a folder
+    fm.move('folder0', 'moveLayer4');
+
+    expect(fm.items[0].id).toBe('draw');
+    expect(fm.items[1].id).toBe('moveLayer1');
+    expect(fm.items[2].id).toBe('moveLayer2');
+    expect(fm.items[3].id).toBe('moveLayer0');
+    expect(fm.items[4].id).toBe('moveLayer3');
+    expect(fm.items[5].id).toBe('folder0');
+    expect(fm.items[6].id).toBe('moveLayer4');
+
+    // move draw after 2
+    fm.move('draw', 'moveLayer2', true);
+
+    expect(fm.items[0].id).toBe('moveLayer1');
+    expect(fm.items[1].id).toBe('moveLayer2');
+    expect(fm.items[2].id).toBe('draw');
+    expect(fm.items[3].id).toBe('moveLayer0');
+    expect(fm.items[4].id).toBe('moveLayer3');
+    expect(fm.items[5].id).toBe('folder0');
+    expect(fm.items[6].id).toBe('moveLayer4');
+
+    // move 1 after the folder, this requires the fourth argument to be true to not reparent the layer
+    fm.move('moveLayer1', 'folder0', true, true);
+
+    expect(fm.items[0].id).toBe('moveLayer2');
+    expect(fm.items[1].id).toBe('draw');
+    expect(fm.items[2].id).toBe('moveLayer0');
+    expect(fm.items[3].id).toBe('moveLayer3');
+    expect(fm.items[4].id).toBe('folder0');
+    expect(fm.items[5].id).toBe('moveLayer1');
+    expect(fm.items[6].id).toBe('moveLayer4');
+  });
+
+  it('should move items around within folders and reparent them', () => {
+    const fm = FolderManager.getInstance();
+    fm.createFolder(folder);
+
+    // insert some layers to move around
+    for (let i = 0; i < 5; i++) {
+      fm.items.push({
+        id: 'moveLayer' + i,
+        type: 'layer',
+        parentId: ''
+      });
+    }
+
+    const folder0 = fm.items[0];
+    expect(folder0.id).toBe('folder0');
+    expect(folder0.children[0].id).toBe('childFolder');
+    expect(folder0.children[1].id).toBe('layer0');
+    expect(folder0.children[2].id).toBe('layer1');
+
+    // move layers within a folder
+    fm.move('layer1', 'layer0');
+
+    expect(folder0.children[0].id).toBe('childFolder');
+    expect(folder0.children[1].id).toBe('layer1');
+    expect(folder0.children[2].id).toBe('layer0');
+
+    // move a folder within a folder after a target layer
+    fm.move('childFolder', 'layer0', true);
+
+    expect(folder0.children[0].id).toBe('layer1');
+    expect(folder0.children[1].id).toBe('layer0');
+    expect(folder0.children[2].id).toBe('childFolder');
+
+    // move a layer into a child folder
+    fm.move('layer1', 'childFolder');
+
+    expect(folder0.children[0].id).toBe('layer0');
+    expect(folder0.children[1].id).toBe('childFolder');
+    let childFolder = folder0.children[1];
+    expect(childFolder.children[0].id).toBe('layer1');
+    expect(childFolder.children[1].id).toBe('childLayer0');
+
+    // move a layer from a child folder back to the root
+    fm.move('layer1', 'moveLayer2');
+
+    expect(fm.items[0].id).toBe('folder0');
+    expect(fm.items[1].id).toBe('draw');
+    expect(fm.items[2].id).toBe('moveLayer0');
+    expect(fm.items[3].id).toBe('moveLayer1');
+    expect(fm.items[4].id).toBe('layer1');
+    expect(fm.items[5].id).toBe('moveLayer2');
+    expect(fm.items[6].id).toBe('moveLayer3');
+    expect(fm.items[7].id).toBe('moveLayer4');
+    childFolder = folder0.children[1];
+    expect(childFolder.children[0].id).toBe('childLayer0');
+
+    // reparent a layer to a new folder, targeting a folder, but adding it as a sibling
+    fm.move('moveLayer4', 'childFolder', false, true);
+
+    expect(folder0.children[0].id).toBe('layer0');
+    expect(folder0.children[1].id).toBe('moveLayer4');
+    expect(folder0.children[2].id).toBe('childFolder');
   });
 
   it('should launch the create window UI', () => {

--- a/test/os/layer/foldermanager.test.js
+++ b/test/os/layer/foldermanager.test.js
@@ -1,0 +1,208 @@
+goog.require('os.data.ZOrder');
+goog.require('os.layer.FolderManager');
+goog.require('os.layer.folder');
+goog.require('os.mock');
+goog.require('os.ui.window');
+
+
+describe('os.layer.FolderManager', () => {
+  const FolderManager = goog.module.get('os.layer.FolderManager');
+  const Settings = goog.module.get('os.config.Settings');
+  const {FolderEventType, SettingsKey} = goog.module.get('os.layer.folder');
+  const ZOrder = goog.module.get('os.data.ZOrder');
+  let folder;
+  let childFolder;
+
+  beforeEach(() => {
+    // clean up the global instance before each
+    FolderManager.getInstance().clear();
+
+    // reset the test folder objects
+    folder = {
+      id: 'folder0',
+      name: 'My Folder',
+      parentId: 'Feature Layers',
+      children: ['layer0', 'layer1'],
+      collapsed: true
+    };
+
+    childFolder = {
+      id: 'childFolder',
+      name: 'My Folder',
+      parentId: 'folder0',
+      children: ['childLayer0'],
+      collapsed: false
+    };
+  });
+
+  it('should restore from settings on instantiation', () => {
+    const mockFolders = [
+      {
+        id: 'folder0',
+        name: 'My Folder',
+        parentId: 'Feature Layers',
+        children: ['layer0', 'layer1'],
+        collapsed: true
+      }
+    ];
+    Settings.getInstance().set(SettingsKey.FOLDERS, mockFolders);
+
+    // create a fresh instance and check that it has the right folders
+    const instance = new FolderManager();
+    const folders = instance.getFolders();
+
+    expect(folders.length).toBe(1);
+    expect(folders[0].id).toBe('folder0');
+    expect(folders[0].name).toBe('My Folder');
+    expect(folders[0].parentId).toBe('Feature Layers');
+    expect(folders[0].children.length).toBe(2);
+    expect(folders[0].children[0]).toBe('layer0');
+    expect(folders[0].children[1]).toBe('layer1');
+    expect(folders[0].collapsed).toBe(true);
+  });
+
+  it('should create and add folders', () => {
+    const fm = FolderManager.getInstance();
+    fm.createFolder(folder);
+
+    const folders = fm.getFolders();
+    expect(folders.length).toBe(1);
+    expect(folders[0]).toEqual(folder);
+  });
+
+  it('should create and add child folders to other folders', () => {
+    const fm = FolderManager.getInstance();
+    fm.createFolder(folder);
+    fm.createFolder(childFolder);
+
+    const folders = fm.getFolders();
+    expect(folders.length).toBe(1);
+    expect(folders[0]).toEqual(folder);
+
+    const managedChildFolder = folders[0].children.find((c) => c.id === 'childFolder');
+    expect(managedChildFolder).toEqual(childFolder);
+  });
+
+  it('should remove folders', () => {
+    const fm = FolderManager.getInstance();
+    fm.createFolder(folder);
+    fm.removeFolder('folder0');
+
+    expect(fm.getFolders().length).toBe(0);
+  });
+
+  it('should remove folders that are children of other folders', () => {
+    const fm = FolderManager.getInstance();
+    fm.createFolder(folder);
+    fm.createFolder(childFolder);
+    fm.removeFolder('childFolder');
+
+    const folders = fm.getFolders();
+    expect(folders.length).toBe(1);
+    expect(folders[0]).toEqual(folder);
+    expect(folders[0].children.includes(childFolder)).toBe(false);
+  });
+
+  it('should get folders by ID', () => {
+    const fm = FolderManager.getInstance();
+    fm.createFolder(folder);
+
+    const result = fm.getFolder('folder0');
+    expect(result).toEqual(folder);
+  });
+
+  it('should get folders that are children to other folders by ID', () => {
+    const fm = FolderManager.getInstance();
+    fm.createFolder(folder);
+    fm.createFolder(childFolder);
+
+    const result = fm.getFolder('childFolder');
+    expect(result).toEqual(childFolder);
+  });
+
+  it('should launch the create window UI', () => {
+    let calledOptions;
+    const mockLaunch = (options) => {
+      calledOptions = options;
+    };
+    spyOn(os.ui.window, 'launchConfirmText').andCallFake(mockLaunch);
+
+    const fm = FolderManager.getInstance();
+    fm.createOrEditFolder(folder);
+
+    expect(calledOptions.defaultValue).toBe('New Folder');
+    expect(calledOptions.windowOptions.label).toBe('Add Folder');
+  });
+
+  it('should sort from z-order', () => {
+    const fm = FolderManager.getInstance();
+    const zMap = {
+      'layer0': 1,
+      'layer1': 2,
+      'layer2': 3,
+      'layer3': 4,
+      'layer4': 5,
+      'layer5': 6,
+      'layer6': 7,
+      'layer7': 8
+    };
+    spyOn(ZOrder.getInstance(), 'getIndex').andCallFake((id) => {
+      return zMap[id];
+    });
+
+    // setup a folder with a child to apply the z-order sort to
+    const zChildFolder = {
+      id: 'zChildFolder',
+      name: 'Z Child Folder Test',
+      parentId: 'zFolder',
+      children: ['layer3', 'layer4', 'layer2', 'layer6'],
+      collapsed: true
+    };
+    const zFolder = {
+      id: 'zFolder',
+      name: 'Z Folder Test',
+      parentId: 'Feature Layers',
+      children: [zChildFolder, 'layer1', 'layer0', 'layer5', 'layer7'],
+      collapsed: true
+    };
+
+    // add the root folder and check the sort
+    fm.createFolder(zFolder);
+
+    // the ZOrder class sorts descending, so the number order will be reversed
+    const sortedFolder = fm.getFolder('zFolder');
+    expect(sortedFolder.children[0]).toBe(zChildFolder);
+    expect(sortedFolder.children[1]).toBe('layer7');
+    expect(sortedFolder.children[2]).toBe('layer5');
+    expect(sortedFolder.children[3]).toBe('layer1');
+    expect(sortedFolder.children[4]).toBe('layer0');
+
+    const sortedChildFolder = fm.getFolder('zChildFolder');
+    expect(sortedChildFolder.children[0]).toBe('layer6');
+    expect(sortedChildFolder.children[1]).toBe('layer4');
+    expect(sortedChildFolder.children[2]).toBe('layer3');
+    expect(sortedChildFolder.children[3]).toBe('layer2');
+  });
+
+  it('should fire change events', () => {
+    let received = false;
+    const fm = FolderManager.getInstance();
+    const listener = (event) => {
+      received = true;
+    };
+
+    fm.listenOnce(FolderEventType.FOLDER_CREATED, listener);
+    fm.createFolder(folder);
+    expect(received).toBe(true);
+    received = false;
+
+    fm.listenOnce(FolderEventType.FOLDER_REMOVED, listener);
+    fm.removeFolder('folder0');
+    expect(received).toBe(true);
+    received = false;
+
+    fm.listenOnce(FolderEventType.FOLDERS_CLEARED, listener);
+    fm.clear();
+    expect(received).toBe(true);
+  });
+});

--- a/views/layers.html
+++ b/views/layers.html
@@ -41,7 +41,7 @@
   </div>
 
   <div class="d-flex flex-row flex-fill mt-1">
-    <layertree class="border" x-data="layerTree" drag-enabled="true" selected="selected" context-menu="contextMenu" checkbox-tooltip="Enable or disable the layer" multi-select="true" disposable="true" show-root="true" group-by="view"></layertree>
+    <layertree class="border" x-data="layerTree" drag-enabled="true" selected="selected" context-menu="contextMenu" checkbox-tooltip="Enable or disable the layer" multi-select="true" disposable="true" no-root="true" group-by="view"></layertree>
   </div>
 
   <uiswitch items="selected" directive-function="layers.getUi" generic="defaultlayerui"></uiswitch>

--- a/views/layers.html
+++ b/views/layers.html
@@ -41,7 +41,7 @@
   </div>
 
   <div class="d-flex flex-row flex-fill mt-1">
-    <layertree class="border" x-data="layerTree" drag-enabled="true" selected="selected" context-menu="contextMenu" checkbox-tooltip="Enable or disable the layer" multi-select="true" disposable="true"></layertree>
+    <layertree class="border" x-data="layerTree" drag-enabled="true" selected="selected" context-menu="contextMenu" checkbox-tooltip="Enable or disable the layer" multi-select="true" disposable="true" show-root="true" group-by="view"></layertree>
   </div>
 
   <uiswitch items="selected" directive-function="layers.getUi" generic="defaultlayerui"></uiswitch>


### PR DESCRIPTION
This PR adds the ability for the user to create their own persistent folders to the layers window. The folder management itself is made to be as decoupled from the layers/z-order management as possible so as to cause no impacts to the way that the layers window works currently if the user doesn't want to create their own folders. It is not currently toggleable as a feature, but it should be totally possible to disable it if it is not desired and for everything to behave exactly like it used to.

- Root level folders are parented to particular groupings in the current group by and only transfer between group bys in the case that there are identical parents available.
- Child folders have standard tree behavior.
- Layers respect z-ordering for their sorting and can be dragged and dropped internally.
- Folders should persist and restore on refresh. 