### PR TITLE
fix(im): handle CSV import from Places tab

### DIFF
--- a/src/plugin/file/csv/csvplugin.js
+++ b/src/plugin/file/csv/csvplugin.js
@@ -67,6 +67,9 @@ plugin.file.csv.CSVPlugin.prototype.init = function() {
   im.registerImportDetails('CSV', true);
   im.registerImportUI(os.file.mime.csv.TYPE, new plugin.file.csv.ui.CSVImportUI());
   im.registerParser(this.id, plugin.file.csv.CSVParser);
+  os.placesImportManager.registerImportDetails('CSV', true);
+  os.placesImportManager.registerImportUI(os.file.mime.csv.TYPE, new plugin.file.csv.ui.CSVImportUI());
+  os.placesImportManager.registerParser(this.id, plugin.file.csv.CSVParser);
 
   // register the csv exporter
   os.ui.exportManager.registerExportMethod(new plugin.file.csv.CSVExporter());

--- a/src/plugin/file/geojson/geojsonplugin.js
+++ b/src/plugin/file/geojson/geojsonplugin.js
@@ -70,6 +70,10 @@ plugin.file.geojson.GeoJSONPlugin.prototype.init = function() {
   im.registerImportUI(plugin.file.geojson.mime.TYPE, new plugin.file.geojson.GeoJSONImportUI());
   im.registerParser(this.id, plugin.file.geojson.GeoJSONSimpleStyleParser);
   im.registerParser(this.id + '-simplespec', plugin.file.geojson.GeoJSONSimpleStyleParser);
+  os.placesImportManager.registerImportDetails('GeoJSON', true);
+  os.placesImportManager.registerImportUI(plugin.file.geojson.mime.TYPE, new plugin.file.geojson.GeoJSONImportUI());
+  os.placesImportManager.registerParser(this.id, plugin.file.geojson.GeoJSONSimpleStyleParser);
+  os.placesImportManager.registerParser(this.id + '-simplespec', plugin.file.geojson.GeoJSONSimpleStyleParser);
 
   // register the geojson exporter
   os.ui.exportManager.registerExportMethod(new plugin.file.geojson.GeoJSONExporter());

--- a/src/plugin/file/kml/kmlplugin.js
+++ b/src/plugin/file/kml/kmlplugin.js
@@ -79,6 +79,9 @@ plugin.file.kml.KMLPlugin.prototype.init = function() {
   im.registerImportUI(plugin.file.kml.mime.KMZ_TYPE, new plugin.file.kml.ui.KMLImportUI());
   im.registerParser(this.id, plugin.file.kml.KMLParser);
   im.registerParser('kmlfeature', plugin.file.kml.KMLFeatureParser);
+  os.placesImportManager.registerImportDetails('KML/KMZ', true);
+  os.placesImportManager.registerParser(this.id, plugin.file.kml.KMLParser);
+  os.placesImportManager.registerParser('kmlfeature', plugin.file.kml.KMLFeatureParser);
 
   // register the kml exporter
   os.ui.exportManager.registerExportMethod(new plugin.file.kml.KMLExporter());

--- a/src/plugin/file/shp/shpplugin.js
+++ b/src/plugin/file/shp/shpplugin.js
@@ -69,6 +69,10 @@ plugin.file.shp.SHPPlugin.prototype.init = function() {
   im.registerImportUI(plugin.file.shp.mime.TYPE, new plugin.file.shp.ui.SHPImportUI());
   im.registerImportUI(plugin.file.shp.mime.ZIP_TYPE, new plugin.file.shp.ui.ZipSHPImportUI());
   im.registerParser(this.id, plugin.file.shp.SHPParser);
+  os.placesImportManager.registerImportDetails('Shapefile (SHP/DBF or ZIP)', true);
+  os.placesImportManager.registerImportUI(plugin.file.shp.mime.TYPE, new plugin.file.shp.ui.SHPImportUI());
+  os.placesImportManager.registerImportUI(plugin.file.shp.mime.ZIP_TYPE, new plugin.file.shp.ui.ZipSHPImportUI());
+  os.placesImportManager.registerParser(this.id, plugin.file.shp.SHPParser);
 
   // register the shp exporter
   os.ui.exportManager.registerExportMethod(new plugin.file.shp.SHPExporter());


### PR DESCRIPTION
Resolves #740 - ensures that CSV, SHP and GeoJSON are all handled by the import dialog off Places.

However I'm not sure this is the right behaviour either. Importing things on Places works, but they may not show up on Places (and don't look like placemarks or KML tracks).

If this is the desired behaviour, then it might be possible to remove the multiple import managers, and just use the global instance.