### PR TITLE
fix(tabs): include flyouts in the tab styling special case

### DIFF
--- a/scss/os/_utils.scss
+++ b/scss/os/_utils.scss
@@ -493,7 +493,7 @@ $u-parent-resizer-count: 0;
 }
 
 .u-bg-flyout {
-  background-color: rgba($modal-content-bg, .95);
+  background-color: $modal-content-bg;
 }
 
 // For when you want a border for spacing but transparent

--- a/scss/overrides_slate/_bootswatch.scss
+++ b/scss/overrides_slate/_bootswatch.scss
@@ -95,8 +95,9 @@ $web-font-path: 'https://fonts.googleapis.com/css?family=Open+Sans:400,700' !def
   }
 }
 
-// Nav tabs within a modal (or window)
-.modal-content {
+// Nav tabs within a modal/window/search flyout
+.modal-content,
+.u-bg-flyout {
   .nav-tabs {
     .nav-link {
       background: $nav-tabs-link-active-bg;


### PR DESCRIPTION
Cleans up tab styling in flyout to match windows. Removes the .95 opacity from the flyout background as well as it doesn't seem to serve much purpose, and can look a little weird in some cases.