### PR TITLE
fix(draw): hit detect drawing features flagged as interactive

### DIFF
--- a/src/os/interaction/interaction.js
+++ b/src/os/interaction/interaction.js
@@ -36,8 +36,9 @@ os.interaction.ROTATE_DELTA = Math.PI / 60;
  */
 os.interaction.getFeatureResult = function(feature, layer) {
   if (feature instanceof ol.Feature) {
-    // do not hit detect "preview" features
-    if (feature.get(os.data.RecordField.DRAWING_LAYER_NODE) === false) {
+    // do not hit detect "preview" features unless they are flagged as interactive
+    if (feature.get(os.data.RecordField.DRAWING_LAYER_NODE) === false &&
+        !feature.get(os.data.RecordField.INTERACTIVE)) {
       return undefined;
     }
 


### PR DESCRIPTION
Features that are omitted from the drawing layer tree are typically preview features for operations like geometry modification, buffering, etc. We avoid hit detecting these features because they're considered temporary. However the `DRAWING_LAYER_NODE` flag is more broadly useful for features added by non-vector layers, which may use the drawing layer to render these features. Such features are typically also given the `INTERACTIVE` flag, which enables hit detecting them in the hover interaction. This flag should also enable hit detection in interactions like the context menu, so options relevant to the hit feature can be displayed.