### PR TITLE
fix(style): enlarges close tab style, css cleanup for positioning

### DIFF
--- a/scss/os/_closetab.scss
+++ b/scss/os/_closetab.scss
@@ -1,5 +1,5 @@
 $close-tab-padding-x: .25rem !default;
-$close-tab-font-size: .5rem !default;
+$close-tab-font-size: 1rem !default;
 
 //
 // A tab for closing flyout panels.
@@ -28,7 +28,7 @@ $close-tab-font-size: .5rem !default;
 .c-close-tab-left {
   @include close-tab();
   border-radius: $border-radius-sm 0 0 $border-radius-sm;
-  left: -($close-tab-padding-x * 2 + $close-tab-font-size);
+  left: -($close-tab-padding-x + $close-tab-font-size);
 
   // Equivalent to "fa fa-chevron-right"
   &::before {


### PR DESCRIPTION
We've had some commentary that the close flyout tab button was a little too small. This ups the size to make it a bit more prominent and easier to see.