### PR TITLE
fix(window): add checks to avoid errors if window is disposed

### DIFF
--- a/src/os/ui/config/abstractsettings.js
+++ b/src/os/ui/config/abstractsettings.js
@@ -120,11 +120,13 @@ os.ui.config.AbstractSettingsCtrl.prototype.reset = function() {
 os.ui.config.AbstractSettingsCtrl.prototype.refresh_ = function() {
   this.scope['settingsNodes'] = this.settingsManager.getChildren();
 
-  this.timeout_(goog.bind(function() {
-    this.scope['selected'] = this.settingsManager.getSelected();
-    if (!this.scope['selected']) {
-      // nothing selected - select the first setting
-      this.scope['selected'] = this.settingsManager.initSelection();
+  this.timeout_(function() {
+    if (this.scope && this.settingsManager) {
+      this.scope['selected'] = this.settingsManager.getSelected();
+      if (!this.scope['selected']) {
+        // nothing selected - select the first setting
+        this.scope['selected'] = this.settingsManager.initSelection();
+      }
     }
-  }, this));
+  }.bind(this));
 };

--- a/src/os/ui/windowui.js
+++ b/src/os/ui/windowui.js
@@ -264,15 +264,17 @@ os.ui.WindowCtrl = function($scope, $element, $timeout) {
 
   // Stack this new window on top of others
   $timeout(function() {
-    // notify anyone listening that this window opened
-    var eventScope = this.element.scope() || this.scope;
-    eventScope.$emit(os.ui.WindowEventType.OPEN, this.element);
+    if (this.element && this.scope) {
+      // notify anyone listening that this window opened
+      var eventScope = this.element.scope() || this.scope;
+      eventScope.$emit(os.ui.WindowEventType.OPEN, this.element);
 
-    this.bringToFront();
+      this.bringToFront();
 
-    if (this.element && !this.resizeFn_) {
-      this.resizeFn_ = this.onWindowResize_.bind(this);
-      os.ui.resize(this.element, this.resizeFn_);
+      if (!this.resizeFn_) {
+        this.resizeFn_ = this.onWindowResize_.bind(this);
+        os.ui.resize(this.element, this.resizeFn_);
+      }
     }
   }.bind(this));
 };


### PR DESCRIPTION
If the Settings window is quickly opened/closed, these timeout callbacks will fail due to the window being disposed and referenced properties being null.

I looked at replacing the window timeout with `$onInit`, but that does get called earlier than a timeout and may impact existing handlers of the `OPEN` event.