### PR TITLE
fix(window): update modal window zindex when clicked

### DIFF
--- a/src/os/ui/windowui.js
+++ b/src/os/ui/windowui.js
@@ -638,9 +638,7 @@ os.ui.WindowCtrl.prototype.onToggleModal_ = function(opt_new, opt_old) {
  * @private
  */
 os.ui.WindowCtrl.prototype.updateZIndex_ = function() {
-  if (!this.scope['modal']) {
-    this.bringToFront();
-  }
+  this.bringToFront();
 
   if (!this.scope['active']) {
     this.scope['active'] = true;


### PR DESCRIPTION
If multiple modal windows are open, they currently do not update their z-index when clicked. This prevents bringing the clicked modal to the front of others on screen, which is not the desired behavior.

This happens because modal windows are ignored in `updateZIndex_` for window stacking. `os.ui.window.stack` correctly handles stacking modal windows against one another, so we do not need to ignore them.

I noticed this while testing #1199, which has a modal Add Server dialog that can open another modal with server URL formatting help. The same behavior can also be observed by importing a CSV and opening the Format Help dialog in the Geometry/Time steps.