### PR TITLE
fix(window): add button role to indicate the element is interactive

### DIFF
--- a/views/window/dockedwindow.html
+++ b/views/window/dockedwindow.html
@@ -1,47 +1,47 @@
 <div class="docked-window d-flex">
-    <div class="modal-content d-flex flex-column flex-fill" ng-class="{'bg-transparent': overlay, 'border-0': !border}">
-      <div class="c-docked-window__buttons">
-        <span class="text-truncate flex-fill" title="{{label}}">
-          <i ng-if="icon" ng-class="icon" class="mr-1"></i>
-          <span ng-if="iconHtml" ng-bind-html="iconHtml"></span>
-          {{label}}
-        </span>
+  <div class="modal-content d-flex flex-column flex-fill" ng-class="{'bg-transparent': overlay, 'border-0': !border}">
+    <div class="c-docked-window__buttons">
+      <span class="text-truncate flex-fill" title="{{label}}">
+        <i ng-if="icon" ng-class="icon" class="mr-1"></i>
+        <span ng-if="iconHtml" ng-bind-html="iconHtml"></span>
+        {{label}}
+      </span>
 
-        <span ng-if="helpContext" class="d-inline-flex">
-          <context-onboarding context="{{helpContext}}"></context-onboarding>
-        </span>
+      <span ng-if="helpContext" class="d-inline-flex">
+        <context-onboarding context="{{helpContext}}"></context-onboarding>
+      </span>
 
-        <span ng-repeat="headerBtnCfg in headerBtns | reverse"
-            ng-click="windowCtrl.onHeaderBtnClick($event, headerBtnCfg);"
-            title="{{headerBtnCfg.tooltip}}">
-          <i class="{{'c-glyph ' + headerBtnCfg.iconClass}}"></i>
-        </span>
+      <span ng-repeat="headerBtnCfg in headerBtns | reverse"
+          ng-click="windowCtrl.onHeaderBtnClick($event, headerBtnCfg);"
+          title="{{headerBtnCfg.tooltip}}">
+        <i class="{{'c-glyph ' + headerBtnCfg.iconClass}}"></i>
+      </span>
 
-        <span ng-if="showCollapse" 
-            ng-click="windowCtrl.toggle()" 
-            title="{{collapsed ? 'Expand' : 'Collapse'}}" 
-            class="d-inline-flex">
-          <i class="fa c-glyph window-close" ng-class="{'fa-compress': !collapsed, 'fa-expand': collapsed}"></i>
-        </span>
+      <span ng-if="showCollapse"
+          ng-click="windowCtrl.toggle()"
+          title="{{collapsed ? 'Expand' : 'Collapse'}}"
+          class="d-inline-flex">
+        <i class="fa c-glyph window-close" ng-class="{'fa-compress': !collapsed, 'fa-expand': collapsed}"></i>
+      </span>
 
-        <span ng-if="showClose" 
-            ng-click="windowCtrl.close(true)" 
-            class="close flex-shrink-0" 
-            aria-label="Close">
-          <span class="c-glyph" aria-hidden="true">&times;</span>
-        </span>
+      <button ng-if="showClose"
+          class="btn border-0 p-0 close flex-shrink-0"
+          type="button"
+          ng-click="windowCtrl.close(true)"
+          aria-label="Close">
+        <span class="c-glyph" aria-hidden="true">&times;</span>
+      </button>
 
-        <span ng-if="showHide" 
-            type="button" 
-            class="close flex-shrink-0" 
-            ng-click="windowCtrl.hide()" 
-            aria-label="Hide">
-          <span class="c-glyph" aria-hidden="true">&times;</span>
-        </span>
-      </div>
-      <div class="c-docked-window__content w-100 flex-fill d-flex flex-column">
-        <div class="js-window__wrapper d-flex flex-column flex-fill" ng-transclude></div>
-      </div>
+      <button ng-if="showHide"
+          class="btn border-0 p-0 close flex-shrink-0"
+          type="button"
+          ng-click="windowCtrl.hide()"
+          aria-label="Hide">
+        <span class="c-glyph" aria-hidden="true">&times;</span>
+      </button>
+    </div>
+    <div class="c-docked-window__content w-100 flex-fill d-flex flex-column">
+      <div class="js-window__wrapper d-flex flex-column flex-fill" ng-transclude></div>
     </div>
   </div>
-  
+</div>


### PR DESCRIPTION
`html-validate` added a new rule in their latest release, [aria-label-misuse](https://html-validate.org/rules/aria-label-misuse.html), that does not allow the `aria-label` attribute in non-interactive elements. To resolve this, the elements were changed to `button` instead of `span`.

Using `<span role="button">` would also indicate the elements are interactive and resolve the error, but would create two new warnings because `button` is preferred by the `prefer-native-element` rule.