### PR TITLE
fix(kmlnodelayer): features with multiple geoms show fill appropriately

### DIFF
--- a/src/plugin/file/kml/kmlnodelayerui.js
+++ b/src/plugin/file/kml/kmlnodelayerui.js
@@ -1092,9 +1092,13 @@ plugin.file.kml.KMLNodeLayerUICtrl.prototype.isFeatureFillable = function() {
   var features = this.getFeatures();
   var feature = features.length > 0 ? features[0] : null;
   if (feature) {
-    var geometry = feature.getGeometry();
+    const hasPolyGeom = [];
 
-    return os.geo.isGeometryPolygonal(geometry);
+    os.feature.forEachGeometry(feature, (geom) => {
+      hasPolyGeom.push(os.geo.isGeometryPolygonal(geom, true));
+    });
+
+    return hasPolyGeom.some((bool) => bool);
   }
 
   return false;


### PR DESCRIPTION
Features with multiple geometries (such as an ellipse that consists of a center point and a ring) will now show fill as an option in the layers menu, and will no longer auto-fill when the color is changed. 