### PR TITLE
feat(formulas): disable input when no cell is selected

### DIFF
--- a/src/plugin/file/kml/kmlnodelayerui.js
+++ b/src/plugin/file/kml/kmlnodelayerui.js
@@ -1092,9 +1092,13 @@ plugin.file.kml.KMLNodeLayerUICtrl.prototype.isFeatureFillable = function() {
   var features = this.getFeatures();
   var feature = features.length > 0 ? features[0] : null;
   if (feature) {
-    var geometry = feature.getGeometry();
+    let hasPolyGeom = false;
 
-    return os.geo.isGeometryPolygonal(geometry);
+    os.feature.forEachGeometry(feature, (geom) => {
+      hasPolyGeom = os.geo.isGeometryPolygonal(geom, true) || hasPolyGeom;
+    });
+
+    return hasPolyGeom;
   }
 
   return false;


### PR DESCRIPTION
Features with multiple geometries (such as an ellipse that consists of a center point and a ring) will now show fill as an option in the layers menu, and will no longer auto-fill when the color is changed.