### PR TITLE
feat(cesium): upgrade cesium to 1.79.1

### DIFF
--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -473,7 +473,8 @@ Cesium.NearFarScalar = function(near, nearValue, far, farValue) {};
  * @typedef {{
  *   blendOption: (Cesium.BlendOption|undefined),
  *   debugShowBoundingVolume: (boolean|undefined),
- *   scene: (Cesium.Scene|undefined)
+ *   scene: (Cesium.Scene|undefined),
+ *   show: (boolean|undefined)
  * }}
  */
 Cesium.BillboardCollectionOptions;
@@ -538,6 +539,12 @@ Cesium.BillboardCollection.prototype.length;
  * @param {Cesium.Billboard} what .
  */
 Cesium.BillboardCollection.prototype.remove = function(what) {};
+
+
+/**
+ * @type {boolean} .
+ */
+Cesium.BillboardCollection.prototype.show;
 
 
 /**
@@ -1733,6 +1740,12 @@ Cesium.PolylineCollection.prototype.remove = function(polyline) {};
 Cesium.PolylineCollection.prototype.removeAll = function() {};
 
 
+/**
+ * @type {boolean}
+ */
+Cesium.PolylineCollection.prototype.show;
+
+
 
 /**
  * @constructor
@@ -2203,6 +2216,12 @@ Cesium.LabelCollection.prototype.removeAll = function() {};
  * @type {Cesium.Matrix4}
  */
 Cesium.LabelCollection.prototype.modelMatrix;
+
+
+/**
+ * @type {boolean}
+ */
+Cesium.LabelCollection.prototype.show;
 
 
 
@@ -2814,6 +2833,12 @@ Cesium.PrimitiveCollection.prototype.destroyPrimitives;
  * @type {number}
  */
 Cesium.PrimitiveCollection.prototype.length;
+
+
+/**
+ * @type {boolean}
+ */
+Cesium.PrimitiveCollection.prototype.show;
 
 
 

--- a/package.json
+++ b/package.json
@@ -305,7 +305,7 @@
     "blob-polyfill": "^2.0.20171115",
     "bootstrap": "4.5.0",
     "bootswatch": "4.5.0",
-    "cesium": "1.67",
+    "cesium": "1.79.1",
     "chardetng-wasm": "^1.0.1",
     "compass-mixins": "^0.12.10",
     "core-js-bundle": "3.6.4",

--- a/src/plugin/cesium/primitive.js
+++ b/src/plugin/cesium/primitive.js
@@ -231,11 +231,9 @@ export const isPrimitiveShown = function(primitive) {
     return primitive.length > 0 ? isPrimitiveShown(primitive[0]) : true;
   } else if (primitive.show != null) {
     return primitive.show;
-  } else if (primitive.length != null) {
-    return primitive.length > 0 ? isPrimitiveShown(primitive.get(0)) : true;
   }
 
-  return !!primitive.show;
+  return false;
 };
 
 /**
@@ -250,10 +248,6 @@ export const setPrimitiveShown = function(primitive, show) {
       }
     } else if (primitive.show != null) {
       primitive.show = show;
-    } else if (primitive.length) {
-      for (let i = 0, n = primitive.length; i < n; i++) {
-        setPrimitiveShown(primitive.get(i), show);
-      }
     }
   }
 };

--- a/test/plugin/cesium/primitive.test.js
+++ b/test/plugin/cesium/primitive.test.js
@@ -352,7 +352,7 @@ describe('plugin.cesium.primitive', () => {
       });
     });
 
-    it('should get the shown value of the first item for collections', () => {
+    it('should get the shown value of collections', () => {
       const billboardCollection = new Cesium.BillboardCollection();
       const polylineCollection = new Cesium.PolylineCollection();
 
@@ -366,6 +366,9 @@ describe('plugin.cesium.primitive', () => {
 
       const collections = [billboardCollection, polylineCollection];
       collections.forEach((collection) => {
+        expect(isPrimitiveShown(collection)).toBe(true);
+
+        collection.show = false;
         expect(isPrimitiveShown(collection)).toBe(false);
       });
     });
@@ -397,7 +400,7 @@ describe('plugin.cesium.primitive', () => {
       expect(isPrimitiveShown(genericPrimitives)).toBe(true);
     });
 
-    it('should set the shown value of all items in collections', () => {
+    it('should set the shown value of collections', () => {
       const billboardCollection = new Cesium.BillboardCollection();
       const billboard1 = primitiveUtils.createBillboard([0, 0, 0]);
       const billboard2 = primitiveUtils.createBillboard([1, 1, 1]);
@@ -413,10 +416,13 @@ describe('plugin.cesium.primitive', () => {
       const collections = [billboardCollection, polylineCollection];
       collections.forEach((collection) => {
         setPrimitiveShown(collection, false);
+        expect(isPrimitiveShown(collection)).toBe(false);
         for (let i = 0, n = collection.length; i < n; i++) {
-          expect(isPrimitiveShown(collection.get(i))).toBe(false);
+          expect(isPrimitiveShown(collection.get(i))).toBe(true);
         }
+
         setPrimitiveShown(collection, true);
+        expect(isPrimitiveShown(collection)).toBe(true);
         for (let i = 0, n = collection.length; i < n; i++) {
           expect(isPrimitiveShown(collection.get(i))).toBe(true);
         }


### PR DESCRIPTION
I upgraded Cesium to start looking into using their [GlobeTranslucency API](https://cesium.com/docs/cesiumjs-ref-doc/GlobeTranslucency.html) to display subsurface/bathymetric data. That will require further investigation, but I did want to pick up bug fixes/performance improvements from their last year of releases.

There were no breaking changes that impacted OpenSphere, but I updated our primitive visibility management to use the new `show` flag on collections. OpenSphere now supports toggling visibility at the collection level, instead of individually toggling primitives within the collection.

Full change log here:
https://github.com/CesiumGS/cesium/blob/master/CHANGES.md