### PR TITLE
Iterate on nav bar collapse behavior

### DIFF
--- a/scss/os/_datepanel.scss
+++ b/scss/os/_datepanel.scss
@@ -3,15 +3,19 @@
     max-width: (6 * $font-size-base) + $input-padding-x;
   }
 
+  .c-date-panel__container {
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 2.5rem;
+    z-index: $u-zindex-base + 1;
+  }
+
   .c-date-panel__extended {
     background: lighten($body-bg, 5%) !important;
     border: 1px solid $border-color;
     border-top: 0;
     color: $body-color;
-    left: 0;
-    min-width: 35rem;
-    position: absolute;
-    right: 0;
-    z-index: $u-zindex-base + 1;
+    max-width: 35rem;
   }
 }

--- a/scss/os/_overrides_bootstrap_variables.scss
+++ b/scss/os/_overrides_bootstrap_variables.scss
@@ -9,7 +9,7 @@ $grid-breakpoints: (
   xs: 0,
   sm: 576px,
   md: 768px,
-  lg: 992px,
-  xl: 1200px,
+  lg: 1170px,
+  xl: 1270px,
   xxl: 1500px
-);
+) !default;

--- a/scss/os/_searchresults.scss
+++ b/scss/os/_searchresults.scss
@@ -6,14 +6,9 @@
   z-index: $u-zindex-base + 1;
 }
 
+// Prevent search results from taking up too much screen space in smaller windows.
 @media (max-width: map-get($grid-breakpoints, lg)) {
   .c-searchresults  {
-    max-width: 75% !important;
-  }
-}
-
-@media (max-width: map-get($grid-breakpoints, md)) {
-  .c-searchresults  {
-    max-width: 95% !important;
+    max-width: 50%;
   }
 }

--- a/src/os/ui/list.js
+++ b/src/os/ui/list.js
@@ -333,7 +333,7 @@ os.ui.ListCtrl.prototype.update_ = function() {
   var prefix = this.prefix || '';
   var suffix = this.suffix || '';
 
-  if (items) {
+  if (this.scope && items) {
     for (var i = 0, n = items.length; i < n; i++) {
       var item = items[i];
 
@@ -344,17 +344,20 @@ os.ui.ListCtrl.prototype.update_ = function() {
         }
 
         var html = prefix + dir + suffix;
+        var elScope = this.scope.$new();
+        item.element = this.compile_(html)(elScope);
+        item.scope = elScope;
 
-        if (this.scope) {
-          var elScope = this.scope.$new();
-          item.element = this.compile_(html)(elScope);
-          item.scope = elScope;
+        // Assumption: existing items will not change in priority. If they do, they must be removed and added again.
+        if (i === 0) {
+          // Insert as the first child.
+          this.element_.prepend(item.element);
+        } else {
+          // Insert after the previous item's element. This takes the extra precaution to insert after the last element,
+          // in case the previous markup produced multiple elements.
+          const previous = items[i - 1].element;
+          item.element.insertAfter(previous[previous.length - 1]);
         }
-      }
-
-      if (item.element) {
-        // Appending an element that already exists in the DOM will update the element's position
-        this.element_.append(item.element);
       }
     }
 

--- a/src/os/ui/nav/navbaroptions.js
+++ b/src/os/ui/nav/navbaroptions.js
@@ -70,13 +70,13 @@ os.ui.navbaroptions.init = function() {
 
   // Bottom navbar options
   os.ui.list.add(os.ui.nav.Location.BOTTOM_LEFT,
-      '<li id="zoom-level" class="nav-item mr-1 my-auto flex-shrink-0"></li>', 100);
+      '<div id="zoom-level" class="nav-item mr-1 my-auto flex-shrink-0"></li>', 100);
   os.ui.list.add(os.ui.nav.Location.BOTTOM_LEFT, '<scale-line></scale-line>', 200);
   os.ui.list.add(os.ui.nav.Location.BOTTOM_LEFT,
-      '<li id="mouse-position" class="nav-item mr-1 my-auto flex-shrink-0"></li>', 300);
+      '<div id="mouse-position" class="nav-item mr-1 my-auto flex-shrink-0"></li>', 300);
 
   os.ui.list.add(os.ui.nav.Location.BOTTOM_RIGHT,
-      '<li id="js-dock-bottom-micro__container"></li>', 0);
+      '<div id="js-dock-bottom-micro__container"></li>', 0);
   os.ui.list.add(os.ui.nav.Location.BOTTOM_RIGHT, 'settings-button', 100);
   os.ui.list.add(os.ui.nav.Location.BOTTOM_RIGHT, 'legend-button', 200);
   os.ui.list.add(os.ui.nav.Location.BOTTOM_RIGHT, 'servers-button', 300);

--- a/src/os/ui/util/punyparent.js
+++ b/src/os/ui/util/punyparent.js
@@ -2,6 +2,7 @@ goog.provide('os.ui.util.PunyParentCtrl');
 goog.provide('os.ui.util.punyParentDirective');
 
 goog.require('goog.Throttle');
+goog.require('goog.async.Delay');
 goog.require('goog.dom.ViewportSizeMonitor');
 goog.require('os.ui');
 goog.require('os.ui.Module');
@@ -29,95 +30,184 @@ os.ui.Module.directive('punyparent', [os.ui.util.punyParentDirective]);
 
 
 /**
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
+ * Controller for the punyparent directive.
+ * @param {!angular.Scope} $scope The Angular scope.
+ * @param {!angular.JQLite} $element The root DOM element.
  * @constructor
  * @ngInject
  */
 os.ui.util.PunyParentCtrl = function($scope, $element) {
   /**
+   * The Angular scope.
    * @type {?angular.Scope}
    * @private
    */
   this.scope_ = $scope;
 
   /**
+   * The root DOM element.
    * @type {?angular.JQLite}
    * @private
    */
   this.element_ = $element;
 
   /**
-   * @type {goog.Throttle}
-   * @private
-   */
-  this.throttle_ = new goog.Throttle(this.onThrottleResize_, 200, this);
-
-  /**
-   * Keep track of our maximum child size. This prevents saying we have enough space after a resize already occured
+   * The maximum child size, to control when collapse/expand occurs.
    * @type {number}
    * @private
    */
-  this.fullSize = 0;
+  this.fullSize_ = 0;
 
-  var vsm = goog.dom.ViewportSizeMonitor.getInstanceForWindow();
-  vsm.listen(goog.events.EventType.RESIZE, this.onResize_, false, this);
+  /**
+   * Children that are watched for size changes.
+   * @type {!Array<!Node>}
+   * @private
+   */
+  this.watchedChildren_ = [];
 
-  $scope.$on('$destroy', this.destroy_.bind(this));
+  /**
+   * Delay to debounce child size updates.
+   * @type {goog.async.Delay}
+   * @private
+   */
+  this.childResizeDelay_ = new goog.async.Delay(this.updateSize_, 50, this);
+
+  /**
+   * Pre-bound function to handle child resize.
+   * @type {Function}
+   * @private
+   */
+  this.onChildResizeFn_ = this.childResizeDelay_.start.bind(this.childResizeDelay_);
+
+  /**
+   * Observer to watch for changes to the element's child list.
+   * @type {MutationObserver}
+   * @private
+   */
+  this.observer_ = new MutationObserver(this.onMutation_.bind(this));
+  this.observer_.observe(this.element_[0], {childList: true});
+
+  /**
+   * Pre-bound function to update the collapsed state.
+   * @type {Function}
+   * @private
+   */
+  this.updateCollapsedFn_ = this.updateCollapsed_.bind(this);
+
+  /**
+   * Throttle to limit how often the controller responds to viewport size changes.
+   * @type {goog.Throttle}
+   * @private
+   */
+  this.vsmThrottle_ = new goog.Throttle(this.updateCollapsed_, 200, this);
+
+  // Listen for viewport size changes.
+  const vsm = goog.dom.ViewportSizeMonitor.getInstanceForWindow();
+  vsm.listen(goog.events.EventType.RESIZE, this.vsmThrottle_.fire, false, this.vsmThrottle_);
+
+  // Update the collapsed state when the root element size changes.
+  os.ui.resize(this.element_, this.updateCollapsedFn_);
 };
 
 
 /**
- * @private
+ * Angular $onDestroy lifecycle hook.
  */
-os.ui.util.PunyParentCtrl.prototype.destroy_ = function() {
-  var vsm = goog.dom.ViewportSizeMonitor.getInstanceForWindow();
-  vsm.unlisten(goog.events.EventType.RESIZE, this.onResize_, false, this);
+os.ui.util.PunyParentCtrl.prototype.$onDestroy = function() {
+  os.ui.removeResize(this.element_, this.updateCollapsedFn_);
 
-  if (this.throttle_) {
-    this.throttle_.dispose();
-    this.throttle_ = null;
-  }
+  this.observer_.disconnect();
+
+  this.watchedChildren_.forEach((child) => {
+    os.ui.removeResize($(child), this.onChildResizeFn_);
+  });
+  this.watchedChildren_.length = 0;
+
+  goog.dispose(this.childResizeDelay_);
+  this.childResizeDelay_ = null;
+
+  const vsm = goog.dom.ViewportSizeMonitor.getInstanceForWindow();
+  vsm.unlisten(goog.events.EventType.RESIZE, this.vsmThrottle_.fire, false, this.vsmThrottle_);
+
+  goog.dispose(this.vsmThrottle_);
+  this.vsmThrottle_ = null;
+
   this.scope_ = null;
   this.element_ = null;
 };
 
 
 /**
+ * Handle mutation event.
+ * @param {!Array<!MutationRecord>} mutationsList The mutation list.
+ * @param {!MutationObserver} observer The observer.
  * @private
  */
-os.ui.util.PunyParentCtrl.prototype.onResize_ = function() {
-  this.throttle_.fire();
+os.ui.util.PunyParentCtrl.prototype.onMutation_ = function(mutationsList, observer) {
+  for (const mutation of mutationsList) {
+    if (mutation.type === 'childList') {
+      mutation.addedNodes.forEach(this.watchChild_, this);
+      mutation.removedNodes.forEach(this.unwatchChild_, this);
+    }
+  }
+};
+
+
+/**
+ * Watch a child node.
+ * @param {!Node} child The child.
+ * @private
+ */
+os.ui.util.PunyParentCtrl.prototype.watchChild_ = function(child) {
+  const childEl = $(child);
+  if (!childEl.hasClass('resize-triggers') && !childEl.hasClass('resize-sensor')) {
+    os.ui.resize(childEl, this.onChildResizeFn_);
+    this.watchedChildren_.push(child);
+  }
+};
+
+
+/**
+ * Unwatch a child node.
+ * @param {!Node} child The child.
+ * @private
+ */
+os.ui.util.PunyParentCtrl.prototype.unwatchChild_ = function(child) {
+  const index = this.watchedChildren_.indexOf(child);
+  if (index > -1) {
+    const childEl = $(child);
+    os.ui.removeResize(childEl, this.onChildResizeFn_);
+    this.watchedChildren_.splice(index, 1);
+  }
+};
+
+
+/**
+ * Updated the max allotted size for all children.
+ * @private
+ */
+os.ui.util.PunyParentCtrl.prototype.updateSize_ = function() {
+  const childrenWidth = this.watchedChildren_.reduce((total, child) => total + $(child).outerWidth(true), 0);
+  this.fullSize_ = Math.max(this.fullSize_, childrenWidth);
+  this.updateCollapsed_();
 };
 
 
 /**
  * @private
  */
-os.ui.util.PunyParentCtrl.prototype.onThrottleResize_ = function() {
+os.ui.util.PunyParentCtrl.prototype.updateCollapsed_ = function() {
   if (this.element_) {
-    var children = this.element_.children().toArray();
-    var childrenWidth = children.reduce((accumulator, child) => {
-      var c = $(child);
-      // ignore the resize trigger since thats the parent size
-      if (!c.hasClass('resize-triggers')) {
-        accumulator += c.outerWidth(true);
-      }
-      return accumulator;
-    }, 0);
+    // Set the collapsed state on the child scopes
+    const collapsed = this.element_.outerWidth(true) < this.fullSize_;
 
-    if (childrenWidth > this.fullSize) {
-      this.fullSize = childrenWidth;
-    }
-
-    // Set the puny state on the child scope
-    children.forEach((child) => {
-      var c = $(child);
-      var cscope = c.scope();
-      if (!c.hasClass('resize-triggers') && cscope) {
-        cscope['puny'] = this.element_.outerWidth(true) < this.fullSize;
+    this.element_.children().toArray().forEach((child) => {
+      const childScope = $(child).scope();
+      if (childScope) {
+        childScope['puny'] = collapsed;
       }
     });
+
     os.ui.apply(this.scope_);
   }
 };

--- a/views/datepanel.html
+++ b/views/datepanel.html
@@ -9,37 +9,36 @@
     </div>
   </div>
 
-  <div id="js-slice-panel" class="u-pointer-events-all" ng-show="ctrl.extended">
-    <div class="c-date-panel__extended d-flex w-100 px-1 pb-1 mt-1 flex-shrink-0 justify-content-center rounded-bottom">
-      <div class="d-flex align-items-center">
-        <div class="mx-1 d-flex align-items-center">
-          <input class="form-control" type="number" min="0" max="23" step="1" ng-model="ctrl.startHour"
-              ng-change="ctrl.onChange('startHour', 0, 23, '{{ctrl.startHour}}')">
-          <span class="flex-shrink-0 ml-1">h</span>
-        </div>
-        <div class="mx-1 d-flex align-items-center">
-          <input class="form-control" type="number" min="0" max="59" step="1" ng-model="ctrl.startMinute"
-              ng-change="ctrl.onChange('startMinute', 0, 59, '{{ctrl.startMinute}}')">
-          <span class="flex-shrink-0 ml-1">m to</span>
-        </div>
-        <div class="mx-1 d-flex align-items-center">
-          <input class="form-control" type="number" min="0" max="23" step="1" ng-model="ctrl.endHour"
-              ng-change="ctrl.onChange('endHour', 0, 23, '{{ctrl.endHour}}')">
-          <span class="flex-shrink-0 ml-1">h</span>
-        </div>
-        <div class="mx-1 d-flex align-items-center">
-          <input class="form-control" type="number" min="0" max="59" step="1" ng-model="ctrl.endMinute"
-              ng-change="ctrl.onChange('endMinute', 0, 59, '{{ctrl.endMinute}}')">
-          <span class="flex-shrink-0 ml-1">m {{ctrl.getOffset()}}</span>
-        </div>
-        <div class="mx-1 d-flex align-items-center flex-shrink-0">
-          <button class="btn" ng-class="{'btn-primary': !ctrl.active, 'btn-secondary': ctrl.active}" ng-click="ctrl.applySlice()" title="Apply time slice" ng-disabled="!ctrl.sliceValid() || ctrl.active">
-            <i class="fa fa-fw fa-check"></i>
-          </button>
-        </div>
-        <div>
-          <popover data-title="ctrl.sliceTitle" content="ctrl.sliceDescription" data-pos="'bottom'"></popover>
-        </div>
+  <div id="js-slice-panel" class="c-date-panel__container d-flex justify-content-center u-pointer-events-all"
+      ng-if="ctrl.extended">
+    <div class="c-date-panel__extended d-flex align-items-center flex-shrink-0 p-1 rounded-bottom">
+      <div class="mx-1 d-flex align-items-center">
+        <input class="form-control" type="number" min="0" max="23" step="1" ng-model="ctrl.startHour"
+            ng-change="ctrl.onChange('startHour', 0, 23, '{{ctrl.startHour}}')">
+        <span class="flex-shrink-0 ml-1">h</span>
+      </div>
+      <div class="mx-1 d-flex align-items-center">
+        <input class="form-control" type="number" min="0" max="59" step="1" ng-model="ctrl.startMinute"
+            ng-change="ctrl.onChange('startMinute', 0, 59, '{{ctrl.startMinute}}')">
+        <span class="flex-shrink-0 ml-1">m to</span>
+      </div>
+      <div class="mx-1 d-flex align-items-center">
+        <input class="form-control" type="number" min="0" max="23" step="1" ng-model="ctrl.endHour"
+            ng-change="ctrl.onChange('endHour', 0, 23, '{{ctrl.endHour}}')">
+        <span class="flex-shrink-0 ml-1">h</span>
+      </div>
+      <div class="mx-1 d-flex align-items-center">
+        <input class="form-control" type="number" min="0" max="59" step="1" ng-model="ctrl.endMinute"
+            ng-change="ctrl.onChange('endMinute', 0, 59, '{{ctrl.endMinute}}')">
+        <span class="flex-shrink-0 ml-1">m {{ctrl.getOffset()}}</span>
+      </div>
+      <div class="mx-1 d-flex align-items-center flex-shrink-0">
+        <button class="btn" ng-class="{'btn-primary': !ctrl.active, 'btn-secondary': ctrl.active}" ng-click="ctrl.applySlice()" title="Apply time slice" ng-disabled="!ctrl.sliceValid() || ctrl.active">
+          <i class="fa fa-fw fa-check"></i>
+        </button>
+      </div>
+      <div>
+        <popover data-title="ctrl.sliceTitle" content="ctrl.sliceDescription" data-pos="'bottom'"></popover>
       </div>
     </div>
   </div>

--- a/views/osnavtop.html
+++ b/views/osnavtop.html
@@ -1,15 +1,15 @@
 <div class="row w-100 p-0 no-gutters">
-  <ul class="navbar-nav col-lg-4 col-6" punyparent
+  <ul class="navbar-nav col-6 col-lg" punyparent
       list list-id="nav-top-left"
       list-prefix="<li class='nav-item mr-1 py-1 my-auto'>"
       list-suffix="</li>">
   </ul>
-  <ul class="navbar-nav col-lg-4 justify-content-center order-2 order-lg-1" punyparent
+  <ul class="navbar-nav col-lg-auto justify-content-center order-2 order-lg-1"
       list list-id="nav-top-center"
-      list-prefix="<li class='nav-item mx-1 py-1 my-auto flex-shrink-0''>"
+      list-prefix="<li class='nav-item mx-1 py-1 my-auto flex-shrink-0'>"
       list-suffix="</li>">
   </ul>
-  <ul class="navbar-nav col-lg-4 col-6 justify-content-end order-1 order-lg-2" punyparent
+  <ul class="navbar-nav col-6 col-lg justify-content-end order-1 order-lg-2" punyparent
       list list-id="nav-top-right"
       list-prefix="<li class='nav-item ml-1 py-1 my-auto'>"
       list-suffix="</li>">

--- a/views/plugin/ogc/ui/ogcserverhelp.html
+++ b/views/plugin/ogc/ui/ogcserverhelp.html
@@ -5,10 +5,10 @@
     <br>
     A GetCapabilities URL can have many different formats, such as:
     <ul>
-      <li>example.com/ogc?service=wms&version=1.3.0&request=GetCapabilities</li>
-      <li>example.com/ogc?service=wfs&version=1.1.0&request=GetCapabilities</li>
-      <li>example.com/ogc/wms?version=1.3.0&request=GetCapabilities</li>
-      <li>example.com/ogc/wfs?version=1.1.0&request=GetCapabilities</li>
+      <li>example.com/ogc?service=wms&amp;version=1.3.0&amp;request=GetCapabilities</li>
+      <li>example.com/ogc?service=wfs&amp;version=1.1.0&amp;request=GetCapabilities</li>
+      <li>example.com/ogc/wms?version=1.3.0&amp;request=GetCapabilities</li>
+      <li>example.com/ogc/wfs?version=1.1.0&amp;request=GetCapabilities</li>
       <li>example.com/geoserver/gwc/service/wmts?REQUEST=GetCapabilities</li>
       <li>example.com/ArcGIS/services/mapservice/MapServer/WMSServer</li>
     </ul>


### PR DESCRIPTION
The top nav had a few issues with its collapse behavior, namely:

1. The collapsed state did not initialize properly, so items would overlap when first loading OpenSphere.
2. The left/right/center were allocated a fixed size, which caused button collapse to happen earlier than needed.
3. The time UI was shifted down to a new row too late, so it would sometimes overlap other elements.
4. Changing the size of the time UI (for example, setting duration to `custom`) would not cause buttons to collapse and could result in overlap.

Changes to address the above:

- The `punyparent` directive now detects when children are added/removed from the element and recomputes the max size needed for the expanded state, then updates the expanded state. (Fixes 1)
- The `osnavtop` template was updated so the center (time UI) takes only as much space as it needs (using `col-lg-auto` instead of `col-lg-4`), and the left/right use remaining space (`col-lg`). (Fixes 2)
- Grid breakpoints were updated to better handle shifting the time UI down, and `!default` was added so plugins/apps can override the breakpoints in their own styles. (Fixes 3)
- The `punyparent` directive now watches for size changes and will update the collapse state when this happens. (Fixes 4)

Additional changes:

- Some nav items are added as an `li` element. The nav lists wrap each item in an `li`, and nested `li` is not allowed so the wrapper was actually being created as a sibling instead of a parent. I changed these items to use `div` instead, so they can be a child of the `li` wrapper.
- The `list` directive was using `append` to move items to the correct position in the update function. We don't currently have an API to change the priority or otherwise move an item (short of removing/adding it), so the `append` call was performing an unnecessary remove/add in the DOM. This was noticed testing the new `MutationObserver` code, as extra events were being fired to remove the elements and re-add them. To resolve this, existing elements are skipped and new elements are inserted after the previous one.
- The search results panel was taking up way too much space in smaller windows. It is now limited to 50% of the screen width once the `lg` breakpoint is hit. Larger windows will use the default max width (no change in behavior).
- The time UI extension (hh/mm button) was not being positioned/sized properly. It should now always be centered below the time UI, and will no longer take up the full screen width when the time UI is shifted to its own row.
- Fixed HTML lint warnings in the new OGC help template.

This branch is deployed to surge.sh here: https://quixotic-trains.surge.sh/