### PR TITLE
feat(cesium): provide more ion info and remove layer if canceled

### DIFF
--- a/src/plugin/cesium/cesium.js
+++ b/src/plugin/cesium/cesium.js
@@ -211,10 +211,13 @@ const promptForAccessToken = function() {
       limit: 2000,
       select: true,
       prompt: `
-        This layer requires a Cesium Ion access token. If you do not have an access token, please
-        <a href="https://cesium.com/ion/" target="_blank">create an account</a>.
+        This layer is provided by <a href="https://cesium.com/platform/cesium-ion/" target="_blank">Cesium Ion</a>
+        and requires an access token to use. Please provide a Cesium Ion access token, or click Cancel to remove the
+        layer.
         <br><br>
-        Once logged in, click on Access Tokens > Default Token. Copy the token and paste it below:
+        If you do not have a Cesium Ion account, you can
+        <a href="https://cesium.com/ion/" target="_blank">create one here</a>. Once logged in, click on Access Tokens >
+        Default Token. Copy the token and paste it below:
       `,
       windowOptions: /** @type {!osx.window.WindowOptions} */ ({
         icon: 'fa fa-warning',

--- a/src/plugin/cesium/tiles/cesium3dtileslayer.js
+++ b/src/plugin/cesium/tiles/cesium3dtileslayer.js
@@ -6,6 +6,8 @@ const dispatcher = goog.require('os.Dispatcher');
 const MapEvent = goog.require('os.MapEvent');
 const ActionEventType = goog.require('os.action.EventType');
 const settings = goog.require('os.config.Settings');
+const LayerEvent = goog.require('os.events.LayerEvent');
+const LayerEventType = goog.require('os.events.LayerEventType');
 const {PROJECTION} = goog.require('os.map');
 const {EPSG4326} = goog.require('os.proj');
 const osStyle = goog.require('os.style');
@@ -112,10 +114,13 @@ class Layer extends PrimitiveLayer {
       if (!isNaN(this.assetId)) {
         if (!this.accessToken) {
           promptForAccessToken().then((accessToken) => {
+            // Access token provided, synchronize again to test it.
             this.accessToken = accessToken;
             this.synchronize();
           }, () => {
-            this.setTokenError_('An access token is required to enable this layer, but one was not provided.');
+            // Remove the layer if the access token prompt was canceled.
+            const removeEvent = new LayerEvent(LayerEventType.REMOVE, this.getId());
+            dispatcher.getInstance().dispatchEvent(removeEvent);
           });
         } else {
           tilesetUrl = createIonAssetUrl(this.assetId, this.accessToken);


### PR DESCRIPTION
Feedback was received that the Cesium Ion access token prompt could be more descriptive. To resolve that, the dialog was reworded as well as adding a link to Ion that more completely describes the service.

It was also determined that cancelling the access token prompt should also remove the layer, so that was also added.