### PR TITLE
Convert Cesium plugin to use goog.module

### DIFF
--- a/docs/guides/plugin_server_guide/src/plugin/tileserver/tileserver.js-parsing
+++ b/docs/guides/plugin_server_guide/src/plugin/tileserver/tileserver.js-parsing
@@ -5,6 +5,7 @@ goog.require('os.data.IDataProvider');
 goog.require('os.fn');
 goog.require('os.net.Request');
 goog.require('os.ui.Icons');
+goog.require('os.ui.icons');
 goog.require('os.ui.data.DescriptorNode');
 goog.require('os.ui.server.AbstractLoadingServer');
 
@@ -95,7 +96,7 @@ plugin.tileserver.Tileserver.prototype.toChildNode = function(layer) {
     'urls': layer['tiles'],
     'extent': layer['bounds'],
     'extentProjection': os.proj.EPSG4326,
-    'icons': os.ui.createIconSet(id, [os.ui.IconsSVG.TILES], [], [255, 255, 255, 1]),
+    'icons': os.ui.icons.createIconSet(id, [os.ui.IconsSVG.TILES], [], [255, 255, 255, 1]),
     'projection': os.proj.EPSG3857,
     'minZoom': Math.max(os.map.MIN_ZOOM, layer['minzoom']),
     'maxZoom': Math.min(os.map.MAX_ZOOM, layer['maxzoom']),

--- a/externs/Cesium.externs.js
+++ b/externs/Cesium.externs.js
@@ -2916,7 +2916,7 @@ Cesium.Credit = function(html, opt_showOnScreen) {};
 
 
 /**
- * @constructor
+ * @interface
  */
 Cesium.TilingScheme = function() {};
 
@@ -2931,6 +2931,12 @@ Cesium.TilingScheme.prototype.ellipsoid;
  * @type {Cesium.Rectangle}
  */
 Cesium.TilingScheme.prototype.rectangle;
+
+
+/**
+ * @type {Cesium.GeographicProjection|Cesium.WebMercatorProjection}
+ */
+Cesium.TilingScheme.prototype.projection;
 
 
 /**
@@ -2997,7 +3003,7 @@ Cesium.GeographicTilingSchemeOptions;
 
 /**
  * @param {Cesium.GeographicTilingSchemeOptions=} opt_options
- * @extends {Cesium.TilingScheme}
+ * @implements {Cesium.TilingScheme}
  * @constructor
  */
 Cesium.GeographicTilingScheme = function(opt_options) {};
@@ -3018,7 +3024,7 @@ Cesium.WebMercatorTilingSchemeOptions;
 
 /**
  * @param {Cesium.WebMercatorTilingSchemeOptions=} opt_options
- * @extends {Cesium.TilingScheme}
+ * @implements {Cesium.TilingScheme}
  * @constructor
  */
 Cesium.WebMercatorTilingScheme = function(opt_options) {};
@@ -5096,7 +5102,7 @@ Cesium.TileProviderError.prototype.error;
 
 
 /**
- * @constructor
+ * @interface
  */
 Cesium.TerrainProvider = function() {};
 
@@ -5194,7 +5200,7 @@ Cesium.ArcGisImageServerTerrainProviderOptions;
 
 /**
  * @param {!Cesium.ArcGisImageServerTerrainProviderOptions} options
- * @extends {Cesium.TerrainProvider}
+ * @implements {Cesium.TerrainProvider}
  * @constructor
  */
 Cesium.ArcGisImageServerTerrainProvider = function(options) {};
@@ -5216,7 +5222,7 @@ Cesium.CesiumTerrainProviderOptions;
 
 /**
  * @param {!Cesium.CesiumTerrainProviderOptions} options
- * @extends {Cesium.TerrainProvider}
+ * @implements {Cesium.TerrainProvider}
  * @constructor
  */
 Cesium.CesiumTerrainProvider = function(options) {};
@@ -5234,7 +5240,7 @@ Cesium.EllipsoidTerrainProviderOptions;
 
 /**
  * @param {Cesium.EllipsoidTerrainProviderOptions=} opt_options
- * @extends {Cesium.TerrainProvider}
+ * @implements {Cesium.TerrainProvider}
  * @constructor
  */
 Cesium.EllipsoidTerrainProvider = function(opt_options) {};

--- a/externs/os.externs.js
+++ b/externs/os.externs.js
@@ -495,6 +495,9 @@ osx.cesium.WMSTerrainLayerOptions;
 
 /**
  * @typedef {{
+ *   id: string,
+ *   title: string,
+ *   type: string,
  *   layers: !Array<!osx.cesium.WMSTerrainLayerOptions>,
  *   url: string,
  *   credit: (Cesium.Credit|string|undefined),

--- a/src/os/command/vectorlayercolorcmd.js
+++ b/src/os/command/vectorlayercolorcmd.js
@@ -5,6 +5,7 @@ goog.require('os.command.style');
 goog.require('os.events.PropertyChangeEvent');
 goog.require('os.metrics');
 goog.require('os.source.PropertyChange');
+goog.require('os.ui.icons');
 
 
 
@@ -99,7 +100,7 @@ os.command.VectorLayerColor.prototype.applyValue = function(config, value) {
     os.style.setFillColor(config, fillColor);
 
     // update the layer icons to reflect the color change
-    os.ui.adjustIconSet(this.layerId, value);
+    os.ui.icons.adjustIconSet(this.layerId, value);
   }
 
   os.command.VectorLayerColor.base(this, 'applyValue', config, value);

--- a/src/os/layer/image.js
+++ b/src/os/layer/image.js
@@ -18,6 +18,8 @@ goog.require('os.source');
 goog.require('os.source.ImageStatic');
 goog.require('os.style');
 goog.require('os.ui.Icons');
+goog.require('os.ui.IconsSVG');
+goog.require('os.ui.icons');
 goog.require('os.ui.layer.defaultLayerUIDirective');
 goog.require('os.ui.renamelayer');
 goog.require('os.ui.window');
@@ -438,7 +440,7 @@ os.layer.Image.prototype.getIcons = function() {
   if (config) {
     var color = os.style.getConfigColor(config, true);
     if (color) {
-      return os.ui.createIconSet(this.getId(), this.getSVGSet(), this.getFASet(), color);
+      return os.ui.icons.createIconSet(this.getId(), this.getSVGSet(), this.getFASet(), color);
     }
   }
 

--- a/src/os/layer/tile.js
+++ b/src/os/layer/tile.js
@@ -26,6 +26,8 @@ goog.require('os.style');
 goog.require('os.tile');
 goog.require('os.ui');
 goog.require('os.ui.Icons');
+goog.require('os.ui.IconsSVG');
+goog.require('os.ui.icons');
 goog.require('os.ui.layer.tileLayerUIDirective');
 goog.require('os.ui.renamelayer');
 
@@ -234,7 +236,7 @@ os.layer.Tile.prototype.setMaxResolution = function(value) {
 os.layer.Tile.prototype.updateIcons_ = function() {
   var color = this.getColor();
   if (color) {
-    os.ui.adjustIconSet(this.getId(), os.color.toHexString(color));
+    os.ui.icons.adjustIconSet(this.getId(), os.color.toHexString(color));
   }
 };
 
@@ -668,7 +670,7 @@ os.layer.Tile.prototype.getIcons = function() {
     color = os.color.toRgbArray(layerColor);
   }
 
-  html += color ? os.ui.createIconSet(this.getId(), this.getSVGIconsInternal(), this.getStateBadge(), color)
+  html += color ? os.ui.icons.createIconSet(this.getId(), this.getSVGIconsInternal(), this.getStateBadge(), color)
     : this.getIconsInternal();
   return html;
 };

--- a/src/os/layer/vector.js
+++ b/src/os/layer/vector.js
@@ -27,8 +27,10 @@ goog.require('os.source.Vector');
 goog.require('os.style');
 goog.require('os.style.label');
 goog.require('os.ui.Icons');
+goog.require('os.ui.IconsSVG');
 goog.require('os.ui.feature.featureInfoDirective');
 goog.require('os.ui.feature.multiFeatureInfoDirective');
+goog.require('os.ui.icons');
 goog.require('os.ui.layer.vectorLayerUIDirective');
 goog.require('os.ui.node.defaultLayerNodeUIDirective');
 goog.require('os.ui.renamelayer');
@@ -395,7 +397,7 @@ os.layer.Vector.prototype.getIcons = function() {
   if (config) {
     var color = os.style.getConfigColor(config, true);
     if (color) {
-      return os.ui.createIconSet(this.getId(), this.getSVGSet(), this.getFASet(), color);
+      return os.ui.icons.createIconSet(this.getId(), this.getSVGSet(), this.getFASet(), color);
     }
   }
 

--- a/src/os/ui/icons.js
+++ b/src/os/ui/icons.js
@@ -1,9 +1,11 @@
 goog.provide('os.ui.Icons');
 goog.provide('os.ui.IconsSVG');
+goog.provide('os.ui.icons');
 
 goog.require('goog.crypt.hash32');
 goog.require('os');
 goog.require('os.color');
+goog.require('os.ui');
 
 
 /**
@@ -47,14 +49,14 @@ os.ui.Icons = {
  * @const
  * @private
  */
-os.ui.white_ = [0xff, 0xff, 0xff];
+os.ui.icons.white_ = [0xff, 0xff, 0xff];
 
 
 /**
  * @type {number}
  * @const
  */
-os.ui.ICON_WIDTH = 16;
+os.ui.icons.ICON_WIDTH = 16;
 
 
 /**
@@ -64,14 +66,14 @@ os.ui.ICON_WIDTH = 16;
  * @param {Array<number>|string} color The icon color
  * @return {string}
  */
-os.ui.createIconSet = function(id, svgIcons, faIcons, color) {
+os.ui.icons.createIconSet = function(id, svgIcons, faIcons, color) {
   var html = '';
-  id = os.ui.hashIconId(id);
+  id = os.ui.icons.hashIconId(id);
 
   if (svgIcons && svgIcons.length > 0) {
     var arrColor = typeof color === 'string' ? os.color.toRgbArray(color) : color;
-    var values = os.color.changeColor(os.ui.white_, arrColor || os.ui.white_);
-    var width = os.ui.ICON_WIDTH * svgIcons.length;
+    var values = os.color.changeColor(os.ui.icons.white_, arrColor || os.ui.icons.white_);
+    var width = os.ui.icons.ICON_WIDTH * svgIcons.length;
     var filter = 'filter_';
     var matrix = 'matrix_';
     html += '<svg width="' + width + 'px" height="16px" class="align-middle" ' +
@@ -80,8 +82,8 @@ os.ui.createIconSet = function(id, svgIcons, faIcons, color) {
     html += svgIcons.join('');
     var re = /x="(\d+)"/g;
 
-    os.ui.xReplaceI_ = 0;
-    html = html.replace(re, os.ui.xReplace_);
+    os.ui.icons.xReplaceI_ = 0;
+    html = html.replace(re, os.ui.icons.xReplace_);
     html += '<filter id="' + filter + id + '">';
     html += '<feColorMatrix id="' + matrix + id + '" values="' + values.join(' ') + '"/>';
     html += '</filter></svg>';
@@ -101,21 +103,43 @@ os.ui.createIconSet = function(id, svgIcons, faIcons, color) {
 
 
 /**
+ * @param {string} id The layer id
+ * @param {Array<string>} svgIcons SVG icons
+ * @param {Array<string>} faIcons Font Awesome icons
+ * @param {Array<number>|string} color The icon color
+ * @return {string}
+ *
+ * @deprecated Please use `os.ui.icons.createIconSet` instead.
+ */
+os.ui.createIconSet = os.ui.icons.createIconSet;
+
+
+/**
  * Hashes an icon ID. This prevents us from putting invalid special characters in an ID selector.
  *
  * @param {string} id
  * @return {string}
  */
-os.ui.hashIconId = function(id) {
+os.ui.icons.hashIconId = function(id) {
   return String(goog.crypt.hash32.encodeString(id));
 };
+
+
+/**
+ * Hashes an icon ID. This prevents us from putting invalid special characters in an ID selector.
+ * @param {string} id
+ * @return {string}
+ *
+ * @deprecated Please use `os.ui.icons.hashIconId` instead.
+ */
+os.ui.hashIconId = os.ui.icons.hashIconId;
 
 
 /**
  * @type {number}
  * @private
  */
-os.ui.xReplaceI_ = 0;
+os.ui.icons.xReplaceI_ = 0;
 
 
 /**
@@ -126,9 +150,9 @@ os.ui.xReplaceI_ = 0;
  * @return {string}
  * @private
  */
-os.ui.xReplace_ = function(match, p1, offset, whole) {
-  var x = os.ui.xReplaceI_ * os.ui.ICON_WIDTH;
-  os.ui.xReplaceI_++;
+os.ui.icons.xReplace_ = function(match, p1, offset, whole) {
+  var x = os.ui.icons.xReplaceI_ * os.ui.icons.ICON_WIDTH;
+  os.ui.icons.xReplaceI_++;
   return match.replace(p1, x.toString());
 };
 
@@ -137,16 +161,25 @@ os.ui.xReplace_ = function(match, p1, offset, whole) {
  * @param {string} id
  * @param {Array<number>|string} color
  */
-os.ui.adjustIconSet = function(id, color) {
+os.ui.icons.adjustIconSet = function(id, color) {
   if (typeof color === 'string') {
     color = os.color.toRgbArray(color);
   }
 
-  var values = os.color.changeColor(os.ui.white_, color || os.ui.white_);
-  id = os.ui.hashIconId(id);
+  var values = os.color.changeColor(os.ui.icons.white_, color || os.ui.icons.white_);
+  id = os.ui.icons.hashIconId(id);
   var matrix = angular.element('#matrix_' + id);
   matrix.attr('values', values.join(' '));
 
-  var hexColor = os.color.toHexString(color || os.ui.white_);
+  var hexColor = os.color.toHexString(color || os.ui.icons.white_);
   angular.element('i.fa.layer-icon-' + id).css('color', hexColor);
 };
+
+
+/**
+ * @param {string} id
+ * @param {Array<number>|string} color
+ *
+ * @deprecated Please use `os.ui.icons.adjustIconSet` instead.
+ */
+os.ui.adjustIconSet = os.ui.icons.adjustIconSet;

--- a/src/plugin/capture/maprenderer.js
+++ b/src/plugin/capture/maprenderer.js
@@ -3,7 +3,6 @@ goog.provide('plugin.capture.MapRenderer');
 goog.require('goog.Promise');
 goog.require('os.map');
 goog.require('os.ui.capture.CanvasRenderer');
-goog.require('plugin.cesium');
 
 
 

--- a/src/plugin/cesium/abstractterrainprovider.js
+++ b/src/plugin/cesium/abstractterrainprovider.js
@@ -1,288 +1,241 @@
-goog.provide('plugin.cesium.AbstractTerrainProvider');
+goog.module('plugin.cesium.AbstractTerrainProvider');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
-
-
-
-/**
- * Base Cesium terrain provider.
- *
- * @param {!osx.map.TerrainProviderOptions} options
- * @extends {Cesium.TerrainProvider}
- * @constructor
- */
-plugin.cesium.AbstractTerrainProvider = function(options) {
-  goog.asserts.assert(options != null, 'options not defined');
-  goog.asserts.assert(options.url != null, 'url not defined');
-
-  //
-  // The following properties are all used by Cesium using the get/set functions defined below. They are already
-  // public via those functions, but if you need a setter for an extending class add it to the Object.defineProperties
-  // section. Renaming these to remove the undersos (to make them protected) will break the get/set functions unless
-  // you change the property name!
-  //
-
-  /**
-   * @type {Cesium.Credit|undefined}
-   * @private
-   */
-  this.credit_ = typeof options.credit === 'string' ? new Cesium.Credit(options.credit) : undefined;
-
-  /**
-   * @type {Cesium.Event}
-   * @private
-   */
-  this.errorEvent_ = new Cesium.Event();
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  this.hasVertexNormals_ = false;
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  this.hasWaterMask_ = false;
-
-  /**
-   * @type {string}
-   * @private
-   */
-  this.name_ = 'Terrain';
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  this.ready_ = false;
-
-  /**
-   * @type {Cesium.GeographicTilingScheme}
-   * @private
-   */
-  this.tilingScheme_ = new Cesium.GeographicTilingScheme({
-    numberOfLevelZeroTilesX: 2,
-    numberOfLevelZeroTilesY: 1
-  });
-
-  //
-  // The rest of the properties are use internally (not by Cesium) and are safe to do as you please.
-  //
-
-  /**
-   * @type {number}
-   * @protected
-   */
-  this.maxLevel = options.maxLevel || plugin.cesium.AbstractTerrainProvider.DEFAULT_MAX_LEVEL_;
-
-  /**
-   * @type {number}
-   * @protected
-   */
-  this.minLevel = options.minLevel || plugin.cesium.AbstractTerrainProvider.DEFAULT_MIN_LEVEL_;
-
-  /**
-   * @type {number}
-   * @protected
-   */
-  this.tileSize = options.tileSize || plugin.cesium.AbstractTerrainProvider.DEFAULT_TILE_SIZE_;
-
-  /**
-   * @type {number}
-   * @protected
-   */
-  this.levelZeroMaximumGeometricError = Cesium.TerrainProvider.getEstimatedLevelZeroGeometricErrorForAHeightmap(
-      this.tilingScheme_.ellipsoid,
-      this.tileSize,
-      this.tilingScheme_.getNumberOfXTilesAtLevel(0));
-
-  /**
-   * @type {Cesium.HeightMapStructure}
-   * @protected
-   */
-  this.terrainDataStructure = {
-    heightScale: 1.0,
-    heightOffset: 0.0,
-    elementsPerHeight: 1,
-    stride: 1,
-    elementMultiplier: 256.0,
-    isBigEndian: false
-  };
-
-  /**
-   * @type {string}
-   * @protected
-   */
-  this.url = options.url;
-
-  /**
-   * @type {boolean}
-   * @protected
-   */
-  this.useProxy = options.useProxy || false;
-};
-
-
-/**
- * The default maximum zoom level to show elevation
- * @type {number}
- * @private
- * @const
- */
-plugin.cesium.AbstractTerrainProvider.DEFAULT_MAX_LEVEL_ = 11;
+const asserts = goog.require('goog.asserts');
 
 
 /**
  * The default minimum zoom level to show elevation
  * @type {number}
- * @private
- * @const
  */
-plugin.cesium.AbstractTerrainProvider.DEFAULT_MIN_LEVEL_ = 8;
+const DEFAULT_MIN_LEVEL = 8;
 
 
 /**
  * The default size for elevation tiles. Much higher than 128 and Cesium will start to have issues.
  * @type {number}
- * @private
- * @const
  */
-plugin.cesium.AbstractTerrainProvider.DEFAULT_TILE_SIZE_ = 128;
+const DEFAULT_TILE_SIZE = 128;
 
 
-// define the properties required by the Cesium.TerrainProvider interface
-Object.defineProperties(plugin.cesium.AbstractTerrainProvider.prototype, {
-  credit: {
-    get:
-        /**
-         * @return {Cesium.Credit|undefined}
-         * @this plugin.cesium.AbstractTerrainProvider
-         */
-        function() {
-          return this.credit_;
-        }
-  },
+/**
+ * Base Cesium terrain provider.
+ * @implements {Cesium.TerrainProvider}
+ * @abstract
+ */
+class AbstractTerrainProvider {
+  /**
+   * Constructor.
+   * @param {!osx.map.TerrainProviderOptions} options
+   */
+  constructor(options) {
+    asserts.assert(options != null, 'options not defined');
+    asserts.assert(options.url != null, 'url not defined');
 
-  errorEvent: {
-    get:
-        /**
-         * @return {Cesium.Event}
-         * @this plugin.cesium.AbstractTerrainProvider
-         */
-        function() {
-          return this.errorEvent_;
-        }
-  },
+    //
+    // The following properties are all used by Cesium using the get/set functions defined below. They are already
+    // public via those functions, but if you need a setter for an extending class add it to the Object.defineProperties
+    // section. Renaming these to remove the undersos (to make them protected) will break the get/set functions unless
+    // you change the property name!
+    //
 
-  ready: {
-    get:
-        /**
-         * @return {boolean}
-         * @this plugin.cesium.AbstractTerrainProvider
-         */
-        function() {
-          return this.ready_;
-        },
-    set:
-        /**
-         * @param {boolean} value
-         * @this plugin.cesium.AbstractTerrainProvider
-         */
-        function(value) {
-          this.ready_ = value;
-        }
-  },
+    /**
+     * @type {Cesium.Credit}
+     * @private
+     */
+    this.credit_ = typeof options.credit === 'string' ? new Cesium.Credit(options.credit) : null;
 
-  tilingScheme: {
-    get:
-        /**
-         * @return {Cesium.GeographicTilingScheme}
-         * @this plugin.cesium.AbstractTerrainProvider
-         */
-        function() {
-          return this.tilingScheme_;
-        }
-  },
+    /**
+     * @type {Cesium.Event}
+     * @private
+     */
+    this.errorEvent_ = new Cesium.Event();
 
-  hasVertexNormals: {
-    get:
-        /**
-         * @return {boolean}
-         * @this plugin.cesium.AbstractTerrainProvider
-         */
-        function() {
-          return this.hasVertexNormals_;
-        }
-  },
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.hasVertexNormals_ = false;
 
-  hasWaterMask: {
-    get:
-        /**
-         * @return {boolean}
-         * @this plugin.cesium.AbstractTerrainProvider
-         */
-        function() {
-          return this.hasWaterMask_;
-        }
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.hasWaterMask_ = false;
+
+    /**
+     * @type {string}
+     * @private
+     */
+    this.name_ = 'Terrain';
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.ready_ = false;
+
+    /**
+     * @type {Cesium.GeographicTilingScheme}
+     * @private
+     */
+    this.tilingScheme_ = new Cesium.GeographicTilingScheme({
+      numberOfLevelZeroTilesX: 2,
+      numberOfLevelZeroTilesY: 1
+    });
+
+    //
+    // The rest of the properties are use internally (not by Cesium) and are safe to do as you please.
+    //
+
+    /**
+     * @type {number}
+     * @protected
+     */
+    this.minLevel = options.minLevel || DEFAULT_MIN_LEVEL;
+
+    /**
+     * @type {number}
+     * @protected
+     */
+    this.tileSize = options.tileSize || DEFAULT_TILE_SIZE;
+
+    /**
+     * @type {number}
+     * @protected
+     */
+    this.levelZeroMaximumGeometricError = Cesium.TerrainProvider.getEstimatedLevelZeroGeometricErrorForAHeightmap(
+        this.tilingScheme_.ellipsoid,
+        this.tileSize,
+        this.tilingScheme_.getNumberOfXTilesAtLevel(0));
+
+    /**
+     * @type {Cesium.HeightMapStructure}
+     * @protected
+     */
+    this.terrainDataStructure = {
+      heightScale: 1.0,
+      heightOffset: 0.0,
+      elementsPerHeight: 1,
+      stride: 1,
+      elementMultiplier: 256.0,
+      isBigEndian: false
+    };
+
+    /**
+     * @type {string}
+     * @protected
+     */
+    this.url = options.url;
+
+    /**
+     * @type {boolean}
+     * @protected
+     */
+    this.useProxy = options.useProxy || false;
   }
-});
 
+  /**
+   * Get the terrain name
+   *
+   * @return {string}
+   * @protected
+   */
+  getName() {
+    return this.name_;
+  }
 
-/**
- * Get the terrain name
- *
- * @return {string}
- * @protected
- */
-plugin.cesium.AbstractTerrainProvider.prototype.getName = function() {
-  return this.name_;
-};
+  /**
+   * Set the terrain name
+   *
+   * @param {string} value
+   * @protected
+   */
+  setName(value) {
+    this.name_ = value;
+  }
 
+  /**
+   * Get the terrain child mask
+   *
+   * @param {number} x
+   * @param {number} y
+   * @param {number} level
+   * @return {number}
+   * @protected
+   */
+  getTerrainChildMask(x, y, level) {
+    var mask = 0;
+    var childLevel = level + 1;
+    mask |= this.getTileDataAvailable(2 * x, 2 * y, childLevel) ? 1 : 0;
+    mask |= this.getTileDataAvailable(2 * x + 1, 2 * y, childLevel) ? 2 : 0;
+    mask |= this.getTileDataAvailable(2 * x, 2 * y + 1, childLevel) ? 4 : 0;
+    mask |= this.getTileDataAvailable(2 * x + 1, 2 * y + 1, childLevel) ? 8 : 0;
+    return mask;
+  }
 
-/**
- * Set the terrain name
- *
- * @param {string} value
- * @protected
- */
-plugin.cesium.AbstractTerrainProvider.prototype.setName = function(value) {
-  this.name_ = value;
-};
+  /**
+   * @inheritDoc
+   */
+  getLevelMaximumGeometricError(level) {
+    return this.levelZeroMaximumGeometricError / (1 << level);
+  }
 
+  /**
+   * @inheritDoc
+   */
+  getTileDataAvailable(x, y, level) {
+    return true;
+  }
 
-/**
- * Get the terrain child mask
- *
- * @param {number} x
- * @param {number} y
- * @param {number} level
- * @return {number}
- * @protected
- */
-plugin.cesium.AbstractTerrainProvider.prototype.getTerrainChildMask = function(x, y, level) {
-  var mask = 0;
-  var childLevel = level + 1;
-  mask |= this.getTileDataAvailable(2 * x, 2 * y, childLevel) ? 1 : 0;
-  mask |= this.getTileDataAvailable(2 * x + 1, 2 * y, childLevel) ? 2 : 0;
-  mask |= this.getTileDataAvailable(2 * x, 2 * y + 1, childLevel) ? 4 : 0;
-  mask |= this.getTileDataAvailable(2 * x + 1, 2 * y + 1, childLevel) ? 8 : 0;
-  return mask;
-};
+  /**
+   * @inheritDoc
+   */
+  get credit() {
+    return this.credit_;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  get errorEvent() {
+    return this.errorEvent_;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.cesium.AbstractTerrainProvider.prototype.getLevelMaximumGeometricError = function(level) {
-  return this.levelZeroMaximumGeometricError / (1 << level);
-};
+  /**
+   * @inheritDoc
+   */
+  get ready() {
+    return this.ready_;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  set ready(value) {
+    this.ready_ = value;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.cesium.AbstractTerrainProvider.prototype.getTileDataAvailable = function(x, y, level) {
-  return true;
-};
+  /**
+   * @inheritDoc
+   */
+  get tilingScheme() {
+    return this.tilingScheme_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  get hasVertexNormals() {
+    return this.hasVertexNormals_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  get hasWaterMask() {
+    return this.hasWaterMask_;
+  }
+}
+
+exports = AbstractTerrainProvider;

--- a/src/plugin/cesium/abstractterrainprovider.js
+++ b/src/plugin/cesium/abstractterrainprovider.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.AbstractTerrainProvider');
-goog.module.declareLegacyNamespace();
 
 const asserts = goog.require('goog.asserts');
 

--- a/src/plugin/cesium/cesium.js
+++ b/src/plugin/cesium/cesium.js
@@ -1,7 +1,6 @@
 goog.module('plugin.cesium');
 
 const MapContainer = goog.require('os.MapContainer');
-const ui = goog.require('os.ui');
 const settings = goog.require('os.config.Settings');
 const Promise = goog.require('goog.Promise');
 const Uri = goog.require('goog.Uri');
@@ -16,6 +15,7 @@ const net = goog.require('os.net');
 const proj = goog.require('os.proj');
 const utils = goog.require('os.query.utils');
 const osString = goog.require('os.string');
+const osWindow = goog.require('os.ui.window');
 const ConfirmUI = goog.require('os.ui.window.ConfirmUI');
 const ImageryProvider = goog.require('plugin.cesium.ImageryProvider');
 
@@ -187,7 +187,7 @@ const loadCesium = function() {
  */
 const promptForAccessToken = function() {
   return new Promise(function(resolve, reject) {
-    ui.window.launchConfirmText(/** @type {!osx.window.ConfirmTextOptions} */ ({
+    osWindow.launchConfirmText(/** @type {!osx.window.ConfirmTextOptions} */ ({
       confirm: (accessToken) => {
         settings.getInstance().set(SettingsKey.ACCESS_TOKEN, accessToken);
         resolve(accessToken);

--- a/src/plugin/cesium/cesium.js
+++ b/src/plugin/cesium/cesium.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium');
-goog.module.declareLegacyNamespace();
 
 const MapContainer = goog.require('os.MapContainer');
 const ui = goog.require('os.ui');
@@ -19,7 +18,6 @@ const utils = goog.require('os.query.utils');
 const osString = goog.require('os.string');
 const ConfirmUI = goog.require('os.ui.window.ConfirmUI');
 const ImageryProvider = goog.require('plugin.cesium.ImageryProvider');
-const WMSTerrainProvider = goog.require('plugin.cesium.WMSTerrainProvider');
 
 
 /**
@@ -48,6 +46,12 @@ const SettingsKey = {
   LOAD_TIMEOUT: 'cesium.loadTimeout',
   SKYBOX_OPTIONS: 'cesium.skyBoxOptions'
 };
+
+/**
+ * Identifier for Cesium plugin components
+ * @type {string}
+ */
+const ID = 'cesium';
 
 /**
  * @type {string}
@@ -531,16 +535,6 @@ const enableWorldTerrain = function() {
 };
 
 /**
- * Create a Cesium WMS terrain provider instance.
- *
- * @param {!osx.cesium.WMSTerrainProviderOptions} options The WMS terrain options.
- * @return {!Promise<!WMSTerrainProvider>}
- */
-const createWMSTerrain = function(options) {
-  return Promise.resolve(new WMSTerrainProvider(options));
-};
-
-/**
  * @type {?Cesium.Cartesian3}
  */
 let scratchCartesian_ = null;
@@ -619,6 +613,8 @@ const reduceBoundingSphere = function(sphere, geom) {
 exports = {
   GeometryInstanceId,
   SettingsKey,
+  TerrainProviderFn,
+  ID,
   CESIUM_ONLY_LAYER,
   ELLIPSOID_REGEXP,
   OUTLINE_REGEXP,
@@ -647,7 +643,5 @@ exports = {
   isWorldTerrainActive,
   hasWorldTerrain,
   enableWorldTerrain,
-  createWMSTerrain,
-  reduceBoundingSphere,
-  TerrainProviderFn
+  reduceBoundingSphere
 };

--- a/src/plugin/cesium/cesiumcamera.js
+++ b/src/plugin/cesium/cesiumcamera.js
@@ -2,20 +2,142 @@
  * @fileoverview ol-cesium camera replacement.
  * @suppress {accessControls}
  */
-goog.provide('plugin.cesium.Camera');
+goog.module('plugin.cesium.Camera');
 
-goog.require('goog.async.Throttle');
-goog.require('goog.math');
-goog.require('ol.Observable');
-goog.require('ol.events');
-goog.require('ol.proj');
-goog.require('olcs.Camera');
-goog.require('olcs.core');
-goog.require('os.map');
-goog.require('os.map.FlightMode');
-goog.require('os.math');
-goog.require('os.webgl.IWebGLCamera');
+const Throttle = goog.require('goog.async.Throttle');
+const googMath = goog.require('goog.math');
+const proj = goog.require('ol.proj');
+const OLCSCamera = goog.require('olcs.Camera');
+const core = goog.require('olcs.core');
+const MapContainer = goog.require('os.MapContainer');
+const osMap = goog.require('os.map');
+const FlightMode = goog.require('os.map.FlightMode');
+const math = goog.require('os.math');
 
+const View = goog.requireType('ol.View');
+const IWebGLCamera = goog.requireType('os.webgl.IWebGLCamera');
+
+
+/**
+ * @type {Cesium.Cartesian3}
+ */
+let scratchCartesian1 = null;
+
+/**
+ * @type {Cesium.Cartesian3}
+ */
+let scratchCartesian2 = null;
+
+/**
+ * @type {Cesium.Cartesian3}
+ */
+let scratchCartesian3 = null;
+
+/**
+ * @type {Cesium.Cartesian2}
+ */
+let scratchPixel1 = null;
+
+/**
+ * @type {Cesium.Cartesian2}
+ */
+let scratchPixel2 = null;
+
+/**
+ * @type {Cesium.Cartographic}
+ */
+let scratchCarto1 = null;
+
+/**
+ * @type {Cesium.Rectangle}
+ */
+let scratchRect = null;
+
+/**
+ * @type {Cesium.Quaternion}
+ */
+let scratchQuaternion = null;
+
+/**
+ * @type {Cesium.Matrix3}
+ */
+let scratchRotation = null;
+
+/**
+ * @type {Cesium.Cartesian3}
+ */
+let onScreenCartesian = null;
+
+/**
+ * @type {Cesium.BoundingSphere}
+ */
+let onScreenBoundingSphere = null;
+
+/**
+ * @type {Cesium.Cartesian4}
+ */
+let scratchCartesian4 = null;
+
+/**
+ * @type {Cesium.Cartesian3}
+ */
+let scratchEyeOffset = null;
+
+/**
+ * @type {Cesium.BoundingRectangle}
+ */
+let scratchViewport = null;
+
+
+/**
+ * Initialize variables used to avoid excess GC.
+ */
+const initExtentComputation = () => {
+  if (!scratchCartesian1) {
+    scratchCartesian1 = new Cesium.Cartesian3();
+    scratchCartesian2 = new Cesium.Cartesian3();
+    scratchCartesian3 = new Cesium.Cartesian3();
+    scratchPixel1 = new Cesium.Cartesian2();
+    scratchPixel2 = new Cesium.Cartesian2();
+    scratchCarto1 = new Cesium.Cartographic();
+    scratchRect = new Cesium.Rectangle();
+    scratchQuaternion = new Cesium.Quaternion();
+    scratchRotation = new Cesium.Matrix3();
+
+    onScreenCartesian = new Cesium.Cartesian3();
+    onScreenBoundingSphere = new Cesium.BoundingSphere();
+
+    scratchCartesian4 = new Cesium.Cartesian4();
+    scratchEyeOffset = new Cesium.Cartesian3();
+
+    scratchViewport = new Cesium.BoundingRectangle();
+  }
+};
+
+
+/**
+ * This is a duplication of the method in Cesium.SceneTransforms because it is not exposed
+ *
+ * @param {Cesium.Cartesian3} position
+ * @param {Cesium.Cartesian3} eyeOffset
+ * @param {Cesium.Camera} camera
+ * @param {Cesium.Cartesian4=} opt_result
+ * @return {Cesium.Cartesian4}
+ */
+const worldToClip = (position, eyeOffset, camera, opt_result) => {
+  var viewMatrix = camera.viewMatrix;
+
+  var positionEC = Cesium.Matrix4.multiplyByVector(viewMatrix,
+      Cesium.Cartesian4.fromElements(position.x, position.y, position.z, 1, scratchCartesian4), scratchCartesian4);
+
+  var zEyeOffset = Cesium.Cartesian3.multiplyComponents(eyeOffset,
+      Cesium.Cartesian3.normalize(positionEC, scratchEyeOffset), scratchEyeOffset);
+  positionEC.x += eyeOffset.x + zEyeOffset.x;
+  positionEC.y += eyeOffset.y + zEyeOffset.y;
+  positionEC.z += zEyeOffset.z;
+
+  return Cesium.Matrix4.multiplyByVector(camera.frustum.projectionMatrix, positionEC, opt_result);
+};
 
 
 /**
@@ -24,148 +146,110 @@ goog.require('os.webgl.IWebGLCamera');
  * This object takes care of additional 3D-specific properties of the view and ensures proper synchronization with the
  * underlying raw Cesium.Camera object.
  *
- * This replaces {@link olcs.Camera}, which syncs the 2D view to the 3D camera instead of using native Cesium camera
+ * This replaces {@link OLCSCamera}, which syncs the 2D view to the 3D camera instead of using native Cesium camera
  * conrols.
  *
- * @param {!Cesium.Scene} scene
- * @param {!ol.Map} map
  *
- * @extends {olcs.Camera}
- * @implements {os.webgl.IWebGLCamera}
- * @constructor
+ * @implements {IWebGLCamera}
  */
-plugin.cesium.Camera = function(scene, map) {
-  this.scene_ = scene;
-  this.cam_ = scene.camera;
-  this.map_ = map;
-  this.tilt_ = 0;
-  this.distance_ = 0;
-  this.lastCameraViewMatrix_ = null;
-  this.viewUpdateInProgress_ = false;
+class Camera extends OLCSCamera {
+  /**
+   * Constructor.
+   * @param {!Cesium.Scene} scene
+   * @param {!ol.Map} map
+   */
+  constructor(scene, map) {
+    super(scene, map);
+
+    /**
+     * This is used to disable any camera updates while not in use.
+     * @type {boolean}
+     * @private
+     */
+    this.enabled_ = false;
+
+    /**
+     * Rate limit how often we update the OL camera to reduce CPU overhead
+     * @type {Throttle}
+     * @private
+     */
+    this.updateThrottle_ = new Throttle(this.updateView, 100, this);
+
+    // Initialize scratch objects.
+    initExtentComputation();
+  }
 
   /**
-   * This is used to disable any camera updates while not in use.
-   * @type {boolean}
-   * @private
+   * If the camera is enabled.
+   *
+   * @return {boolean}
    */
-  this.enabled_ = false;
+  getEnabled() {
+    return this.enabled_;
+  }
 
   /**
-   * Rate limit how often we update the OL camera to reduce CPU overhead
-   * @type {goog.async.Throttle}
-   * @private
+   * Set if the camera is enabled.
+   *
+   * @param {boolean} value If the camera should be enabled.
    */
-  this.updateThrottle_ = new goog.async.Throttle(this.updateView, 100, this);
-};
-goog.inherits(plugin.cesium.Camera, olcs.Camera);
+  setEnabled(value) {
+    this.enabled_ = value;
 
-
-/**
- * Replace the olcs camera with ours.
- */
-plugin.cesium.replaceCamera = function() {
-  olcs.Camera = plugin.cesium.Camera;
-};
-plugin.cesium.replaceCamera();
-
-
-/**
- * If the camera is enabled.
- *
- * @return {boolean}
- */
-plugin.cesium.Camera.prototype.getEnabled = function() {
-  return this.enabled_;
-};
-
-
-/**
- * Set if the camera is enabled.
- *
- * @param {boolean} value If the camera should be enabled.
- */
-plugin.cesium.Camera.prototype.setEnabled = function(value) {
-  this.enabled_ = value;
-
-  if (this.enabled_) {
-    this.readFromView();
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.getAltitude = function() {
-  return this.cam_.positionCartographic.height;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.setAltitude = function(altitude) {
-  this.flyTo(/** @type {!osx.map.FlyToOptions} */ ({
-    altitude: altitude,
-    positionCamera: true
-  }));
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.getCenter = function() {
-  var view = this.map_.getView();
-
-  if (!view) {
-    return undefined;
+    if (this.enabled_) {
+      this.readFromView();
+    }
   }
 
-  return view.getCenter();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.setCenter = function(center) {
-  this.flyTo(/** @type {!osx.map.FlyToOptions} */ ({
-    center: center,
-    positionCamera: true
-  }));
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.getExtent = function() {
-  if (!this.computeCorrectExtent_) {
-    this.initExtentComputation_();
+  /**
+   * @inheritDoc
+   */
+  getAltitude() {
+    return this.cam_.positionCartographic.height;
   }
-  var rect = this.computeCorrectExtent_();
 
-  // the values are returned in radians, so map them to degrees
-  return rect ? [rect.west, rect.south, rect.east, rect.north].map(Cesium.Math.toDegrees) : undefined;
-};
+  /**
+   * @inheritDoc
+   */
+  setAltitude(altitude) {
+    this.flyTo(/** @type {!osx.map.FlyToOptions} */ ({
+      altitude: altitude,
+      positionCamera: true
+    }));
+  }
 
+  /**
+   * @inheritDoc
+   */
+  getCenter() {
+    var view = this.map_.getView();
 
+    if (!view) {
+      return undefined;
+    }
 
-/**
- * @private
- */
-plugin.cesium.Camera.prototype.initExtentComputation_ = function() {
-  // avoid needless GC
-  var scratchCartesian1 = new Cesium.Cartesian3();
-  var scratchCartesian2 = new Cesium.Cartesian3();
-  var scratchCartesian3 = new Cesium.Cartesian3();
-  var scratchPixel1 = new Cesium.Cartesian2();
-  var scratchPixel2 = new Cesium.Cartesian2();
-  var scratchCarto1 = new Cesium.Cartographic();
-  var scratchRect = new Cesium.Rectangle();
-  var scratchQuaternion = new Cesium.Quaternion();
-  var scratchRotation = new Cesium.Matrix3();
+    return view.getCenter();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setCenter(center) {
+    this.flyTo(/** @type {!osx.map.FlyToOptions} */ ({
+      center: center,
+      positionCamera: true
+    }));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getExtent() {
+    var rect = this.computeCorrectExtent_();
+
+    // the values are returned in radians, so map them to degrees
+    return rect ? [rect.west, rect.south, rect.east, rect.north].map(Cesium.Math.toDegrees) : undefined;
+  }
 
   /**
    * Generates points along the canvas edges
@@ -174,7 +258,7 @@ plugin.cesium.Camera.prototype.initExtentComputation_ = function() {
    * @return {Array<ol.Pixel>}
    * @private
    */
-  plugin.cesium.Camera.prototype.generateScreenBoundaries_ = function(opt_segmentsPerSide) {
+  generateScreenBoundaries_(opt_segmentsPerSide) {
     opt_segmentsPerSide = opt_segmentsPerSide || 16;
 
     var size = this.map_.getSize();
@@ -193,18 +277,14 @@ plugin.cesium.Camera.prototype.initExtentComputation_ = function() {
     }
 
     return pixels;
-  };
-
-
-  var onScreenCartesian = new Cesium.Cartesian3();
-  var onScreenBoundingSphere = new Cesium.BoundingSphere();
+  }
 
   /**
    * @param {Cesium.Cartographic} cartographic
    * @return {boolean} Whether or not the given coordinate is on screen
    * @protected
    */
-  plugin.cesium.Camera.prototype.onScreen = function(cartographic) {
+  onScreen(cartographic) {
     var scratchCartesian = onScreenCartesian;
     var scratchSphere = onScreenBoundingSphere;
 
@@ -216,43 +296,12 @@ plugin.cesium.Camera.prototype.initExtentComputation_ = function() {
 
     return occluder.isPointVisible(position) &&
         cullingVolume.computeVisibility(scratchSphere) === Cesium.Intersect.INSIDE;
-  };
-
-
-  // This is a duplication of the method in Cesium.SceneTransforms because it is not exposed
-  var scratchCartesian4 = new Cesium.Cartesian4();
-  var scratchEyeOffset = new Cesium.Cartesian3();
-
-  /**
-   * This is a duplication of the method in Cesium.SceneTransforms because it is not exposed
-   *
-   * @param {Cesium.Cartesian3} position
-   * @param {Cesium.Cartesian3} eyeOffset
-   * @param {Cesium.Camera} camera
-   * @param {Cesium.Cartesian4=} opt_result
-   * @return {Cesium.Cartesian4}
-   */
-  var worldToClip = function(position, eyeOffset, camera, opt_result) {
-    var viewMatrix = camera.viewMatrix;
-
-    var positionEC = Cesium.Matrix4.multiplyByVector(viewMatrix,
-        Cesium.Cartesian4.fromElements(position.x, position.y, position.z, 1, scratchCartesian4), scratchCartesian4);
-
-    var zEyeOffset = Cesium.Cartesian3.multiplyComponents(eyeOffset,
-        Cesium.Cartesian3.normalize(positionEC, scratchEyeOffset), scratchEyeOffset);
-    positionEC.x += eyeOffset.x + zEyeOffset.x;
-    positionEC.y += eyeOffset.y + zEyeOffset.y;
-    positionEC.z += zEyeOffset.z;
-
-    return Cesium.Matrix4.multiplyByVector(camera.frustum.projectionMatrix, positionEC, opt_result);
-  };
-
-  var scratchViewport = new Cesium.BoundingRectangle();
+  }
 
   /**
    * @return {Cesium.Rectangle|undefined}
    */
-  plugin.cesium.Camera.prototype.computeCorrectExtent_ = function() {
+  computeCorrectExtent_() {
     var rect = scratchRect;
 
     // generate 16 segments along each edge of the canvas for a total of 64
@@ -377,545 +426,528 @@ plugin.cesium.Camera.prototype.initExtentComputation_ = function() {
     }
 
     return rect;
-  };
-};
-
-
-
-/**
- * @return {number}
- * @override
- */
-plugin.cesium.Camera.prototype.getHeading = function() {
-  return this.cam_.heading;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.setHeading = function(heading) {
-  var carto = this.cam_.positionCartographic;
-  this.cam_.setView({
-    destionation: carto,
-    orientation: {
-      heading: heading,
-      pitch: this.cam_.pitch,
-      roll: this.cam_.roll
-    }
-  });
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.getTilt = function() {
-  return this.tilt_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.setTilt = function(tilt) {
-  this.tilt_ = tilt;
-  this.updateCamera_();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.setPosition = function(position) {
-  this.flyTo(/** @type {!osx.map.FlyToOptions} */ ({
-    center: position,
-    positionCamera: true
-  }));
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.rotateLeft = function(opt_value) {
-  if (this.cam_) {
-    this.cam_.rotateLeft(opt_value);
   }
-};
 
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.rotateRight = function(opt_value) {
-  if (this.cam_) {
-    this.cam_.rotateRight(opt_value);
+  /**
+   * @return {number}
+   * @override
+   */
+  getHeading() {
+    return this.cam_.heading;
   }
-};
 
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.rotateUp = function(opt_value) {
-  if (this.cam_) {
-    this.cam_.rotateUp(opt_value);
+  /**
+   * @inheritDoc
+   */
+  setHeading(heading) {
+    var carto = this.cam_.positionCartographic;
+    this.cam_.setView({
+      destionation: carto,
+      orientation: {
+        heading: heading,
+        pitch: this.cam_.pitch,
+        roll: this.cam_.roll
+      }
+    });
   }
-};
 
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.rotateDown = function(opt_value) {
-  if (this.cam_) {
-    this.cam_.rotateDown(opt_value);
+  /**
+   * @inheritDoc
+   */
+  getTilt() {
+    return this.tilt_;
   }
-};
 
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.twistLeft = function(opt_value) {
-  if (this.cam_) {
-    this.cam_.twistLeft(opt_value);
+  /**
+   * @inheritDoc
+   */
+  setTilt(tilt) {
+    this.tilt_ = tilt;
+    this.updateCamera_();
   }
-};
 
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.twistRight = function(opt_value) {
-  if (this.cam_) {
-    this.cam_.twistRight(opt_value);
+  /**
+   * @inheritDoc
+   */
+  setPosition(position) {
+    this.flyTo(/** @type {!osx.map.FlyToOptions} */ ({
+      center: position,
+      positionCamera: true
+    }));
   }
-};
 
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.cancelFlight = function() {
-  if (this.enabled_ && this.cam_) {
-    this.cam_.cancelFlight();
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.flyTo = function(options) {
-  if (this.enabled_) {
-    var duration = options.duration != null ? options.duration : os.MapContainer.FLY_ZOOM_DURATION;
-    var easingFunction = options.flightMode === os.map.FlightMode.SMOOTH ?
-      Cesium.EasingFunction.LINEAR_NONE : undefined;
-
-    var target;
-    if (options.center) {
-      var center = ol.proj.transform(options.center, os.map.PROJECTION, os.proj.EPSG4326);
-      target = new Cesium.Cartographic(ol.math.toRadians(center[0]), ol.math.toRadians(center[1]));
-    } else {
-      // clone the current position or Cesium won't animate the change
-      target = this.cam_.positionCartographic.clone();
-    }
-
-    // use current altitude if not defined, and cap to the maximum value
-    var altitude = options.altitude != null ? options.altitude : this.getAltitude();
-    var maxAltitude = this.scene_.screenSpaceCameraController.maximumZoomDistance;
-    altitude = Math.min(altitude, maxAltitude);
-
-    var heading = options.heading != null ? ol.math.toRadians(options.heading) : this.cam_.heading;
-    // KML standard pitch is 0 to look directly at the Earth, Cesium is -90
-    var pitch = options.pitch != null ? ol.math.toRadians(options.pitch - 90) : this.cam_.pitch;
-    var roll = options.roll != null ? ol.math.toRadians(options.roll) : this.cam_.roll;
-
-    if (options.positionCamera) {
-      // move the camera to the specified position
-      target.height = altitude;
-
-      this.cam_.flyTo({
-        destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(target),
-        duration: duration / 1000,
-        easingFunction: easingFunction,
-        orientation: {
-          heading: heading,
-          pitch: pitch,
-          roll: roll
-        }
-      });
-    } else {
-      // point the camera at the specified position, on the ground
-      target.height = 0;
-
-      var boundingSphere = new Cesium.BoundingSphere(Cesium.Ellipsoid.WGS84.cartographicToCartesian(target));
-      var range = options.range != null ? options.range : altitude;
-      var offset = new Cesium.HeadingPitchRange(heading, pitch, range);
-
-      this.cam_.flyToBoundingSphere(boundingSphere, {
-        offset: offset,
-        duration: duration / 1000,
-        easingFunction: easingFunction
-      });
+  /**
+   * @inheritDoc
+   */
+  rotateLeft(opt_value) {
+    if (this.cam_) {
+      this.cam_.rotateLeft(opt_value);
     }
   }
-};
 
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.getDistanceToCenter = function() {
-  var center;
-  var canvas = /** @type {HTMLCanvasElement} */ (document.querySelector(os.map.WEBGL_CANVAS));
-  if (canvas) {
-    center = this.cam_.pickEllipsoid(new Cesium.Cartesian2(canvas.width / 2, canvas.height / 2));
+  /**
+   * @inheritDoc
+   */
+  rotateRight(opt_value) {
+    if (this.cam_) {
+      this.cam_.rotateRight(opt_value);
+    }
   }
 
-  // try to base zoom on the distance from the camera to the globe at the center of the screen, otherwise use the
-  // camera's current altitude from the globe.
-  return center ? Cesium.Cartesian3.distance(this.cam_.positionWC, center) : this.getAltitude();
-};
+  /**
+   * @inheritDoc
+   */
+  rotateUp(opt_value) {
+    if (this.cam_) {
+      this.cam_.rotateUp(opt_value);
+    }
+  }
 
+  /**
+   * @inheritDoc
+   */
+  rotateDown(opt_value) {
+    if (this.cam_) {
+      this.cam_.rotateDown(opt_value);
+    }
+  }
 
-/**
- * Get the distance from the camera to a world coordinate. Returns undefined if the coordinate is obscured by the
- * ellipsoid.
- *
- * @param {!Cesium.Cartesian3} position The position
- * @return {number|undefined}
- */
-plugin.cesium.Camera.prototype.getDistanceToPosition = function(position) {
-  var distance;
+  /**
+   * @inheritDoc
+   */
+  twistLeft(opt_value) {
+    if (this.cam_) {
+      this.cam_.twistLeft(opt_value);
+    }
+  }
 
-  // get the window pixel of the position within the scene. make sure a pixel is returned and is not negative.
-  var pixel = Cesium.SceneTransforms.wgs84ToWindowCoordinates(this.scene_, position);
-  if (pixel && pixel.x > 0 && pixel.y > 0) {
-    // make sure the pixel is within the bounds of the canvas
-    var canvas = /** @type {HTMLCanvasElement} */ (document.querySelector(os.map.WEBGL_CANVAS));
-    if (pixel.x <= canvas.width && pixel.y <= canvas.height) {
-      // get the distance to the position
-      distance = Cesium.Cartesian3.distance(position, this.cam_.positionWC);
+  /**
+   * @inheritDoc
+   */
+  twistRight(opt_value) {
+    if (this.cam_) {
+      this.cam_.twistRight(opt_value);
+    }
+  }
 
-      // try to pick the ellipsoid. if it isn't picked, the position is off the ellipsoid and is in view. if it is
-      // picked, check if the ellipsoid is blocking the position.
-      var ellipsoidPosition = this.cam_.pickEllipsoid(pixel);
-      if (ellipsoidPosition) {
-        var ellipsoidDistance = Cesium.Cartesian3.distance(ellipsoidPosition, this.cam_.positionWC);
-        if (ellipsoidDistance < distance) {
-          // ellipsoid is closer to the camera, so the position isn't in view
-          distance = undefined;
-        }
+  /**
+   * @inheritDoc
+   */
+  cancelFlight() {
+    if (this.enabled_ && this.cam_) {
+      this.cam_.cancelFlight();
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  flyTo(options) {
+    if (this.enabled_) {
+      var duration = options.duration != null ? options.duration : MapContainer.FLY_ZOOM_DURATION;
+      var easingFunction = options.flightMode === FlightMode.SMOOTH ?
+        Cesium.EasingFunction.LINEAR_NONE : undefined;
+
+      var target;
+      if (options.center) {
+        var center = proj.transform(options.center, osMap.PROJECTION, os.proj.EPSG4326);
+        target = new Cesium.Cartographic(Cesium.Math.toRadians(center[0]), Cesium.Math.toRadians(center[1]));
+      } else {
+        // clone the current position or Cesium won't animate the change
+        target = this.cam_.positionCartographic.clone();
+      }
+
+      // use current altitude if not defined, and cap to the maximum value
+      var altitude = options.altitude != null ? options.altitude : this.getAltitude();
+      var maxAltitude = this.scene_.screenSpaceCameraController.maximumZoomDistance;
+      altitude = Math.min(altitude, maxAltitude);
+
+      var heading = options.heading != null ? Cesium.Math.toRadians(options.heading) : this.cam_.heading;
+      // KML standard pitch is 0 to look directly at the Earth, Cesium is -90
+      var pitch = options.pitch != null ? Cesium.Math.toRadians(options.pitch - 90) : this.cam_.pitch;
+      var roll = options.roll != null ? Cesium.Math.toRadians(options.roll) : this.cam_.roll;
+
+      if (options.positionCamera) {
+        // move the camera to the specified position
+        target.height = altitude;
+
+        this.cam_.flyTo({
+          destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(target),
+          duration: duration / 1000,
+          easingFunction: easingFunction,
+          orientation: {
+            heading: heading,
+            pitch: pitch,
+            roll: roll
+          }
+        });
+      } else {
+        // point the camera at the specified position, on the ground
+        target.height = 0;
+
+        var boundingSphere = new Cesium.BoundingSphere(Cesium.Ellipsoid.WGS84.cartographicToCartesian(target));
+        var range = options.range != null ? options.range : altitude;
+        var offset = new Cesium.HeadingPitchRange(heading, pitch, range);
+
+        this.cam_.flyToBoundingSphere(boundingSphere, {
+          offset: offset,
+          duration: duration / 1000,
+          easingFunction: easingFunction
+        });
       }
     }
   }
 
-  return distance;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.zoomByDelta = function(delta) {
-  var camDistance = this.getDistanceToCenter();
-  var distance = camDistance - camDistance * delta;
-
-  // don't zoom out beyond the maximum zoom distance set on the controller
-  var sscc = this.scene_.screenSpaceCameraController;
-  var maxDistance = sscc.maximumZoomDistance;
-  if (distance < camDistance - maxDistance) {
-    distance = camDistance - maxDistance;
-  }
-
-  // only zoom if the distance exceeds the minimum zoom distance set on the controller
-  if (Math.abs(distance) > sscc.minimumZoomDistance) {
-    this.cam_.zoomIn(distance);
-  }
-};
-
-
-/**
- * Updates the state of the underlying Cesium.Camera
- * according to the current values of the properties.
- *
- * @private
- * @override
- */
-plugin.cesium.Camera.prototype.updateCamera_ = function() {
-  var view = this.map_.getView();
-  if (!view) {
-    return;
-  }
-  var center = view.getCenter();
-  if (!center) {
-    return;
-  }
-  var ll = ol.proj.transform(center, os.map.PROJECTION, os.proj.EPSG4326);
-  goog.asserts.assert(ll != null);
-
-  var carto = new Cesium.Cartographic(ol.math.toRadians(ll[0]),
-      ol.math.toRadians(ll[1]));
-  if (this.scene_.globe) {
-    var height = this.scene_.globe.getHeight(carto);
-    carto.height = height != null ? height : 0;
-  }
-
-  var destination = Cesium.Ellipsoid.WGS84.cartographicToCartesian(carto);
-
-  /** @type {Cesium.optionsOrientation} */
-  var orientation = {
-    pitch: this.tilt_ - Cesium.Math.PI_OVER_TWO,
-    heading: -view.getRotation(),
-    roll: undefined
-  };
-  this.cam_.setView({
-    destination: destination,
-    orientation: orientation
-  });
-
-  this.cam_.moveBackward(this.distance_);
-
-  this.checkCameraChange(true);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.readFromView = function() {
-  var view = this.map_.getView();
-  if (!this.enabled_ || !view) {
-    return;
-  }
-
-  var center = view.getCenter();
-  if (!center) {
-    return;
-  }
-
-  var ll = ol.proj.transform(center, os.map.PROJECTION, os.proj.EPSG4326);
-  goog.asserts.assert(ll != null);
-
-  // determine distance at equator so the projection doesn't cause a large difference between 2d/3d
-  var resolution = view.getResolution() || 0;
-  this.distance_ = this.calcDistanceForResolution(resolution, 0);
-
-  this.updateCamera_();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.updateView = function() {
-  var view = this.map_.getView();
-  if (!this.enabled_ || !view) {
-    return;
-  }
-  this.viewUpdateInProgress_ = true;
-
-  // target & distance
-  var ellipsoid = Cesium.Ellipsoid.WGS84;
-  var scene = this.scene_;
-  var target = olcs.core.pickCenterPoint(scene);
-
-  var bestTarget = target;
-  if (!bestTarget) {
-    // TODO: how to handle this properly ?
-    var globe = scene.globe;
-    var carto = this.cam_.positionCartographic.clone();
-    var height = globe.getHeight(carto);
-    carto.height = height != null ? height : 0;
-    bestTarget = Cesium.Ellipsoid.WGS84.cartographicToCartesian(carto);
-  }
-
-  this.distance_ = Cesium.Cartesian3.distance(bestTarget, this.cam_.position);
-
-  var bestTargetCartographic = ellipsoid.cartesianToCartographic(bestTarget);
-  var longitude = bestTargetCartographic ? bestTargetCartographic.longitude : 0;
-  var latitude = bestTargetCartographic ? bestTargetCartographic.latitude : 0;
-
-
-  view.setCenter(ol.proj.transform([
-    ol.math.toDegrees(longitude),
-    ol.math.toDegrees(latitude)], os.proj.EPSG4326, os.map.PROJECTION));
-
-  // determine distance at equator so the projection doesn't cause a large difference between 2d/3d
-  var resolution = this.calcResolutionForDistance(this.distance_, 0);
-  view.setResolution(view.constrainResolution(resolution, 0, 0));
-
-  /*
-   * Since we are positioning the target, the values of heading and tilt
-   * need to be calculated _at the target_.
+  /**
+   * @inheritDoc
    */
-  if (target) {
-    var pos = this.cam_.position;
+  getDistanceToCenter() {
+    var center;
+    var canvas = /** @type {HTMLCanvasElement} */ (document.querySelector(osMap.WEBGL_CANVAS));
+    if (canvas) {
+      center = this.cam_.pickEllipsoid(new Cesium.Cartesian2(canvas.width / 2, canvas.height / 2));
+    }
 
-    // normal to the ellipsoid at the target
-    var targetNormal = new Cesium.Cartesian3();
-    ellipsoid.geocentricSurfaceNormal(target, targetNormal);
-
-    // vector from the target to the camera
-    var targetToCamera = new Cesium.Cartesian3();
-    Cesium.Cartesian3.subtract(pos, target, targetToCamera);
-    Cesium.Cartesian3.normalize(targetToCamera, targetToCamera);
-
-    // HEADING
-    var up = this.cam_.up;
-    var right = this.cam_.right;
-    var normal = new Cesium.Cartesian3(-target.y, target.x, 0); // what is it?
-    var heading = Cesium.Cartesian3.angleBetween(right, normal);
-    var cross = Cesium.Cartesian3.cross(target, up, new Cesium.Cartesian3());
-    var orientation = cross.z;
-
-    view.setRotation((orientation < 0 ? heading : -heading));
-
-    // TILT
-    var tiltAngle = Math.acos(Cesium.Cartesian3.dot(targetNormal, targetToCamera));
-    this.tilt_ = isNaN(tiltAngle) ? 0 : tiltAngle;
-  } else {
-    // fallback when there is no target
-    view.setRotation(this.cam_.heading);
-    this.tilt_ = -this.cam_.pitch + Math.PI / 2;
+    // try to base zoom on the distance from the camera to the globe at the center of the screen, otherwise use the
+    // camera's current altitude from the globe.
+    return center ? Cesium.Cartesian3.distance(this.cam_.positionWC, center) : this.getAltitude();
   }
 
-  this.viewUpdateInProgress_ = false;
-};
+  /**
+   * Get the distance from the camera to a world coordinate. Returns undefined if the coordinate is obscured by the
+   * ellipsoid.
+   *
+   * @param {!Cesium.Cartesian3} position The position
+   * @return {number|undefined}
+   */
+  getDistanceToPosition(position) {
+    var distance;
 
+    // get the window pixel of the position within the scene. make sure a pixel is returned and is not negative.
+    var pixel = Cesium.SceneTransforms.wgs84ToWindowCoordinates(this.scene_, position);
+    if (pixel && pixel.x > 0 && pixel.y > 0) {
+      // make sure the pixel is within the bounds of the canvas
+      var canvas = /** @type {HTMLCanvasElement} */ (document.querySelector(osMap.WEBGL_CANVAS));
+      if (pixel.x <= canvas.width && pixel.y <= canvas.height) {
+        // get the distance to the position
+        distance = Cesium.Cartesian3.distance(position, this.cam_.positionWC);
 
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.checkCameraChange = function(opt_dontSync) {
-  var old = this.lastCameraViewMatrix_;
-  var current = this.cam_.viewMatrix;
+        // try to pick the ellipsoid. if it isn't picked, the position is off the ellipsoid and is in view. if it is
+        // picked, check if the ellipsoid is blocking the position.
+        var ellipsoidPosition = this.cam_.pickEllipsoid(pixel);
+        if (ellipsoidPosition) {
+          var ellipsoidDistance = Cesium.Cartesian3.distance(ellipsoidPosition, this.cam_.positionWC);
+          if (ellipsoidDistance < distance) {
+            // ellipsoid is closer to the camera, so the position isn't in view
+            distance = undefined;
+          }
+        }
+      }
+    }
 
-  if (!old || !Cesium.Matrix4.equalsEpsilon(old, current, 1e-5)) {
-    this.lastCameraViewMatrix_ = current.clone();
-    if (opt_dontSync !== true) {
-      this.updateThrottle_.fire();
+    return distance;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  zoomByDelta(delta) {
+    var camDistance = this.getDistanceToCenter();
+    var distance = camDistance - camDistance * delta;
+
+    // don't zoom out beyond the maximum zoom distance set on the controller
+    var sscc = this.scene_.screenSpaceCameraController;
+    var maxDistance = sscc.maximumZoomDistance;
+    if (distance < camDistance - maxDistance) {
+      distance = camDistance - maxDistance;
+    }
+
+    // only zoom if the distance exceeds the minimum zoom distance set on the controller
+    if (Math.abs(distance) > sscc.minimumZoomDistance) {
+      this.cam_.zoomIn(distance);
     }
   }
-};
 
+  /**
+   * Updates the state of the underlying Cesium.Camera
+   * according to the current values of the properties.
+   *
+   * @private
+   * @override
+   */
+  updateCamera_() {
+    var view = this.map_.getView();
+    if (!view) {
+      return;
+    }
+    var center = view.getCenter();
+    if (!center) {
+      return;
+    }
+    var ll = proj.transform(center, osMap.PROJECTION, os.proj.EPSG4326);
+    goog.asserts.assert(ll != null);
+
+    var carto = new Cesium.Cartographic(Cesium.Math.toRadians(ll[0]),
+        Cesium.Math.toRadians(ll[1]));
+    if (this.scene_.globe) {
+      var height = this.scene_.globe.getHeight(carto);
+      carto.height = height != null ? height : 0;
+    }
+
+    var destination = Cesium.Ellipsoid.WGS84.cartographicToCartesian(carto);
+
+    /** @type {Cesium.optionsOrientation} */
+    var orientation = {
+      pitch: this.tilt_ - Cesium.Math.PI_OVER_TWO,
+      heading: -view.getRotation(),
+      roll: undefined
+    };
+    this.cam_.setView({
+      destination: destination,
+      orientation: orientation
+    });
+
+    this.cam_.moveBackward(this.distance_);
+
+    this.checkCameraChange(true);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  readFromView() {
+    var view = this.map_.getView();
+    if (!this.enabled_ || !view) {
+      return;
+    }
+
+    var center = view.getCenter();
+    if (!center) {
+      return;
+    }
+
+    var ll = proj.transform(center, osMap.PROJECTION, os.proj.EPSG4326);
+    goog.asserts.assert(ll != null);
+
+    // determine distance at equator so the projection doesn't cause a large difference between 2d/3d
+    var resolution = view.getResolution() || 0;
+    this.distance_ = this.calcDistanceForResolution(resolution, 0);
+
+    this.updateCamera_();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  updateView() {
+    var view = this.map_.getView();
+    if (!this.enabled_ || !view) {
+      return;
+    }
+    this.viewUpdateInProgress_ = true;
+
+    // target & distance
+    var ellipsoid = Cesium.Ellipsoid.WGS84;
+    var scene = this.scene_;
+    var target = core.pickCenterPoint(scene);
+
+    var bestTarget = target;
+    if (!bestTarget) {
+      // TODO: how to handle this properly ?
+      var globe = scene.globe;
+      var carto = this.cam_.positionCartographic.clone();
+      var height = globe.getHeight(carto);
+      carto.height = height != null ? height : 0;
+      bestTarget = Cesium.Ellipsoid.WGS84.cartographicToCartesian(carto);
+    }
+
+    this.distance_ = Cesium.Cartesian3.distance(bestTarget, this.cam_.position);
+
+    var bestTargetCartographic = ellipsoid.cartesianToCartographic(bestTarget);
+    var longitude = bestTargetCartographic ? bestTargetCartographic.longitude : 0;
+    var latitude = bestTargetCartographic ? bestTargetCartographic.latitude : 0;
+
+
+    view.setCenter(proj.transform([
+      Cesium.Math.toDegrees(longitude),
+      Cesium.Math.toDegrees(latitude)], os.proj.EPSG4326, osMap.PROJECTION));
+
+    // determine distance at equator so the projection doesn't cause a large difference between 2d/3d
+    var resolution = this.calcResolutionForDistance(this.distance_, 0);
+    view.setResolution(view.constrainResolution(resolution, 0, 0));
+
+    /*
+     * Since we are positioning the target, the values of heading and tilt
+     * need to be calculated _at the target_.
+     */
+    if (target) {
+      var pos = this.cam_.position;
+
+      // normal to the ellipsoid at the target
+      var targetNormal = new Cesium.Cartesian3();
+      ellipsoid.geocentricSurfaceNormal(target, targetNormal);
+
+      // vector from the target to the camera
+      var targetToCamera = new Cesium.Cartesian3();
+      Cesium.Cartesian3.subtract(pos, target, targetToCamera);
+      Cesium.Cartesian3.normalize(targetToCamera, targetToCamera);
+
+      // HEADING
+      var up = this.cam_.up;
+      var right = this.cam_.right;
+      var normal = new Cesium.Cartesian3(-target.y, target.x, 0); // what is it?
+      var heading = Cesium.Cartesian3.angleBetween(right, normal);
+      var cross = Cesium.Cartesian3.cross(target, up, new Cesium.Cartesian3());
+      var orientation = cross.z;
+
+      view.setRotation((orientation < 0 ? heading : -heading));
+
+      // TILT
+      var tiltAngle = Math.acos(Cesium.Cartesian3.dot(targetNormal, targetToCamera));
+      this.tilt_ = isNaN(tiltAngle) ? 0 : tiltAngle;
+    } else {
+      // fallback when there is no target
+      view.setRotation(this.cam_.heading);
+      this.tilt_ = -this.cam_.pitch + Math.PI / 2;
+    }
+
+    this.viewUpdateInProgress_ = false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  checkCameraChange(opt_dontSync) {
+    var old = this.lastCameraViewMatrix_;
+    var current = this.cam_.viewMatrix;
+
+    if (!old || !Cesium.Matrix4.equalsEpsilon(old, current, 1e-5)) {
+      this.lastCameraViewMatrix_ = current.clone();
+      if (opt_dontSync !== true) {
+        this.updateThrottle_.fire();
+      }
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  calcDistanceForResolution(resolution, latitude) {
+    var canvas = this.scene_.canvas;
+    var fovy = this.cam_.frustum.fovy; // vertical field of view
+    var view = this.map_.getView();
+    var metersPerUnit = view.getProjection().getMetersPerUnit();
+
+    // canvas.clientHeight can in some cases be 0, which breaks this entire calculation. If that is the case, it's
+    // better to choose some arbitrary non-zero value and use it.
+    var height = canvas.clientHeight || 300;
+
+    // number of "map units" visible in 2D (vertically)
+    var visibleMapUnits = resolution * height;
+
+    // The metersPerUnit does not take latitude into account, but it should
+    // be lower with increasing latitude -- we have to compensate.
+    // In 3D it is not possible to maintain the resolution at more than one point,
+    // so it only makes sense to use the latitude of the "target" point.
+    var relativeCircumference = Math.cos(Math.abs(latitude));
+
+    // how many meters should be visible in 3D
+    var visibleMeters = visibleMapUnits * metersPerUnit * relativeCircumference;
+
+    // distance required to view the calculated length in meters
+    //
+    //  fovy/2
+    //    |\
+    //  x | \
+    //    |--\
+    // visibleMeters/2
+    var requiredDistance = (visibleMeters / 2) / Math.tan(fovy / 2);
+
+    // NOTE: This calculation is not absolutely precise, because metersPerUnit
+    // is a great simplification. It does not take ellipsoid/terrain into account.
+
+    return requiredDistance;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  calcResolutionForDistance(distance, latitude) {
+    // See the reverse calculation (calcDistanceForResolution) for details
+    var canvas = this.scene_.canvas;
+    var fovy = this.cam_.frustum.fovy;
+    var view = this.map_.getView();
+    var metersPerUnit = view.getProjection().getMetersPerUnit();
+
+    var visibleMeters = 2 * distance * Math.tan(fovy / 2);
+    var relativeCircumference = Math.cos(Math.abs(latitude));
+    var visibleMapUnits = visibleMeters / metersPerUnit / relativeCircumference;
+    var resolution = visibleMapUnits / canvas.clientHeight;
+
+    return resolution;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  persist() {
+    goog.asserts.assert(!!this.cam_, 'camera not defined');
+
+    var carto = this.cam_.positionCartographic;
+    var latitude = math.roundWithPrecision(googMath.toDegrees(carto.latitude), 12) || 0;
+    var longitude = math.roundWithPrecision(googMath.toDegrees(carto.longitude), 12) || 0;
+
+    var altitude = carto.height;
+    var projection = this.map_.getView().getProjection();
+    var resolution = osMap.resolutionForDistance(this.map_, altitude);
+    var zoom = osMap.resolutionToZoom(resolution, projection, 1);
+
+    // Cesium heading and roll follow the KML spec
+    var heading = googMath.toDegrees(this.cam_.heading);
+    var roll = googMath.toDegrees(this.cam_.roll);
+
+    // translate Cesium pitch to the KML tilt spec:
+    //   Cesium pitch: -90 is perpendicular to the globe, 0 is parallel.
+    //   KML pitch: 0 is perpendicular to the globe, 90 is parallel.
+    var tilt = googMath.clamp(googMath.toDegrees(this.cam_.pitch), -90, 0) + 90;
+
+    return /** @type {!osx.map.CameraState} */ ({
+      center: [longitude, latitude],
+      altitude: altitude,
+      heading: heading,
+      roll: roll,
+      tilt: tilt,
+      zoom: zoom
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  restore(cameraState) {
+    goog.asserts.assert(!!this.cam_, 'camera not defined');
+
+    var carto = new Cesium.Cartographic(googMath.toRadians(cameraState.center[0]),
+        googMath.toRadians(cameraState.center[1]), cameraState.altitude);
+
+    // translate from KML spec for tilt back to Cesium pitch:
+    //   Cesium pitch: -90 is perpendicular to the globe, 0 is parallel
+    //   KML pitch: 0 is perpendicular to the globe, 90 is parallel
+    this.cam_.setView({
+      destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(carto),
+      orientation: /** @type {Cesium.optionsOrientation} */ ({
+        heading: googMath.toRadians(cameraState.heading),
+        pitch: googMath.toRadians(cameraState.tilt - 90),
+        roll: googMath.toRadians(cameraState.roll)
+      })
+    });
+  }
+}
 
 /**
- * @inheritDoc
+ * Drop the OLCS view management. We will do this ourselves.
+ * @param {?View} view New view to use.
  */
-plugin.cesium.Camera.prototype.calcDistanceForResolution = function(resolution, latitude) {
-  var canvas = this.scene_.canvas;
-  var fovy = this.cam_.frustum.fovy; // vertical field of view
-  var view = this.map_.getView();
-  var metersPerUnit = view.getProjection().getMetersPerUnit();
+OLCSCamera.prototype.setView_ = (view) => {};
 
-  // canvas.clientHeight can in some cases be 0, which breaks this entire calculation. If that is the case, it's
-  // better to choose some arbitrary non-zero value and use it.
-  var height = canvas.clientHeight || 300;
-
-  // number of "map units" visible in 2D (vertically)
-  var visibleMapUnits = resolution * height;
-
-  // The metersPerUnit does not take latitude into account, but it should
-  // be lower with increasing latitude -- we have to compensate.
-  // In 3D it is not possible to maintain the resolution at more than one point,
-  // so it only makes sense to use the latitude of the "target" point.
-  var relativeCircumference = Math.cos(Math.abs(latitude));
-
-  // how many meters should be visible in 3D
-  var visibleMeters = visibleMapUnits * metersPerUnit * relativeCircumference;
-
-  // distance required to view the calculated length in meters
-  //
-  //  fovy/2
-  //    |\
-  //  x | \
-  //    |--\
-  // visibleMeters/2
-  var requiredDistance = (visibleMeters / 2) / Math.tan(fovy / 2);
-
-  // NOTE: This calculation is not absolutely precise, because metersPerUnit
-  // is a great simplification. It does not take ellipsoid/terrain into account.
-
-  return requiredDistance;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.calcResolutionForDistance = function(distance, latitude) {
-  // See the reverse calculation (calcDistanceForResolution) for details
-  var canvas = this.scene_.canvas;
-  var fovy = this.cam_.frustum.fovy;
-  var view = this.map_.getView();
-  var metersPerUnit = view.getProjection().getMetersPerUnit();
-
-  var visibleMeters = 2 * distance * Math.tan(fovy / 2);
-  var relativeCircumference = Math.cos(Math.abs(latitude));
-  var visibleMapUnits = visibleMeters / metersPerUnit / relativeCircumference;
-  var resolution = visibleMapUnits / canvas.clientHeight;
-
-  return resolution;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.persist = function() {
-  goog.asserts.assert(!!this.cam_, 'camera not defined');
-
-  var carto = this.cam_.positionCartographic;
-  var latitude = os.math.roundWithPrecision(goog.math.toDegrees(carto.latitude), 12) || 0;
-  var longitude = os.math.roundWithPrecision(goog.math.toDegrees(carto.longitude), 12) || 0;
-
-  var altitude = carto.height;
-  var projection = this.map_.getView().getProjection();
-  var resolution = os.map.resolutionForDistance(this.map_, altitude);
-  var zoom = os.map.resolutionToZoom(resolution, projection, 1);
-
-  // Cesium heading and roll follow the KML spec
-  var heading = goog.math.toDegrees(this.cam_.heading);
-  var roll = goog.math.toDegrees(this.cam_.roll);
-
-  // translate Cesium pitch to the KML tilt spec:
-  //   Cesium pitch: -90 is perpendicular to the globe, 0 is parallel.
-  //   KML pitch: 0 is perpendicular to the globe, 90 is parallel.
-  var tilt = goog.math.clamp(goog.math.toDegrees(this.cam_.pitch), -90, 0) + 90;
-
-  return /** @type {!osx.map.CameraState} */ ({
-    center: [longitude, latitude],
-    altitude: altitude,
-    heading: heading,
-    roll: roll,
-    tilt: tilt,
-    zoom: zoom
-  });
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.Camera.prototype.restore = function(cameraState) {
-  goog.asserts.assert(!!this.cam_, 'camera not defined');
-
-  var carto = new Cesium.Cartographic(goog.math.toRadians(cameraState.center[0]),
-      goog.math.toRadians(cameraState.center[1]), cameraState.altitude);
-
-  // translate from KML spec for tilt back to Cesium pitch:
-  //   Cesium pitch: -90 is perpendicular to the globe, 0 is parallel
-  //   KML pitch: 0 is perpendicular to the globe, 90 is parallel
-  this.cam_.setView({
-    destination: Cesium.Ellipsoid.WGS84.cartographicToCartesian(carto),
-    orientation: /** @type {Cesium.optionsOrientation} */ ({
-      heading: goog.math.toRadians(cameraState.heading),
-      pitch: goog.math.toRadians(cameraState.tilt - 90),
-      roll: goog.math.toRadians(cameraState.roll)
-    })
-  });
-};
+exports = Camera;

--- a/src/plugin/cesium/cesiumcamera.js
+++ b/src/plugin/cesium/cesiumcamera.js
@@ -4,16 +4,19 @@
  */
 goog.module('plugin.cesium.Camera');
 
+const asserts = goog.require('goog.asserts');
 const Throttle = goog.require('goog.async.Throttle');
 const googMath = goog.require('goog.math');
-const proj = goog.require('ol.proj');
+const olProj = goog.require('ol.proj');
 const OLCSCamera = goog.require('olcs.Camera');
 const core = goog.require('olcs.core');
 const MapContainer = goog.require('os.MapContainer');
 const osMap = goog.require('os.map');
 const FlightMode = goog.require('os.map.FlightMode');
 const math = goog.require('os.math');
+const osProj = goog.require('os.proj');
 
+const OLMap = goog.requireType('ol.Map');
 const View = goog.requireType('ol.View');
 const IWebGLCamera = goog.requireType('os.webgl.IWebGLCamera');
 
@@ -156,7 +159,7 @@ class Camera extends OLCSCamera {
   /**
    * Constructor.
    * @param {!Cesium.Scene} scene
-   * @param {!ol.Map} map
+   * @param {!OLMap} map
    */
   constructor(scene, map) {
     super(scene, map);
@@ -550,7 +553,7 @@ class Camera extends OLCSCamera {
 
       var target;
       if (options.center) {
-        var center = proj.transform(options.center, osMap.PROJECTION, os.proj.EPSG4326);
+        var center = olProj.transform(options.center, osMap.PROJECTION, osProj.EPSG4326);
         target = new Cesium.Cartographic(Cesium.Math.toRadians(center[0]), Cesium.Math.toRadians(center[1]));
       } else {
         // clone the current position or Cesium won't animate the change
@@ -684,8 +687,8 @@ class Camera extends OLCSCamera {
     if (!center) {
       return;
     }
-    var ll = proj.transform(center, osMap.PROJECTION, os.proj.EPSG4326);
-    goog.asserts.assert(ll != null);
+    var ll = olProj.transform(center, osMap.PROJECTION, osProj.EPSG4326);
+    asserts.assert(ll != null);
 
     var carto = new Cesium.Cartographic(Cesium.Math.toRadians(ll[0]),
         Cesium.Math.toRadians(ll[1]));
@@ -726,8 +729,8 @@ class Camera extends OLCSCamera {
       return;
     }
 
-    var ll = proj.transform(center, osMap.PROJECTION, os.proj.EPSG4326);
-    goog.asserts.assert(ll != null);
+    var ll = olProj.transform(center, osMap.PROJECTION, osProj.EPSG4326);
+    asserts.assert(ll != null);
 
     // determine distance at equator so the projection doesn't cause a large difference between 2d/3d
     var resolution = view.getResolution() || 0;
@@ -768,9 +771,9 @@ class Camera extends OLCSCamera {
     var latitude = bestTargetCartographic ? bestTargetCartographic.latitude : 0;
 
 
-    view.setCenter(proj.transform([
+    view.setCenter(olProj.transform([
       Cesium.Math.toDegrees(longitude),
-      Cesium.Math.toDegrees(latitude)], os.proj.EPSG4326, osMap.PROJECTION));
+      Cesium.Math.toDegrees(latitude)], osProj.EPSG4326, osMap.PROJECTION));
 
     // determine distance at equator so the projection doesn't cause a large difference between 2d/3d
     var resolution = this.calcResolutionForDistance(this.distance_, 0);
@@ -891,7 +894,7 @@ class Camera extends OLCSCamera {
    * @inheritDoc
    */
   persist() {
-    goog.asserts.assert(!!this.cam_, 'camera not defined');
+    asserts.assert(!!this.cam_, 'camera not defined');
 
     var carto = this.cam_.positionCartographic;
     var latitude = math.roundWithPrecision(googMath.toDegrees(carto.latitude), 12) || 0;
@@ -925,7 +928,7 @@ class Camera extends OLCSCamera {
    * @inheritDoc
    */
   restore(cameraState) {
-    goog.asserts.assert(!!this.cam_, 'camera not defined');
+    asserts.assert(!!this.cam_, 'camera not defined');
 
     var carto = new Cesium.Cartographic(googMath.toRadians(cameraState.center[0]),
         googMath.toRadians(cameraState.center[1]), cameraState.altitude);

--- a/src/plugin/cesium/cesiummenu.js
+++ b/src/plugin/cesium/cesiummenu.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.menu');
-goog.module.declareLegacyNamespace();
 
 const ui = goog.require('os.ui');
 const osUiMenuImport = goog.require('os.ui.menu.import');

--- a/src/plugin/cesium/cesiummenu.js
+++ b/src/plugin/cesium/cesiummenu.js
@@ -1,41 +1,41 @@
-goog.provide('plugin.cesium.menu');
+goog.module('plugin.cesium.menu');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.ui.menu.import');
-goog.require('plugin.cesium');
-goog.require('plugin.cesium.importIonAssetDirective');
+const ui = goog.require('os.ui');
+const osUiMenuImport = goog.require('os.ui.menu.import');
+const cesium = goog.require('plugin.cesium');
+const {directiveTag: importIonAssetTag} = goog.require('plugin.cesium.ImportIonAssetUI');
 
 
 /**
  * Cesium menu event types.
  * @enum {string}
  */
-plugin.cesium.menu.EventType = {
+const EventType = {
   ADD_ION_RESOURCE: 'cesium:addIonResource'
 };
-
 
 /**
  * Add Cesium items to the import menu.
  */
-plugin.cesium.menu.importSetup = function() {
-  if (os.ui.menu.import.MENU && plugin.cesium.isIonEnabled()) {
-    var group = os.ui.menu.import.MENU.getRoot().find(os.ui.menu.import.GroupType.MAJOR);
+const importSetup = function() {
+  if (osUiMenuImport.MENU && cesium.isIonEnabled()) {
+    var group = osUiMenuImport.MENU.getRoot().find(osUiMenuImport.GroupType.MAJOR);
     group.addChild({
       label: 'Add Cesium Ion Asset',
-      eventType: plugin.cesium.menu.EventType.ADD_ION_RESOURCE,
+      eventType: EventType.ADD_ION_RESOURCE,
       tooltip: 'Loads a Cesium Ion asset in 3D mode',
       icons: ['<i class="fa fa-fw fa-plus"></i>'],
-      handler: plugin.cesium.menu.launchAddIonAsset,
+      handler: launchAddIonAsset,
       sort: 10
     });
   }
 };
 
-
 /**
  * Launch a dialog to add a Cesium Ion asset.
  */
-plugin.cesium.menu.launchAddIonAsset = function() {
+const launchAddIonAsset = function() {
   var windowId = 'importIonAsset';
   var windowOptions = {
     'id': windowId,
@@ -51,6 +51,12 @@ plugin.cesium.menu.launchAddIonAsset = function() {
     'modal': false
   };
 
-  var template = '<importionasset></importionasset>';
-  os.ui.window.create(windowOptions, template);
+  var template = `<${importIonAssetTag}></${importIonAssetTag}>`;
+  ui.window.create(windowOptions, template);
+};
+
+exports = {
+  EventType,
+  importSetup,
+  launchAddIonAsset
 };

--- a/src/plugin/cesium/cesiummenu.js
+++ b/src/plugin/cesium/cesiummenu.js
@@ -1,6 +1,6 @@
 goog.module('plugin.cesium.menu');
 
-const osUiMenuImport = goog.require('os.ui.menu.import');
+const importMenu = goog.require('os.ui.menu.import');
 const osWindow = goog.require('os.ui.window');
 const cesium = goog.require('plugin.cesium');
 const {directiveTag: importIonAssetTag} = goog.require('plugin.cesium.ImportIonAssetUI');
@@ -18,8 +18,8 @@ const EventType = {
  * Add Cesium items to the import menu.
  */
 const importSetup = function() {
-  if (osUiMenuImport.MENU && cesium.isIonEnabled()) {
-    var group = osUiMenuImport.MENU.getRoot().find(osUiMenuImport.GroupType.MAJOR);
+  if (importMenu.MENU && cesium.isIonEnabled()) {
+    var group = importMenu.MENU.getRoot().find(importMenu.GroupType.MAJOR);
     group.addChild({
       label: 'Add Cesium Ion Asset',
       eventType: EventType.ADD_ION_RESOURCE,

--- a/src/plugin/cesium/cesiummenu.js
+++ b/src/plugin/cesium/cesiummenu.js
@@ -1,7 +1,7 @@
 goog.module('plugin.cesium.menu');
 
-const ui = goog.require('os.ui');
 const osUiMenuImport = goog.require('os.ui.menu.import');
+const osWindow = goog.require('os.ui.window');
 const cesium = goog.require('plugin.cesium');
 const {directiveTag: importIonAssetTag} = goog.require('plugin.cesium.ImportIonAssetUI');
 
@@ -51,7 +51,7 @@ const launchAddIonAsset = function() {
   };
 
   var template = `<${importIonAssetTag}></${importIonAssetTag}>`;
-  ui.window.create(windowOptions, template);
+  osWindow.create(windowOptions, template);
 };
 
 exports = {

--- a/src/plugin/cesium/cesiumplugin.js
+++ b/src/plugin/cesium/cesiumplugin.js
@@ -4,11 +4,14 @@ goog.module.declareLegacyNamespace();
 const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
 const MapContainer = goog.require('os.MapContainer');
 const settings = goog.require('os.config.Settings');
+const DataManager = goog.require('os.data.DataManager');
 const ProviderEntry = goog.require('os.data.ProviderEntry');
+const osImplements = goog.require('os.implements');
 const Group = goog.require('os.layer.Group');
 const ILayer = goog.require('os.layer.ILayer');
 const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
 const ImportManager = goog.require('os.ui.im.ImportManager');
+const AbstractWebGLRenderer = goog.require('os.webgl.AbstractWebGLRenderer');
 const {
   ID,
   CESIUM_ONLY_LAYER,
@@ -48,7 +51,7 @@ class Plugin extends AbstractPlugin {
 
     // check if cesium is the active renderer
     var mapContainer = MapContainer.getInstance();
-    if (settings.getInstance().get(os.webgl.AbstractWebGLRenderer.ACTIVE_SETTINGS_KEY) == ID) {
+    if (settings.getInstance().get(AbstractWebGLRenderer.ACTIVE_SETTINGS_KEY) == ID) {
       this.registerCesiumTypes_();
       mapContainer.setWebGLRenderer(new CesiumRenderer());
     } else {
@@ -67,7 +70,7 @@ class Plugin extends AbstractPlugin {
     var lcm = LayerConfigManager.getInstance();
     lcm.registerLayerConfig(tiles.ID, LayerConfig);
 
-    var dm = os.dataManager;
+    var dm = DataManager.getInstance();
     dm.registerProviderType(new ProviderEntry(
         tiles.ID,
         Provider,
@@ -80,11 +83,8 @@ class Plugin extends AbstractPlugin {
     group.setPriority(3);
     group.setOSType(CESIUM_ONLY_LAYER);
     group.setCheckFunc(function(layer) {
-      if (os.implements(layer, ILayer.ID)) {
-        return (
-          /** @type {ILayer} */
-          (layer).getOSType() === CESIUM_ONLY_LAYER
-        );
+      if (osImplements(layer, ILayer.ID)) {
+        return /** @type {ILayer} */ (layer).getOSType() === CESIUM_ONLY_LAYER;
       }
       return false;
     });

--- a/src/plugin/cesium/cesiumplugin.js
+++ b/src/plugin/cesium/cesiumplugin.js
@@ -9,7 +9,13 @@ const Group = goog.require('os.layer.Group');
 const ILayer = goog.require('os.layer.ILayer');
 const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
 const ImportManager = goog.require('os.ui.im.ImportManager');
-const cesium = goog.require('plugin.cesium');
+const {
+  ID,
+  CESIUM_ONLY_LAYER,
+  DEFAULT_ION_URL,
+  SettingsKey,
+  setIonUrl
+} = goog.require('plugin.cesium');
 const CesiumRenderer = goog.require('plugin.cesium.CesiumRenderer');
 const tiles = goog.require('plugin.cesium.tiles');
 const Descriptor = goog.require('plugin.cesium.tiles.Descriptor');
@@ -28,7 +34,7 @@ class Plugin extends AbstractPlugin {
    */
   constructor() {
     super();
-    this.id = Plugin.ID;
+    this.id = ID;
   }
 
   /**
@@ -37,13 +43,12 @@ class Plugin extends AbstractPlugin {
   init() {
     // update the Ion service URL from settings. this should be done first, as it impacts if Ion-related features are
     // loaded in the application.
-    const ionUrl = /** @type {string} */ (settings.getInstance().get(cesium.SettingsKey.ION_URL,
-        cesium.DEFAULT_ION_URL));
-    cesium.setIonUrl(ionUrl);
+    const ionUrl = /** @type {string} */ (settings.getInstance().get(SettingsKey.ION_URL, DEFAULT_ION_URL));
+    setIonUrl(ionUrl);
 
     // check if cesium is the active renderer
     var mapContainer = MapContainer.getInstance();
-    if (settings.getInstance().get(os.webgl.AbstractWebGLRenderer.ACTIVE_SETTINGS_KEY) == Plugin.ID) {
+    if (settings.getInstance().get(os.webgl.AbstractWebGLRenderer.ACTIVE_SETTINGS_KEY) == ID) {
       this.registerCesiumTypes_();
       mapContainer.setWebGLRenderer(new CesiumRenderer());
     } else {
@@ -73,12 +78,12 @@ class Plugin extends AbstractPlugin {
     // add 3D layer group
     var group = new Group();
     group.setPriority(3);
-    group.setOSType(cesium.CESIUM_ONLY_LAYER);
+    group.setOSType(CESIUM_ONLY_LAYER);
     group.setCheckFunc(function(layer) {
       if (os.implements(layer, ILayer.ID)) {
         return (
           /** @type {ILayer} */
-          (layer).getOSType() === cesium.CESIUM_ONLY_LAYER
+          (layer).getOSType() === CESIUM_ONLY_LAYER
         );
       }
       return false;
@@ -91,14 +96,5 @@ class Plugin extends AbstractPlugin {
     im.registerImportUI(mime.TYPE, new TilesetImportUI());
   }
 }
-
-
-/**
- * The plugin identifier.
- * @type {string}
- * @const
- */
-Plugin.ID = 'cesium';
-
 
 exports = Plugin;

--- a/src/plugin/cesium/cesiumplugin.js
+++ b/src/plugin/cesium/cesiumplugin.js
@@ -1,32 +1,96 @@
-goog.provide('plugin.cesium.Plugin');
+goog.module('plugin.cesium.Plugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.MapContainer');
-goog.require('os.data.ProviderEntry');
-goog.require('os.layer.Group');
-goog.require('os.layer.ILayer');
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.ui.im.ImportManager');
-goog.require('plugin.cesium');
-goog.require('plugin.cesium.CesiumRenderer');
-goog.require('plugin.cesium.tiles');
-goog.require('plugin.cesium.tiles.Descriptor');
-goog.require('plugin.cesium.tiles.LayerConfig');
-goog.require('plugin.cesium.tiles.Provider');
-goog.require('plugin.cesium.tiles.TilesetImportUI');
-goog.require('plugin.cesium.tiles.mime');
+const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
+const MapContainer = goog.require('os.MapContainer');
+const settings = goog.require('os.config.Settings');
+const ProviderEntry = goog.require('os.data.ProviderEntry');
+const Group = goog.require('os.layer.Group');
+const ILayer = goog.require('os.layer.ILayer');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const cesium = goog.require('plugin.cesium');
+const CesiumRenderer = goog.require('plugin.cesium.CesiumRenderer');
+const tiles = goog.require('plugin.cesium.tiles');
+const Descriptor = goog.require('plugin.cesium.tiles.Descriptor');
+const LayerConfig = goog.require('plugin.cesium.tiles.LayerConfig');
+const Provider = goog.require('plugin.cesium.tiles.Provider');
+const TilesetImportUI = goog.require('plugin.cesium.tiles.TilesetImportUI');
+const mime = goog.require('plugin.cesium.tiles.mime');
 
 
 /**
  * Provides a WebGL renderer for the map, powered by Cesium.
- *
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.cesium.Plugin = function() {
-  plugin.cesium.Plugin.base(this, 'constructor');
-  this.id = plugin.cesium.Plugin.ID;
-};
-goog.inherits(plugin.cesium.Plugin, os.plugin.AbstractPlugin);
+class Plugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = Plugin.ID;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    // update the Ion service URL from settings. this should be done first, as it impacts if Ion-related features are
+    // loaded in the application.
+    const ionUrl = /** @type {string} */ (settings.getInstance().get(cesium.SettingsKey.ION_URL,
+        cesium.DEFAULT_ION_URL));
+    cesium.setIonUrl(ionUrl);
+
+    // check if cesium is the active renderer
+    var mapContainer = MapContainer.getInstance();
+    if (settings.getInstance().get(os.webgl.AbstractWebGLRenderer.ACTIVE_SETTINGS_KEY) == Plugin.ID) {
+      this.registerCesiumTypes_();
+      mapContainer.setWebGLRenderer(new CesiumRenderer());
+    } else {
+      mapContainer.addWebGLRenderer(new CesiumRenderer());
+    }
+  }
+
+  /**
+   * Register OpenSphere data types used by Cesium.
+   * @private
+   */
+  registerCesiumTypes_() {
+    var mapContainer = MapContainer.getInstance();
+
+    // register 3D tiles layers
+    var lcm = LayerConfigManager.getInstance();
+    lcm.registerLayerConfig(tiles.ID, LayerConfig);
+
+    var dm = os.dataManager;
+    dm.registerProviderType(new ProviderEntry(
+        tiles.ID,
+        Provider,
+        tiles.TYPE,
+        tiles.TYPE));
+    dm.registerDescriptorType(tiles.ID, Descriptor);
+
+    // add 3D layer group
+    var group = new Group();
+    group.setPriority(3);
+    group.setOSType(cesium.CESIUM_ONLY_LAYER);
+    group.setCheckFunc(function(layer) {
+      if (os.implements(layer, ILayer.ID)) {
+        return (
+          /** @type {ILayer} */
+          (layer).getOSType() === cesium.CESIUM_ONLY_LAYER
+        );
+      }
+      return false;
+    });
+
+    mapContainer.addGroup(group);
+
+    var im = ImportManager.getInstance();
+    im.registerImportDetails(tiles.TYPE, true);
+    im.registerImportUI(mime.TYPE, new TilesetImportUI());
+  }
+}
 
 
 /**
@@ -34,62 +98,7 @@ goog.inherits(plugin.cesium.Plugin, os.plugin.AbstractPlugin);
  * @type {string}
  * @const
  */
-plugin.cesium.Plugin.ID = 'cesium';
+Plugin.ID = 'cesium';
 
 
-/**
- * @inheritDoc
- */
-plugin.cesium.Plugin.prototype.init = function() {
-  // update the Ion service URL from settings. this should be done first, as it impacts if Ion-related features are
-  // loaded in the application.
-  plugin.cesium.ionUrl = /** @type {string} */ (os.settings.get(plugin.cesium.SettingsKey.ION_URL,
-      plugin.cesium.DEFAULT_ION_URL));
-
-  // check if cesium is the active renderer
-  var mapContainer = os.MapContainer.getInstance();
-  if (os.settings.get(os.webgl.AbstractWebGLRenderer.ACTIVE_SETTINGS_KEY) == plugin.cesium.Plugin.ID) {
-    this.registerCesiumTypes_();
-    mapContainer.setWebGLRenderer(new plugin.cesium.CesiumRenderer());
-  } else {
-    mapContainer.addWebGLRenderer(new plugin.cesium.CesiumRenderer());
-  }
-};
-
-
-/**
- * Register OpenSphere data types used by Cesium.
- * @private
- */
-plugin.cesium.Plugin.prototype.registerCesiumTypes_ = function() {
-  var mapContainer = os.MapContainer.getInstance();
-
-  // register 3D tiles layers
-  var lcm = os.layer.config.LayerConfigManager.getInstance();
-  lcm.registerLayerConfig(plugin.cesium.tiles.ID, plugin.cesium.tiles.LayerConfig);
-
-  var dm = os.dataManager;
-  dm.registerProviderType(new os.data.ProviderEntry(
-      plugin.cesium.tiles.ID,
-      plugin.cesium.tiles.Provider,
-      plugin.cesium.tiles.TYPE,
-      plugin.cesium.tiles.TYPE));
-  dm.registerDescriptorType(plugin.cesium.tiles.ID, plugin.cesium.tiles.Descriptor);
-
-  // add 3D layer group
-  var group = new os.layer.Group();
-  group.setPriority(3);
-  group.setOSType(plugin.cesium.CESIUM_ONLY_LAYER);
-  group.setCheckFunc(function(layer) {
-    if (os.implements(layer, os.layer.ILayer.ID)) {
-      return /** @type {os.layer.ILayer} */ (layer).getOSType() === plugin.cesium.CESIUM_ONLY_LAYER;
-    }
-    return false;
-  });
-
-  mapContainer.addGroup(group);
-
-  var im = os.ui.im.ImportManager.getInstance();
-  im.registerImportDetails(plugin.cesium.tiles.TYPE, true);
-  im.registerImportUI(plugin.cesium.tiles.mime.TYPE, new plugin.cesium.tiles.TilesetImportUI());
-};
+exports = Plugin;

--- a/src/plugin/cesium/command/flytospherecmd.js
+++ b/src/plugin/cesium/command/flytospherecmd.js
@@ -1,88 +1,91 @@
-goog.provide('plugin.cesium.command.FlyToSphere');
+goog.module('plugin.cesium.command.FlyToSphere');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.command.AbstractSyncCommand');
+const mapContainer = goog.require('os.MapContainer');
+const AbstractSyncCommand = goog.require('os.command.AbstractSyncCommand');
 
 
 /**
- * @constructor
- * @param {!Cesium.BoundingSphere} sphere
- * @param {Cesium.optionsCameraFlyToBoundingSphere=} opt_options
- * @extends {os.command.AbstractSyncCommand}
  * @suppress {accessControls}
  */
-plugin.cesium.command.FlyToSphere = function(sphere, opt_options) {
-  plugin.cesium.command.FlyToSphere.base(this, 'constructor');
-  this.title = 'Zoom to Bounding Sphere';
-
+class FlyToSphere extends AbstractSyncCommand {
   /**
-   * @type {!Cesium.BoundingSphere}
-   * @private
+   * Constructor.
+   * @param {!Cesium.BoundingSphere} sphere
+   * @param {Cesium.optionsCameraFlyToBoundingSphere=} opt_options
    */
-  this.sphere_ = sphere;
+  constructor(sphere, opt_options) {
+    super();
+    this.title = 'Zoom to Bounding Sphere';
 
-  /**
-   * @type {osx.map.CameraState}
-   * @private
-   */
-  this.oldPosition_ = os.map.mapContainer.persistCameraState();
+    /**
+     * @type {!Cesium.BoundingSphere}
+     * @private
+     */
+    this.sphere_ = sphere;
 
-  var cam = /** @type {plugin.cesium.Camera} */ (os.map.mapContainer.getWebGLCamera());
-  var minRange = cam.calcDistanceForResolution(
-      os.map.zoomToResolution(os.map.MAX_AUTO_ZOOM, os.map.PROJECTION), 0);
+    /**
+     * @type {osx.map.CameraState}
+     * @private
+     */
+    this.oldPosition_ = mapContainer.getInstance().persistCameraState();
 
-  sphere.radius = sphere.radius || 10;
+    var cam = /** @type {plugin.cesium.Camera} */ (mapContainer.getInstance().getWebGLCamera());
+    var minRange = cam.calcDistanceForResolution(
+        os.map.zoomToResolution(os.map.MAX_AUTO_ZOOM, os.map.PROJECTION), 0);
 
-  // gets the default offset
-  var camera = /** @type {plugin.cesium.Camera} */ (os.map.mapContainer.getWebGLCamera());
-  var offset = new Cesium.HeadingPitchRange(camera.cam_.heading, camera.cam_.pitch,
-      os.command.FlyToExtent.DEFAULT_BUFFER * 2 * sphere.radius);
+    sphere.radius = sphere.radius || 10;
 
-  offset.range = Math.max(offset.range, minRange);
+    // gets the default offset
+    var camera = /** @type {plugin.cesium.Camera} */ (mapContainer.getInstance().getWebGLCamera());
+    var offset = new Cesium.HeadingPitchRange(camera.cam_.heading, camera.cam_.pitch,
+        os.command.FlyToExtent.DEFAULT_BUFFER * 2 * sphere.radius);
 
-  // the min range needs to include the furthest eye offset for the given sphere altitude
-  // @see plugin.cesium.sync.VectorSynchronizer.updateLabelOffsets
-  var distance = Cesium.Cartographic.fromCartesian(sphere.center).height + offset.range;
-  offset.range += os.command.FlyToExtent.DEFAULT_BUFFER * distance / 10;
+    offset.range = Math.max(offset.range, minRange);
 
-  /**
-   * @type {Cesium.optionsCameraFlyToBoundingSphere}
-   * @private
-   */
-  this.options_ = opt_options || /** @type {Cesium.optionsCameraFlyToBoundingSphere} */ ({
-    offset: offset
-  });
-};
-goog.inherits(plugin.cesium.command.FlyToSphere, os.command.AbstractSyncCommand);
+    // the min range needs to include the furthest eye offset for the given sphere altitude
+    // @see plugin.cesium.sync.VectorSynchronizer.updateLabelOffsets
+    var distance = Cesium.Cartographic.fromCartesian(sphere.center).height + offset.range;
+    offset.range += os.command.FlyToExtent.DEFAULT_BUFFER * distance / 10;
 
-
-/**
- * @inheritDoc
- * @suppress {accessControls}
- */
-plugin.cesium.command.FlyToSphere.prototype.execute = function() {
-  this.state = os.command.State.EXECUTING;
-
-  this.sphere_.radius *= os.command.FlyToExtent.DEFAULT_BUFFER;
-
-  var cam = /** @type {plugin.cesium.Camera} */ (os.map.mapContainer.getWebGLCamera());
-  cam.cam_.flyToBoundingSphere(this.sphere_, this.options_);
-
-  this.sphere_.radius /= os.command.FlyToExtent.DEFAULT_BUFFER;
-
-  return this.finish();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.command.FlyToSphere.prototype.revert = function() {
-  this.state = os.command.State.REVERTING;
-
-  if (this.oldPosition_) {
-    os.map.mapContainer.restoreCameraState(this.oldPosition_);
+    /**
+     * @type {Cesium.optionsCameraFlyToBoundingSphere}
+     * @private
+     */
+    this.options_ = opt_options || /** @type {Cesium.optionsCameraFlyToBoundingSphere} */ ({
+      offset: offset
+    });
   }
 
-  return plugin.cesium.command.FlyToSphere.base(this, 'revert');
-};
+  /**
+   * @inheritDoc
+   * @suppress {accessControls}
+   */
+  execute() {
+    this.state = os.command.State.EXECUTING;
 
+    this.sphere_.radius *= os.command.FlyToExtent.DEFAULT_BUFFER;
+
+    var cam = /** @type {plugin.cesium.Camera} */ (mapContainer.getInstance().getWebGLCamera());
+    cam.cam_.flyToBoundingSphere(this.sphere_, this.options_);
+
+    this.sphere_.radius /= os.command.FlyToExtent.DEFAULT_BUFFER;
+
+    return this.finish();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  revert() {
+    this.state = os.command.State.REVERTING;
+
+    if (this.oldPosition_) {
+      mapContainer.getInstance().restoreCameraState(this.oldPosition_);
+    }
+
+    return super.revert();
+  }
+}
+
+exports = FlyToSphere;

--- a/src/plugin/cesium/imageryprovider.js
+++ b/src/plugin/cesium/imageryprovider.js
@@ -3,12 +3,14 @@ goog.module('plugin.cesium.ImageryProvider');
 goog.require('os.mixin.VectorImageTile');
 
 const ol = goog.require('ol');
+const TileState = goog.require('ol.TileState');
 const ImageTile = goog.require('ol.ImageTile');
 const VectorImageTile = goog.require('ol.VectorImageTile');
 const events = goog.require('ol.events');
 const VectorTile = goog.require('ol.source.VectorTile');
 const olTilegrid = goog.require('ol.tilegrid');
 const OLImageryProvider = goog.require('olcs.core.OLImageryProvider');
+const {getSourceProjection} = goog.require('olcs.util');
 const TileGridTilingScheme = goog.require('plugin.cesium.TileGridTilingScheme');
 const IDisposable = goog.requireType('goog.disposable.IDisposable');
 
@@ -66,7 +68,7 @@ class ImageryProvider extends OLImageryProvider {
    */
   handleSourceChanged_() {
     if (!this.ready_ && this.source_.getState() == 'ready') {
-      this.projection_ = olcs.util.getSourceProjection(this.source_) || this.fallbackProj_;
+      this.projection_ = getSourceProjection(this.source_) || this.fallbackProj_;
       this.credit_ = OLImageryProvider.createCreditForSource(this.source_) || null;
 
       if (this.source_ instanceof VectorTile) {
@@ -114,15 +116,15 @@ class ImageryProvider extends OLImageryProvider {
     var tile = this.source_.getTile(z_, x, y_, 1, this.projection_);
     var state = tile.getState();
 
-    if (state === ol.TileState.EMPTY) {
+    if (state === TileState.EMPTY) {
       deferred.resolve(this.emptyCanvas_);
-    } else if (state === ol.TileState.LOADED) {
+    } else if (state === TileState.LOADED) {
       if (tile instanceof ImageTile) {
         deferred.resolve(tile.getImage());
       } else if (tile instanceof VectorImageTile) {
         deferred.resolve(tile.getDrawnImage(this.layer_));
       }
-    } else if (state === ol.TileState.ERROR) {
+    } else if (state === TileState.ERROR) {
       deferred.resolve(this.emptyCanvas_);
     } else {
       tile.load();
@@ -130,17 +132,17 @@ class ImageryProvider extends OLImageryProvider {
       var layer = this.layer_;
       var unlisten = events.listen(tile, events.EventType.CHANGE, function() {
         var state = tile.getState();
-        if (state === ol.TileState.EMPTY) {
+        if (state === TileState.EMPTY) {
           deferred.resolve(this.emptyCanvas_);
           events.unlistenByKey(unlisten);
-        } else if (state === ol.TileState.LOADED) {
+        } else if (state === TileState.LOADED) {
           if (tile instanceof ImageTile) {
             deferred.resolve(tile.getImage());
           } else if (tile instanceof VectorImageTile) {
             deferred.resolve(tile.getDrawnImage(layer));
           }
           events.unlistenByKey(unlisten);
-        } else if (state === ol.TileState.ERROR) {
+        } else if (state === TileState.ERROR) {
           deferred.resolve(this.emptyCanvas_);
           events.unlistenByKey(unlisten);
         }

--- a/src/plugin/cesium/imageryprovider.js
+++ b/src/plugin/cesium/imageryprovider.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.ImageryProvider');
-goog.module.declareLegacyNamespace();
 
 goog.require('os.mixin.VectorImageTile');
 

--- a/src/plugin/cesium/imageryprovider.js
+++ b/src/plugin/cesium/imageryprovider.js
@@ -1,215 +1,202 @@
-goog.provide('plugin.cesium.ImageryProvider');
+goog.module('plugin.cesium.ImageryProvider');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.disposable.IDisposable');
-goog.require('ol');
-goog.require('ol.ImageTile');
-goog.require('ol.VectorImageTile');
-goog.require('ol.events');
-goog.require('ol.source.VectorTile');
-goog.require('ol.tilegrid');
-goog.require('olcs.core.OLImageryProvider');
 goog.require('os.mixin.VectorImageTile');
-goog.require('os.proj');
-goog.require('plugin.cesium.TileGridTilingScheme');
+
+const ol = goog.require('ol');
+const ImageTile = goog.require('ol.ImageTile');
+const VectorImageTile = goog.require('ol.VectorImageTile');
+const events = goog.require('ol.events');
+const VectorTile = goog.require('ol.source.VectorTile');
+const olTilegrid = goog.require('ol.tilegrid');
+const OLImageryProvider = goog.require('olcs.core.OLImageryProvider');
+const TileGridTilingScheme = goog.require('plugin.cesium.TileGridTilingScheme');
+const IDisposable = goog.requireType('goog.disposable.IDisposable');
+
+const Layer = goog.requireType('ol.layer.Layer');
+const Projection = goog.requireType('ol.proj.Projection');
+const TileSource = goog.requireType('ol.source.Tile');
+const TileImageSource = goog.requireType('ol.source.TileImage');
 
 
 /**
- * @param {!ol.source.Tile} source
- * @param {?ol.layer.Layer} layer
- * @param {ol.proj.Projection=} opt_fallbackProj Projection to assume if the projection of the source is not defined.
- * @extends {olcs.core.OLImageryProvider}
- * @implements {goog.disposable.IDisposable}
- * @constructor
+ * @implements {IDisposable}
  *
  * @suppress {invalidCasts}
  */
-plugin.cesium.ImageryProvider = function(source, layer, opt_fallbackProj) {
-  plugin.cesium.ImageryProvider.base(this, 'constructor',
-      /** @type {!ol.source.TileImage} */ (source), opt_fallbackProj);
-
+class ImageryProvider extends OLImageryProvider {
   /**
-   * @type {boolean}
-   * @private
+   * Constructor.
+   * @param {!TileSource} source
+   * @param {?Layer} layer
+   * @param {Projection=} opt_fallbackProj Projection to assume if the projection of the source is not defined.
    */
-  this.disposed_ = false;
+  constructor(source, layer, opt_fallbackProj) {
+    super(/** @type {!TileImageSource} */ (source), opt_fallbackProj);
 
-  /**
-   * @type {?ol.layer.Layer}
-   * @private
-   */
-  this.layer_ = layer;
-};
-goog.inherits(plugin.cesium.ImageryProvider, olcs.core.OLImageryProvider);
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.disposed_ = false;
 
-
-/**
- * @inheritDoc
- */
-plugin.cesium.ImageryProvider.prototype.dispose = function() {
-  this.disposed_ = true;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.ImageryProvider.prototype.isDisposed = function() {
-  return this.disposed_;
-};
-
-
-/**
- * @inheritDoc
- * @suppress {accessControls}
- */
-plugin.cesium.ImageryProvider.prototype.handleSourceChanged_ = function() {
-  if (!this.ready_ && this.source_.getState() == 'ready') {
-    this.projection_ = olcs.util.getSourceProjection(this.source_) || this.fallbackProj_;
-    this.credit_ = olcs.core.OLImageryProvider.createCreditForSource(this.source_) || null;
-
-    if (this.source_ instanceof ol.source.VectorTile) {
-      // For vector tiles, create a copy of the tile grid with min/max zoom covering all levels. This ensures Cesium
-      // will render tiles at all levels.
-      const sourceTileGrid = this.source_.getTileGrid();
-      const tileGrid = ol.tilegrid.createXYZ({
-        extent: sourceTileGrid.getExtent(),
-        maxZoom: ol.DEFAULT_MAX_ZOOM,
-        minZoom: 0,
-        tileSize: sourceTileGrid.getTileSize()
-      });
-
-      this.tilingScheme_ = new plugin.cesium.TileGridTilingScheme(this.source_, tileGrid);
-    } else {
-      this.tilingScheme_ = new plugin.cesium.TileGridTilingScheme(this.source_);
-    }
-
-    this.rectangle_ = this.tilingScheme_.rectangle;
-    this.ready_ = true;
-  }
-};
-
-
-/**
- * @override
- * @suppress {accessControls}
- * @export
- */
-plugin.cesium.ImageryProvider.prototype.requestImage = function(x, y, level) {
-  var z_ = level;
-  var y_ = -y - 1;
-
-  var deferred = Cesium.when.defer();
-
-  // If the source doesn't have tiles at the current level, return an empty canvas.
-  if (!(this.source_ instanceof ol.source.VectorTile)) {
-    var tilegrid = this.source_.getTileGridForProjection(this.projection_);
-
-    if (z_ < tilegrid.getMinZoom() - 1 || z_ > tilegrid.getMaxZoom()) {
-      deferred.resolve(this.emptyCanvas_); // no data
-      return deferred.promise;
-    }
+    /**
+     * @type {?Layer}
+     * @private
+     */
+    this.layer_ = layer;
   }
 
-  var tile = this.source_.getTile(z_, x, y_, 1, this.projection_);
-  var state = tile.getState();
+  /**
+   * @inheritDoc
+   */
+  dispose() {
+    this.disposed_ = true;
+  }
 
-  if (state === ol.TileState.EMPTY) {
-    deferred.resolve(this.emptyCanvas_);
-  } else if (state === ol.TileState.LOADED) {
-    if (tile instanceof ol.ImageTile) {
-      deferred.resolve(tile.getImage());
-    } else if (tile instanceof ol.VectorImageTile) {
-      deferred.resolve(tile.getDrawnImage(this.layer_));
-    }
-  } else if (state === ol.TileState.ERROR) {
-    deferred.resolve(this.emptyCanvas_);
-  } else {
-    tile.load();
+  /**
+   * @inheritDoc
+   */
+  isDisposed() {
+    return this.disposed_;
+  }
 
-    var layer = this.layer_;
-    var unlisten = ol.events.listen(tile, ol.events.EventType.CHANGE, function() {
-      var state = tile.getState();
-      if (state === ol.TileState.EMPTY) {
-        deferred.resolve(this.emptyCanvas_);
-        ol.events.unlistenByKey(unlisten);
-      } else if (state === ol.TileState.LOADED) {
-        if (tile instanceof ol.ImageTile) {
-          deferred.resolve(tile.getImage());
-        } else if (tile instanceof ol.VectorImageTile) {
-          deferred.resolve(tile.getDrawnImage(layer));
-        }
-        ol.events.unlistenByKey(unlisten);
-      } else if (state === ol.TileState.ERROR) {
-        deferred.resolve(this.emptyCanvas_);
-        ol.events.unlistenByKey(unlisten);
+  /**
+   * @inheritDoc
+   * @suppress {accessControls}
+   */
+  handleSourceChanged_() {
+    if (!this.ready_ && this.source_.getState() == 'ready') {
+      this.projection_ = olcs.util.getSourceProjection(this.source_) || this.fallbackProj_;
+      this.credit_ = OLImageryProvider.createCreditForSource(this.source_) || null;
+
+      if (this.source_ instanceof VectorTile) {
+        // For vector tiles, create a copy of the tile grid with min/max zoom covering all levels. This ensures Cesium
+        // will render tiles at all levels.
+        const sourceTileGrid = this.source_.getTileGrid();
+        const tileGrid = olTilegrid.createXYZ({
+          extent: sourceTileGrid.getExtent(),
+          maxZoom: ol.DEFAULT_MAX_ZOOM,
+          minZoom: 0,
+          tileSize: sourceTileGrid.getTileSize()
+        });
+
+        this.tilingScheme_ = new TileGridTilingScheme(this.source_, tileGrid);
+      } else {
+        this.tilingScheme_ = new TileGridTilingScheme(this.source_);
       }
-    });
+
+      this.rectangle_ = this.tilingScheme_.rectangle;
+      this.ready_ = true;
+    }
   }
 
-  return deferred.promise;
-};
+  /**
+   * @override
+   * @suppress {accessControls}
+   * @export
+   */
+  requestImage(x, y, level) {
+    var z_ = level;
+    var y_ = -y - 1;
 
+    var deferred = Cesium.when.defer();
 
-// definitions of getters that are required to be present
-// in the Cesium.ImageryProvider instance:
-Object.defineProperties(plugin.cesium.ImageryProvider.prototype, {
-  maximumLevel: {
-    get:
-        /**
-         * @this plugin.cesium.ImageryProvider
-         * @return {number}
-         * @suppress {accessControls}
-         */
-        function() {
-          // Vector tiles can be rendered at all zoom levels using data from other levels.
-          if (!(this.source_ instanceof ol.source.VectorTile)) {
-            const tg = this.source_.getTileGrid();
-            return tg ? tg.getMaxZoom() : 18;
+    // If the source doesn't have tiles at the current level, return an empty canvas.
+    if (!(this.source_ instanceof VectorTile)) {
+      var tilegrid = this.source_.getTileGridForProjection(this.projection_);
+
+      if (z_ < tilegrid.getMinZoom() - 1 || z_ > tilegrid.getMaxZoom()) {
+        deferred.resolve(this.emptyCanvas_); // no data
+        return deferred.promise;
+      }
+    }
+
+    var tile = this.source_.getTile(z_, x, y_, 1, this.projection_);
+    var state = tile.getState();
+
+    if (state === ol.TileState.EMPTY) {
+      deferred.resolve(this.emptyCanvas_);
+    } else if (state === ol.TileState.LOADED) {
+      if (tile instanceof ImageTile) {
+        deferred.resolve(tile.getImage());
+      } else if (tile instanceof VectorImageTile) {
+        deferred.resolve(tile.getDrawnImage(this.layer_));
+      }
+    } else if (state === ol.TileState.ERROR) {
+      deferred.resolve(this.emptyCanvas_);
+    } else {
+      tile.load();
+
+      var layer = this.layer_;
+      var unlisten = events.listen(tile, events.EventType.CHANGE, function() {
+        var state = tile.getState();
+        if (state === ol.TileState.EMPTY) {
+          deferred.resolve(this.emptyCanvas_);
+          events.unlistenByKey(unlisten);
+        } else if (state === ol.TileState.LOADED) {
+          if (tile instanceof ImageTile) {
+            deferred.resolve(tile.getImage());
+          } else if (tile instanceof VectorImageTile) {
+            deferred.resolve(tile.getDrawnImage(layer));
           }
-          return ol.DEFAULT_MAX_ZOOM;
+          events.unlistenByKey(unlisten);
+        } else if (state === ol.TileState.ERROR) {
+          deferred.resolve(this.emptyCanvas_);
+          events.unlistenByKey(unlisten);
         }
-  },
-  minimumLevel: {
-    get:
-        /**
-         * @this plugin.cesium.ImageryProvider
-         * @return {number}
-         */
-        function() {
-          // apparently level 0 tiles look like garbage and we're just gonna pass on those
-          return 1;
-        }
-  },
-  tileWidth: {
-    get:
-        /**
-         * @this plugin.cesium.ImageryProvider
-         * @return {number}
-         * @suppress {accessControls}
-         */
-        function() {
-          var tg = this.source_.getTileGrid();
-          if (tg) {
-            var tileSize = tg.getTileSize(tg.getMinZoom());
-            return Array.isArray(tileSize) ? tileSize[0] : tileSize;
-          }
-          return 256;
-        }
-  },
-  tileHeight: {
-    get:
-        /**
-         * @this plugin.cesium.ImageryProvider
-         * @return {number}
-         * @suppress {accessControls}
-         */
-        function() {
-          var tg = this.source_.getTileGrid();
-          if (tg) {
-            var tileSize = tg.getTileSize(tg.getMinZoom());
-            return Array.isArray(tileSize) ? tileSize[1] : tileSize;
-          }
-          return 256;
-        }
+      });
+    }
+
+    return deferred.promise;
   }
-});
+
+  /**
+   * @inheritDoc
+   * @suppress {accessControls}
+   */
+  get maximumLevel() {
+    // Vector tiles can be rendered at all zoom levels using data from other levels.
+    if (!(this.source_ instanceof VectorTile)) {
+      const tg = this.source_.getTileGrid();
+      return tg ? tg.getMaxZoom() : 18;
+    }
+    return ol.DEFAULT_MAX_ZOOM;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  get minimumLevel() {
+    // apparently level 0 tiles look like garbage and we're just gonna pass on those
+    return 1;
+  }
+
+  /**
+   * @inheritDoc
+   * @suppress {accessControls}
+   */
+  get tileWidth() {
+    var tg = this.source_.getTileGrid();
+    if (tg) {
+      var tileSize = tg.getTileSize(tg.getMinZoom());
+      return Array.isArray(tileSize) ? tileSize[0] : tileSize;
+    }
+    return 256;
+  }
+
+  /**
+   * @inheritDoc
+   * @suppress {accessControls}
+   */
+  get tileHeight() {
+    var tg = this.source_.getTileGrid();
+    if (tg) {
+      var tileSize = tg.getTileSize(tg.getMinZoom());
+      return Array.isArray(tileSize) ? tileSize[1] : tileSize;
+    }
+    return 256;
+  }
+}
+
+exports = ImageryProvider;

--- a/src/plugin/cesium/importionasset.js
+++ b/src/plugin/cesium/importionasset.js
@@ -1,10 +1,13 @@
-goog.provide('plugin.cesium.ImportIonAssetCtrl');
-goog.provide('plugin.cesium.importIonAssetDirective');
+goog.module('plugin.cesium.ImportIonAssetUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Disposable');
-goog.require('os.ui');
-goog.require('os.ui.Module');
-goog.require('os.ui.window');
+const {ROOT} = goog.require('os');
+const DataManager = goog.require('os.data.DataManager');
+const Module = goog.require('os.ui.Module');
+const WindowEventType = goog.require('os.ui.WindowEventType');
+const osWindow = goog.require('os.ui.window');
+const TilesDescriptor = goog.require('plugin.cesium.tiles.Descriptor');
+const TilesProvider = goog.require('plugin.cesium.tiles.Provider');
 
 
 /**
@@ -12,111 +15,116 @@ goog.require('os.ui.window');
  *
  * @return {angular.Directive}
  */
-plugin.cesium.importIonAssetDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    scope: true,
-    templateUrl: os.ROOT + 'views/plugin/cesium/importionasset.html',
-    controller: plugin.cesium.ImportIonAssetCtrl,
-    controllerAs: 'ctrl'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  scope: true,
+  templateUrl: ROOT + 'views/plugin/cesium/importionasset.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
 
 
 /**
- * Add the directive to the os.ui module
+ * The element tag for the directive.
+ * @type {string}
  */
-os.ui.Module.directive('importionasset', [plugin.cesium.importIonAssetDirective]);
+const directiveTag = 'importionasset';
+
+
+/**
+ * Add the directive to the ui module
+ */
+Module.directive(directiveTag, [directive]);
 
 
 
 /**
  * Controller for the Ion asset import dialog.
- *
- * @param {!angular.Scope} $scope The Angular scope.
- * @param {!angular.JQLite} $element The root DOM element.
- * @extends {goog.Disposable}
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.cesium.ImportIonAssetCtrl = function($scope, $element) {
-  plugin.cesium.ImportIonAssetCtrl.base(this, 'constructor');
+class Controller {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope The Angular scope.
+   * @param {!angular.JQLite} $element The root DOM element.
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    /**
+     * @type {?angular.JQLite}
+     * @private
+     */
+    this.element_ = $element;
+
+    /**
+     * @type {number}
+     */
+    this['assetId'] = 0;
+
+    /**
+     * @type {string}
+     */
+    this['accessToken'] = '';
+
+    /**
+     * @type {string}
+     */
+    this['title'] = 'New Ion Asset';
+
+    /**
+     * @type {string}
+     */
+    this['description'] = '';
+
+    /**
+     * @type {string}
+     */
+    this['tags'] = '';
+
+    $scope.$emit(WindowEventType.READY);
+  }
 
   /**
-   * @type {?angular.JQLite}
-   * @private
+   * Angular $onDestroy lifecycle hook.
    */
-  this.element_ = $element;
+  $onDestroy() {
+    this.element_ = null;
+  }
 
   /**
-   * @type {number}
+   * Import the asset and close the window.
+   *
+   * @export
    */
-  this['assetId'] = 0;
+  accept() {
+    const descriptor = TilesDescriptor.create({
+      'accessToken': this['accessToken'],
+      'assetId': this['assetId'],
+      'title': this['title'],
+      'description': this['description'],
+      'tags': this['tags']
+    });
+    DataManager.getInstance().addDescriptor(descriptor);
+
+    const provider = TilesProvider.getInstance();
+    provider.addDescriptor(descriptor);
+
+    this.close();
+  }
 
   /**
-   * @type {string}
+   * Close the window.
+   *
+   * @export
    */
-  this['accessToken'] = '';
+  close() {
+    osWindow.close(this.element_);
+  }
+}
 
-  /**
-   * @type {string}
-   */
-  this['title'] = 'New Ion Asset';
-
-  /**
-   * @type {string}
-   */
-  this['description'] = '';
-
-  /**
-   * @type {string}
-   */
-  this['tags'] = '';
-
-  $scope.$emit(os.ui.WindowEventType.READY);
-  $scope.$on('$destroy', this.dispose.bind(this));
-};
-goog.inherits(plugin.cesium.ImportIonAssetCtrl, goog.Disposable);
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.ImportIonAssetCtrl.prototype.disposeInternal = function() {
-  plugin.cesium.ImportIonAssetCtrl.base(this, 'disposeInternal');
-
-  this.element_ = null;
-};
-
-
-/**
- * Import the asset and close the window.
- *
- * @export
- */
-plugin.cesium.ImportIonAssetCtrl.prototype.accept = function() {
-  var descriptor = plugin.cesium.tiles.Descriptor.createFromConfig({
-    'accessToken': this['accessToken'],
-    'assetId': this['assetId'],
-    'title': this['title'],
-    'description': this['description'],
-    'tags': this['tags']
-  });
-  os.dataManager.addDescriptor(descriptor);
-
-  var provider = plugin.cesium.tiles.Provider.getInstance();
-  provider.addDescriptor(descriptor);
-
-  this.close();
-};
-
-
-/**
- * Close the window.
- *
- * @export
- */
-plugin.cesium.ImportIonAssetCtrl.prototype.close = function() {
-  os.ui.window.close(this.element_);
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/cesium/importionasset.js
+++ b/src/plugin/cesium/importionasset.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.ImportIonAssetUI');
-goog.module.declareLegacyNamespace();
 
 const {ROOT} = goog.require('os');
 const DataManager = goog.require('os.data.DataManager');

--- a/src/plugin/cesium/interaction/cesiumdragboxinteraction.js
+++ b/src/plugin/cesium/interaction/cesiumdragboxinteraction.js
@@ -1,32 +1,35 @@
-goog.provide('plugin.cesium.interaction.dragbox');
+goog.module('plugin.cesium.interaction.dragbox');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.interaction.DragBox');
-goog.require('os.interaction.DrawPolygon');
-goog.require('plugin.cesium');
+const dispatcher = goog.require('os.Dispatcher');
+const MapContainer = goog.require('os.MapContainer');
+const DragBox = goog.require('os.interaction.DragBox');
+const DrawPolygon = goog.require('os.interaction.DrawPolygon');
+const cesium = goog.require('plugin.cesium');
 
 
 /**
  * The Cesium box primitive.
  * @type {Cesium.Primitive|undefined}
  */
-os.interaction.DragBox.prototype.cesiumBox = undefined;
+DragBox.prototype.cesiumBox = undefined;
 
 
 /**
  * The Cesium box color.
  * @type {Cesium.ColorGeometryInstanceAttribute|undefined}
  */
-os.interaction.DragBox.prototype.cesiumColor = undefined;
+DragBox.prototype.cesiumColor = undefined;
 
 
 /**
  * Clean up the drag box interaction in Cesium.
  *
- * @this {os.interaction.DragBox}
+ * @this {DragBox}
  */
-plugin.cesium.interaction.dragbox.cleanupWebGL = function() {
-  var webgl = /** @type {plugin.cesium.CesiumRenderer|undefined} */ (
-    os.MapContainer.getInstance().getWebGLRenderer());
+const cleanupWebGL = function() {
+  var webgl = /** @type {cesium.CesiumRenderer|undefined} */ (
+    MapContainer.getInstance().getWebGLRenderer());
   var scene = webgl ? webgl.getCesiumScene() : undefined;
   if (scene && this.cesiumBox) {
     scene.groundPrimitives.remove(this.cesiumBox);
@@ -34,15 +37,14 @@ plugin.cesium.interaction.dragbox.cleanupWebGL = function() {
   }
 };
 
-
 /**
  * Draw the box in Cesium.
  * @param {ol.geom.Polygon} geometry
- * @this {os.interaction.DragBox}
+ * @this {DragBox}
  * @suppress {accessControls}
  */
-plugin.cesium.interaction.dragbox.updateWebGL = function(geometry) {
-  if (os.MapContainer.getInstance().is3DEnabled()) {
+const updateWebGL = function(geometry) {
+  if (MapContainer.getInstance().is3DEnabled()) {
     if (!this.cesiumColor) {
       this.cesiumColor = new Cesium.ColorGeometryInstanceAttribute(
           Cesium.Color.byteToFloat(this.color[0]),
@@ -51,8 +53,8 @@ plugin.cesium.interaction.dragbox.updateWebGL = function(geometry) {
           this.color[3]);
     }
 
-    var webgl = /** @type {plugin.cesium.CesiumRenderer|undefined} */ (
-      os.MapContainer.getInstance().getWebGLRenderer());
+    var webgl = /** @type {cesium.CesiumRenderer|undefined} */ (
+      MapContainer.getInstance().getWebGLRenderer());
     var scene = webgl ? webgl.getCesiumScene() : undefined;
 
     if (scene && geometry) {
@@ -61,12 +63,12 @@ plugin.cesium.interaction.dragbox.updateWebGL = function(geometry) {
       }
 
       var coords = geometry.getCoordinates()[0];
-      var lonlats = coords.map(os.interaction.DrawPolygon.coordToLonLat);
+      var lonlats = coords.map(DrawPolygon.coordToLonLat);
 
       this.cesiumBox = new Cesium.GroundPolylinePrimitive({
         asynchronous: false,
         geometryInstances: new Cesium.GeometryInstance({
-          id: plugin.cesium.GeometryInstanceId.GEOM_OUTLINE,
+          id: cesium.GeometryInstanceId.GEOM_OUTLINE,
           geometry: new Cesium.GroundPolylineGeometry({
             positions: olcs.core.ol4326CoordinateArrayToCsCartesians(lonlats),
             arcType: Cesium.ArcType.RHUMB,
@@ -80,7 +82,12 @@ plugin.cesium.interaction.dragbox.updateWebGL = function(geometry) {
       });
 
       scene.groundPrimitives.add(this.cesiumBox);
-      os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
+      dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
     }
   }
+};
+
+exports = {
+  cleanupWebGL,
+  updateWebGL
 };

--- a/src/plugin/cesium/interaction/cesiumdragboxinteraction.js
+++ b/src/plugin/cesium/interaction/cesiumdragboxinteraction.js
@@ -1,25 +1,29 @@
 goog.module('plugin.cesium.interaction.dragbox');
-goog.module.declareLegacyNamespace();
 
-const dispatcher = goog.require('os.Dispatcher');
+const {ol4326CoordinateArrayToCsCartesians} = goog.require('olcs.core');
+const Dispatcher = goog.require('os.Dispatcher');
 const MapContainer = goog.require('os.MapContainer');
-const DragBox = goog.require('os.interaction.DragBox');
+const MapEvent = goog.require('os.MapEvent');
 const DrawPolygon = goog.require('os.interaction.DrawPolygon');
-const cesium = goog.require('plugin.cesium');
+const {GeometryInstanceId} = goog.require('plugin.cesium');
+
+const Polygon = goog.requireType('ol.geom.Polygon');
+const DragBox = goog.requireType('os.interaction.DragBox');
+const CesiumRenderer = goog.requireType('plugin.cesium.CesiumRenderer');
 
 
 /**
  * The Cesium box primitive.
  * @type {Cesium.Primitive|undefined}
  */
-DragBox.prototype.cesiumBox = undefined;
+let cesiumBox = undefined;
 
 
 /**
  * The Cesium box color.
  * @type {Cesium.ColorGeometryInstanceAttribute|undefined}
  */
-DragBox.prototype.cesiumColor = undefined;
+let cesiumColor = undefined;
 
 
 /**
@@ -28,61 +32,59 @@ DragBox.prototype.cesiumColor = undefined;
  * @this {DragBox}
  */
 const cleanupWebGL = function() {
-  var webgl = /** @type {cesium.CesiumRenderer|undefined} */ (
-    MapContainer.getInstance().getWebGLRenderer());
+  var webgl = /** @type {CesiumRenderer|undefined} */ (MapContainer.getInstance().getWebGLRenderer());
   var scene = webgl ? webgl.getCesiumScene() : undefined;
-  if (scene && this.cesiumBox) {
-    scene.groundPrimitives.remove(this.cesiumBox);
-    this.cesiumBox = undefined;
+  if (scene && cesiumBox) {
+    scene.groundPrimitives.remove(cesiumBox);
+    cesiumBox = undefined;
   }
 };
 
 /**
  * Draw the box in Cesium.
- * @param {ol.geom.Polygon} geometry
+ * @param {Polygon} geometry
  * @this {DragBox}
  * @suppress {accessControls}
  */
 const updateWebGL = function(geometry) {
   if (MapContainer.getInstance().is3DEnabled()) {
-    if (!this.cesiumColor) {
-      this.cesiumColor = new Cesium.ColorGeometryInstanceAttribute(
+    if (!cesiumColor) {
+      cesiumColor = new Cesium.ColorGeometryInstanceAttribute(
           Cesium.Color.byteToFloat(this.color[0]),
           Cesium.Color.byteToFloat(this.color[1]),
           Cesium.Color.byteToFloat(this.color[2]),
           this.color[3]);
     }
 
-    var webgl = /** @type {cesium.CesiumRenderer|undefined} */ (
-      MapContainer.getInstance().getWebGLRenderer());
+    var webgl = /** @type {CesiumRenderer|undefined} */ (MapContainer.getInstance().getWebGLRenderer());
     var scene = webgl ? webgl.getCesiumScene() : undefined;
 
     if (scene && geometry) {
-      if (this.cesiumBox) {
-        scene.groundPrimitives.remove(this.cesiumBox);
+      if (cesiumBox) {
+        scene.groundPrimitives.remove(cesiumBox);
       }
 
       var coords = geometry.getCoordinates()[0];
       var lonlats = coords.map(DrawPolygon.coordToLonLat);
 
-      this.cesiumBox = new Cesium.GroundPolylinePrimitive({
+      cesiumBox = new Cesium.GroundPolylinePrimitive({
         asynchronous: false,
         geometryInstances: new Cesium.GeometryInstance({
-          id: cesium.GeometryInstanceId.GEOM_OUTLINE,
+          id: GeometryInstanceId.GEOM_OUTLINE,
           geometry: new Cesium.GroundPolylineGeometry({
-            positions: olcs.core.ol4326CoordinateArrayToCsCartesians(lonlats),
+            positions: ol4326CoordinateArrayToCsCartesians(lonlats),
             arcType: Cesium.ArcType.RHUMB,
             width: 2
           }),
           attributes: {
-            color: this.cesiumColor
+            color: cesiumColor
           }
         }),
         appearance: new Cesium.PolylineColorAppearance()
       });
 
-      scene.groundPrimitives.add(this.cesiumBox);
-      dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
+      scene.groundPrimitives.add(cesiumBox);
+      Dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
     }
   }
 };

--- a/src/plugin/cesium/interaction/cesiumdragcircleinteraction.js
+++ b/src/plugin/cesium/interaction/cesiumdragcircleinteraction.js
@@ -1,41 +1,44 @@
-goog.provide('plugin.cesium.interaction.dragcircle');
+goog.module('plugin.cesium.interaction.dragcircle');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.interaction.DragCircle');
-goog.require('plugin.cesium');
+const dispatcher = goog.require('os.Dispatcher');
+const MapContainer = goog.require('os.MapContainer');
+const DragCircle = goog.require('os.interaction.DragCircle');
+const cesium = goog.require('plugin.cesium');
 
 
 /**
  * The Cesium circle primitive.
  * @type {Cesium.Primitive|undefined}
  */
-os.interaction.DragCircle.prototype.cesiumCircle = undefined;
+DragCircle.prototype.cesiumCircle = undefined;
 
 /**
  * The Cesium label collection.
  * @type {Cesium.LabelCollection|undefined}
  */
-os.interaction.DragCircle.prototype.cesiumLabels = undefined;
+DragCircle.prototype.cesiumLabels = undefined;
 
 /**
  * The Cesium label.
  * @type {Cesium.Label|undefined}
  */
-os.interaction.DragCircle.prototype.cesiumLabel = undefined;
+DragCircle.prototype.cesiumLabel = undefined;
 
 /**
  * The Cesium circle color.
  * @type {Cesium.ColorGeometryInstanceAttribute|undefined}
  */
-os.interaction.DragCircle.prototype.cesiumColor = undefined;
+DragCircle.prototype.cesiumColor = undefined;
 
 
 /**
  * Clean up the drag circle interaction in Cesium.
  *
- * @this {os.interaction.DragCircle}
+ * @this {DragCircle}
  */
-plugin.cesium.interaction.dragcircle.cleanupWebGL = function() {
-  var webgl = /** @type {plugin.cesium.CesiumRenderer|undefined} */ (os.MapContainer.getInstance().getWebGLRenderer());
+const cleanupWebGL = function() {
+  var webgl = /** @type {cesium.CesiumRenderer|undefined} */ (MapContainer.getInstance().getWebGLRenderer());
   var scene = webgl ? webgl.getCesiumScene() : undefined;
   if (scene) {
     if (this.cesiumCircle) {
@@ -52,23 +55,22 @@ plugin.cesium.interaction.dragcircle.cleanupWebGL = function() {
   }
 };
 
-
 /**
  * Draw the circle in Cesium.
  *
  * @param {ol.Coordinate} start The start coordinate.
  * @param {ol.Coordinate} end The end coordinate.
- * @this {os.interaction.DragCircle}
+ * @this {DragCircle}
  * @suppress {accessControls}
  */
-plugin.cesium.interaction.dragcircle.updateWebGL = function(start, end) {
-  if (os.MapContainer.getInstance().is3DEnabled()) {
+const updateWebGL = function(start, end) {
+  if (MapContainer.getInstance().is3DEnabled()) {
     if (!this.cesiumColor) {
       this.cesiumColor = new Cesium.ColorGeometryInstanceAttribute(0, 1, 1, 1);
     }
 
-    var webgl = /** @type {plugin.cesium.CesiumRenderer|undefined} */ (
-      os.MapContainer.getInstance().getWebGLRenderer());
+    var webgl = /** @type {cesium.CesiumRenderer|undefined} */ (
+      MapContainer.getInstance().getWebGLRenderer());
     var scene = webgl ? webgl.getCesiumScene() : undefined;
 
     start = ol.proj.toLonLat(start, this.getMap().getView().getProjection());
@@ -111,7 +113,7 @@ plugin.cesium.interaction.dragcircle.updateWebGL = function(start, end) {
         appearance: new Cesium.PolylineColorAppearance(),
         geometryInstances: new Cesium.GeometryInstance({
           geometry: new Cesium.GroundPolylineGeometry({
-            positions: plugin.cesium.generateCirclePositions(center, this.distance),
+            positions: cesium.generateCirclePositions(center, this.distance),
             arcType: os.interpolate.getMethod() === os.interpolate.Method.RHUMB ?
               Cesium.ArcType.RHUMB : Cesium.ArcType.GEODESIC,
             width: 2
@@ -127,7 +129,12 @@ plugin.cesium.interaction.dragcircle.updateWebGL = function(start, end) {
       this.cesiumLabel.show = true;
 
       scene.groundPrimitives.add(this.cesiumCircle);
-      os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
+      dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
     }
   }
+};
+
+exports = {
+  cleanupWebGL,
+  updateWebGL
 };

--- a/src/plugin/cesium/interaction/cesiumdragcircleinteraction.js
+++ b/src/plugin/cesium/interaction/cesiumdragcircleinteraction.js
@@ -1,35 +1,41 @@
 goog.module('plugin.cesium.interaction.dragcircle');
-goog.module.declareLegacyNamespace();
 
-const dispatcher = goog.require('os.Dispatcher');
+const {toLonLat} = goog.require('ol.proj');
+const Dispatcher = goog.require('os.Dispatcher');
 const MapContainer = goog.require('os.MapContainer');
-const DragCircle = goog.require('os.interaction.DragCircle');
-const cesium = goog.require('plugin.cesium');
+const MapEvent = goog.require('os.MapEvent');
+const osInterpolate = goog.require('os.interpolate');
+const osLabel = goog.require('os.style.label');
+const UnitManager = goog.require('os.unit.UnitManager');
+const {generateCirclePositions} = goog.require('plugin.cesium');
+
+const DragCircle = goog.requireType('os.interaction.DragCircle');
+const CesiumRenderer = goog.requireType('plugin.cesium.CesiumRenderer');
 
 
 /**
  * The Cesium circle primitive.
  * @type {Cesium.Primitive|undefined}
  */
-DragCircle.prototype.cesiumCircle = undefined;
+let cesiumCircle = undefined;
 
 /**
  * The Cesium label collection.
  * @type {Cesium.LabelCollection|undefined}
  */
-DragCircle.prototype.cesiumLabels = undefined;
+let cesiumLabels = undefined;
 
 /**
  * The Cesium label.
  * @type {Cesium.Label|undefined}
  */
-DragCircle.prototype.cesiumLabel = undefined;
+let cesiumLabel = undefined;
 
 /**
  * The Cesium circle color.
  * @type {Cesium.ColorGeometryInstanceAttribute|undefined}
  */
-DragCircle.prototype.cesiumColor = undefined;
+let cesiumColor = undefined;
 
 
 /**
@@ -38,20 +44,20 @@ DragCircle.prototype.cesiumColor = undefined;
  * @this {DragCircle}
  */
 const cleanupWebGL = function() {
-  var webgl = /** @type {cesium.CesiumRenderer|undefined} */ (MapContainer.getInstance().getWebGLRenderer());
+  var webgl = /** @type {CesiumRenderer|undefined} */ (MapContainer.getInstance().getWebGLRenderer());
   var scene = webgl ? webgl.getCesiumScene() : undefined;
   if (scene) {
-    if (this.cesiumCircle) {
-      scene.groundPrimitives.remove(this.cesiumCircle);
+    if (cesiumCircle) {
+      scene.groundPrimitives.remove(cesiumCircle);
     }
 
-    if (this.cesiumLabels) {
-      scene.groundPrimitives.remove(this.cesiumLabels);
+    if (cesiumLabels) {
+      scene.groundPrimitives.remove(cesiumLabels);
     }
 
-    this.cesiumCircle = undefined;
-    this.cesiumLabels = undefined;
-    this.cesiumLabel = undefined;
+    cesiumCircle = undefined;
+    cesiumLabels = undefined;
+    cesiumLabel = undefined;
   }
 };
 
@@ -65,31 +71,30 @@ const cleanupWebGL = function() {
  */
 const updateWebGL = function(start, end) {
   if (MapContainer.getInstance().is3DEnabled()) {
-    if (!this.cesiumColor) {
-      this.cesiumColor = new Cesium.ColorGeometryInstanceAttribute(0, 1, 1, 1);
+    if (!cesiumColor) {
+      cesiumColor = new Cesium.ColorGeometryInstanceAttribute(0, 1, 1, 1);
     }
 
-    var webgl = /** @type {cesium.CesiumRenderer|undefined} */ (
-      MapContainer.getInstance().getWebGLRenderer());
+    var webgl = /** @type {CesiumRenderer|undefined} */ (MapContainer.getInstance().getWebGLRenderer());
     var scene = webgl ? webgl.getCesiumScene() : undefined;
 
-    start = ol.proj.toLonLat(start, this.getMap().getView().getProjection());
-    end = ol.proj.toLonLat(end, this.getMap().getView().getProjection());
+    start = toLonLat(start, this.getMap().getView().getProjection());
+    end = toLonLat(end, this.getMap().getView().getProjection());
 
     if (scene && start && end && this.distance) {
-      if (!this.cesiumLabels) {
-        this.cesiumLabels = new Cesium.LabelCollection({
+      if (!cesiumLabels) {
+        cesiumLabels = new Cesium.LabelCollection({
           scene: scene
         });
-        scene.groundPrimitives.add(this.cesiumLabels);
+        scene.groundPrimitives.add(cesiumLabels);
       }
 
       var center = Cesium.Cartesian3.fromDegrees(start[0], start[1]);
-      var um = os.unit.UnitManager.getInstance();
+      var um = UnitManager.getInstance();
       var labelText = um.formatToBestFit('distance', this.distance, 'm', um.getBaseSystem(), 3);
 
-      if (!this.cesiumLabel) {
-        this.cesiumLabel = this.cesiumLabels.add(/** @type {Cesium.optionsLabelCollection} */ ({
+      if (!cesiumLabel) {
+        cesiumLabel = cesiumLabels.add(/** @type {Cesium.optionsLabelCollection} */ ({
           position: center,
           heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
           show: false,
@@ -99,37 +104,37 @@ const updateWebGL = function(start, end) {
           style: Cesium.LabelStyle.FILL_AND_OUTLINE,
           horizontalOrigin: Cesium.HorizontalOrigin.LEFT,
           verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
-          font: os.style.label.getFont(),
+          font: osLabel.getFont(),
           text: labelText
         }));
       }
 
-      if (this.cesiumCircle) {
-        scene.groundPrimitives.remove(this.cesiumCircle);
+      if (cesiumCircle) {
+        scene.groundPrimitives.remove(cesiumCircle);
       }
 
-      this.cesiumCircle = new Cesium.GroundPolylinePrimitive({
+      cesiumCircle = new Cesium.GroundPolylinePrimitive({
         asynchronous: false,
         appearance: new Cesium.PolylineColorAppearance(),
         geometryInstances: new Cesium.GeometryInstance({
           geometry: new Cesium.GroundPolylineGeometry({
-            positions: cesium.generateCirclePositions(center, this.distance),
-            arcType: os.interpolate.getMethod() === os.interpolate.Method.RHUMB ?
+            positions: generateCirclePositions(center, this.distance),
+            arcType: osInterpolate.getMethod() === osInterpolate.Method.RHUMB ?
               Cesium.ArcType.RHUMB : Cesium.ArcType.GEODESIC,
             width: 2
           }),
           attributes: {
-            color: this.cesiumColor
+            color: cesiumColor
           }
         })
       });
 
-      this.cesiumLabel.position = center;
-      this.cesiumLabel.text = labelText;
-      this.cesiumLabel.show = true;
+      cesiumLabel.position = center;
+      cesiumLabel.text = labelText;
+      cesiumLabel.show = true;
 
-      scene.groundPrimitives.add(this.cesiumCircle);
-      dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
+      scene.groundPrimitives.add(cesiumCircle);
+      Dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
     }
   }
 };

--- a/src/plugin/cesium/interaction/cesiumdrawpolygoninteraction.js
+++ b/src/plugin/cesium/interaction/cesiumdrawpolygoninteraction.js
@@ -1,7 +1,10 @@
-goog.provide('plugin.cesium.interaction.drawpolygon');
+goog.module('plugin.cesium.interaction.drawpolygon');
+goog.module.declareLegacyNamespace();
 
-goog.require('olcs.core');
-goog.require('os.interaction.DrawPolygon');
+const dispatcher = goog.require('os.Dispatcher');
+const MapContainer = goog.require('os.MapContainer');
+const core = goog.require('olcs.core');
+const DrawPolygon = goog.require('os.interaction.DrawPolygon');
 
 
 /**
@@ -9,7 +12,7 @@ goog.require('os.interaction.DrawPolygon');
  * @type {Cesium.ColorGeometryInstanceAttribute|undefined}
  * @protected
  */
-os.interaction.DrawPolygon.prototype.cesiumColor = undefined;
+DrawPolygon.prototype.cesiumColor = undefined;
 
 
 /**
@@ -17,17 +20,17 @@ os.interaction.DrawPolygon.prototype.cesiumColor = undefined;
  * @type {Cesium.GroundPolylinePrimitive|undefined}
  * @protected
  */
-os.interaction.DrawPolygon.prototype.cesiumLine = undefined;
+DrawPolygon.prototype.cesiumLine = undefined;
 
 
 /**
  * Clean up the draw polygon interaction in Cesium.
  *
- * @this {os.interaction.DrawPolygon}
+ * @this {DrawPolygon}
  */
-plugin.cesium.interaction.drawpolygon.cleanupWebGL = function() {
+const cleanupWebGL = function() {
   var webgl = /** @type {plugin.cesium.CesiumRenderer|undefined} */ (
-    os.MapContainer.getInstance().getWebGLRenderer());
+    MapContainer.getInstance().getWebGLRenderer());
   var scene = webgl ? webgl.getCesiumScene() : undefined;
   if (scene) {
     this.cesiumColor = undefined;
@@ -39,15 +42,14 @@ plugin.cesium.interaction.drawpolygon.cleanupWebGL = function() {
   }
 };
 
-
 /**
  * Draw the polygon in Cesium.
  *
- * @this {os.interaction.DrawPolygon}
+ * @this {DrawPolygon}
  * @suppress {accessControls}
  */
-plugin.cesium.interaction.drawpolygon.updateWebGL = function() {
-  if (os.MapContainer.getInstance().is3DEnabled()) {
+const updateWebGL = function() {
+  if (MapContainer.getInstance().is3DEnabled()) {
     if (!this.cesiumColor) {
       this.cesiumColor = new Cesium.ColorGeometryInstanceAttribute(
           Cesium.Color.byteToFloat(this.color[0]),
@@ -57,11 +59,11 @@ plugin.cesium.interaction.drawpolygon.updateWebGL = function() {
     }
 
     var webgl = /** @type {plugin.cesium.CesiumRenderer|undefined} */ (
-      os.MapContainer.getInstance().getWebGLRenderer());
+      MapContainer.getInstance().getWebGLRenderer());
     var scene = webgl ? webgl.getCesiumScene() : undefined;
 
     var coords = /** @type {ol.geom.LineString} */ (this.line2D.getGeometry()).getCoordinates();
-    var lonlats = coords.map(os.interaction.DrawPolygon.coordToLonLat);
+    var lonlats = coords.map(DrawPolygon.coordToLonLat);
 
     var l = lonlats.length;
     if (l > 1 && Math.abs(lonlats[l - 1][0] - lonlats[l - 2][0]) < 1E-12 &&
@@ -81,7 +83,7 @@ plugin.cesium.interaction.drawpolygon.updateWebGL = function() {
         appearance: new Cesium.PolylineColorAppearance(),
         geometryInstances: new Cesium.GeometryInstance({
           geometry: new Cesium.GroundPolylineGeometry({
-            positions: olcs.core.ol4326CoordinateArrayToCsCartesians(lonlats),
+            positions: core.ol4326CoordinateArrayToCsCartesians(lonlats),
             arcType: os.interpolate.getMethod() === os.interpolate.Method.RHUMB ?
               Cesium.ArcType.RHUMB : Cesium.ArcType.GEODESIC,
             width: 2
@@ -93,7 +95,12 @@ plugin.cesium.interaction.drawpolygon.updateWebGL = function() {
       });
 
       scene.groundPrimitives.add(this.cesiumLine);
-      os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
+      dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
     }
   }
+};
+
+exports = {
+  cleanupWebGL,
+  updateWebGL
 };

--- a/src/plugin/cesium/interaction/cesiumdrawpolygoninteraction.js
+++ b/src/plugin/cesium/interaction/cesiumdrawpolygoninteraction.js
@@ -1,10 +1,14 @@
 goog.module('plugin.cesium.interaction.drawpolygon');
-goog.module.declareLegacyNamespace();
 
 const dispatcher = goog.require('os.Dispatcher');
 const MapContainer = goog.require('os.MapContainer');
+const MapEvent = goog.require('os.MapEvent');
+const osInterpolate = goog.require('os.interpolate');
 const core = goog.require('olcs.core');
 const DrawPolygon = goog.require('os.interaction.DrawPolygon');
+
+const LineString = goog.requireType('ol.geom.LineString');
+const CesiumRenderer = goog.requireType('plugin.cesium.CesiumRenderer');
 
 
 /**
@@ -12,7 +16,7 @@ const DrawPolygon = goog.require('os.interaction.DrawPolygon');
  * @type {Cesium.ColorGeometryInstanceAttribute|undefined}
  * @protected
  */
-DrawPolygon.prototype.cesiumColor = undefined;
+let cesiumColor = undefined;
 
 
 /**
@@ -20,7 +24,7 @@ DrawPolygon.prototype.cesiumColor = undefined;
  * @type {Cesium.GroundPolylinePrimitive|undefined}
  * @protected
  */
-DrawPolygon.prototype.cesiumLine = undefined;
+let cesiumLine = undefined;
 
 
 /**
@@ -29,15 +33,15 @@ DrawPolygon.prototype.cesiumLine = undefined;
  * @this {DrawPolygon}
  */
 const cleanupWebGL = function() {
-  var webgl = /** @type {plugin.cesium.CesiumRenderer|undefined} */ (
+  var webgl = /** @type {CesiumRenderer|undefined} */ (
     MapContainer.getInstance().getWebGLRenderer());
   var scene = webgl ? webgl.getCesiumScene() : undefined;
   if (scene) {
-    this.cesiumColor = undefined;
+    cesiumColor = undefined;
 
-    if (this.cesiumLine) {
-      scene.groundPrimitives.remove(this.cesiumLine);
-      this.cesiumLine = undefined;
+    if (cesiumLine) {
+      scene.groundPrimitives.remove(cesiumLine);
+      cesiumLine = undefined;
     }
   }
 };
@@ -50,19 +54,19 @@ const cleanupWebGL = function() {
  */
 const updateWebGL = function() {
   if (MapContainer.getInstance().is3DEnabled()) {
-    if (!this.cesiumColor) {
-      this.cesiumColor = new Cesium.ColorGeometryInstanceAttribute(
+    if (!cesiumColor) {
+      cesiumColor = new Cesium.ColorGeometryInstanceAttribute(
           Cesium.Color.byteToFloat(this.color[0]),
           Cesium.Color.byteToFloat(this.color[1]),
           Cesium.Color.byteToFloat(this.color[2]),
           this.color[3]);
     }
 
-    var webgl = /** @type {plugin.cesium.CesiumRenderer|undefined} */ (
+    var webgl = /** @type {CesiumRenderer|undefined} */ (
       MapContainer.getInstance().getWebGLRenderer());
     var scene = webgl ? webgl.getCesiumScene() : undefined;
 
-    var coords = /** @type {ol.geom.LineString} */ (this.line2D.getGeometry()).getCoordinates();
+    var coords = /** @type {LineString} */ (this.line2D.getGeometry()).getCoordinates();
     var lonlats = coords.map(DrawPolygon.coordToLonLat);
 
     var l = lonlats.length;
@@ -73,29 +77,29 @@ const updateWebGL = function() {
     }
 
     if (scene && lonlats.length > 1) {
-      if (this.cesiumLine) {
-        scene.groundPrimitives.remove(this.cesiumLine);
+      if (cesiumLine) {
+        scene.groundPrimitives.remove(cesiumLine);
       }
 
 
-      this.cesiumLine = new Cesium.GroundPolylinePrimitive({
+      cesiumLine = new Cesium.GroundPolylinePrimitive({
         asynchronous: false,
         appearance: new Cesium.PolylineColorAppearance(),
         geometryInstances: new Cesium.GeometryInstance({
           geometry: new Cesium.GroundPolylineGeometry({
             positions: core.ol4326CoordinateArrayToCsCartesians(lonlats),
-            arcType: os.interpolate.getMethod() === os.interpolate.Method.RHUMB ?
+            arcType: osInterpolate.getMethod() === osInterpolate.Method.RHUMB ?
               Cesium.ArcType.RHUMB : Cesium.ArcType.GEODESIC,
             width: 2
           }),
           attributes: {
-            color: this.cesiumColor
+            color: cesiumColor
           }
         })
       });
 
-      scene.groundPrimitives.add(this.cesiumLine);
-      dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
+      scene.groundPrimitives.add(cesiumLine);
+      dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
     }
   }
 };

--- a/src/plugin/cesium/interaction/cesiuminteraction.js
+++ b/src/plugin/cesium/interaction/cesiuminteraction.js
@@ -1,15 +1,15 @@
-goog.provide('plugin.cesium.interaction');
+goog.module('plugin.cesium.interaction');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.interaction.DragBox');
-goog.require('os.interaction.DragCircle');
-goog.require('os.interaction.DrawPolygon');
-goog.require('os.interaction.Measure');
-goog.require('os.interaction.Modify');
-goog.require('os.map');
-goog.require('plugin.cesium.interaction.dragbox');
-goog.require('plugin.cesium.interaction.dragcircle');
-goog.require('plugin.cesium.interaction.drawpolygon');
-goog.require('plugin.cesium.interaction.measure');
+const DragBox = goog.require('os.interaction.DragBox');
+const DragCircle = goog.require('os.interaction.DragCircle');
+const DrawPolygon = goog.require('os.interaction.DrawPolygon');
+const Measure = goog.require('os.interaction.Measure');
+const map = goog.require('os.map');
+const dragbox = goog.require('plugin.cesium.interaction.dragbox');
+const dragcircle = goog.require('plugin.cesium.interaction.dragcircle');
+const drawpolygon = goog.require('plugin.cesium.interaction.drawpolygon');
+const measure = goog.require('plugin.cesium.interaction.measure');
 
 
 /**
@@ -18,9 +18,9 @@ goog.require('plugin.cesium.interaction.measure');
  * @param {!plugin.cesium.Camera} camera The camera.
  * @param {Cesium.ScreenSpaceCameraController} sscc The camera controller.
  */
-plugin.cesium.interaction.configureCesium = function(camera, sscc) {
+const configureCesium = function(camera, sscc) {
   // allow zooming out further in the 3D view
-  var maxResolution = os.map.zoomToResolution(0, os.map.PROJECTION);
+  var maxResolution = map.zoomToResolution(0, map.PROJECTION);
   sscc.maximumZoomDistance = camera.calcDistanceForResolution(maxResolution, 0);
 
   // shift + right drag to change the camera direction
@@ -58,20 +58,24 @@ plugin.cesium.interaction.configureCesium = function(camera, sscc) {
   sscc.inertiaZoom = 0;
 };
 
-
 /**
  * Load Cesium mixins for OpenSphere interactions.
  */
-plugin.cesium.interaction.loadInteractionMixins = function() {
-  os.interaction.DragBox.prototype.cleanupWebGL = plugin.cesium.interaction.dragbox.cleanupWebGL;
-  os.interaction.DragBox.prototype.updateWebGL = plugin.cesium.interaction.dragbox.updateWebGL;
+const loadInteractionMixins = function() {
+  DragBox.prototype.cleanupWebGL = dragbox.cleanupWebGL;
+  DragBox.prototype.updateWebGL = dragbox.updateWebGL;
 
-  os.interaction.DragCircle.prototype.cleanupWebGL = plugin.cesium.interaction.dragcircle.cleanupWebGL;
-  os.interaction.DragCircle.prototype.updateWebGL = plugin.cesium.interaction.dragcircle.updateWebGL;
+  DragCircle.prototype.cleanupWebGL = dragcircle.cleanupWebGL;
+  DragCircle.prototype.updateWebGL = dragcircle.updateWebGL;
 
-  os.interaction.DrawPolygon.prototype.cleanupWebGL = plugin.cesium.interaction.drawpolygon.cleanupWebGL;
-  os.interaction.DrawPolygon.prototype.updateWebGL = plugin.cesium.interaction.drawpolygon.updateWebGL;
+  DrawPolygon.prototype.cleanupWebGL = drawpolygon.cleanupWebGL;
+  DrawPolygon.prototype.updateWebGL = drawpolygon.updateWebGL;
 
-  os.interaction.Measure.prototype.cleanupWebGL = plugin.cesium.interaction.measure.cleanupWebGL;
-  os.interaction.Measure.prototype.updateWebGL = plugin.cesium.interaction.measure.updateWebGL;
+  Measure.prototype.cleanupWebGL = measure.cleanupWebGL;
+  Measure.prototype.updateWebGL = measure.updateWebGL;
+};
+
+exports = {
+  configureCesium,
+  loadInteractionMixins
 };

--- a/src/plugin/cesium/interaction/cesiuminteraction.js
+++ b/src/plugin/cesium/interaction/cesiuminteraction.js
@@ -1,26 +1,27 @@
 goog.module('plugin.cesium.interaction');
-goog.module.declareLegacyNamespace();
 
 const DragBox = goog.require('os.interaction.DragBox');
 const DragCircle = goog.require('os.interaction.DragCircle');
 const DrawPolygon = goog.require('os.interaction.DrawPolygon');
 const Measure = goog.require('os.interaction.Measure');
-const map = goog.require('os.map');
+const {PROJECTION, zoomToResolution} = goog.require('os.map');
 const dragbox = goog.require('plugin.cesium.interaction.dragbox');
 const dragcircle = goog.require('plugin.cesium.interaction.dragcircle');
 const drawpolygon = goog.require('plugin.cesium.interaction.drawpolygon');
 const measure = goog.require('plugin.cesium.interaction.measure');
 
+const Camera = goog.requireType('plugin.cesium.Camera');
+
 
 /**
  * Configure Cesium interactions.
  *
- * @param {!plugin.cesium.Camera} camera The camera.
+ * @param {!Camera} camera The camera.
  * @param {Cesium.ScreenSpaceCameraController} sscc The camera controller.
  */
 const configureCesium = function(camera, sscc) {
   // allow zooming out further in the 3D view
-  var maxResolution = map.zoomToResolution(0, map.PROJECTION);
+  var maxResolution = zoomToResolution(0, PROJECTION);
   sscc.maximumZoomDistance = camera.calcDistanceForResolution(maxResolution, 0);
 
   // shift + right drag to change the camera direction

--- a/src/plugin/cesium/interaction/cesiummeasureinteraction.js
+++ b/src/plugin/cesium/interaction/cesiummeasureinteraction.js
@@ -1,8 +1,10 @@
-goog.provide('plugin.cesium.interaction.measure');
+goog.module('plugin.cesium.interaction.measure');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.interaction.DrawPolygon');
-goog.require('os.interaction.Measure');
-goog.require('plugin.cesium.interaction.drawpolygon');
+const MapContainer = goog.require('os.MapContainer');
+const DrawPolygon = goog.require('os.interaction.DrawPolygon');
+const Measure = goog.require('os.interaction.Measure');
+const drawpolygon = goog.require('plugin.cesium.interaction.drawpolygon');
 
 
 /**
@@ -10,18 +12,18 @@ goog.require('plugin.cesium.interaction.drawpolygon');
  * @type {Cesium.LabelCollection|undefined}
  * @protected
  */
-os.interaction.Measure.prototype.cesiumLabels = undefined;
+Measure.prototype.cesiumLabels = undefined;
 
 
 /**
  * Clean up the draw polygon interaction in Cesium.
  *
- * @this {os.interaction.Measure}
+ * @this {Measure}
  */
-plugin.cesium.interaction.measure.cleanupWebGL = function() {
-  plugin.cesium.interaction.drawpolygon.cleanupWebGL.call(this);
+const cleanupWebGL = function() {
+  drawpolygon.cleanupWebGL.call(this);
 
-  var webgl = /** @type {plugin.cesium.CesiumRenderer|undefined} */ (os.MapContainer.getInstance().getWebGLRenderer());
+  var webgl = /** @type {plugin.cesium.CesiumRenderer|undefined} */ (MapContainer.getInstance().getWebGLRenderer());
   var scene = webgl ? webgl.getCesiumScene() : undefined;
   if (scene) {
     if (this.cesiumLabels) {
@@ -31,25 +33,24 @@ plugin.cesium.interaction.measure.cleanupWebGL = function() {
   }
 };
 
-
 /**
  * Draw the measure line in Cesium.
  *
- * @this {os.interaction.Measure}
+ * @this {Measure}
  * @suppress {accessControls}
  */
-plugin.cesium.interaction.measure.updateWebGL = function() {
-  plugin.cesium.interaction.drawpolygon.updateWebGL.call(this);
+const updateWebGL = function() {
+  drawpolygon.updateWebGL.call(this);
 
-  if (os.MapContainer.getInstance().is3DEnabled()) {
+  if (MapContainer.getInstance().is3DEnabled()) {
     var webgl = /** @type {plugin.cesium.CesiumRenderer|undefined} */ (
-      os.MapContainer.getInstance().getWebGLRenderer());
+      MapContainer.getInstance().getWebGLRenderer());
     var scene = webgl ? webgl.getCesiumScene() : undefined;
 
-    var lonlats = this.coords.map(os.interaction.DrawPolygon.coordToLonLat);
+    var lonlats = this.coords.map(DrawPolygon.coordToLonLat);
 
     if (scene && lonlats.length > 1) {
-      var camera = os.MapContainer.getInstance().getWebGLCamera();
+      var camera = MapContainer.getInstance().getWebGLCamera();
 
       if (!this.cesiumLabels) {
         this.cesiumLabels = new Cesium.LabelCollection();
@@ -69,7 +70,7 @@ plugin.cesium.interaction.measure.updateWebGL = function() {
       var i = this.distances_.length - 1;
       label.show = false;
       label.eyeOffset = new Cesium.Cartesian3(0.0, 0.0, -(camera.getDistanceToCenter() / 5));
-      label.font = os.style.label.getFont(os.interaction.Measure.LABEL_FONT_SIZE_);
+      label.font = os.style.label.getFont(Measure.LABEL_FONT_SIZE_);
       label.style = Cesium.LabelStyle.FILL_AND_OUTLINE;
       label.outlineWidth = 2;
       label.outlineColor = new Cesium.Color(0, 0, 0);
@@ -79,4 +80,9 @@ plugin.cesium.interaction.measure.updateWebGL = function() {
       label.show = true;
     }
   }
+};
+
+exports = {
+  cleanupWebGL,
+  updateWebGL
 };

--- a/src/plugin/cesium/interaction/cesiummeasureinteraction.js
+++ b/src/plugin/cesium/interaction/cesiummeasureinteraction.js
@@ -1,18 +1,19 @@
 goog.module('plugin.cesium.interaction.measure');
-goog.module.declareLegacyNamespace();
 
 const MapContainer = goog.require('os.MapContainer');
 const DrawPolygon = goog.require('os.interaction.DrawPolygon');
 const Measure = goog.require('os.interaction.Measure');
+const osLabel = goog.require('os.style.label');
 const drawpolygon = goog.require('plugin.cesium.interaction.drawpolygon');
+
+const CesiumRenderer = goog.requireType('plugin.cesium.CesiumRenderer');
 
 
 /**
  * The Cesium labels.
  * @type {Cesium.LabelCollection|undefined}
- * @protected
  */
-Measure.prototype.cesiumLabels = undefined;
+let cesiumLabels = undefined;
 
 
 /**
@@ -23,12 +24,12 @@ Measure.prototype.cesiumLabels = undefined;
 const cleanupWebGL = function() {
   drawpolygon.cleanupWebGL.call(this);
 
-  var webgl = /** @type {plugin.cesium.CesiumRenderer|undefined} */ (MapContainer.getInstance().getWebGLRenderer());
+  var webgl = /** @type {CesiumRenderer|undefined} */ (MapContainer.getInstance().getWebGLRenderer());
   var scene = webgl ? webgl.getCesiumScene() : undefined;
   if (scene) {
-    if (this.cesiumLabels) {
-      scene.primitives.remove(this.cesiumLabels);
-      this.cesiumLabels = null;
+    if (cesiumLabels) {
+      scene.primitives.remove(cesiumLabels);
+      cesiumLabels = null;
     }
   }
 };
@@ -43,7 +44,7 @@ const updateWebGL = function() {
   drawpolygon.updateWebGL.call(this);
 
   if (MapContainer.getInstance().is3DEnabled()) {
-    var webgl = /** @type {plugin.cesium.CesiumRenderer|undefined} */ (
+    var webgl = /** @type {CesiumRenderer|undefined} */ (
       MapContainer.getInstance().getWebGLRenderer());
     var scene = webgl ? webgl.getCesiumScene() : undefined;
 
@@ -52,25 +53,25 @@ const updateWebGL = function() {
     if (scene && lonlats.length > 1) {
       var camera = MapContainer.getInstance().getWebGLCamera();
 
-      if (!this.cesiumLabels) {
-        this.cesiumLabels = new Cesium.LabelCollection();
-        scene.primitives.add(this.cesiumLabels);
+      if (!cesiumLabels) {
+        cesiumLabels = new Cesium.LabelCollection();
+        scene.primitives.add(cesiumLabels);
       }
 
       var label = null;
 
-      if (this.cesiumLabels.length === this.distances_.length) {
+      if (cesiumLabels.length === this.distances_.length) {
         // modify the last one
-        label = this.cesiumLabels.get(this.cesiumLabels.length - 1);
+        label = cesiumLabels.get(cesiumLabels.length - 1);
       } else {
         // add a new one
-        label = this.cesiumLabels.add();
+        label = cesiumLabels.add();
       }
 
       var i = this.distances_.length - 1;
       label.show = false;
       label.eyeOffset = new Cesium.Cartesian3(0.0, 0.0, -(camera.getDistanceToCenter() / 5));
-      label.font = os.style.label.getFont(Measure.LABEL_FONT_SIZE_);
+      label.font = osLabel.getFont(Measure.LABEL_FONT_SIZE_);
       label.style = Cesium.LabelStyle.FILL_AND_OUTLINE;
       label.outlineWidth = 2;
       label.outlineColor = new Cesium.Color(0, 0, 0);

--- a/src/plugin/cesium/layer.js
+++ b/src/plugin/cesium/layer.js
@@ -1,7 +1,6 @@
 goog.module('plugin.cesium.Layer');
 
 const dispatcher = goog.require('os.Dispatcher');
-const ui = goog.require('os.ui');
 const mapContainer = goog.require('os.MapContainer');
 const MapContainer = goog.require('os.MapContainer');
 const Delay = goog.require('goog.async.Delay');
@@ -16,6 +15,9 @@ const osImplements = goog.require('os.implements');
 const IColorableLayer = goog.require('os.layer.IColorableLayer');
 const ILayer = goog.require('os.layer.ILayer');
 const PropertyChange = goog.require('os.layer.PropertyChange');
+const {adjustIconSet, createIconSet} = goog.require('os.ui.icons');
+
+const IActionTarget = goog.requireType('os.ui.action.IActionTarget');
 
 
 /**
@@ -294,7 +296,7 @@ class Layer extends OLLayer {
   updateIcons_() {
     var color = this.getColor();
     if (color) {
-      ui.adjustIconSet(this.getId(), osColor.toHexString(color));
+      adjustIconSet(this.getId(), osColor.toHexString(color));
     }
   }
 
@@ -327,7 +329,7 @@ class Layer extends OLLayer {
       color = osColor.toRgbArray(layerColor);
     }
 
-    html += color ? ui.createIconSet(this.getId(), null, [this.icons_], color) : this.icons_;
+    html += color ? createIconSet(this.getId(), null, [this.icons_], color) : this.icons_;
     return html;
   }
 
@@ -602,7 +604,7 @@ class Layer extends OLLayer {
 
   /**
    * @inheritDoc
-   * @see {ui.action.IActionTarget}
+   * @see {IActionTarget}
    */
   supportsAction(type, opt_actionArgs) {
     if (os.action) {

--- a/src/plugin/cesium/layer.js
+++ b/src/plugin/cesium/layer.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.Layer');
-goog.module.declareLegacyNamespace();
 
 const dispatcher = goog.require('os.Dispatcher');
 const ui = goog.require('os.ui');
@@ -8,7 +7,7 @@ const MapContainer = goog.require('os.MapContainer');
 const Delay = goog.require('goog.async.Delay');
 const log = goog.require('goog.log');
 const googString = goog.require('goog.string');
-const olLayerLayer = goog.require('ol.layer.Layer');
+const OLLayer = goog.require('ol.layer.Layer');
 const IGroupable = goog.require('os.IGroupable');
 const osColor = goog.require('os.color');
 const LayerEvent = goog.require('os.events.LayerEvent');
@@ -20,11 +19,18 @@ const PropertyChange = goog.require('os.layer.PropertyChange');
 
 
 /**
+ * The logger.
+ * @type {log.Logger}
+ */
+const logger = log.getLogger('plugin.cesium.Layer');
+
+
+/**
  * @implements {ILayer}
  * @implements {IColorableLayer}
  * @implements {IGroupable}
  */
-class Layer extends olLayerLayer {
+class Layer extends OLLayer {
   /**
    * Constructor.
    */
@@ -124,7 +130,7 @@ class Layer extends olLayerLayer {
      * @type {log.Logger}
      * @protected
      */
-    this.log = Layer.LOGGER_;
+    this.log = logger;
 
     // set the openlayers type to something that won't find a renderer, because there's
     // no way to render Cesium-specific items in OpenLayers anyway
@@ -514,14 +520,14 @@ class Layer extends olLayerLayer {
   }
 
   /**
-   * @return {!function(!olLayerLayer)}
+   * @return {!function(!OLLayer)}
    */
   getRefreshFunction() {
     return goog.nullFunction;
   }
 
   /**
-   * @param {!function(!olLayerLayer)} refreshFunction
+   * @param {!function(!OLLayer)} refreshFunction
    */
   setRefreshFunction(refreshFunction) {
   }
@@ -729,34 +735,22 @@ class Layer extends olLayerLayer {
       this.setLoading(true);
     }
   }
-}
 
+  /**
+   * Identify the layer on the map.
+   * @protected
+   */
+  identify() {}
+
+  /**
+   * Forces the layer to refresh.
+   * @protected
+   */
+  refresh() {}
+}
 osImplements(Layer, ILayer.ID);
 osImplements(Layer, IColorableLayer.ID);
 osImplements(Layer, IGroupable.ID);
-
-
-/**
- * The logger.
- * @type {log.Logger}
- * @private
- * @const
- */
-Layer.LOGGER_ = log.getLogger('plugin.cesium.Layer');
-
-
-/**
- * Forces the layer to refresh.
- * @protected
- */
-Layer.prototype.refresh = goog.nullFunction;
-
-
-/**
- * Identify the layer on the map.
- * @protected
- */
-Layer.prototype.identify = goog.nullFunction;
 
 
 exports = Layer;

--- a/src/plugin/cesium/mixin/cesiummixin.js
+++ b/src/plugin/cesium/mixin/cesiummixin.js
@@ -2,10 +2,13 @@
  * @fileoverview mixins for Cesium
  * @suppress {missingProvide}
  */
-goog.provide('plugin.cesium.mixin');
+goog.module('plugin.cesium.mixin');
 
-goog.require('os.MapEvent');
-goog.require('os.net.Request');
+goog.module.declareLegacyNamespace();
+
+const dispatcher = goog.require('os.Dispatcher');
+const MapEvent = goog.require('os.MapEvent');
+const Request = goog.require('os.net.Request');
 
 
 /**
@@ -13,7 +16,7 @@ goog.require('os.net.Request');
  *
  * @throws {Error} If Cesium has not been loaded.
  */
-plugin.cesium.mixin.loadCesiumMixins = function() {
+const loadCesiumMixins = function() {
   if (window.Cesium === undefined) {
     throw new Error('Cesium has not been loaded!');
   }
@@ -70,7 +73,7 @@ plugin.cesium.mixin.loadCesiumMixins = function() {
    * @return {Cesium.Promise<*>}
    */
   Cesium.Resource.prototype._makeRequest = function(options) {
-    var req = new os.net.Request(options.url || this.url);
+    var req = new Request(options.url || this.url);
     var headers = options.headers || this.headers;
 
     if (headers) {
@@ -91,7 +94,7 @@ plugin.cesium.mixin.loadCesiumMixins = function() {
       // The old olcs render loop fired a repaint when requests returned. While that shouldn't
       // be necessary with Cesium's new explicit rendering, there are still cases like async
       // Billboard/Icon loading which do not appear to be triggering a render request.
-      os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
+      dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
     });
 
     return deferred.promise;
@@ -198,4 +201,8 @@ plugin.cesium.mixin.loadCesiumMixins = function() {
     return new Cesium.PickId(this, key, Cesium.Color.fromRgba(key));
   };
   Cesium.Context.prototype['createPickId'] = Cesium.Context.prototype.createPickId;
+};
+
+exports = {
+  loadCesiumMixins
 };

--- a/src/plugin/cesium/mixin/cesiummixin.js
+++ b/src/plugin/cesium/mixin/cesiummixin.js
@@ -9,6 +9,9 @@ import {load as loadRenderLoopMixin} from './renderloopmixin';
 
 const dispatcher = goog.require('os.Dispatcher');
 const MapEvent = goog.require('os.MapEvent');
+const {prune} = goog.require('os.object');
+const {getCrossOrigin} = goog.require('os.net');
+const CrossOrigin = goog.require('os.net.CrossOrigin');
 const Request = goog.require('os.net.Request');
 
 
@@ -69,8 +72,8 @@ export const load = function() {
   Cesium.Resource._Implementations.createImage = (options, crossOrigin, promise, flipY, preferImageBitmap) => {
     let url = options.url || '';
     if (crossOrigin) {
-      const osCrossOrigin = os.net.getCrossOrigin(url);
-      if (osCrossOrigin == os.net.CrossOrigin.USE_CREDENTIALS) {
+      const osCrossOrigin = getCrossOrigin(url);
+      if (osCrossOrigin == CrossOrigin.USE_CREDENTIALS) {
         url = new URL(url);
         Cesium.TrustedServers.add(url.hostname, getPort(url));
       }
@@ -175,7 +178,7 @@ export const load = function() {
    * Remove undefined values from the pick id array.
    */
   Cesium.Context.prototype.cleanupPickIds = function() {
-    this._pickObjects = os.object.prune(this._pickObjects);
+    this._pickObjects = prune(this._pickObjects);
   };
 
 

--- a/src/plugin/cesium/mixin/cesiummixin.js
+++ b/src/plugin/cesium/mixin/cesiummixin.js
@@ -2,9 +2,10 @@
  * @fileoverview mixins for Cesium
  * @suppress {missingProvide}
  */
-goog.module('plugin.cesium.mixin');
+goog.declareModuleId('plugin.cesium.mixin');
 
-goog.module.declareLegacyNamespace();
+import {load as loadOLCesiumMixin} from './olcesiummixin';
+import {load as loadRenderLoopMixin} from './renderloopmixin';
 
 const dispatcher = goog.require('os.Dispatcher');
 const MapEvent = goog.require('os.MapEvent');
@@ -12,14 +13,27 @@ const Request = goog.require('os.net.Request');
 
 
 /**
+ * If the mixin has been loaded.
+ * @type {boolean}
+ */
+let loaded = false;
+
+
+/**
  * Load Cesium mixins.
  *
  * @throws {Error} If Cesium has not been loaded.
  */
-const loadCesiumMixins = function() {
+export const load = function() {
   if (window.Cesium === undefined) {
     throw new Error('Cesium has not been loaded!');
   }
+
+  if (loaded) {
+    return;
+  }
+
+  loaded = true;
 
   const oldCreateImage = Cesium.Resource._Implementations.createImage;
 
@@ -201,8 +215,7 @@ const loadCesiumMixins = function() {
     return new Cesium.PickId(this, key, Cesium.Color.fromRgba(key));
   };
   Cesium.Context.prototype['createPickId'] = Cesium.Context.prototype.createPickId;
-};
 
-exports = {
-  loadCesiumMixins
+  loadOLCesiumMixin();
+  loadRenderLoopMixin();
 };

--- a/src/plugin/cesium/mixin/olcesiummixin.js
+++ b/src/plugin/cesium/mixin/olcesiummixin.js
@@ -1,21 +1,22 @@
-goog.provide('plugin.cesium.mixin.olcs');
+goog.module('plugin.cesium.mixin.olcs');
+goog.module.declareLegacyNamespace();
 
-goog.require('olcs.OLCesium');
-goog.require('os.I3DSupport');
+const OLCesium = goog.require('olcs.OLCesium');
+const I3DSupport = goog.require('os.I3DSupport');
 
 
 /**
  * Timeout id to resize the Cesium canvas.
  * @type {number|undefined}
  */
-olcs.OLCesium.prototype.resizeTimeout;
+OLCesium.prototype.resizeTimeout;
 
 
 /**
  * @private
  * @suppress {accessControls|duplicate|unusedPrivateMembers}
  */
-olcs.OLCesium.prototype.handleResize_ = function() {
+OLCesium.prototype.handleResize_ = function() {
   var width = this.canvas_.clientWidth;
   var height = this.canvas_.clientHeight;
 
@@ -66,7 +67,7 @@ olcs.OLCesium.prototype.handleResize_ = function() {
  * @param {boolean} enable
  * @suppress {accessControls|duplicate}
  */
-olcs.OLCesium.prototype.setEnabled = function(enable) {
+OLCesium.prototype.setEnabled = function(enable) {
   if (this.enabled_ === enable) {
     return;
   }
@@ -81,8 +82,8 @@ olcs.OLCesium.prototype.setEnabled = function(enable) {
       var interactions = this.map_.getInteractions();
       interactions.forEach(function(el, i, arr) {
         var interaction = /** @type {ol.interaction.Interaction} */ (el);
-        if (!os.implements(interaction, os.I3DSupport.ID) ||
-            !(/** @type {os.I3DSupport} */ (interaction)).is3DSupported()) {
+        if (!os.implements(interaction, I3DSupport.ID) ||
+            !(/** @type {I3DSupport} */ (interaction)).is3DSupported()) {
           interaction.setActive(false);
         }
       });
@@ -107,8 +108,8 @@ olcs.OLCesium.prototype.setEnabled = function(enable) {
       interactions = this.map_.getInteractions();
       interactions.forEach(function(el, i, arr) {
         var interaction = /** @type {ol.interaction.Interaction} */ (el);
-        if (!os.implements(interaction, os.I3DSupport.ID) ||
-              !(/** @type {os.I3DSupport} */ (interaction)).is3DSupported()) {
+        if (!os.implements(interaction, I3DSupport.ID) ||
+              !(/** @type {I3DSupport} */ (interaction)).is3DSupported()) {
           interaction.setActive(true);
         }
       });

--- a/src/plugin/cesium/mixin/olcesiummixin.js
+++ b/src/plugin/cesium/mixin/olcesiummixin.js
@@ -1,7 +1,9 @@
 goog.declareModuleId('plugin.cesium.mixin.olcs');
 
 const OLCesium = goog.require('olcs.OLCesium');
+const {supportsImageRenderingPixelated} = goog.require('olcs.util');
 const I3DSupport = goog.require('os.I3DSupport');
+const osImplements = goog.require('os.implements');
 
 const Interaction = goog.requireType('ol.interaction.Interaction');
 
@@ -57,7 +59,7 @@ export const load = () => {
 
       this.resizeTimeout = setTimeout(function() {
         var resolutionScale = this.resolutionScale_;
-        if (!olcs.util.supportsImageRenderingPixelated()) {
+        if (!supportsImageRenderingPixelated()) {
           resolutionScale *= window.devicePixelRatio || 1.0;
         }
         this.resolutionScaleChanged_ = false;
@@ -100,7 +102,7 @@ export const load = () => {
         var interactions = this.map_.getInteractions();
         interactions.forEach(function(el, i, arr) {
           var interaction = /** @type {Interaction} */ (el);
-          if (!os.implements(interaction, I3DSupport.ID) ||
+          if (!osImplements(interaction, I3DSupport.ID) ||
               !(/** @type {I3DSupport} */ (interaction)).is3DSupported()) {
             interaction.setActive(false);
           }
@@ -126,7 +128,7 @@ export const load = () => {
         interactions = this.map_.getInteractions();
         interactions.forEach(function(el, i, arr) {
           var interaction = /** @type {Interaction} */ (el);
-          if (!os.implements(interaction, I3DSupport.ID) ||
+          if (!osImplements(interaction, I3DSupport.ID) ||
                 !(/** @type {I3DSupport} */ (interaction)).is3DSupported()) {
             interaction.setActive(true);
           }

--- a/src/plugin/cesium/mixin/olcesiummixin.js
+++ b/src/plugin/cesium/mixin/olcesiummixin.js
@@ -1,123 +1,142 @@
-goog.module('plugin.cesium.mixin.olcs');
-goog.module.declareLegacyNamespace();
+goog.declareModuleId('plugin.cesium.mixin.olcs');
 
 const OLCesium = goog.require('olcs.OLCesium');
 const I3DSupport = goog.require('os.I3DSupport');
 
-
-/**
- * Timeout id to resize the Cesium canvas.
- * @type {number|undefined}
- */
-OLCesium.prototype.resizeTimeout;
+const Interaction = goog.requireType('ol.interaction.Interaction');
 
 
 /**
- * @private
- * @suppress {accessControls|duplicate|unusedPrivateMembers}
+ * If the mixin has been loaded.
+ * @type {boolean}
  */
-OLCesium.prototype.handleResize_ = function() {
-  var width = this.canvas_.clientWidth;
-  var height = this.canvas_.clientHeight;
-
-  if (width === 0 || height === 0) {
-    // The canvas DOM element is not ready yet.
-    return;
-  }
-
-  if (width === this.canvasClientWidth_ &&
-      height === this.canvasClientHeight_ &&
-      !this.resolutionScaleChanged_) {
-    return;
-  }
-
-  // if the canvas is resized too soon, Cesium may exhibit broken rendering behavior. this includes drawing lines
-  // through the globe, and the "black hole" effect where primitives in the middle of the screen are not drawn at all.
-  // this delay is intended to let the DOM adjust, then resize Cesium's canvas.
-  if (this.resizeTimeout == null) {
-    this.setBlockCesiumRendering(true);
-
-    this.resizeTimeout = setTimeout(function() {
-      var resolutionScale = this.resolutionScale_;
-      if (!olcs.util.supportsImageRenderingPixelated()) {
-        resolutionScale *= window.devicePixelRatio || 1.0;
-      }
-      this.resolutionScaleChanged_ = false;
-
-      this.canvasClientWidth_ = width;
-      this.canvasClientHeight_ = height;
-
-      width *= resolutionScale;
-      height *= resolutionScale;
-
-      this.canvas_.width = width;
-      this.canvas_.height = height;
-      this.scene_.camera.frustum.aspectRatio = width / height;
-
-      this.resizeTimeout = undefined;
-      this.setBlockCesiumRendering(false);
-    }.bind(this), 100);
-  }
-};
+let loaded = false;
 
 
 /**
- * Changed to allow some interactions to be disabled rather than removed entirely
- *
- * @param {boolean} enable
- * @suppress {accessControls|duplicate}
+ * @suppress {accessControls}
  */
-OLCesium.prototype.setEnabled = function(enable) {
-  if (this.enabled_ === enable) {
+export const load = () => {
+  if (loaded) {
     return;
   }
-  this.enabled_ = enable;
 
-  // some Cesium operations are operating with canvas.clientWidth,
-  // so we can't remove it from DOM or even make display:none;
-  this.container_.style.visibility = this.enabled_ ? 'visible' : 'hidden';
+  loaded = true;
 
-  if (this.enabled_) {
-    if (this.isOverMap_) {
-      var interactions = this.map_.getInteractions();
-      interactions.forEach(function(el, i, arr) {
-        var interaction = /** @type {ol.interaction.Interaction} */ (el);
-        if (!os.implements(interaction, I3DSupport.ID) ||
-            !(/** @type {I3DSupport} */ (interaction)).is3DSupported()) {
-          interaction.setActive(false);
-        }
-      });
+  /**
+   * Timeout id to resize the Cesium canvas.
+   * @type {number|undefined}
+   */
+  OLCesium.prototype.resizeTimeout;
 
-      var rootGroup = this.map_.getLayerGroup();
-      if (rootGroup.getVisible()) {
-        this.hiddenRootGroup_ = rootGroup;
-        this.hiddenRootGroup_.setVisible(false);
-      }
+
+  /**
+   * @private
+   * @suppress {accessControls|duplicate|unusedPrivateMembers}
+   */
+  OLCesium.prototype.handleResize_ = function() {
+    var width = this.canvas_.clientWidth;
+    var height = this.canvas_.clientHeight;
+
+    if (width === 0 || height === 0) {
+      // The canvas DOM element is not ready yet.
+      return;
     }
 
-    // enable the cesium camera and update it from OpenLayers view
-    /** @type {plugin.cesium.Camera} */ (this.camera_).setEnabled(true);
-    this.camera_.readFromView();
-    this.render_();
-  } else {
-    // update the OpenLayers view from the cesium camera, then disable the camera
-    this.camera_.updateView();
-    /** @type {plugin.cesium.Camera} */ (this.camera_).setEnabled(false);
+    if (width === this.canvasClientWidth_ &&
+        height === this.canvasClientHeight_ &&
+        !this.resolutionScaleChanged_) {
+      return;
+    }
 
-    if (this.isOverMap_) {
-      interactions = this.map_.getInteractions();
-      interactions.forEach(function(el, i, arr) {
-        var interaction = /** @type {ol.interaction.Interaction} */ (el);
-        if (!os.implements(interaction, I3DSupport.ID) ||
+    // if the canvas is resized too soon, Cesium may exhibit broken rendering behavior. this includes drawing lines
+    // through the globe, and the "black hole" effect where primitives in the middle of the screen are not drawn at all.
+    // this delay is intended to let the DOM adjust, then resize Cesium's canvas.
+    if (this.resizeTimeout == null) {
+      this.setBlockCesiumRendering(true);
+
+      this.resizeTimeout = setTimeout(function() {
+        var resolutionScale = this.resolutionScale_;
+        if (!olcs.util.supportsImageRenderingPixelated()) {
+          resolutionScale *= window.devicePixelRatio || 1.0;
+        }
+        this.resolutionScaleChanged_ = false;
+
+        this.canvasClientWidth_ = width;
+        this.canvasClientHeight_ = height;
+
+        width *= resolutionScale;
+        height *= resolutionScale;
+
+        this.canvas_.width = width;
+        this.canvas_.height = height;
+        this.scene_.camera.frustum.aspectRatio = width / height;
+
+        this.resizeTimeout = undefined;
+        this.setBlockCesiumRendering(false);
+      }.bind(this), 100);
+    }
+  };
+
+
+  /**
+   * Changed to allow some interactions to be disabled rather than removed entirely
+   *
+   * @param {boolean} enable
+   * @suppress {accessControls|duplicate}
+   */
+  OLCesium.prototype.setEnabled = function(enable) {
+    if (this.enabled_ === enable) {
+      return;
+    }
+    this.enabled_ = enable;
+
+    // some Cesium operations are operating with canvas.clientWidth,
+    // so we can't remove it from DOM or even make display:none;
+    this.container_.style.visibility = this.enabled_ ? 'visible' : 'hidden';
+
+    if (this.enabled_) {
+      if (this.isOverMap_) {
+        var interactions = this.map_.getInteractions();
+        interactions.forEach(function(el, i, arr) {
+          var interaction = /** @type {Interaction} */ (el);
+          if (!os.implements(interaction, I3DSupport.ID) ||
               !(/** @type {I3DSupport} */ (interaction)).is3DSupported()) {
-          interaction.setActive(true);
-        }
-      });
+            interaction.setActive(false);
+          }
+        });
 
-      if (this.hiddenRootGroup_ !== null) {
-        this.hiddenRootGroup_.setVisible(true);
-        this.hiddenRootGroup_ = null;
+        var rootGroup = this.map_.getLayerGroup();
+        if (rootGroup.getVisible()) {
+          this.hiddenRootGroup_ = rootGroup;
+          this.hiddenRootGroup_.setVisible(false);
+        }
+      }
+
+      // enable the cesium camera and update it from OpenLayers view
+      /** @type {plugin.cesium.Camera} */ (this.camera_).setEnabled(true);
+      this.camera_.readFromView();
+      this.render_();
+    } else {
+      // update the OpenLayers view from the cesium camera, then disable the camera
+      this.camera_.updateView();
+      /** @type {plugin.cesium.Camera} */ (this.camera_).setEnabled(false);
+
+      if (this.isOverMap_) {
+        interactions = this.map_.getInteractions();
+        interactions.forEach(function(el, i, arr) {
+          var interaction = /** @type {Interaction} */ (el);
+          if (!os.implements(interaction, I3DSupport.ID) ||
+                !(/** @type {I3DSupport} */ (interaction)).is3DSupported()) {
+            interaction.setActive(true);
+          }
+        });
+
+        if (this.hiddenRootGroup_ !== null) {
+          this.hiddenRootGroup_.setVisible(true);
+          this.hiddenRootGroup_ = null;
+        }
       }
     }
-  }
+  };
 };

--- a/src/plugin/cesium/mixin/renderloopmixin.js
+++ b/src/plugin/cesium/mixin/renderloopmixin.js
@@ -1,52 +1,54 @@
-goog.provide('plugin.cesium.mixin.renderloop');
+goog.module('plugin.cesium.mixin.renderloop');
+goog.module.declareLegacyNamespace();
 
-goog.require('olcs.AutoRenderLoop');
-goog.require('os.MapEvent');
-goog.require('os.time.TimelineController');
-goog.require('os.time.TimelineEventType');
+const dispatcher = goog.require('os.Dispatcher');
+const AutoRenderLoop = goog.require('olcs.AutoRenderLoop');
+const MapEvent = goog.require('os.MapEvent');
+const TimelineController = goog.require('os.time.TimelineController');
+const TimelineEventType = goog.require('os.time.TimelineEventType');
 
 
 /**
  * @suppress {accessControls}
  */
 (function() {
-  var origEnable = olcs.AutoRenderLoop.prototype.enable;
+  var origEnable = AutoRenderLoop.prototype.enable;
 
   /**
-   * Overridden to listen to <code>os.MapEvent.GL_REPAINT</code> events in addition
+   * Overridden to listen to <code>MapEvent.GL_REPAINT</code> events in addition
    * to timeline show events for rendering the scene.
    */
-  olcs.AutoRenderLoop.prototype.enable = function() {
-    os.dispatcher.listen(os.MapEvent.GL_REPAINT, this.notifyRepaintRequired, false, this);
-    os.time.TimelineController.getInstance().listen(os.time.TimelineEventType.SHOW,
+  AutoRenderLoop.prototype.enable = function() {
+    dispatcher.getInstance().listen(MapEvent.GL_REPAINT, this.notifyRepaintRequired, false, this);
+    TimelineController.getInstance().listen(TimelineEventType.SHOW,
         this.notifyRepaintRequired, false, this);
 
     this.scene_.postUpdate.addEventListener(this.onPostUpdate_, this);
     origEnable.call(this);
   };
 
-  var origDisable = olcs.AutoRenderLoop.prototype.disable;
+  var origDisable = AutoRenderLoop.prototype.disable;
 
   /**
-   * Overridden to unlisten to <code>os.MapEvent.GL_REPAINT</code> events in addition
+   * Overridden to unlisten to <code>MapEvent.GL_REPAINT</code> events in addition
    * to timeline show events for rendering the scene.
    */
-  olcs.AutoRenderLoop.prototype.disable = function() {
-    os.dispatcher.unlisten(os.MapEvent.GL_REPAINT, this.notifyRepaintRequired, false, this);
-    os.time.TimelineController.getInstance().unlisten(os.time.TimelineEventType.SHOW,
+  AutoRenderLoop.prototype.disable = function() {
+    dispatcher.getInstance().unlisten(MapEvent.GL_REPAINT, this.notifyRepaintRequired, false, this);
+    TimelineController.getInstance().unlisten(TimelineEventType.SHOW,
         this.notifyRepaintRequired, false, this);
     this.scene_.postUpdate.removeEventListener(this.onPostUpdate_, this);
     origDisable.call(this);
   };
 
-  var origNotify = olcs.AutoRenderLoop.prototype.notifyRepaintRequired;
+  var origNotify = AutoRenderLoop.prototype.notifyRepaintRequired;
 
   var lastRepaintEventTime = 0;
 
   /**
    * @private
    */
-  olcs.AutoRenderLoop.prototype.onPostUpdate_ = function() {
+  AutoRenderLoop.prototype.onPostUpdate_ = function() {
     // render for at least a whole second after a GL_REPAINT event is fired
     if (Date.now() - lastRepaintEventTime < 1000) {
       this.scene_.requestRender();
@@ -58,7 +60,7 @@ goog.require('os.time.TimelineEventType');
    *
    * @param {Event=} opt_evt
    */
-  olcs.AutoRenderLoop.prototype.notifyRepaintRequired = function(opt_evt) {
+  AutoRenderLoop.prototype.notifyRepaintRequired = function(opt_evt) {
     if (opt_evt && opt_evt.type && opt_evt.type.indexOf('move') > -1) {
       // we only care about move events when a button is down
       var btnDown = opt_evt['buttons'] || // mouse events

--- a/src/plugin/cesium/primitive.js
+++ b/src/plugin/cesium/primitive.js
@@ -1,6 +1,7 @@
 goog.declareModuleId('plugin.cesium.primitive');
 
 const Delay = goog.require('goog.async.Delay');
+const {clamp} = goog.require('goog.math');
 const {GeometryInstanceId} = goog.require('plugin.cesium');
 const {unsafeClone} = goog.require('os.object');
 const {getHeightReference, isPrimitiveClassTypeChanging} = goog.require('plugin.cesium.sync.HeightReference');
@@ -192,7 +193,7 @@ export const createGeometryInstance = (id, geometry, color, opt_modelMatrix) => 
  * @param {number} lineWidth
  */
 export const updateLineWidth = (options, lineWidth) => {
-  options.renderState.lineWidth = goog.math.clamp(lineWidth, Cesium.ContextLimits.minimumAliasedLineWidth,
+  options.renderState.lineWidth = clamp(lineWidth, Cesium.ContextLimits.minimumAliasedLineWidth,
       Cesium.ContextLimits.maximumAliasedLineWidth);
 };
 

--- a/src/plugin/cesium/primitivelayer.js
+++ b/src/plugin/cesium/primitivelayer.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.PrimitiveLayer');
-goog.module.declareLegacyNamespace();
 
 const geo = goog.require('os.geo');
 const dispatcher = goog.require('os.Dispatcher');

--- a/src/plugin/cesium/primitivelayer.js
+++ b/src/plugin/cesium/primitivelayer.js
@@ -1,8 +1,11 @@
 goog.module('plugin.cesium.PrimitiveLayer');
 
-const geo = goog.require('os.geo');
+const olProj = goog.require('ol.proj');
 const dispatcher = goog.require('os.Dispatcher');
 const MapEvent = goog.require('os.MapEvent');
+const geo = goog.require('os.geo');
+const osMap = goog.require('os.map');
+const osProj = goog.require('os.proj');
 const Layer = goog.require('plugin.cesium.Layer');
 
 
@@ -110,7 +113,7 @@ class PrimitiveLayer extends Layer {
         geo.R2D * (cartographicCenter.longitude + angle),
         geo.R2D * (cartographicCenter.latitude + angle)];
 
-      return ol.proj.transformExtent(extent, os.proj.EPSG4326, os.map.PROJECTION);
+      return olProj.transformExtent(extent, osProj.EPSG4326, osMap.PROJECTION);
     }
 
     return undefined;

--- a/src/plugin/cesium/sync/cesiumsynchronizer.js
+++ b/src/plugin/cesium/sync/cesiumsynchronizer.js
@@ -1,28 +1,33 @@
-goog.provide('plugin.cesium.sync.CesiumSynchronizer');
+goog.module('plugin.cesium.sync.CesiumSynchronizer');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.webgl.AbstractWebGLSynchronizer');
-
+const AbstractWebGLSynchronizer = goog.require('os.webgl.AbstractWebGLSynchronizer');
 
 
 /**
  * Abstract class to synchronize an OpenLayers layer to Cesium.
  *
  * @abstract
- * @param {!T} layer The OpenLayers layer.
- * @param {!ol.PluggableMap} map The OpenLayers map.
- * @param {!Cesium.Scene} scene The Cesium scene.
- * @extends {os.webgl.AbstractWebGLSynchronizer<T>}
- * @constructor
+ * @extends {AbstractWebGLSynchronizer<T>}
  * @template T
  */
-plugin.cesium.sync.CesiumSynchronizer = function(layer, map, scene) {
-  plugin.cesium.sync.CesiumSynchronizer.base(this, 'constructor', layer, map);
-
+class CesiumSynchronizer extends AbstractWebGLSynchronizer {
   /**
-   * The Cesium scene.
-   * @type {!Cesium.Scene}
-   * @protected
+   * Constructor.
+   * @param {!T} layer The OpenLayers layer.
+   * @param {!ol.PluggableMap} map The OpenLayers map.
+   * @param {!Cesium.Scene} scene The Cesium scene.
    */
-  this.scene = scene;
-};
-goog.inherits(plugin.cesium.sync.CesiumSynchronizer, os.webgl.AbstractWebGLSynchronizer);
+  constructor(layer, map, scene) {
+    super(layer, map);
+
+    /**
+     * The Cesium scene.
+     * @type {!Cesium.Scene}
+     * @protected
+     */
+    this.scene = scene;
+  }
+}
+
+exports = CesiumSynchronizer;

--- a/src/plugin/cesium/sync/cesiumsynchronizer.js
+++ b/src/plugin/cesium/sync/cesiumsynchronizer.js
@@ -2,6 +2,8 @@ goog.module('plugin.cesium.sync.CesiumSynchronizer');
 
 const AbstractWebGLSynchronizer = goog.require('os.webgl.AbstractWebGLSynchronizer');
 
+const PluggableMap = goog.requireType('ol.PluggableMap');
+
 
 /**
  * Abstract class to synchronize an OpenLayers layer to Cesium.
@@ -14,7 +16,7 @@ class CesiumSynchronizer extends AbstractWebGLSynchronizer {
   /**
    * Constructor.
    * @param {!T} layer The OpenLayers layer.
-   * @param {!ol.PluggableMap} map The OpenLayers map.
+   * @param {!PluggableMap} map The OpenLayers map.
    * @param {!Cesium.Scene} scene The Cesium scene.
    */
   constructor(layer, map, scene) {

--- a/src/plugin/cesium/sync/cesiumsynchronizer.js
+++ b/src/plugin/cesium/sync/cesiumsynchronizer.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.sync.CesiumSynchronizer');
-goog.module.declareLegacyNamespace();
 
 const AbstractWebGLSynchronizer = goog.require('os.webgl.AbstractWebGLSynchronizer');
 

--- a/src/plugin/cesium/sync/dynamiclinestring.js
+++ b/src/plugin/cesium/sync/dynamiclinestring.js
@@ -1,17 +1,16 @@
 goog.module('plugin.cesium.sync.DynamicLineString');
 
+const {GeometryInstanceId} = goog.require('plugin.cesium');
 const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
 const {getDashPattern, getLineStringPositions} = goog.require('plugin.cesium.sync.linestring');
 
 const Feature = goog.requireType('ol.Feature');
-const {GeometryInstanceId} = goog.require('plugin.cesium');
-
-const Ellipse = goog.requireType('os.geom.Ellipse');
 const LineString = goog.requireType('ol.geom.LineString');
 const MultiLineString = goog.requireType('ol.geom.MultiLineString');
 const MultiPolygon = goog.requireType('ol.geom.MultiPolygon');
 const Polygon = goog.requireType('ol.geom.Polygon');
 const Style = goog.requireType('ol.style.Style');
+const Ellipse = goog.requireType('os.geom.Ellipse');
 const VectorContext = goog.requireType('plugin.cesium.VectorContext');
 
 

--- a/src/plugin/cesium/sync/ellipseconverter.js
+++ b/src/plugin/cesium/sync/ellipseconverter.js
@@ -12,8 +12,8 @@ const EllipsoidConverter = goog.require('plugin.cesium.sync.EllipsoidConverter')
 const PolygonConverter = goog.require('plugin.cesium.sync.PolygonConverter');
 
 const Feature = goog.requireType('ol.Feature');
-const Ellipse = goog.requireType('os.geom.Ellipse');
 const Style = goog.requireType('ol.style.Style');
+const Ellipse = goog.requireType('os.geom.Ellipse');
 const VectorContext = goog.requireType('plugin.cesium.VectorContext');
 const IConverter = goog.requireType('plugin.cesium.sync.IConverter');
 
@@ -66,7 +66,7 @@ const getConverter = (context) => isEllipsoid(context) ? ellipsoidConverter : po
  * @return {boolean}
  */
 const isEllipsoid = (context) => {
-  const layer = /** @type {os.layer.ILayer} */ (context.layer);
+  const layer = /** @type {ILayer} */ (context.layer);
   const config = StyleManager.getInstance().getLayerConfig(layer.getId());
   return config && config[StyleField.SHOW_ELLIPSOIDS];
 };

--- a/src/plugin/cesium/sync/ellipsoid.js
+++ b/src/plugin/cesium/sync/ellipsoid.js
@@ -1,5 +1,6 @@
 goog.module('plugin.cesium.sync.ellipsoid');
 
+const {ol4326CoordinateToCesiumCartesian} = goog.require('olcs.core');
 const {GeometryInstanceId} = goog.require('plugin.cesium');
 const {createColoredPrimitive} = goog.require('plugin.cesium.primitive');
 const {getColor} = goog.require('plugin.cesium.sync.style');
@@ -20,7 +21,7 @@ const VectorContext = goog.requireType('plugin.cesium.VectorContext');
  */
 const createEllipsoid = (feature, geometry, style, context) => {
   const olCenter = geometry.getCenter();
-  const center = olcs.core.ol4326CoordinateToCesiumCartesian(olCenter);
+  const center = ol4326CoordinateToCesiumCartesian(olCenter);
 
   const semiMajor = geometry.getSemiMajor();
   const semiMinor = geometry.getSemiMinor();

--- a/src/plugin/cesium/sync/gettransformfunction.js
+++ b/src/plugin/cesium/sync/gettransformfunction.js
@@ -1,6 +1,9 @@
 goog.module('plugin.cesium.sync.getTransformFunction');
 
+const olProj = goog.require('ol.proj');
 const Projection = goog.requireType('ol.proj.Projection');
+const osMap = goog.require('os.map');
+const osProj = goog.require('os.proj');
 
 
 /**
@@ -42,14 +45,14 @@ const transformFunction = (coord, opt_output, opt_dimensions) => {
  * @return {ol.TransformFunction|null}
  */
 exports = () => {
-  const pFrom = os.map.PROJECTION;
+  const pFrom = osMap.PROJECTION;
 
   if (lastProjection !== pFrom) {
-    const pTo = ol.proj.get(os.proj.EPSG4326);
-    if (ol.proj.equivalent(pTo, pFrom)) {
+    const pTo = olProj.get(osProj.EPSG4326);
+    if (olProj.equivalent(pTo, pFrom)) {
       olTransform = null;
     } else {
-      olTransform = ol.proj.getTransform(pFrom, pTo);
+      olTransform = olProj.getTransform(pFrom, pTo);
     }
 
     lastProjection = pFrom;

--- a/src/plugin/cesium/sync/heatmapsynchronizer.js
+++ b/src/plugin/cesium/sync/heatmapsynchronizer.js
@@ -3,9 +3,12 @@ goog.module('plugin.cesium.sync.HeatmapSynchronizer');
 const asserts = goog.require('goog.asserts');
 const Delay = goog.require('goog.async.Delay');
 const EventType = goog.require('goog.events.EventType');
+const olEvents = goog.require('ol.events');
+const {scaleFromCenter} = goog.require('ol.extent');
 const dispatcher = goog.require('os.Dispatcher');
 const MapContainer = goog.require('os.MapContainer');
 const MapEvent = goog.require('os.MapEvent');
+const PropertyChangeEvent = goog.require('os.events.PropertyChangeEvent');
 const PropertyChange = goog.require('os.layer.PropertyChange');
 const events = goog.require('os.ol.events');
 const cesium = goog.require('plugin.cesium');
@@ -14,6 +17,9 @@ const HeatmapPropertyType = goog.require('plugin.heatmap.HeatmapPropertyType');
 const HeatmapField = goog.require('plugin.heatmap.HeatmapField');
 
 const GoogEvent = goog.requireType('goog.events.Event');
+const OLObject = goog.requireType('ol.Object');
+const PluggableMap = goog.requireType('ol.PluggableMap');
+const MapCanvasRenderer = goog.requireType('ol.renderer.canvas.Map');
 
 /**
  * Synchronizes a single OpenLayers image layer to Cesium.
@@ -24,7 +30,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
   /**
    * Constructor.
    * @param {!plugin.heatmap.Heatmap} layer The OpenLayers heatmap layer.
-   * @param {!ol.PluggableMap} map The OpenLayers map.
+   * @param {!PluggableMap} map The OpenLayers map.
    * @param {!Cesium.Scene} scene The Cesium scene.
    */
   constructor(layer, map, scene) {
@@ -62,7 +68,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
      */
     this.syncDelay_ = new Delay(this.synchronizeInternal, 75, this);
 
-    ol.events.listen(this.layer, EventType.PROPERTYCHANGE, this.onLayerPropertyChange_, this);
+    olEvents.listen(this.layer, EventType.PROPERTYCHANGE, this.onLayerPropertyChange_, this);
     events.listenEach(this.layer, HeatmapSynchronizer.STYLE_KEYS_, this.onStyleChange_, this);
   }
 
@@ -73,7 +79,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
     goog.dispose(this.syncDelay_);
     this.syncDelay_ = null;
 
-    ol.events.unlisten(this.layer, EventType.PROPERTYCHANGE, this.onLayerPropertyChange_, this);
+    olEvents.unlisten(this.layer, EventType.PROPERTYCHANGE, this.onLayerPropertyChange_, this);
     events.unlistenEach(this.layer, HeatmapSynchronizer.STYLE_KEYS_, this.onStyleChange_, this);
 
     this.cesiumLayers_.remove(this.activeLayer_);
@@ -120,7 +126,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
     if (img) {
       // scale back the extent so the image is positioned in the correct location
       var extent = this.layer.getExtent().slice();
-      ol.extent.scaleFromCenter(extent, 1 / plugin.heatmap.EXTENT_SCALE_FACTOR);
+      scaleFromCenter(extent, 1 / plugin.heatmap.EXTENT_SCALE_FACTOR);
 
       this.activeLayer_ = this.cesiumLayers_.addImageryProvider(new Cesium.SingleTileImageryProvider({
         url: img,
@@ -137,12 +143,12 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
   /**
    * Handle visibility
    *
-   * @param {os.events.PropertyChangeEvent} event
+   * @param {PropertyChangeEvent} event
    * @private
    */
   onLayerPropertyChange_(event) {
     // ol3 also fires 'propertychange' events, so ignore those
-    if (event instanceof os.events.PropertyChangeEvent) {
+    if (event instanceof PropertyChangeEvent) {
       var p = event.getProperty();
       if (p == PropertyChange.VISIBLE) {
         this.visible_ = /** @type {boolean} */ (event.getNewValue());
@@ -162,7 +168,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
   /**
    * Update Cesium layer properties when the style changes.
    *
-   * @param {ol.Object.Event} event
+   * @param {OLObject.Event} event
    * @private
    */
   onStyleChange_(event) {
@@ -185,7 +191,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
 
     // force the 2D map to adjust to our new zoom/location
     this.map.renderSync();
-    var renderer = /** @type {ol.renderer.canvas.Map} */ (this.map.getRenderer());
+    var renderer = /** @type {MapCanvasRenderer} */ (this.map.getRenderer());
     var frameState = this.map.frameState_;
 
     // always make the heatmap visible
@@ -199,7 +205,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
         frameState.layerStatesArray[i].extent = undefined;
 
         var extent = frameState.extent.slice();
-        ol.extent.scaleFromCenter(extent, 2);
+        scaleFromCenter(extent, 2);
         frameState.extent = extent;
       }
     }

--- a/src/plugin/cesium/sync/heatmapsynchronizer.js
+++ b/src/plugin/cesium/sync/heatmapsynchronizer.js
@@ -4,6 +4,8 @@ goog.module.declareLegacyNamespace();
 const asserts = goog.require('goog.asserts');
 const Delay = goog.require('goog.async.Delay');
 const EventType = goog.require('goog.events.EventType');
+const dispatcher = goog.require('os.Dispatcher');
+const MapContainer = goog.require('os.MapContainer');
 const MapEvent = goog.require('os.MapEvent');
 const PropertyChange = goog.require('os.layer.PropertyChange');
 const events = goog.require('os.ol.events');
@@ -127,7 +129,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
       asserts.assert(this.activeLayer_);
       asserts.assert(this.layer);
       cesium.updateCesiumLayerProperties(this.layer, this.activeLayer_);
-      os.dispatcher.dispatchEvent(MapEvent.GL_REPAINT);
+      dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
     }
   }
 
@@ -146,7 +148,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
 
         if (this.layer && this.activeLayer_) {
           cesium.updateCesiumLayerProperties(this.layer, this.activeLayer_);
-          os.dispatcher.dispatchEvent(MapEvent.GL_REPAINT);
+          dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
         }
       } else if (p == HeatmapPropertyType.INTENSITY ||
           p == HeatmapPropertyType.SIZE ||
@@ -166,7 +168,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
     asserts.assert(this.layer !== null);
     asserts.assert(this.activeLayer_ !== null);
     cesium.updateCesiumLayerProperties(this.layer, this.activeLayer_);
-    os.dispatcher.dispatchEvent(MapEvent.GL_REPAINT);
+    dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
   }
 
   /**
@@ -176,7 +178,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
    * @suppress {accessControls}
    */
   createHeatmap(opt_event) {
-    if (!os.MapContainer.getInstance().is3DEnabled() || !this.visible_) {
+    if (!MapContainer.getInstance().is3DEnabled() || !this.visible_) {
       return;
     }
 

--- a/src/plugin/cesium/sync/heatmapsynchronizer.js
+++ b/src/plugin/cesium/sync/heatmapsynchronizer.js
@@ -13,6 +13,8 @@ const CesiumSynchronizer = goog.require('plugin.cesium.sync.CesiumSynchronizer')
 const HeatmapPropertyType = goog.require('plugin.heatmap.HeatmapPropertyType');
 const HeatmapField = goog.require('plugin.heatmap.HeatmapField');
 
+const GoogEvent = goog.requireType('goog.events.Event');
+
 /**
  * Synchronizes a single OpenLayers image layer to Cesium.
  *
@@ -173,7 +175,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
   /**
    * Re-create the heatmap by forcing a call to OpenLayers.
    *
-   * @param {goog.events.Event=} opt_event
+   * @param {GoogEvent=} opt_event
    * @suppress {accessControls}
    */
   createHeatmap(opt_event) {

--- a/src/plugin/cesium/sync/heatmapsynchronizer.js
+++ b/src/plugin/cesium/sync/heatmapsynchronizer.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.sync.HeatmapSynchronizer');
-goog.module.declareLegacyNamespace();
 
 const asserts = goog.require('goog.asserts');
 const Delay = goog.require('goog.async.Delay');

--- a/src/plugin/cesium/sync/imagestaticsynchronizer.js
+++ b/src/plugin/cesium/sync/imagestaticsynchronizer.js
@@ -1,157 +1,156 @@
-goog.provide('plugin.cesium.sync.ImageStaticSynchronizer');
+goog.module('plugin.cesium.sync.ImageStaticSynchronizer');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.source.ImageStatic');
-goog.require('os.MapEvent');
-goog.require('os.source.ImageStatic');
-goog.require('plugin.cesium.sync.CesiumSynchronizer');
-
+const dispatcher = goog.require('os.Dispatcher');
+const olSourceImageStatic = goog.require('ol.source.ImageStatic');
+const MapEvent = goog.require('os.MapEvent');
+const ImageStatic = goog.require('os.source.ImageStatic');
+const CesiumSynchronizer = goog.require('plugin.cesium.sync.CesiumSynchronizer');
 
 
 /**
  * Synchronizes a single OpenLayers ImageStatic source to Cesium
  *
- * @param {!ol.layer.Image} layer The OpenLayers image layer
- * @param {!ol.PluggableMap} map The map
- * @param {!Cesium.Scene} scene
- * @extends {plugin.cesium.sync.CesiumSynchronizer<os.layer.Image>}
- * @constructor
+ * @extends {CesiumSynchronizer<os.layer.Image>}
  */
-plugin.cesium.sync.ImageStaticSynchronizer = function(layer, map, scene) {
-  plugin.cesium.sync.ImageStaticSynchronizer.base(this, 'constructor', layer, map, scene);
-
+class ImageStaticSynchronizer extends CesiumSynchronizer {
   /**
-   * @type {ol.source.Image}
-   * @protected
+   * Constructor.
+   * @param {!ol.layer.Image} layer The OpenLayers image layer
+   * @param {!ol.PluggableMap} map The map
+   * @param {!Cesium.Scene} scene
    */
-  this.source = this.layer.getSource();
+  constructor(layer, map, scene) {
+    super(layer, map, scene);
+
+    /**
+     * @type {ol.source.Image}
+     * @protected
+     */
+    this.source = this.layer.getSource();
 
 
-  /**
-   * @type {ol.ImageBase}
-   * @protected
-   */
-  this.image;
+    /**
+     * @type {ol.ImageBase}
+     * @protected
+     */
+    this.image;
 
-  /**
-   * @type {Cesium.Primitive}
-   * @protected
-   */
-  this.primitive;
+    /**
+     * @type {Cesium.Primitive}
+     * @protected
+     */
+    this.primitive;
 
-  ol.events.listen(this.layer, goog.events.EventType.PROPERTYCHANGE, this.onLayerPropertyChange, this);
-};
-goog.inherits(plugin.cesium.sync.ImageStaticSynchronizer, plugin.cesium.sync.CesiumSynchronizer);
-
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.sync.ImageStaticSynchronizer.prototype.disposeInternal = function() {
-  this.resetInternal();
-  this.source = null;
-  plugin.cesium.sync.ImageStaticSynchronizer.base(this, 'disposeInternal');
-};
-
-
-
-/**
- * @inheritDoc
- * @suppress {accessControls}
- */
-plugin.cesium.sync.ImageStaticSynchronizer.prototype.synchronize = function() {
-  if (!this.image) {
-    if (!(this.source instanceof ol.source.ImageStatic)) {
-      return;
-    }
-
-    this.image = this.source.image_;
-    ol.events.listen(this.image, ol.events.EventType.CHANGE, this.synchronize, this);
+    ol.events.listen(this.layer, goog.events.EventType.PROPERTYCHANGE, this.onLayerPropertyChange, this);
   }
 
-  if (this.source instanceof os.source.ImageStatic) {
-    // This source supports rotation and must be loaded first. Other source types such as ol.source.ImageStatic
-    // can pass the img.src parameter through to the Cesium material.
-    if (this.image.getState() === ol.ImageState.IDLE) {
-      this.image.load();
-    }
-
-    if (this.image.getState() !== ol.ImageState.LOADED) {
-      return;
-    }
-
-    if (this.image !== this.source.rotatedImage) {
-      ol.events.unlisten(this.image, ol.events.EventType.CHANGE, this.synchronize, this);
-      this.image = this.source.rotatedImage;
-    }
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    this.resetInternal();
+    this.source = null;
+    super.disposeInternal();
   }
 
-  var url;
-  var el = this.image.getImage();
+  /**
+   * @inheritDoc
+   * @suppress {accessControls}
+   */
+  synchronize() {
+    if (!this.image) {
+      if (!(this.source instanceof olSourceImageStatic)) {
+        return;
+      }
 
-  if (el instanceof HTMLVideoElement || el instanceof Image) {
-    url = el.src;
-  } else if (el instanceof HTMLCanvasElement) {
-    url = el.toDataURL();
-  }
+      this.image = this.source.image_;
+      ol.events.listen(this.image, ol.events.EventType.CHANGE, this.synchronize, this);
+    }
 
-  var extent = ol.proj.transformExtent(this.image.getExtent(), os.map.PROJECTION, os.proj.EPSG4326);
+    if (this.source instanceof ImageStatic) {
+      // This source supports rotation and must be loaded first. Other source types such as olSourceImageStatic
+      // can pass the img.src parameter through to the Cesium material.
+      if (this.image.getState() === ol.ImageState.IDLE) {
+        this.image.load();
+      }
 
-  if (!this.primitive && url && extent) {
-    this.primitive = new Cesium.Primitive({
-      geometryInstances: new Cesium.GeometryInstance({
-        geometry: new Cesium.RectangleGeometry({
-          rectangle: Cesium.Rectangle.fromDegrees(extent[0], extent[1], extent[2], extent[3])
+      if (this.image.getState() !== ol.ImageState.LOADED) {
+        return;
+      }
+
+      if (this.image !== this.source.rotatedImage) {
+        ol.events.unlisten(this.image, ol.events.EventType.CHANGE, this.synchronize, this);
+        this.image = this.source.rotatedImage;
+      }
+    }
+
+    var url;
+    var el = this.image.getImage();
+
+    if (el instanceof HTMLVideoElement || el instanceof Image) {
+      url = el.src;
+    } else if (el instanceof HTMLCanvasElement) {
+      url = el.toDataURL();
+    }
+
+    var extent = ol.proj.transformExtent(this.image.getExtent(), os.map.PROJECTION, os.proj.EPSG4326);
+
+    if (!this.primitive && url && extent) {
+      this.primitive = new Cesium.Primitive({
+        geometryInstances: new Cesium.GeometryInstance({
+          geometry: new Cesium.RectangleGeometry({
+            rectangle: Cesium.Rectangle.fromDegrees(extent[0], extent[1], extent[2], extent[3])
+          }),
+          id: this.layer.getId()
         }),
-        id: this.layer.getId()
-      }),
-      appearance: new Cesium.MaterialAppearance({
-        material: Cesium.Material.fromType('Image', {
-          image: url
-        })
-      }),
-      show: this.layer.getVisible()
-    });
+        appearance: new Cesium.MaterialAppearance({
+          material: Cesium.Material.fromType('Image', {
+            image: url
+          })
+        }),
+        show: this.layer.getVisible()
+      });
 
-    this.scene.primitives.add(this.primitive);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.sync.ImageStaticSynchronizer.prototype.reset = function() {
-  this.resetInternal();
-  this.synchronize();
-};
-
-
-/**
- * @protected
- */
-plugin.cesium.sync.ImageStaticSynchronizer.prototype.resetInternal = function() {
-  if (this.image) {
-    ol.events.unlisten(this.image, ol.events.EventType.CHANGE, this.synchronize, this);
-    this.image = null;
+      this.scene.primitives.add(this.primitive);
+    }
   }
 
-  if (this.primitive) {
-    this.scene.primitives.remove(this.primitive);
-    this.primitive = null;
+  /**
+   * @inheritDoc
+   */
+  reset() {
+    this.resetInternal();
+    this.synchronize();
   }
-};
 
+  /**
+   * @protected
+   */
+  resetInternal() {
+    if (this.image) {
+      ol.events.unlisten(this.image, ol.events.EventType.CHANGE, this.synchronize, this);
+      this.image = null;
+    }
 
-/**
- * Handle visibility
- *
- * @param {os.events.PropertyChangeEvent} event
- * @protected
- */
-plugin.cesium.sync.ImageStaticSynchronizer.prototype.onLayerPropertyChange = function(event) {
-  if (this.primitive && event instanceof ol.Object.Event && event.key == os.layer.PropertyChange.VISIBLE) {
-    this.primitive.show = this.layer.getVisible();
-    os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
+    if (this.primitive) {
+      this.scene.primitives.remove(this.primitive);
+      this.primitive = null;
+    }
   }
-};
+
+  /**
+   * Handle visibility
+   *
+   * @param {os.events.PropertyChangeEvent} event
+   * @protected
+   */
+  onLayerPropertyChange(event) {
+    if (this.primitive && event instanceof ol.Object.Event && event.key == os.layer.PropertyChange.VISIBLE) {
+      this.primitive.show = this.layer.getVisible();
+      dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
+    }
+  }
+}
+
+exports = ImageStaticSynchronizer;

--- a/src/plugin/cesium/sync/imagestaticsynchronizer.js
+++ b/src/plugin/cesium/sync/imagestaticsynchronizer.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.sync.ImageStaticSynchronizer');
-goog.module.declareLegacyNamespace();
 
 const dispatcher = goog.require('os.Dispatcher');
 const olSourceImageStatic = goog.require('ol.source.ImageStatic');

--- a/src/plugin/cesium/sync/imagesynchronizer.js
+++ b/src/plugin/cesium/sync/imagesynchronizer.js
@@ -1,305 +1,301 @@
-goog.provide('plugin.cesium.sync.ImageSynchronizer');
+goog.module('plugin.cesium.sync.ImageSynchronizer');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
-goog.require('goog.events.EventType');
-goog.require('ol.events');
-goog.require('ol.events.EventType');
-goog.require('ol.layer.Tile');
-goog.require('os.Map');
-goog.require('os.MapContainer');
-goog.require('os.MapEvent');
-goog.require('os.events.SelectionType');
-goog.require('os.layer.PropertyChange');
-goog.require('os.source.ImageStatic');
-goog.require('plugin.cesium.sync.CesiumSynchronizer');
+const dispatcher = goog.require('os.Dispatcher');
+const geo = goog.require('os.geo');
+const mapContainer = goog.require('os.MapContainer');
+const googEventsEventType = goog.require('goog.events.EventType');
+const events = goog.require('ol.events');
+const EventType = goog.require('ol.events.EventType');
+const MapEvent = goog.require('os.MapEvent');
+const PropertyChange = goog.require('os.layer.PropertyChange');
+const CesiumSynchronizer = goog.require('plugin.cesium.sync.CesiumSynchronizer');
 
+const Map = goog.requireType('os.Map');
 
 
 /**
  * Synchronizes a single OpenLayers image layer to Cesium.
  *
- * @param {!os.layer.Image} layer The OpenLayers image layer.
- * @param {!ol.PluggableMap} map The OpenLayers map.
- * @param {!Cesium.Scene} scene The Cesium scene.
- * @extends {plugin.cesium.sync.CesiumSynchronizer.<os.layer.Image>}
- * @constructor
+ * @extends {CesiumSynchronizer.<os.layer.Image>}
  */
-plugin.cesium.sync.ImageSynchronizer = function(layer, map, scene) {
-  plugin.cesium.sync.ImageSynchronizer.base(this, 'constructor', layer, map, scene);
+class ImageSynchronizer extends CesiumSynchronizer {
+  /**
+   * Constructor.
+   * @param {!os.layer.Image} layer The OpenLayers image layer.
+   * @param {!ol.PluggableMap} map The OpenLayers map.
+   * @param {!Cesium.Scene} scene The Cesium scene.
+   */
+  constructor(layer, map, scene) {
+    super(layer, map, scene);
+
+    /**
+     * @type {Cesium.Primitive}
+     * @private
+     */
+    this.activePrimitive_ = null;
+
+    /**
+     * @type {ol.source.Image}
+     * @private
+     */
+    this.source_ = this.layer.getSource();
+
+    /**
+     * @type {number}
+     * @private
+     */
+    this.lastRevision_ = -1;
+
+    /**
+     * @type {!Cesium.PrimitiveCollection}
+     * @private
+     */
+    this.collection_ = new Cesium.PrimitiveCollection();
+
+    /**
+     * @type {number}
+     * @private
+     */
+    this.nextId_ = 0;
+
+    /**
+     * @type {ol.ImageBase|undefined}
+     * @private
+     */
+    this.image_;
+
+    /**
+     * @type {ol.Extent|undefined}
+     * @private
+     */
+    this.lastExtent_;
+
+    /**
+     * @type {string|undefined}
+     * @private
+     */
+    this.lastUrl_;
+
+    /**
+     * Flag for fixing a bug with the first render loop pass.
+     * @type {boolean}
+     * @private
+     */
+    this.firstLoopFixed_ = false;
+
+    this.onPrimitiveReady_ = this.onPrimitiveReadyInternal.bind(this);
+    this.scene.primitives.add(this.collection_);
+
+    events.listen(this.layer, googEventsEventType.PROPERTYCHANGE, this.onLayerPropertyChange, this);
+    events.listen(this.source_, EventType.CHANGE, this.syncInternal, this);
+    mapContainer.getInstance().listen(MapEvent.VIEW_CHANGE, this.onSyncChange, false, this);
+  }
 
   /**
-   * @type {Cesium.Primitive}
-   * @private
+   * @inheritDoc
    */
-  this.activePrimitive_ = null;
+  disposeInternal() {
+    events.unlisten(this.layer, googEventsEventType.PROPERTYCHANGE, this.onLayerPropertyChange, this);
+    events.unlisten(this.source_, EventType.CHANGE, this.syncInternal, this);
+    mapContainer.getInstance().unlisten(MapEvent.VIEW_CHANGE, this.onSyncChange, false, this);
+
+    this.activePrimitive_ = null;
+    this.source_ = null;
+
+    this.scene.primitives.remove(this.collection_);
+    super.disposeInternal();
+  }
 
   /**
-   * @type {ol.source.Image}
-   * @private
+   * @inheritDoc
    */
-  this.source_ = this.layer.getSource();
+  synchronize() {
+    this.syncInternal();
+  }
 
   /**
-   * @type {number}
-   * @private
+   * @param {boolean=} opt_force Force an update regardless of the current source revision
+   * @protected
    */
-  this.lastRevision_ = -1;
+  syncInternal(opt_force) {
+    if (this.source_ && (this.lastRevision_ !== this.source_.getRevision() || opt_force)) {
+      this.lastRevision_ = this.source_.getRevision();
 
-  /**
-   * @type {!Cesium.PrimitiveCollection}
-   * @private
-   */
-  this.collection_ = new Cesium.PrimitiveCollection();
-
-  /**
-   * @type {number}
-   * @private
-   */
-  this.nextId_ = 0;
-
-  /**
-   * @type {ol.ImageBase|undefined}
-   * @private
-   */
-  this.image_;
-
-  /**
-   * @type {ol.Extent|undefined}
-   * @private
-   */
-  this.lastExtent_;
-
-  /**
-   * @type {string|undefined}
-   * @private
-   */
-  this.lastUrl_;
-
-  /**
-   * Flag for fixing a bug with the first render loop pass.
-   * @type {boolean}
-   * @private
-   */
-  this.firstLoopFixed_ = false;
-
-  this.onPrimitiveReady_ = this.onPrimitiveReadyInternal.bind(this);
-  this.scene.primitives.add(this.collection_);
-
-  ol.events.listen(this.layer, goog.events.EventType.PROPERTYCHANGE, this.onLayerPropertyChange, this);
-  ol.events.listen(this.source_, ol.events.EventType.CHANGE, this.syncInternal, this);
-  os.map.mapContainer.listen(os.MapEvent.VIEW_CHANGE, this.onSyncChange, false, this);
-};
-goog.inherits(plugin.cesium.sync.ImageSynchronizer, plugin.cesium.sync.CesiumSynchronizer);
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.sync.ImageSynchronizer.prototype.disposeInternal = function() {
-  ol.events.unlisten(this.layer, goog.events.EventType.PROPERTYCHANGE, this.onLayerPropertyChange, this);
-  ol.events.unlisten(this.source_, ol.events.EventType.CHANGE, this.syncInternal, this);
-  os.map.mapContainer.unlisten(os.MapEvent.VIEW_CHANGE, this.onSyncChange, false, this);
-
-  this.activePrimitive_ = null;
-  this.source_ = null;
-
-  this.scene.primitives.remove(this.collection_);
-  plugin.cesium.sync.ImageSynchronizer.base(this, 'disposeInternal');
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.sync.ImageSynchronizer.prototype.synchronize = function() {
-  this.syncInternal();
-};
-
-
-/**
- * @param {boolean=} opt_force Force an update regardless of the current source revision
- * @protected
- */
-plugin.cesium.sync.ImageSynchronizer.prototype.syncInternal = function(opt_force) {
-  if (this.source_ && (this.lastRevision_ !== this.source_.getRevision() || opt_force)) {
-    this.lastRevision_ = this.source_.getRevision();
-
-    if (this.activePrimitive_) {
-      this.activePrimitive_.show = this.layer.getVisible();
-    }
-
-    var map = /** @type {os.Map} */ (os.map.mapContainer.getMap());
-    var viewExtent = map.getExtent();
-    if (ol.extent.containsExtent(viewExtent, os.map.PROJECTION.getWorldExtent())) {
-      // never allow an extent larger than the world to be requested
-      return;
-    }
-
-    // normalize the extent across the antimeridian
-    viewExtent = os.extent.normalize(viewExtent, -360, 0);
-
-    if (!viewExtent) {
-      this.removeImmediate_();
-      return;
-    }
-
-    var resolution = map.getView().getResolution();
-    let img;
-    if (!isNaN(resolution) && resolution != null) {
-      if (!this.firstLoopFixed_) {
-        // HACK ALERT: when initially loading into Cesium, the image for this layer has already been created and loaded
-        // by a single render call on the 2D map. The extent for this request is incompatible with 3D since it's
-        // often wider than the world extent. OL also caches the bad image, so this tiny change to the resolution
-        // is designed to defeat that cache.
-        resolution += os.geo.EPSILON;
-        this.firstLoopFixed_ = true;
+      if (this.activePrimitive_) {
+        this.activePrimitive_.show = this.layer.getVisible();
       }
 
-      img = this.source_.getImage(viewExtent, resolution, window.devicePixelRatio, os.map.PROJECTION);
+      var map = /** @type {Map} */ (mapContainer.getInstance().getMap());
+      var viewExtent = map.getExtent();
+      if (ol.extent.containsExtent(viewExtent, os.map.PROJECTION.getWorldExtent())) {
+        // never allow an extent larger than the world to be requested
+        return;
+      }
 
-      if (img) {
-        if (img !== this.image_) {
-          if (this.image_) {
-            ol.events.unlisten(this.image_, ol.events.EventType.CHANGE, this.onSyncChange, this);
-          }
+      // normalize the extent across the antimeridian
+      viewExtent = os.extent.normalize(viewExtent, -360, 0);
 
-          var imageState = img.getState();
-          if (imageState != ol.ImageState.LOADED && imageState != ol.ImageState.ERROR) {
-            ol.events.listen(img, ol.events.EventType.CHANGE, this.onSyncChange, this);
-          }
-
-          if (imageState == ol.ImageState.ERROR) {
-            // don't do anything, leave the old image rendered
-            return;
-          }
-
-          if (imageState == ol.ImageState.IDLE) {
-            img.load();
-          }
-
-          this.image_ = img;
-          return;
-        }
-      } else {
+      if (!viewExtent) {
         this.removeImmediate_();
         return;
       }
-    }
 
-    var url;
-    var el = img.getImage();
+      var resolution = map.getView().getResolution();
+      let img;
+      if (!isNaN(resolution) && resolution != null) {
+        if (!this.firstLoopFixed_) {
+          // HACK ALERT: when initially loading into Cesium, the image for this layer has already been created and loaded
+          // by a single render call on the 2D map. The extent for this request is incompatible with 3D since it's
+          // often wider than the world extent. OL also caches the bad image, so this tiny change to the resolution
+          // is designed to defeat that cache.
+          resolution += geo.EPSILON;
+          this.firstLoopFixed_ = true;
+        }
 
-    if (el instanceof HTMLVideoElement || el instanceof Image) {
-      url = el.src;
-    } else if (el instanceof HTMLCanvasElement) {
-      url = el.toDataURL();
-    }
+        img = this.source_.getImage(viewExtent, resolution, window.devicePixelRatio, os.map.PROJECTION);
 
-    var changed = this.lastUrl_ !== url;
-    this.lastUrl_ = url;
-    var extent = ol.proj.transformExtent(img.getExtent(), os.map.PROJECTION, os.proj.EPSG4326);
-    if (this.lastExtent_) {
-      for (var i = 0, n = extent.length; i < n; i++) {
-        if (Math.abs(extent[i] - this.lastExtent_[i]) > 1E-12) {
-          changed = true;
-          break;
+        if (img) {
+          if (img !== this.image_) {
+            if (this.image_) {
+              events.unlisten(this.image_, EventType.CHANGE, this.onSyncChange, this);
+            }
+
+            var imageState = img.getState();
+            if (imageState != ol.ImageState.LOADED && imageState != ol.ImageState.ERROR) {
+              events.listen(img, EventType.CHANGE, this.onSyncChange, this);
+            }
+
+            if (imageState == ol.ImageState.ERROR) {
+              // don't do anything, leave the old image rendered
+              return;
+            }
+
+            if (imageState == ol.ImageState.IDLE) {
+              img.load();
+            }
+
+            this.image_ = img;
+            return;
+          }
+        } else {
+          this.removeImmediate_();
+          return;
         }
       }
-    } else {
-      changed = true;
-    }
-    this.lastExtent_ = extent.slice();
 
-    if (url && extent) {
-      if (changed) {
-        var minX = viewExtent[0];
-        var minY = viewExtent[1];
-        var maxX = viewExtent[2] - os.geo.EPSILON;
-        var maxY = viewExtent[3] - os.geo.EPSILON;
-        var flatCoordinates = [minX, minY, minX, maxY, maxX, maxY, maxX, minY, minX, minY];
+      var url;
+      var el = img.getImage();
 
-        var primitive = new Cesium.GroundPrimitive({
-          geometryInstances: new Cesium.GeometryInstance({
-            geometry: new Cesium.PolygonGeometry({
-              polygonHierarchy: new Cesium.PolygonHierarchy(Cesium.Cartesian3.fromDegreesArray(flatCoordinates)),
-              height: 5000,
-              arcType: Cesium.ArcType.RHUMB
-            }),
-            id: this.layer.getId() + '.' + (this.nextId_++)
-          }),
-          appearance: new Cesium.MaterialAppearance({
-            material: Cesium.Material.fromType('Image', {
-              image: el
-            })
-          }),
-          show: this.layer.getVisible()
-        });
-
-        primitive.readyPromise.then(this.onPrimitiveReady_);
-        this.collection_.add(primitive);
-        os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
+      if (el instanceof HTMLVideoElement || el instanceof Image) {
+        url = el.src;
+      } else if (el instanceof HTMLCanvasElement) {
+        url = el.toDataURL();
       }
-    } else {
-      this.removeImmediate_();
+
+      var changed = this.lastUrl_ !== url;
+      this.lastUrl_ = url;
+      var extent = ol.proj.transformExtent(img.getExtent(), os.map.PROJECTION, os.proj.EPSG4326);
+      if (this.lastExtent_) {
+        for (var i = 0, n = extent.length; i < n; i++) {
+          if (Math.abs(extent[i] - this.lastExtent_[i]) > 1E-12) {
+            changed = true;
+            break;
+          }
+        }
+      } else {
+        changed = true;
+      }
+      this.lastExtent_ = extent.slice();
+
+      if (url && extent) {
+        if (changed) {
+          var minX = viewExtent[0];
+          var minY = viewExtent[1];
+          var maxX = viewExtent[2] - geo.EPSILON;
+          var maxY = viewExtent[3] - geo.EPSILON;
+          var flatCoordinates = [minX, minY, minX, maxY, maxX, maxY, maxX, minY, minX, minY];
+
+          var primitive = new Cesium.GroundPrimitive({
+            geometryInstances: new Cesium.GeometryInstance({
+              geometry: new Cesium.PolygonGeometry({
+                polygonHierarchy: new Cesium.PolygonHierarchy(Cesium.Cartesian3.fromDegreesArray(flatCoordinates)),
+                height: 5000,
+                arcType: Cesium.ArcType.RHUMB
+              }),
+              id: this.layer.getId() + '.' + (this.nextId_++)
+            }),
+            appearance: new Cesium.MaterialAppearance({
+              material: Cesium.Material.fromType('Image', {
+                image: el
+              })
+            }),
+            show: this.layer.getVisible()
+          });
+
+          primitive.readyPromise.then(this.onPrimitiveReady_);
+          this.collection_.add(primitive);
+          dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
+        }
+      } else {
+        this.removeImmediate_();
+      }
     }
   }
-};
 
+  /**
+   * @param {!Cesium.Primitive} primitive
+   * @protected
+   */
+  onPrimitiveReadyInternal(primitive) {
+    this.activePrimitive_ = primitive;
 
-/**
- * @param {!Cesium.Primitive} primitive
- * @protected
- */
-plugin.cesium.sync.ImageSynchronizer.prototype.onPrimitiveReadyInternal = function(primitive) {
-  this.activePrimitive_ = primitive;
+    let i = this.collection_.length;
+    while (i--) {
+      var item = this.collection_.get(i);
 
-  let i = this.collection_.length;
-  while (i--) {
-    var item = this.collection_.get(i);
-
-    if (item !== this.activePrimitive_) {
-      this.collection_.remove(item);
+      if (item !== this.activePrimitive_) {
+        this.collection_.remove(item);
+      }
     }
   }
-};
 
-
-/**
- * @protected
- */
-plugin.cesium.sync.ImageSynchronizer.prototype.onSyncChange = function() {
-  this.syncInternal(true);
-};
-
-
-/**
- * Immediately remove the primitive
- * @private
- */
-plugin.cesium.sync.ImageSynchronizer.prototype.removeImmediate_ = function() {
-  this.activePrimitive_ = null;
-  this.lastExtent_ = undefined;
-  this.lastUrl_ = undefined;
-  this.collection_.removeAll();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.sync.ImageSynchronizer.prototype.reset = function() {
-  this.syncInternal(true);
-};
-
-
-/**
- * Handle visibility
- *
- * @param {os.events.PropertyChangeEvent} event
- * @protected
- */
-plugin.cesium.sync.ImageSynchronizer.prototype.onLayerPropertyChange = function(event) {
-  if (event instanceof ol.Object.Event && event.key == os.layer.PropertyChange.VISIBLE) {
+  /**
+   * @protected
+   */
+  onSyncChange() {
     this.syncInternal(true);
   }
-};
+
+  /**
+   * Immediately remove the primitive
+   * @private
+   */
+  removeImmediate_() {
+    this.activePrimitive_ = null;
+    this.lastExtent_ = undefined;
+    this.lastUrl_ = undefined;
+    this.collection_.removeAll();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  reset() {
+    this.syncInternal(true);
+  }
+
+  /**
+   * Handle visibility
+   *
+   * @param {os.events.PropertyChangeEvent} event
+   * @protected
+   */
+  onLayerPropertyChange(event) {
+    if (event instanceof ol.Object.Event && event.key == PropertyChange.VISIBLE) {
+      this.syncInternal(true);
+    }
+  }
+}
+
+exports = ImageSynchronizer;

--- a/src/plugin/cesium/sync/imagesynchronizer.js
+++ b/src/plugin/cesium/sync/imagesynchronizer.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.sync.ImageSynchronizer');
-goog.module.declareLegacyNamespace();
 
 const dispatcher = goog.require('os.Dispatcher');
 const geo = goog.require('os.geo');

--- a/src/plugin/cesium/sync/labelconverter.js
+++ b/src/plugin/cesium/sync/labelconverter.js
@@ -1,16 +1,14 @@
 goog.module('plugin.cesium.sync.LabelConverter');
 
-goog.require('goog.asserts');
-goog.require('goog.string');
-
-const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
+const asserts = goog.require('goog.asserts');
 const GeometryType = goog.require('ol.geom.GeometryType');
+const olcsCore = goog.require('olcs.core');
 const {GeometryInstanceId} = goog.require('plugin.cesium');
 const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
 const {getHeightReference} = goog.require('plugin.cesium.sync.HeightReference');
 const getTransformFunction = goog.require('plugin.cesium.sync.getTransformFunction');
 const {isPrimitiveShown} = goog.require('plugin.cesium.primitive');
-const olcsCore = goog.require('olcs.core');
+const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
 
 const Geometry = goog.requireType('ol.geom.Geometry');
 const MultiPoint = goog.requireType('ol.geom.MultiPoint');
@@ -216,7 +214,7 @@ const updateHorizontalOrigin = (label, textStyle) => {
     if (textAlign in textAlignMap) {
       label.horizontalOrigin = textAlignMap[textAlign];
     } else {
-      goog.asserts.fail('unhandled text align ' + textAlign);
+      asserts.fail('unhandled text align ' + textAlign);
     }
   }
 };
@@ -257,7 +255,7 @@ const updateVerticalOrigin = (label, textStyle) => {
     if (textBaseline in textBaselineMap) {
       label.verticalOrigin = textBaselineMap[textBaseline];
     } else {
-      goog.asserts.fail('unhandled baseline ' + textBaseline);
+      asserts.fail('unhandled baseline ' + textBaseline);
     }
   }
 };

--- a/src/plugin/cesium/sync/labelconverter.js
+++ b/src/plugin/cesium/sync/labelconverter.js
@@ -1,8 +1,12 @@
 goog.module('plugin.cesium.sync.LabelConverter');
 
 const asserts = goog.require('goog.asserts');
+const olExtent = goog.require('ol.extent');
+const Geometry = goog.require('ol.geom.Geometry');
 const GeometryType = goog.require('ol.geom.GeometryType');
+const SimpleGeometry = goog.require('ol.geom.SimpleGeometry');
 const olcsCore = goog.require('olcs.core');
+const osLabel = goog.require('os.style.label');
 const {GeometryInstanceId} = goog.require('plugin.cesium');
 const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
 const {getHeightReference} = goog.require('plugin.cesium.sync.HeightReference');
@@ -10,7 +14,6 @@ const getTransformFunction = goog.require('plugin.cesium.sync.getTransformFuncti
 const {isPrimitiveShown} = goog.require('plugin.cesium.primitive');
 const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
 
-const Geometry = goog.requireType('ol.geom.Geometry');
 const MultiPoint = goog.requireType('ol.geom.MultiPoint');
 const Point = goog.requireType('ol.geom.Point');
 const Text = goog.requireType('ol.style.Text');
@@ -55,8 +58,8 @@ class LabelConverter extends BaseConverter {
     }
 
     const geom = style.getGeometry();
-    if (geom instanceof ol.geom.Geometry) {
-      geometry = /** @type {!ol.geom.Geometry} */ (geom);
+    if (geom instanceof Geometry) {
+      geometry = /** @type {!Geometry} */ (geom);
     }
 
     const textStyle = style.getText();
@@ -68,7 +71,7 @@ class LabelConverter extends BaseConverter {
     updateVerticalOrigin(label, textStyle);
     updateText(label, textStyle);
 
-    label.font = textStyle.getFont() || os.style.label.getFont();
+    label.font = textStyle.getFont() || osLabel.getFont();
     label.pixelOffset = new Cesium.Cartesian2(textStyle.getOffsetX(), textStyle.getOffsetY());
 
     // check if there is an associated primitive, and if it is shown
@@ -106,7 +109,7 @@ const updatePosition = (label, geometry) => {
         labelPosition = transform(labelPosition);
       }
 
-      if (geometry instanceof ol.geom.SimpleGeometry) {
+      if (geometry instanceof SimpleGeometry) {
         let first = geometry.getFirstCoordinate();
         if (transform) {
           first = transform(first, undefined, first.length);
@@ -130,7 +133,7 @@ const scratchCoord = [];
 /**
  * Get the label position for a geometry.
  *
- * @param {!ol.geom.Geometry} geometry The geometry.
+ * @param {!Geometry} geometry The geometry.
  * @return {Array<number>} The position to use for the label.
  */
 const getLabelPosition = (geometry) => {
@@ -148,7 +151,7 @@ const getLabelPosition = (geometry) => {
 
       return scratchCoord;
     default:
-      return ol.extent.getCenter(geometry.getExtent());
+      return olExtent.getCenter(geometry.getExtent());
   }
 };
 

--- a/src/plugin/cesium/sync/linestring.js
+++ b/src/plugin/cesium/sync/linestring.js
@@ -257,4 +257,3 @@ exports = {
   isDashChanging,
   isLineWidthChanging
 };
-

--- a/src/plugin/cesium/sync/point.js
+++ b/src/plugin/cesium/sync/point.js
@@ -1,11 +1,13 @@
 goog.module('plugin.cesium.sync.point');
 
-
+const {hashCode} = goog.require('goog.string');
+const {getUid} = goog.require('ol');
 const olcsCore = goog.require('olcs.core');
 const {getHeightReference} = goog.require('plugin.cesium.sync.HeightReference');
 const getTransformFunction = goog.require('plugin.cesium.sync.getTransformFunction');
 const {drawShape} = goog.require('plugin.cesium.sync.shape');
 const OLIconStyle = goog.require('ol.style.Icon');
+const {ZoomScale} = goog.require('os.map');
 const OSIconStyle = goog.require('os.style.Icon');
 const OLRegularShape = goog.require('ol.style.RegularShape');
 
@@ -183,7 +185,7 @@ const updateImageShape = (style, bb) => {
   hash = 31 * hash + (fill ? 1 : 0) >>> 0;
   hash = 31 * hash + style.getPoints() >>> 0;
   hash = 31 * hash + style.getRadius() >>> 0;
-  hash = 31 * hash + goog.string.hashCode(style.getAngle().toString()) >>> 0;
+  hash = 31 * hash + hashCode(style.getAngle().toString()) >>> 0;
 
   const imageId = hash.toString();
   if (imageId && imageId != bb.imageId && imageId != bb._imageId) {
@@ -206,7 +208,7 @@ const updateImageShape = (style, bb) => {
  */
 const updateImageDefault = (style, bb) => {
   const image = style.getImage(1);
-  const imageId = style['id'] || ol.getUid(image);
+  const imageId = style['id'] || getUid(image);
 
   if (image && imageId != bb.imageId && imageId != bb._imageId) {
     updateBillboardImage(bb, imageId, image);
@@ -279,8 +281,8 @@ const getDistanceScalar = () => {
   if (!distanceScalar) {
     // this sets up the constant after Cesium is initialized
     distanceScalar = new Cesium.NearFarScalar(
-        os.map.ZoomScale.NEAR, os.map.ZoomScale.NEAR_SCALE,
-        os.map.ZoomScale.FAR, os.map.ZoomScale.FAR_SCALE);
+        ZoomScale.NEAR, ZoomScale.NEAR_SCALE,
+        ZoomScale.FAR, ZoomScale.FAR_SCALE);
   }
   return distanceScalar;
 };

--- a/src/plugin/cesium/sync/polygon.js
+++ b/src/plugin/cesium/sync/polygon.js
@@ -2,6 +2,7 @@ goog.module('plugin.cesium.sync.polygon');
 goog.module.declareLegacyNamespace();
 
 const olcsCore = goog.require('olcs.core');
+const geo = goog.require('os.geo');
 const {GeometryInstanceId} = goog.require('plugin.cesium');
 const getTransformFunction = goog.require('plugin.cesium.sync.getTransformFunction');
 const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
@@ -62,7 +63,7 @@ const createPolygon = (feature, geometry, style, context, opt_polyFlats, opt_off
   // extruded polygons cannot be rendered as a polyline. since polygons will not respect line width on Windows, make
   // sure the geometry is both extruded and has an altitude before using the polygon primitive.
   const extrude = opt_extrude != undefined ? opt_extrude : !!geometry.get('extrude');
-  if (extrude && os.geo.hasAltitudeGeometry(geometry)) {
+  if (extrude && geo.hasAltitudeGeometry(geometry)) {
     return createPolygonPrimitive(feature, geometry, style, context, groupPrimitive, opt_polyFlats, opt_offset,
         opt_ringEnds, opt_extrude, opt_index);
   }

--- a/src/plugin/cesium/sync/polygon.js
+++ b/src/plugin/cesium/sync/polygon.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.sync.polygon');
-goog.module.declareLegacyNamespace();
 
 const olcsCore = goog.require('olcs.core');
 const geo = goog.require('os.geo');

--- a/src/plugin/cesium/sync/polygon.js
+++ b/src/plugin/cesium/sync/polygon.js
@@ -1,5 +1,6 @@
 goog.module('plugin.cesium.sync.polygon');
 
+const asserts = goog.require('goog.asserts');
 const olcsCore = goog.require('olcs.core');
 const geo = goog.require('os.geo');
 const {GeometryInstanceId} = goog.require('plugin.cesium');
@@ -99,7 +100,7 @@ const createPolygonAsPolyline = (feature, geometry, style, context, result, opt_
     });
   }
 
-  goog.asserts.assert(csRings.length > 0);
+  asserts.assert(csRings.length > 0);
 
   const width = getLineWidthFromStyle(style);
   const lineDash = getDashPattern(style);

--- a/src/plugin/cesium/sync/rootsynchronizer.js
+++ b/src/plugin/cesium/sync/rootsynchronizer.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.sync.RootSynchronizer');
-goog.module.declareLegacyNamespace();
 
 const dispatcher = goog.require('os.Dispatcher');
 const MapContainer = goog.require('os.MapContainer');

--- a/src/plugin/cesium/sync/rootsynchronizer.js
+++ b/src/plugin/cesium/sync/rootsynchronizer.js
@@ -1,157 +1,158 @@
-goog.provide('plugin.cesium.sync.RootSynchronizer');
+goog.module('plugin.cesium.sync.RootSynchronizer');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
-goog.require('os.layer.Image');
-goog.require('os.layer.Tile');
-goog.require('os.layer.Vector');
-goog.require('os.layer.VectorTile');
-goog.require('os.webgl.AbstractRootSynchronizer');
+const dispatcher = goog.require('os.Dispatcher');
+const MapContainer = goog.require('os.MapContainer');
+const asserts = goog.require('goog.asserts');
+const Image = goog.require('os.layer.Image');
+const Tile = goog.require('os.layer.Tile');
+const Vector = goog.require('os.layer.Vector');
+const VectorTile = goog.require('os.layer.VectorTile');
+const AbstractRootSynchronizer = goog.require('os.webgl.AbstractRootSynchronizer');
 
 
 /**
  * The root synchronizer for the Cesium renderer.
- *
- * @param {!ol.PluggableMap} map The OpenLayers map.
- * @param {!Cesium.Scene} scene The Cesium scene.
- * @extends {os.webgl.AbstractRootSynchronizer}
- * @constructor
  */
-plugin.cesium.sync.RootSynchronizer = function(map, scene) {
-  plugin.cesium.sync.RootSynchronizer.base(this, 'constructor', map);
+class RootSynchronizer extends AbstractRootSynchronizer {
+  /**
+   * Constructor.
+   * @param {!ol.PluggableMap} map The OpenLayers map.
+   * @param {!Cesium.Scene} scene The Cesium scene.
+   */
+  constructor(map, scene) {
+    super(map);
+
+    /**
+     * The Cesium scene.
+     * @type {Cesium.Scene|undefined}
+     * @private
+     */
+    this.scene_ = scene;
+
+    // Initialize ol-cesium library
+    olcs.core.glAliasedLineWidthRange = this.scene_.maximumAliasedLineWidth;
+  }
 
   /**
-   * The Cesium scene.
-   * @type {Cesium.Scene|undefined}
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
+    this.scene_ = undefined;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  createSynchronizer(constructor, layer) {
+    asserts.assert(!!this.map);
+    asserts.assert(!!this.scene_);
+    asserts.assert(!!layer);
+
+    return /** @type {!os.webgl.AbstractWebGLSynchronizer} */ (new
+    /** @type {function(new: Object, ol.layer.Layer, ol.PluggableMap, (Cesium.Scene|undefined))} */ (
+      constructor)(layer, this.map, this.scene_));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  updateGroupZ(group) {
+    var layers = group.getLayers().getArray();
+    if (layers.length > 0) {
+      var layerCount = 0;
+      var startIndex = 0;
+
+      if (layers[0] instanceof Tile) {
+        layerCount = MapContainer.getInstance().getLayerCount(Tile);
+        startIndex = this.getGroupStartIndex_(group);
+      } else if (layers[0] instanceof Vector) {
+        layerCount = MapContainer.getInstance().getLayerCount(Vector);
+
+        // higher z-index is displayed on top, lowest z-index should be 1. determine the layer index by:
+        // total vector layers - start of current group - layers in current group + 1
+        startIndex = layerCount - this.getVectorGroupStartIndex_(group) - layers.length + 1;
+      } else if (layers[0] instanceof Image) {
+        layerCount = MapContainer.getInstance().getLayerCount(Image);
+        startIndex = this.getGroupStartIndex_(group);
+      } else if (layers[0] instanceof VectorTile) {
+        layerCount = MapContainer.getInstance().getLayerCount(VectorTile);
+        startIndex = this.getGroupStartIndex_(group);
+      }
+
+      for (var i = 0, n = layers.length; i < n; i++) {
+        var layerId = /** @type {os.layer.ILayer} */ (layers[i]).getId();
+        var synchronizer = this.synchronizers[layerId];
+        if (synchronizer) {
+          startIndex = synchronizer.reposition(startIndex, layerCount);
+        }
+      }
+
+      dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
+    }
+  }
+
+  /**
+   * Gets the start index of the provided tile or image group by looking up the last index of the previous group,
+   * or 0 if passed the first group on the map.
+   *
+   * @param {!os.layer.Group} group The group to look up
+   * @return {number} The first index in the layers array
    * @private
    */
-  this.scene_ = scene;
-
-  // Initialize ol-cesium library
-  olcs.core.glAliasedLineWidthRange = this.scene_.maximumAliasedLineWidth;
-};
-goog.inherits(plugin.cesium.sync.RootSynchronizer, os.webgl.AbstractRootSynchronizer);
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.sync.RootSynchronizer.prototype.disposeInternal = function() {
-  plugin.cesium.sync.RootSynchronizer.base(this, 'disposeInternal');
-  this.scene_ = undefined;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.sync.RootSynchronizer.prototype.createSynchronizer = function(constructor, layer) {
-  goog.asserts.assert(!!this.map);
-  goog.asserts.assert(!!this.scene_);
-  goog.asserts.assert(!!layer);
-
-  return /** @type {!os.webgl.AbstractWebGLSynchronizer} */ (new
-  /** @type {function(new: Object, ol.layer.Layer, ol.PluggableMap, (Cesium.Scene|undefined))} */ (
-    constructor)(layer, this.map, this.scene_));
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.sync.RootSynchronizer.prototype.updateGroupZ = function(group) {
-  var layers = group.getLayers().getArray();
-  if (layers.length > 0) {
-    var layerCount = 0;
+  getGroupStartIndex_(group) {
     var startIndex = 0;
 
-    if (layers[0] instanceof os.layer.Tile) {
-      layerCount = os.MapContainer.getInstance().getLayerCount(os.layer.Tile);
-      startIndex = this.getGroupStartIndex_(group);
-    } else if (layers[0] instanceof os.layer.Vector) {
-      layerCount = os.MapContainer.getInstance().getLayerCount(os.layer.Vector);
-
-      // higher z-index is displayed on top, lowest z-index should be 1. determine the layer index by:
-      // total vector layers - start of current group - layers in current group + 1
-      startIndex = layerCount - this.getVectorGroupStartIndex_(group) - layers.length + 1;
-    } else if (layers[0] instanceof os.layer.Image) {
-      layerCount = os.MapContainer.getInstance().getLayerCount(os.layer.Image);
-      startIndex = this.getGroupStartIndex_(group);
-    } else if (layers[0] instanceof os.layer.VectorTile) {
-      layerCount = os.MapContainer.getInstance().getLayerCount(os.layer.VectorTile);
-      startIndex = this.getGroupStartIndex_(group);
-    }
-
-    for (var i = 0, n = layers.length; i < n; i++) {
-      var layerId = /** @type {os.layer.ILayer} */ (layers[i]).getId();
-      var synchronizer = this.synchronizers[layerId];
-      if (synchronizer) {
-        startIndex = synchronizer.reposition(startIndex, layerCount);
-      }
-    }
-
-    os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
-  }
-};
-
-
-/**
- * Gets the start index of the provided tile or image group by looking up the last index of the previous group,
- * or 0 if passed the first group on the map.
- *
- * @param {!os.layer.Group} group The group to look up
- * @return {number} The first index in the layers array
- * @private
- */
-plugin.cesium.sync.RootSynchronizer.prototype.getGroupStartIndex_ = function(group) {
-  var startIndex = 0;
-
-  var groups = this.map.getLayers().getArray();
-  var idx = groups.indexOf(group);
-  if (idx > 0) {
-    // find the first group with layers and get its start index
-    while (idx--) {
-      var previousLayers = /** @type {os.layer.Group} */ (groups[idx]).getLayers().getArray();
-      if (previousLayers.length > 0) {
-        var layer = previousLayers[previousLayers.length - 1];
-        if (layer instanceof os.layer.Image || layer instanceof os.layer.Tile ||
-            layer instanceof os.layer.VectorTile) {
-          var layerId = /** @type {os.layer.ILayer} */ (layer).getId();
-          var synchronizer = this.synchronizers[layerId];
-          if (synchronizer) {
-            startIndex = synchronizer.getLastIndex() + 1;
-            break;
+    var groups = this.map.getLayers().getArray();
+    var idx = groups.indexOf(group);
+    if (idx > 0) {
+      // find the first group with layers and get its start index
+      while (idx--) {
+        var previousLayers = /** @type {os.layer.Group} */ (groups[idx]).getLayers().getArray();
+        if (previousLayers.length > 0) {
+          var layer = previousLayers[previousLayers.length - 1];
+          if (layer instanceof Image || layer instanceof Tile ||
+              layer instanceof VectorTile) {
+            var layerId = /** @type {os.layer.ILayer} */ (layer).getId();
+            var synchronizer = this.synchronizers[layerId];
+            if (synchronizer) {
+              startIndex = synchronizer.getLastIndex() + 1;
+              break;
+            }
           }
         }
       }
     }
+
+    return startIndex;
   }
 
-  return startIndex;
-};
+  /**
+   * Gets the start index of the provided vector group by counting the number of previous vector layers.
+   *
+   * @param {!os.layer.Group} group The group to look up
+   * @return {number} The first index in the layers array
+   * @private
+   */
+  getVectorGroupStartIndex_(group) {
+    var startIndex = 0;
 
+    var groups = this.map.getLayers().getArray();
+    var i = groups.length;
+    while (i--) {
+      if (groups[i] == group) {
+        break;
+      }
 
-/**
- * Gets the start index of the provided vector group by counting the number of previous vector layers.
- *
- * @param {!os.layer.Group} group The group to look up
- * @return {number} The first index in the layers array
- * @private
- */
-plugin.cesium.sync.RootSynchronizer.prototype.getVectorGroupStartIndex_ = function(group) {
-  var startIndex = 0;
-
-  var groups = this.map.getLayers().getArray();
-  var i = groups.length;
-  while (i--) {
-    if (groups[i] == group) {
-      break;
+      var previousLayers = /** @type {os.layer.Group} */ (groups[i]).getLayers().getArray();
+      if (previousLayers.length > 0 && previousLayers[previousLayers.length - 1] instanceof Vector) {
+        startIndex += previousLayers.length;
+      }
     }
 
-    var previousLayers = /** @type {os.layer.Group} */ (groups[i]).getLayers().getArray();
-    if (previousLayers.length > 0 && previousLayers[previousLayers.length - 1] instanceof os.layer.Vector) {
-      startIndex += previousLayers.length;
-    }
+    return startIndex;
   }
+}
 
-  return startIndex;
-};
+exports = RootSynchronizer;

--- a/src/plugin/cesium/sync/shape.js
+++ b/src/plugin/cesium/sync/shape.js
@@ -1,5 +1,9 @@
 goog.module('plugin.cesium.sync.shape');
 
+const {asColorLike} = goog.require('ol.colorlike');
+const {createCanvasContext2D} = goog.require('ol.dom');
+const has = goog.require('ol.has');
+const renderCanvas = goog.require('ol.render.canvas');
 const OLRegularShape = goog.require('ol.style.RegularShape');
 
 
@@ -39,7 +43,7 @@ const drawShape = (style) => {
   scratchFakeShape.fill_ = style.getFill();
   scratchFakeShape.stroke_ = style.getStroke();
 
-  const context = ol.dom.createCanvasContext2D(renderOptions.size, renderOptions.size);
+  const context = createCanvasContext2D(renderOptions.size, renderOptions.size);
   renderOptions.size = context.canvas.width;
   OLRegularShape.prototype.draw_.call(scratchFakeShape, renderOptions, context, 0, 0);
 
@@ -68,30 +72,30 @@ const getRenderOptions = (style) => {
   if (stroke) {
     strokeStyle = stroke.getColor();
     if (strokeStyle === null) {
-      strokeStyle = ol.render.canvas.defaultStrokeStyle;
+      strokeStyle = renderCanvas.defaultStrokeStyle;
     }
-    strokeStyle = ol.colorlike.asColorLike(strokeStyle);
+    strokeStyle = asColorLike(strokeStyle);
     strokeWidth = stroke.getWidth();
     if (strokeWidth === undefined) {
-      strokeWidth = ol.render.canvas.defaultLineWidth;
+      strokeWidth = renderCanvas.defaultLineWidth;
     }
     lineDash = stroke.getLineDash();
     lineDashOffset = stroke.getLineDashOffset();
-    if (!ol.has.CANVAS_LINE_DASH) {
+    if (!has.CANVAS_LINE_DASH) {
       lineDash = null;
       lineDashOffset = 0;
     }
     lineJoin = stroke.getLineJoin();
     if (lineJoin === undefined) {
-      lineJoin = ol.render.canvas.defaultLineJoin;
+      lineJoin = renderCanvas.defaultLineJoin;
     }
     lineCap = stroke.getLineCap();
     if (lineCap === undefined) {
-      lineCap = ol.render.canvas.defaultLineCap;
+      lineCap = renderCanvas.defaultLineCap;
     }
     miterLimit = stroke.getMiterLimit();
     if (miterLimit === undefined) {
-      miterLimit = ol.render.canvas.defaultMiterLimit;
+      miterLimit = renderCanvas.defaultMiterLimit;
     }
   }
 

--- a/src/plugin/cesium/sync/style.js
+++ b/src/plugin/cesium/sync/style.js
@@ -1,6 +1,8 @@
 goog.module('plugin.cesium.sync.style');
 
-const olcsCore = goog.require('olcs.core');
+const {convertColorToCesium} = goog.require('olcs.core');
+const {DEFAULT_FEATURE_SIZE, DEFAULT_HIGHLIGHT_CONFIG} = goog.require('os.style');
+const {OUTLINE_REGEXP} = goog.require('plugin.cesium');
 
 const Style = goog.requireType('ol.style.Style');
 const Text = goog.requireType('ol.style.Text');
@@ -14,7 +16,7 @@ const VectorContext = goog.requireType('plugin.cesium.VectorContext');
  * @return {!Cesium.Color}
  */
 const getColor = (style, context, geometryInstanceId) => {
-  const isOutline = plugin.cesium.OUTLINE_REGEXP.test(geometryInstanceId);
+  const isOutline = OUTLINE_REGEXP.test(geometryInstanceId);
   const color = getColorFromStyle(style, isOutline);
 
   if (isOutline && !isHighlightStyle(style) && !style.getStroke()) {
@@ -36,8 +38,7 @@ const getColor = (style, context, geometryInstanceId) => {
  */
 const getLineWidthFromStyle = (style) => {
   // make sure the width is at least 1px
-  return Math.max(1, /** @type {number} */ (style.getStroke() && style.getStroke().getWidth() ||
-      os.style.DEFAULT_FEATURE_SIZE));
+  return Math.max(1, /** @type {number} */ (style.getStroke() && style.getStroke().getWidth() || DEFAULT_FEATURE_SIZE));
 };
 
 
@@ -59,7 +60,7 @@ const getColorFromStyle = (style, isOutline) => {
     olColor = fillColor;
   }
 
-  return olcsCore.convertColorToCesium(olColor);
+  return convertColorToCesium(olColor);
 };
 
 
@@ -69,7 +70,7 @@ const getColorFromStyle = (style, isOutline) => {
  */
 const isHighlightStyle = (style) => {
   if (style && style.getStroke()) {
-    return (os.style.DEFAULT_HIGHLIGHT_CONFIG.stroke.color === style.getStroke().getColor());
+    return (DEFAULT_HIGHLIGHT_CONFIG.stroke.color === style.getStroke().getColor());
   }
   return false;
 };

--- a/src/plugin/cesium/sync/style.js
+++ b/src/plugin/cesium/sync/style.js
@@ -79,4 +79,3 @@ exports = {
   getColor,
   getLineWidthFromStyle
 };
-

--- a/src/plugin/cesium/sync/tilesynchronizer.js
+++ b/src/plugin/cesium/sync/tilesynchronizer.js
@@ -3,9 +3,11 @@ goog.module('plugin.cesium.sync.TileSynchronizer');
 const asserts = goog.require('goog.asserts');
 const Delay = goog.require('goog.async.Delay');
 const EventType = goog.require('goog.events.EventType');
+const googObject = goog.require('goog.object');
 const googString = goog.require('goog.string');
 const olEvents = goog.require('ol.events');
 const TileWMS = goog.require('ol.source.TileWMS');
+
 const Dispatcher = goog.require('os.Dispatcher');
 const MapContainer = goog.require('os.MapContainer');
 const MapEvent = goog.require('os.MapEvent');
@@ -15,9 +17,14 @@ const AnimatedTile = goog.require('os.layer.AnimatedTile');
 const PropertyChange = goog.require('os.layer.PropertyChange');
 const osMap = goog.require('os.map');
 const events = goog.require('os.ol.events');
+const osTime = goog.require('os.time');
 const {tileLayerToImageryLayer, updateCesiumLayerProperties} = goog.require('plugin.cesium');
 const ImageryProvider = goog.require('plugin.cesium.ImageryProvider');
 const CesiumSynchronizer = goog.require('plugin.cesium.sync.CesiumSynchronizer');
+
+const GoogEvent = goog.requireType('goog.events.Event');
+const OLObject = goog.requireType('ol.Object');
+const PluggableMap = goog.requireType('ol.PluggableMap');
 
 
 /**
@@ -53,7 +60,7 @@ class TileSynchronizer extends CesiumSynchronizer {
   /**
    * Constructor.
    * @param {!osLayer.Tile} layer The OpenLayers tile layer.
-   * @param {!ol.PluggableMap} map The OpenLayers map.
+   * @param {!PluggableMap} map The OpenLayers map.
    * @param {!Cesium.Scene} scene The Cesium scene.
    */
   constructor(layer, map, scene) {
@@ -157,7 +164,7 @@ class TileSynchronizer extends CesiumSynchronizer {
   /**
    * Handles min/max zoom
    *
-   * @param {goog.events.Event=} opt_evt
+   * @param {GoogEvent=} opt_evt
    * @private
    */
   onZoomChange_(opt_evt) {
@@ -220,7 +227,7 @@ class TileSynchronizer extends CesiumSynchronizer {
   getLastIndex() {
     var lastIndex = this.getFirstIndex();
     if (lastIndex > -1 && this.animationCache_) {
-      lastIndex += goog.object.getCount(this.animationCache_);
+      lastIndex += googObject.getCount(this.animationCache_);
     }
 
     return lastIndex;
@@ -384,8 +391,8 @@ class TileSynchronizer extends CesiumSynchronizer {
     var end = this.tlc.getCurrent();
 
     return AnimatedTile.getTimeParameter(dateFormat, timeFormat,
-        os.time.offset(new Date(start), duration, offset).getTime(),
-        os.time.offset(new Date(end), duration, offset).getTime(),
+        osTime.offset(new Date(start), duration, offset).getTime(),
+        osTime.offset(new Date(end), duration, offset).getTime(),
         duration);
   }
 
@@ -455,7 +462,7 @@ class TileSynchronizer extends CesiumSynchronizer {
   /**
    * Update Cesium layer properties when the style changes.
    *
-   * @param {ol.Object.Event} event
+   * @param {OLObject.Event} event
    * @private
    */
   onStyleChange_(event) {
@@ -468,7 +475,7 @@ class TileSynchronizer extends CesiumSynchronizer {
   /**
    * Handle generic 'change' events on the tile layer.
    *
-   * @param {ol.Object.Event} event
+   * @param {OLObject.Event} event
    * @private
    */
   onChange_(event) {

--- a/src/plugin/cesium/sync/tilesynchronizer.js
+++ b/src/plugin/cesium/sync/tilesynchronizer.js
@@ -1,74 +1,491 @@
-goog.provide('plugin.cesium.sync.TileSynchronizer');
+goog.module('plugin.cesium.sync.TileSynchronizer');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
-goog.require('goog.async.Delay');
-goog.require('goog.events.EventType');
-goog.require('goog.string');
-goog.require('ol.layer.Tile');
-goog.require('ol.source.TileWMS');
-goog.require('os.MapEvent');
-goog.require('os.events.PropertyChangeEvent');
-goog.require('os.events.SelectionType');
-goog.require('os.layer');
-goog.require('os.layer.AnimatedTile');
-goog.require('os.layer.PropertyChange');
-goog.require('os.map');
-goog.require('os.ol.events');
-goog.require('os.source.Vector');
-goog.require('plugin.cesium.ImageryProvider');
-goog.require('plugin.cesium.sync.CesiumSynchronizer');
+const dispatcher = goog.require('os.Dispatcher');
+const MapContainer = goog.require('os.MapContainer');
+const asserts = goog.require('goog.asserts');
+const Delay = goog.require('goog.async.Delay');
+const EventType = goog.require('goog.events.EventType');
+const googString = goog.require('goog.string');
+const TileWMS = goog.require('ol.source.TileWMS');
+const MapEvent = goog.require('os.MapEvent');
+const PropertyChangeEvent = goog.require('os.events.PropertyChangeEvent');
+const osLayer = goog.require('os.layer');
+const AnimatedTile = goog.require('os.layer.AnimatedTile');
+const PropertyChange = goog.require('os.layer.PropertyChange');
+const osMap = goog.require('os.map');
+const events = goog.require('os.ol.events');
+const ImageryProvider = goog.require('plugin.cesium.ImageryProvider');
+const CesiumSynchronizer = goog.require('plugin.cesium.sync.CesiumSynchronizer');
 
 
 /**
  * Synchronizes a single OpenLayers tile layer to Cesium.
  *
- * @param {!os.layer.Tile} layer The OpenLayers tile layer.
- * @param {!ol.PluggableMap} map The OpenLayers map.
- * @param {!Cesium.Scene} scene The Cesium scene.
- * @extends {plugin.cesium.sync.CesiumSynchronizer.<os.layer.Tile>}
- * @constructor
+ * @extends {CesiumSynchronizer.<osLayer.Tile>}
  */
-plugin.cesium.sync.TileSynchronizer = function(layer, map, scene) {
-  plugin.cesium.sync.TileSynchronizer.base(this, 'constructor', layer, map, scene);
-
+class TileSynchronizer extends CesiumSynchronizer {
   /**
-   * @type {Cesium.ImageryLayerCollection}
-   * @private
+   * Constructor.
+   * @param {!osLayer.Tile} layer The OpenLayers tile layer.
+   * @param {!ol.PluggableMap} map The OpenLayers map.
+   * @param {!Cesium.Scene} scene The Cesium scene.
    */
-  this.cesiumLayers_ = scene.imageryLayers;
+  constructor(layer, map, scene) {
+    super(layer, map, scene);
 
-  /**
-   * @type {Cesium.ImageryLayer}
-   * @private
-   */
-  this.activeLayer_ = null;
+    /**
+     * @type {Cesium.ImageryLayerCollection}
+     * @private
+     */
+    this.cesiumLayers_ = scene.imageryLayers;
 
-  /**
-   * @type {Object<string, Cesium.ImageryLayer>}
-   * @private
-   */
-  this.animationCache_ = null;
+    /**
+     * @type {Cesium.ImageryLayer}
+     * @private
+     */
+    this.activeLayer_ = null;
 
-  /**
-   * The last z-order start index for the layer.
-   * @type {number}
-   * @private
-   */
-  this.lastStart_ = -1;
+    /**
+     * @type {Object<string, Cesium.ImageryLayer>}
+     * @private
+     */
+    this.animationCache_ = null;
 
-  /**
-   * Delay to debounce synchronize calls.
-   * @type {goog.async.Delay}
-   * @private
-   */
-  this.syncDelay_ = new goog.async.Delay(this.synchronizeInternal, 50, this);
+    /**
+     * The last z-order start index for the layer.
+     * @type {number}
+     * @private
+     */
+    this.lastStart_ = -1;
 
-  var view = os.MapContainer.getInstance().getMap().getView();
-  if (view) {
-    ol.events.listen(view, 'change:resolution', this.onZoomChange_, this);
+    /**
+     * Delay to debounce synchronize calls.
+     * @type {Delay}
+     * @private
+     */
+    this.syncDelay_ = new Delay(this.synchronizeInternal, 50, this);
+
+    var view = MapContainer.getInstance().getMap().getView();
+    if (view) {
+      ol.events.listen(view, 'change:resolution', this.onZoomChange_, this);
+    }
   }
-};
-goog.inherits(plugin.cesium.sync.TileSynchronizer, plugin.cesium.sync.CesiumSynchronizer);
+
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    goog.dispose(this.syncDelay_);
+    this.syncDelay_ = null;
+
+    var view = MapContainer.getInstance().getMap().getView();
+    if (view) {
+      ol.events.unlisten(view, 'change:resolution', this.onZoomChange_, this);
+    }
+
+    ol.events.unlisten(this.layer, EventType.PROPERTYCHANGE, this.onLayerPropertyChange_, this);
+
+    this.disposeSingle_();
+    this.disposeCache_();
+
+    this.cesiumLayers_ = null;
+
+    super.disposeInternal();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  synchronize() {
+    if (this.syncDelay_) {
+      this.syncDelay_.start();
+    }
+  }
+
+  /**
+   * Synchronize the tile layer.
+   *
+   * @protected
+   */
+  synchronizeInternal() {
+    // clean up existing layers
+    this.disposeSingle_();
+    this.disposeCache_();
+
+    // create the base layer
+    this.createSingle_();
+
+    if (this.layer instanceof AnimatedTile && this.layer.getAnimationEnabled()) {
+      // for animation layers, enable the layer cache if the timeline is up
+      this.createCache_();
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  reset() {
+    // nothing to do yet
+  }
+
+  /**
+   * Handles min/max zoom
+   *
+   * @param {goog.events.Event=} opt_evt
+   * @private
+   */
+  onZoomChange_(opt_evt) {
+    if (this.layer && this.activeLayer_ && !this.animationCache_) {
+      var proj = this.view.getProjection();
+      var current = this.view.getResolution();
+      var min = this.layer.getMinResolution();
+      var max = this.layer.getMaxResolution();
+
+      min = min !== undefined ? min : osMap.zoomToResolution(42, proj);
+      max = max !== undefined ? max : osMap.zoomToResolution(1, proj);
+
+      var maxZoom = osMap.resolutionToZoom(min, proj);
+      // for layers with a max zoom of 20 or greater, we will assume that they should just stay on indefinitely as
+      // the user zooms in (since they are probably last in the base map "stack")
+      this.activeLayer_.show = (maxZoom >= 20 || min <= current) && current <= max && this.layer.getVisible();
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  reposition(start, end) {
+    if (this.lastStart_ !== start) {
+      this.lastStart_ = start;
+
+      if (this.activeLayer_) {
+        this.cesiumLayers_.remove(this.activeLayer_, false);
+        this.cesiumLayers_.add(this.activeLayer_, start++);
+      }
+
+      if (this.animationCache_) {
+        for (var key in this.animationCache_) {
+          this.cesiumLayers_.remove(this.animationCache_[key], false);
+          this.cesiumLayers_.add(this.animationCache_[key], start++);
+        }
+      }
+    } else {
+      // the layer is positioned correctly, so return the last index + 1
+      start = this.getLastIndex() + 1;
+    }
+
+    return start;
+  }
+
+  /**
+   * Get the first index of this synchronizer's layers in the Cesium imagery layer array.
+   *
+   * @return {number}
+   */
+  getFirstIndex() {
+    return this.activeLayer_ ? this.cesiumLayers_.indexOf(this.activeLayer_) : -1;
+  }
+
+  /**
+   * Get the last index of this synchronizer's layers in the Cesium imagery layer array.
+   *
+   * @return {number}
+   */
+  getLastIndex() {
+    var lastIndex = this.getFirstIndex();
+    if (lastIndex > -1 && this.animationCache_) {
+      lastIndex += goog.object.getCount(this.animationCache_);
+    }
+
+    return lastIndex;
+  }
+
+  /**
+   * Creates a single Cesium layer to represent the OpenLayers tile layer.
+   *
+   * @private
+   */
+  createSingle_() {
+    asserts.assert(this.layer != null);
+    asserts.assert(this.view != null);
+
+    ol.events.listen(this.layer, EventType.PROPERTYCHANGE, this.onLayerPropertyChange_, this);
+    this.activeLayer_ = plugin.cesium.tileLayerToImageryLayer(this.layer, this.view.getProjection());
+
+    if (this.activeLayer_) {
+      // update the layer style and add it to the scene
+      plugin.cesium.updateCesiumLayerProperties(this.layer, this.activeLayer_);
+      this.onZoomChange_();
+      this.cesiumLayers_.add(this.activeLayer_, this.lastStart_ > -1 ? this.lastStart_ : undefined);
+
+      // register listeners to update the layer
+      events.listenEach(this.layer, TileSynchronizer.STYLE_KEYS_, this.onStyleChange_, this);
+      events.listenEach(this.layer, TileSynchronizer.RESOLUTION_KEYS_, this.onZoomChange_, this);
+      ol.events.listen(this.layer, 'change:extent', this.synchronize, this);
+      ol.events.listen(this.layer, 'change', this.onChange_, this);
+    }
+  }
+
+  /**
+   * Disposes of the single Cesium layer if it exists.
+   *
+   * @private
+   */
+  disposeSingle_() {
+    ol.events.unlisten(this.layer, EventType.PROPERTYCHANGE, this.onLayerPropertyChange_, this);
+
+    if (this.activeLayer_) {
+      // clean up listeners
+      events.unlistenEach(this.layer, TileSynchronizer.STYLE_KEYS_, this.onStyleChange_, this);
+      events.unlistenEach(this.layer, TileSynchronizer.RESOLUTION_KEYS_, this.onZoomChange_,
+          this);
+      ol.events.unlisten(this.layer, 'change:extent', this.synchronize, this);
+      ol.events.unlisten(this.layer, 'change', this.onChange_, this);
+
+      if (this.activeLayer_.imageryProvider instanceof ImageryProvider) {
+        this.activeLayer_.imageryProvider.dispose();
+      }
+
+      // remove layer from the scene and destroy it
+      this.cesiumLayers_.remove(this.activeLayer_, true);
+      this.activeLayer_ = null;
+
+      dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
+    }
+  }
+
+  /**
+   * Creates Cesium layer cache based on a single OpenLayers tile layer to facilitate tile animation.
+   *
+   * @private
+   */
+  createCache_() {
+    if (this.activeLayer_ && this.layer.getSource() instanceof TileWMS) {
+      // hide the active layer and disable any events that would update it
+      this.activeLayer_.show = false;
+      events.unlistenEach(this.layer, TileSynchronizer.STYLE_KEYS_, this.onStyleChange_, this);
+      ol.events.unlisten(this.layer, 'change', this.onChange_, this);
+
+      // create the cache
+      this.updateAnimationCache_();
+
+      // update the layer cache when the style changes, or a change event is fired (ie, params/url changed). in the
+      // future we may have to clear the cache if something other than the TIME param changes (like user changes to
+      // the url) but currently there isn't a way to do that.
+      events.listenEach(this.layer, TileSynchronizer.STYLE_KEYS_, this.updateAnimationCache_,
+          this);
+      ol.events.listen(this.layer, 'change', this.updateAnimationCache_, this);
+    }
+  }
+
+  /**
+   * Disposes of the Cesium tile layer cache.
+   *
+   * @private
+   */
+  disposeCache_() {
+    // remove cache listeners
+    events.unlistenEach(this.layer, TileSynchronizer.STYLE_KEYS_, this.updateAnimationCache_,
+        this);
+    ol.events.unlisten(this.layer, 'change', this.updateAnimationCache_, this);
+
+    // destroy the cache
+    if (this.animationCache_) {
+      for (var key in this.animationCache_) {
+        this.cesiumLayers_.remove(this.animationCache_[key], true);
+
+        if (this.animationCache_[key].imageryProvider instanceof ImageryProvider) {
+          this.animationCache_[key].imageryProvider.dispose();
+        }
+
+        delete this.animationCache_[key];
+      }
+
+      this.animationCache_ = null;
+    }
+
+    // reactivate the active layer and its listeners. the show flag will be determined by layer visibility.
+    if (this.layer && this.activeLayer_) {
+      plugin.cesium.updateCesiumLayerProperties(this.layer, this.activeLayer_);
+      events.listenEach(this.layer, TileSynchronizer.STYLE_KEYS_, this.onStyleChange_, this);
+      ol.events.listen(this.layer, 'change', this.onChange_, this);
+    }
+  }
+
+  /**
+   * Caches tile layers for the current timeline window and the tile boundary on either side of the window. Preloading
+   * tiles makes them available to the GPU immediately so seamless transition between tiles is possible. While animating,
+   * tile layers are cached for each tile boundary within the animation loop.
+   *
+   * @private
+   */
+  updateAnimationCache_() {
+    var newCache = {};
+
+    // get the current layer from the cache and put it in the new cache
+    var timeParam = this.getTimeParameter_(0);
+    newCache[timeParam] = this.getCacheLayer_(timeParam, true);
+
+    // hide all of the other layers that aren't the current by setting their alpha to 0
+    // this.animationCache_ no longer contains the current layer as the call above removes it
+    if (this.animationCache_) {
+      for (var key in this.animationCache_) {
+        newCache[key] = this.animationCache_[key];
+        newCache[key].alpha = 0;
+      }
+    }
+
+    this.animationCache_ = newCache;
+    dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
+  }
+
+  /**
+   * Creates a WMS TIME parameter based on the timeline controller's current start/end, offset by the provided number
+   * of timeline durations (ie, day week month). This is a convenience function for creating tile boundaries around
+   * the current time window.
+   *
+   * @param {number} offset The number of timeline durations (day, week, month, etc) to offset this range.
+   * @return {string} WMS TIME parameter for the requested offset.
+   * @private
+   */
+  getTimeParameter_(offset) {
+    asserts.assertInstanceof(this.layer, AnimatedTile);
+
+    var dateFormat = this.layer.getDateFormat();
+    var timeFormat = this.layer.getTimeFormat();
+    var duration = this.tlc.getDuration();
+    var start = this.tlc.getCurrent() - this.tlc.getOffset();
+    var end = this.tlc.getCurrent();
+
+    return AnimatedTile.getTimeParameter(dateFormat, timeFormat,
+        os.time.offset(new Date(start), duration, offset).getTime(),
+        os.time.offset(new Date(end), duration, offset).getTime(),
+        duration);
+  }
+
+  /**
+   * Caches a layer for the given time and sets the visibility.
+   *
+   * @param {string} timeParam The TIME param for the layer.
+   * @param {boolean} show If the layer should be shown.
+   * @return {Cesium.ImageryLayer}
+   * @private
+   */
+  getCacheLayer_(timeParam, show) {
+    asserts.assert(this.layer !== null);
+
+    var cesiumLayer = this.animationCache_ ? this.animationCache_[timeParam] : undefined;
+    if (!cesiumLayer) {
+      // layer doesn't exist, so create it and add it to the scene. insert it after the active layer.
+      var activePosition = this.cesiumLayers_.indexOf(this.activeLayer_);
+      cesiumLayer = this.getLayerByTime_(timeParam);
+      this.cesiumLayers_.add(cesiumLayer, activePosition + 1);
+    } else {
+      // layer already exists, so remove it from the current cache and return it
+      delete this.animationCache_[timeParam];
+    }
+
+    plugin.cesium.updateCesiumLayerProperties(this.layer, cesiumLayer);
+    cesiumLayer.alpha = show ? (this.layer.getOpacity() || 0) : 0;
+    return cesiumLayer;
+  }
+
+  /**
+   * Creates a Cesium layer representing this synchronizer's layer with a custom time range. This is used when caching
+   * multiple time ranges for animation.
+   *
+   * @param {string} timeParam Time to use for the WMS TIME parameter
+   * @return {!Cesium.ImageryLayer} The Cesium imagery layer
+   * @private
+   * @suppress {accessControls}
+   */
+  getLayerByTime_(timeParam) {
+    asserts.assertInstanceof(this.layer, AnimatedTile);
+    asserts.assert(this.view !== null);
+
+    var originalSource = /** @type {TileWMS} */ (this.layer.getSource());
+    asserts.assertInstanceof(originalSource, TileWMS);
+
+    var options = this.layer.getLayerOptions();
+    // just to be sure, make the ID different
+    options['id'] = googString.getRandomString();
+
+    var clone = /** @type {osLayer.Tile} */ (osLayer.createFromOptions(options));
+    var source = /** @type {TileWMS} */ (clone.getSource());
+
+    // don't leak the layer and its ties to the source
+    clone.setSource(null);
+    clone.dispose();
+
+    var params = originalSource.getParams();
+    params['TIME'] = timeParam;
+    source.updateParams(params);
+
+    var provider = new ImageryProvider(source, null);
+    var cesiumLayer = new Cesium.ImageryLayer(provider);
+    return cesiumLayer;
+  }
+
+  /**
+   * Update Cesium layer properties when the style changes.
+   *
+   * @param {ol.Object.Event} event
+   * @private
+   */
+  onStyleChange_(event) {
+    asserts.assert(this.layer !== null);
+    asserts.assert(this.activeLayer_ !== null);
+    plugin.cesium.updateCesiumLayerProperties(this.layer, this.activeLayer_);
+    this.onZoomChange_();
+  }
+
+  /**
+   * Handle generic 'change' events on the tile layer.
+   *
+   * @param {ol.Object.Event} event
+   * @private
+   */
+  onChange_(event) {
+    // don't bother re-adding if the layer isn't shown. the change will take effect when the layer is shown again.
+    if (this.activeLayer_ && this.activeLayer_.show) {
+      // when the source changes, re-add the layer to force update
+      var activePosition = this.cesiumLayers_.indexOf(this.activeLayer_);
+      if (activePosition >= 0) {
+        this.cesiumLayers_.remove(this.activeLayer_, false);
+        this.cesiumLayers_.add(this.activeLayer_, activePosition);
+      }
+    }
+
+    dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
+  }
+
+  /**
+   * Handle property change events on the layer.
+   *
+   * @param {PropertyChangeEvent} event
+   * @private
+   */
+  onLayerPropertyChange_(event) {
+    // ol3 also fires 'propertychange' events, so ignore those
+    if (event instanceof PropertyChangeEvent) {
+      var p = event.getProperty();
+      if (p == PropertyChange.ANIMATION_ENABLED) {
+        // enable/disable the cache based on the animation state (fired when the timeline is opened/closed)
+        var enabled = /** @type {boolean} */ (event.getNewValue());
+        if (enabled) {
+          this.createCache_();
+        } else {
+          this.disposeCache_();
+        }
+      } else if (p == PropertyChange.STYLE) {
+        this.synchronize();
+      }
+    }
+
+    dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
+  }
+}
 
 
 /**
@@ -76,7 +493,7 @@ goog.inherits(plugin.cesium.sync.TileSynchronizer, plugin.cesium.sync.CesiumSync
  * @const
  * @private
  */
-plugin.cesium.sync.TileSynchronizer.STYLE_KEYS_ = [
+TileSynchronizer.STYLE_KEYS_ = [
   'change:brightness',
   'change:contrast',
   'change:hue',
@@ -91,441 +508,10 @@ plugin.cesium.sync.TileSynchronizer.STYLE_KEYS_ = [
  * @const
  * @private
  */
-plugin.cesium.sync.TileSynchronizer.RESOLUTION_KEYS_ = [
+TileSynchronizer.RESOLUTION_KEYS_ = [
   'change:minResolution',
   'change:maxResolution'
 ];
 
 
-/**
- * @inheritDoc
- */
-plugin.cesium.sync.TileSynchronizer.prototype.disposeInternal = function() {
-  goog.dispose(this.syncDelay_);
-  this.syncDelay_ = null;
-
-  var view = os.MapContainer.getInstance().getMap().getView();
-  if (view) {
-    ol.events.unlisten(view, 'change:resolution', this.onZoomChange_, this);
-  }
-
-  ol.events.unlisten(this.layer, goog.events.EventType.PROPERTYCHANGE, this.onLayerPropertyChange_, this);
-
-  this.disposeSingle_();
-  this.disposeCache_();
-
-  this.cesiumLayers_ = null;
-
-  plugin.cesium.sync.TileSynchronizer.base(this, 'disposeInternal');
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.sync.TileSynchronizer.prototype.synchronize = function() {
-  if (this.syncDelay_) {
-    this.syncDelay_.start();
-  }
-};
-
-
-/**
- * Synchronize the tile layer.
- *
- * @protected
- */
-plugin.cesium.sync.TileSynchronizer.prototype.synchronizeInternal = function() {
-  // clean up existing layers
-  this.disposeSingle_();
-  this.disposeCache_();
-
-  // create the base layer
-  this.createSingle_();
-
-  if (this.layer instanceof os.layer.AnimatedTile && this.layer.getAnimationEnabled()) {
-    // for animation layers, enable the layer cache if the timeline is up
-    this.createCache_();
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.sync.TileSynchronizer.prototype.reset = function() {
-  // nothing to do yet
-};
-
-
-/**
- * Handles min/max zoom
- *
- * @param {goog.events.Event=} opt_evt
- * @private
- */
-plugin.cesium.sync.TileSynchronizer.prototype.onZoomChange_ = function(opt_evt) {
-  if (this.layer && this.activeLayer_ && !this.animationCache_) {
-    var proj = this.view.getProjection();
-    var current = this.view.getResolution();
-    var min = this.layer.getMinResolution();
-    var max = this.layer.getMaxResolution();
-
-    min = min !== undefined ? min : os.map.zoomToResolution(42, proj);
-    max = max !== undefined ? max : os.map.zoomToResolution(1, proj);
-
-    var maxZoom = os.map.resolutionToZoom(min, proj);
-    // for layers with a max zoom of 20 or greater, we will assume that they should just stay on indefinitely as
-    // the user zooms in (since they are probably last in the base map "stack")
-    this.activeLayer_.show = (maxZoom >= 20 || min <= current) && current <= max && this.layer.getVisible();
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.sync.TileSynchronizer.prototype.reposition = function(start, end) {
-  if (this.lastStart_ !== start) {
-    this.lastStart_ = start;
-
-    if (this.activeLayer_) {
-      this.cesiumLayers_.remove(this.activeLayer_, false);
-      this.cesiumLayers_.add(this.activeLayer_, start++);
-    }
-
-    if (this.animationCache_) {
-      for (var key in this.animationCache_) {
-        this.cesiumLayers_.remove(this.animationCache_[key], false);
-        this.cesiumLayers_.add(this.animationCache_[key], start++);
-      }
-    }
-  } else {
-    // the layer is positioned correctly, so return the last index + 1
-    start = this.getLastIndex() + 1;
-  }
-
-  return start;
-};
-
-
-/**
- * Get the first index of this synchronizer's layers in the Cesium imagery layer array.
- *
- * @return {number}
- */
-plugin.cesium.sync.TileSynchronizer.prototype.getFirstIndex = function() {
-  return this.activeLayer_ ? this.cesiumLayers_.indexOf(this.activeLayer_) : -1;
-};
-
-
-/**
- * Get the last index of this synchronizer's layers in the Cesium imagery layer array.
- *
- * @return {number}
- */
-plugin.cesium.sync.TileSynchronizer.prototype.getLastIndex = function() {
-  var lastIndex = this.getFirstIndex();
-  if (lastIndex > -1 && this.animationCache_) {
-    lastIndex += goog.object.getCount(this.animationCache_);
-  }
-
-  return lastIndex;
-};
-
-
-/**
- * Creates a single Cesium layer to represent the OpenLayers tile layer.
- *
- * @private
- */
-plugin.cesium.sync.TileSynchronizer.prototype.createSingle_ = function() {
-  // goog.asserts.assertInstanceof(this.layer, ol.layer.Tile);
-  goog.asserts.assert(this.layer != null);
-  goog.asserts.assert(this.view != null);
-
-  ol.events.listen(this.layer, goog.events.EventType.PROPERTYCHANGE, this.onLayerPropertyChange_, this);
-  this.activeLayer_ = plugin.cesium.tileLayerToImageryLayer(this.layer, this.view.getProjection());
-
-  if (this.activeLayer_) {
-    // update the layer style and add it to the scene
-    plugin.cesium.updateCesiumLayerProperties(this.layer, this.activeLayer_);
-    this.onZoomChange_();
-    this.cesiumLayers_.add(this.activeLayer_, this.lastStart_ > -1 ? this.lastStart_ : undefined);
-
-    // register listeners to update the layer
-    os.ol.events.listenEach(this.layer, plugin.cesium.sync.TileSynchronizer.STYLE_KEYS_, this.onStyleChange_, this);
-    os.ol.events.listenEach(this.layer, plugin.cesium.sync.TileSynchronizer.RESOLUTION_KEYS_, this.onZoomChange_, this);
-    ol.events.listen(this.layer, 'change:extent', this.synchronize, this);
-    ol.events.listen(this.layer, 'change', this.onChange_, this);
-  }
-};
-
-
-/**
- * Disposes of the single Cesium layer if it exists.
- *
- * @private
- */
-plugin.cesium.sync.TileSynchronizer.prototype.disposeSingle_ = function() {
-  ol.events.unlisten(this.layer, goog.events.EventType.PROPERTYCHANGE, this.onLayerPropertyChange_, this);
-
-  if (this.activeLayer_) {
-    // clean up listeners
-    os.ol.events.unlistenEach(this.layer, plugin.cesium.sync.TileSynchronizer.STYLE_KEYS_, this.onStyleChange_, this);
-    os.ol.events.unlistenEach(this.layer, plugin.cesium.sync.TileSynchronizer.RESOLUTION_KEYS_, this.onZoomChange_,
-        this);
-    ol.events.unlisten(this.layer, 'change:extent', this.synchronize, this);
-    ol.events.unlisten(this.layer, 'change', this.onChange_, this);
-
-    if (this.activeLayer_.imageryProvider instanceof plugin.cesium.ImageryProvider) {
-      this.activeLayer_.imageryProvider.dispose();
-    }
-
-    // remove layer from the scene and destroy it
-    this.cesiumLayers_.remove(this.activeLayer_, true);
-    this.activeLayer_ = null;
-
-    os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
-  }
-};
-
-
-/**
- * Creates Cesium layer cache based on a single OpenLayers tile layer to facilitate tile animation.
- *
- * @private
- */
-plugin.cesium.sync.TileSynchronizer.prototype.createCache_ = function() {
-  if (this.activeLayer_ && this.layer.getSource() instanceof ol.source.TileWMS) {
-    // hide the active layer and disable any events that would update it
-    this.activeLayer_.show = false;
-    os.ol.events.unlistenEach(this.layer, plugin.cesium.sync.TileSynchronizer.STYLE_KEYS_, this.onStyleChange_, this);
-    ol.events.unlisten(this.layer, 'change', this.onChange_, this);
-
-    // create the cache
-    this.updateAnimationCache_();
-
-    // update the layer cache when the style changes, or a change event is fired (ie, params/url changed). in the
-    // future we may have to clear the cache if something other than the TIME param changes (like user changes to
-    // the url) but currently there isn't a way to do that.
-    os.ol.events.listenEach(this.layer, plugin.cesium.sync.TileSynchronizer.STYLE_KEYS_, this.updateAnimationCache_,
-        this);
-    ol.events.listen(this.layer, 'change', this.updateAnimationCache_, this);
-  }
-};
-
-
-/**
- * Disposes of the Cesium tile layer cache.
- *
- * @private
- */
-plugin.cesium.sync.TileSynchronizer.prototype.disposeCache_ = function() {
-  // remove cache listeners
-  os.ol.events.unlistenEach(this.layer, plugin.cesium.sync.TileSynchronizer.STYLE_KEYS_, this.updateAnimationCache_,
-      this);
-  ol.events.unlisten(this.layer, 'change', this.updateAnimationCache_, this);
-
-  // destroy the cache
-  if (this.animationCache_) {
-    for (var key in this.animationCache_) {
-      this.cesiumLayers_.remove(this.animationCache_[key], true);
-
-      if (this.animationCache_[key].imageryProvider instanceof plugin.cesium.ImageryProvider) {
-        this.animationCache_[key].imageryProvider.dispose();
-      }
-
-      delete this.animationCache_[key];
-    }
-
-    this.animationCache_ = null;
-  }
-
-  // reactivate the active layer and its listeners. the show flag will be determined by layer visibility.
-  if (this.layer && this.activeLayer_) {
-    plugin.cesium.updateCesiumLayerProperties(this.layer, this.activeLayer_);
-    os.ol.events.listenEach(this.layer, plugin.cesium.sync.TileSynchronizer.STYLE_KEYS_, this.onStyleChange_, this);
-    ol.events.listen(this.layer, 'change', this.onChange_, this);
-  }
-};
-
-
-/**
- * Caches tile layers for the current timeline window and the tile boundary on either side of the window. Preloading
- * tiles makes them available to the GPU immediately so seamless transition between tiles is possible. While animating,
- * tile layers are cached for each tile boundary within the animation loop.
- *
- * @private
- */
-plugin.cesium.sync.TileSynchronizer.prototype.updateAnimationCache_ = function() {
-  var newCache = {};
-
-  // get the current layer from the cache and put it in the new cache
-  var timeParam = this.getTimeParameter_(0);
-  newCache[timeParam] = this.getCacheLayer_(timeParam, true);
-
-  // hide all of the other layers that aren't the current by setting their alpha to 0
-  // this.animationCache_ no longer contains the current layer as the call above removes it
-  if (this.animationCache_) {
-    for (var key in this.animationCache_) {
-      newCache[key] = this.animationCache_[key];
-      newCache[key].alpha = 0;
-    }
-  }
-
-  this.animationCache_ = newCache;
-  os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
-};
-
-
-/**
- * Creates a WMS TIME parameter based on the timeline controller's current start/end, offset by the provided number
- * of timeline durations (ie, day week month). This is a convenience function for creating tile boundaries around
- * the current time window.
- *
- * @param {number} offset The number of timeline durations (day, week, month, etc) to offset this range.
- * @return {string} WMS TIME parameter for the requested offset.
- * @private
- */
-plugin.cesium.sync.TileSynchronizer.prototype.getTimeParameter_ = function(offset) {
-  goog.asserts.assertInstanceof(this.layer, os.layer.AnimatedTile);
-
-  var dateFormat = this.layer.getDateFormat();
-  var timeFormat = this.layer.getTimeFormat();
-  var duration = this.tlc.getDuration();
-  var start = this.tlc.getCurrent() - this.tlc.getOffset();
-  var end = this.tlc.getCurrent();
-
-  return os.layer.AnimatedTile.getTimeParameter(dateFormat, timeFormat,
-      os.time.offset(new Date(start), duration, offset).getTime(),
-      os.time.offset(new Date(end), duration, offset).getTime(),
-      duration);
-};
-
-
-/**
- * Caches a layer for the given time and sets the visibility.
- *
- * @param {string} timeParam The TIME param for the layer.
- * @param {boolean} show If the layer should be shown.
- * @return {Cesium.ImageryLayer}
- * @private
- */
-plugin.cesium.sync.TileSynchronizer.prototype.getCacheLayer_ = function(timeParam, show) {
-  goog.asserts.assert(this.layer !== null);
-
-  var cesiumLayer = this.animationCache_ ? this.animationCache_[timeParam] : undefined;
-  if (!cesiumLayer) {
-    // layer doesn't exist, so create it and add it to the scene. insert it after the active layer.
-    var activePosition = this.cesiumLayers_.indexOf(this.activeLayer_);
-    cesiumLayer = this.getLayerByTime_(timeParam);
-    this.cesiumLayers_.add(cesiumLayer, activePosition + 1);
-  } else {
-    // layer already exists, so remove it from the current cache and return it
-    delete this.animationCache_[timeParam];
-  }
-
-  plugin.cesium.updateCesiumLayerProperties(this.layer, cesiumLayer);
-  cesiumLayer.alpha = show ? (this.layer.getOpacity() || 0) : 0;
-  return cesiumLayer;
-};
-
-
-/**
- * Creates a Cesium layer representing this synchronizer's layer with a custom time range. This is used when caching
- * multiple time ranges for animation.
- *
- * @param {string} timeParam Time to use for the WMS TIME parameter
- * @return {!Cesium.ImageryLayer} The Cesium imagery layer
- * @private
- * @suppress {accessControls}
- */
-plugin.cesium.sync.TileSynchronizer.prototype.getLayerByTime_ = function(timeParam) {
-  goog.asserts.assertInstanceof(this.layer, os.layer.AnimatedTile);
-  goog.asserts.assert(this.view !== null);
-
-  var originalSource = /** @type {ol.source.TileWMS} */ (this.layer.getSource());
-  goog.asserts.assertInstanceof(originalSource, ol.source.TileWMS);
-
-  var options = this.layer.getLayerOptions();
-  // just to be sure, make the ID different
-  options['id'] = goog.string.getRandomString();
-
-  var clone = /** @type {os.layer.Tile} */ (os.layer.createFromOptions(options));
-  var source = /** @type {ol.source.TileWMS} */ (clone.getSource());
-
-  // don't leak the layer and its ties to the source
-  clone.setSource(null);
-  clone.dispose();
-
-  var params = originalSource.getParams();
-  params['TIME'] = timeParam;
-  source.updateParams(params);
-
-  var provider = new plugin.cesium.ImageryProvider(source, null);
-  var cesiumLayer = new Cesium.ImageryLayer(provider);
-  return cesiumLayer;
-};
-
-
-/**
- * Update Cesium layer properties when the style changes.
- *
- * @param {ol.Object.Event} event
- * @private
- */
-plugin.cesium.sync.TileSynchronizer.prototype.onStyleChange_ = function(event) {
-  goog.asserts.assert(this.layer !== null);
-  goog.asserts.assert(this.activeLayer_ !== null);
-  plugin.cesium.updateCesiumLayerProperties(this.layer, this.activeLayer_);
-  this.onZoomChange_();
-};
-
-
-/**
- * Handle generic 'change' events on the tile layer.
- *
- * @param {ol.Object.Event} event
- * @private
- */
-plugin.cesium.sync.TileSynchronizer.prototype.onChange_ = function(event) {
-  // don't bother re-adding if the layer isn't shown. the change will take effect when the layer is shown again.
-  if (this.activeLayer_ && this.activeLayer_.show) {
-    // when the source changes, re-add the layer to force update
-    var activePosition = this.cesiumLayers_.indexOf(this.activeLayer_);
-    if (activePosition >= 0) {
-      this.cesiumLayers_.remove(this.activeLayer_, false);
-      this.cesiumLayers_.add(this.activeLayer_, activePosition);
-    }
-  }
-
-  os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
-};
-
-
-/**
- * Handle property change events on the layer.
- *
- * @param {os.events.PropertyChangeEvent} event
- * @private
- */
-plugin.cesium.sync.TileSynchronizer.prototype.onLayerPropertyChange_ = function(event) {
-  // ol3 also fires 'propertychange' events, so ignore those
-  if (event instanceof os.events.PropertyChangeEvent) {
-    var p = event.getProperty();
-    if (p == os.layer.PropertyChange.ANIMATION_ENABLED) {
-      // enable/disable the cache based on the animation state (fired when the timeline is opened/closed)
-      var enabled = /** @type {boolean} */ (event.getNewValue());
-      if (enabled) {
-        this.createCache_();
-      } else {
-        this.disposeCache_();
-      }
-    } else if (p == os.layer.PropertyChange.STYLE) {
-      this.synchronize();
-    }
-  }
-
-  os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
-};
+exports = TileSynchronizer;

--- a/src/plugin/cesium/sync/vectorsynchronizer.js
+++ b/src/plugin/cesium/sync/vectorsynchronizer.js
@@ -6,6 +6,8 @@ const objectUtils = goog.require('goog.object');
 const events = goog.require('ol.events');
 const OLVectorLayer = goog.require('ol.layer.Vector');
 const VectorEventType = goog.require('ol.source.VectorEventType');
+const dispatcher = goog.require('os.Dispatcher');
+const MapContainer = goog.require('os.MapContainer');
 const MapEvent = goog.require('os.MapEvent');
 const SelectionType = goog.require('os.events.SelectionType');
 const LayerPropertyChange = goog.require('os.layer.PropertyChange');
@@ -190,7 +192,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
       this.csContext.dispose();
       this.csContext = null;
 
-      os.dispatcher.dispatchEvent(MapEvent.GL_REPAINT);
+      dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
     }
   }
 
@@ -202,7 +204,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
   onLayerVisibility_(opt_event) {
     if (this.csContext && this.layer) {
       this.csContext.setVisibility(this.layer.getVisible());
-      os.dispatcher.dispatchEvent(MapEvent.GL_REPAINT);
+      dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
     }
   }
 
@@ -464,7 +466,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
           this.initializePrimitives_([feature]);
         }
 
-        os.dispatcher.dispatchEvent(MapEvent.GL_REPAINT);
+        dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
       }
     }
   }
@@ -509,7 +511,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
         this.updatePrimitiveVisibility_(feature, !!shown);
       }
 
-      os.dispatcher.dispatchEvent(MapEvent.GL_REPAINT);
+      dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
     }
   }
 
@@ -531,7 +533,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
         this.initializePrimitive(primitives[i], feature);
       }
 
-      os.dispatcher.dispatchEvent(MapEvent.GL_REPAINT);
+      dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
     } else {
       // primitive(s) haven't been created, so mark if they should be shown on creation. this typically happens when an
       // icon needs to be loaded prior to creating a billboard.
@@ -551,7 +553,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
 
     if (feature !== null && this.csContext) {
       this.csContext.cleanup(feature);
-      os.dispatcher.dispatchEvent(MapEvent.GL_REPAINT);
+      dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
     }
   }
 
@@ -619,7 +621,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
       }
     }
 
-    os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
+    dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
   }
 
 
@@ -650,7 +652,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
    * Update the eye offsets of all labels
    */
   updateLabelOffsets() {
-    const camera = os.MapContainer.getInstance().getWebGLCamera();
+    const camera = MapContainer.getInstance().getWebGLCamera();
     if (this.csContext && camera) {
       // Find the z-index step from the camera altitude
       const cameraDistance = camera.getDistanceToCenter();
@@ -685,7 +687,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
       }
     }
 
-    os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
+    dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
   }
 
 
@@ -695,7 +697,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
    * @private
    */
   setFeatureHighlight_(primitive, value) {
-    const camera = /** @type {Camera} */ (os.MapContainer.getInstance().getWebGLCamera());
+    const camera = /** @type {Camera} */ (MapContainer.getInstance().getWebGLCamera());
 
     if (primitive && primitive.eyeOffset) {
       if (value && camera) {
@@ -747,7 +749,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
    * Update the billboard offsets
    */
   updateBillboardOffsets() {
-    const camera = os.MapContainer.getInstance().getWebGLCamera();
+    const camera = MapContainer.getInstance().getWebGLCamera();
     if (camera) {
       // Find the z-index step from the camera altitude
       const cameraDistance = camera.getDistanceToCenter();
@@ -768,7 +770,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
   updateFromCamera() {
     this.updateLabelOffsets();
     this.updateBillboardOffsets();
-    os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
+    dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
   }
 }
 

--- a/src/plugin/cesium/sync/vectorsynchronizer.js
+++ b/src/plugin/cesium/sync/vectorsynchronizer.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.sync.VectorSynchronizer');
-goog.module.declareLegacyNamespace();
 
 const EventType = goog.require('goog.events.EventType');
 const objectUtils = goog.require('goog.object');
@@ -183,7 +182,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
       events.unlisten(this.source, EventType.PROPERTYCHANGE, this.onSourcePropertyChange_, this);
 
       // sources don't listen to these events (see above)
-      if (!(this.source instanceof os.source.Vector)) {
+      if (!(this.source instanceof VectorSource)) {
         events.unlisten(this.source, VectorEventType.ADDFEATURE, this.onAddFeature_, this);
         events.unlisten(this.source, VectorEventType.REMOVEFEATURE, this.onRemoveFeature_, this);
         events.unlisten(this.source, VectorEventType.CLEAR, this.clearFeatures_, this);
@@ -322,7 +321,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
       return;
     }
 
-    const source = /** @type {os.source.Vector} */ (this.source);
+    const source = /** @type {VectorSource} */ (this.source);
 
     let oldVal;
     let newVal;
@@ -366,7 +365,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
 
         break;
       case SourcePropertyChange.ALTITUDE:
-        if (this.source instanceof os.source.Vector) {
+        if (this.source instanceof VectorSource) {
           this.refreshFeatures_(source.getFeatures());
         }
         break;
@@ -461,7 +460,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
 
         // added to fix initial primitive.show state when the geometry changes on a feature
         // putting this in featureconverter causes ellipse flickers
-        if (this.source instanceof os.source.Vector &&
+        if (this.source instanceof VectorSource &&
             (!this.source.getTimeEnabled() || !this.source.getAnimationEnabled())) {
           this.initializePrimitives_([feature]);
         }
@@ -566,7 +565,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
    * @protected
    */
   shouldShowFeature(feature) {
-    if (this.source instanceof os.source.Vector) {
+    if (this.source instanceof VectorSource) {
       //
       // show the feature if:
       //  - it is not hidden
@@ -590,7 +589,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
    * @protected
    */
   initializePrimitive(primitive, feature) {
-    if (this.source instanceof os.source.Vector) {
+    if (this.source instanceof VectorSource) {
       const featureId = feature.getUid();
       this.csContext.featureToShownMap[featureId] = this.shouldShowFeature(feature);
       setPrimitiveShown(primitive, !!this.csContext.featureToShownMap[featureId]);
@@ -621,7 +620,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
       }
     }
 
-    dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
+    dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
   }
 
 
@@ -687,7 +686,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
       }
     }
 
-    dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
+    dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
   }
 
 
@@ -770,7 +769,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
   updateFromCamera() {
     this.updateLabelOffsets();
     this.updateBillboardOffsets();
-    dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
+    dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
   }
 }
 

--- a/src/plugin/cesium/sync/vectorsynchronizer.js
+++ b/src/plugin/cesium/sync/vectorsynchronizer.js
@@ -1,5 +1,6 @@
 goog.module('plugin.cesium.sync.VectorSynchronizer');
 
+const asserts = goog.require('goog.asserts');
 const EventType = goog.require('goog.events.EventType');
 const objectUtils = goog.require('goog.object');
 const events = goog.require('ol.events');
@@ -10,6 +11,7 @@ const MapContainer = goog.require('os.MapContainer');
 const MapEvent = goog.require('os.MapEvent');
 const SelectionType = goog.require('os.events.SelectionType');
 const LayerPropertyChange = goog.require('os.layer.PropertyChange');
+const VectorLayer = goog.require('os.layer.Vector');
 const SourcePropertyChange = goog.require('os.source.PropertyChange');
 const VectorSource = goog.require('os.source.Vector');
 const styleUtils = goog.require('os.style');
@@ -18,7 +20,11 @@ const {isPrimitiveShown, setPrimitiveShown} = goog.require('plugin.cesium.primit
 const CesiumSynchronizer = goog.require('plugin.cesium.sync.CesiumSynchronizer');
 const convert = goog.require('plugin.cesium.sync.convert');
 
+const GoogEvent = goog.requireType('goog.events.Event');
+const Feature = goog.requireType('ol.Feature');
+const OLObject = goog.requireType('ol.Object');
 const PluggableMap = goog.requireType('ol.PluggableMap');
+const View = goog.requireType('ol.View');
 const OLVectorSource = goog.requireType('ol.source.Vector');
 const PropertyChangeEvent = goog.requireType('os.events.PropertyChangeEvent');
 const Camera = goog.requireType('plugin.cesium.Camera');
@@ -110,8 +116,8 @@ class VectorSynchronizer extends CesiumSynchronizer {
    * @private
    */
   createLayerPrimitives_() {
-    goog.asserts.assertInstanceof(this.layer, OLVectorLayer);
-    goog.asserts.assert(this.view !== null);
+    asserts.assertInstanceof(this.layer, OLVectorLayer);
+    asserts.assert(this.view !== null);
 
     this.csContext = this.createVectorContext(this.layer, this.view);
     this.onLayerVisibility_();
@@ -139,8 +145,8 @@ class VectorSynchronizer extends CesiumSynchronizer {
   }
 
   /**
-   * @param {!ol.layer.Vector} layer
-   * @param {!ol.View} view
+   * @param {!OLVectorLayer} layer
+   * @param {!View} view
    * @return {!VectorContext}
    * @protected
    */
@@ -197,7 +203,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
 
 
   /**
-   * @param {ol.Object.Event=} opt_event
+   * @param {OLObject.Event=} opt_event
    * @private
    */
   onLayerVisibility_(opt_event) {
@@ -211,7 +217,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
   /**
    * Handle style changes to the layer, updating all features.
    *
-   * @param {goog.events.Event} event
+   * @param {GoogEvent} event
    * @private
    */
   onLayerOpacity_(event) {
@@ -228,11 +234,11 @@ class VectorSynchronizer extends CesiumSynchronizer {
    * @private
    */
   onLayerPropertyChange_(event) {
-    goog.asserts.assertInstanceof(this.layer, os.layer.Vector, 'not an os layer');
+    asserts.assertInstanceof(this.layer, VectorLayer, 'not an os layer');
 
     let p;
     try {
-      // openlayers' ol.ObjectEventType.PROPERTYCHANGE is the same as goog.events.EventType.PROPERTYCHANGE, so make sure
+      // openlayers' ObjectEventType.PROPERTYCHANGE is the same as goog.events.EventType.PROPERTYCHANGE, so make sure
       // the event is from us
       p = event.getProperty();
     } catch (e) {
@@ -240,7 +246,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
     }
 
     if (this.source && p && REFRESH_PROPERTIES[p]) {
-      const features = /** @type {Array<!ol.Feature>} */ (event.getNewValue() || this.source.getFeatures());
+      const features = /** @type {Array<!Feature>} */ (event.getNewValue() || this.source.getFeatures());
       this.refreshFeatures_(features);
     }
   }
@@ -249,12 +255,12 @@ class VectorSynchronizer extends CesiumSynchronizer {
   /**
    * Handle feature add event from the source.
    *
-   * @param {ol.source.Vector.Event} event
+   * @param {OLVectorSource.Event} event
    * @private
    */
   onAddFeature_(event) {
     const feature = event.feature;
-    goog.asserts.assert(feature != null);
+    asserts.assert(feature != null);
     this.addFeature(feature);
   }
 
@@ -262,12 +268,12 @@ class VectorSynchronizer extends CesiumSynchronizer {
   /**
    * Handle feature remove event from the source.
    *
-   * @param {ol.source.Vector.Event} event
+   * @param {OLVectorSource.Event} event
    * @private
    */
   onRemoveFeature_(event) {
     const feature = event.feature;
-    goog.asserts.assert(feature != null);
+    asserts.assert(feature != null);
     this.removeFeature(feature);
   }
 
@@ -275,12 +281,12 @@ class VectorSynchronizer extends CesiumSynchronizer {
   /**
    * Handle feature change event from the source.
    *
-   * @param {ol.source.Vector.Event} event
+   * @param {OLVectorSource.Event} event
    * @private
    */
   onChangeFeature_(event) {
     const feature = event.feature;
-    goog.asserts.assert(feature != null);
+    asserts.assert(feature != null);
     this.updateFeature_(feature);
   }
 
@@ -292,7 +298,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
    * @private
    */
   clearFeatures_(opt_event) {
-    goog.asserts.assert(this.csContext != null);
+    asserts.assert(this.csContext != null);
     objectUtils.forEach(this.csContext.featureToCesiumMap,
         /**
          * @param {Array<!Cesium.PrimitiveLike>|undefined} val
@@ -314,7 +320,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
   onSourcePropertyChange_(event) {
     let p;
     try {
-      // openlayers' ol.ObjectEventType.PROPERTYCHANGE is the same as goog.events.EventType.PROPERTYCHANGE, so make sure
+      // openlayers' ObjectEventType.PROPERTYCHANGE is the same as goog.events.EventType.PROPERTYCHANGE, so make sure
       // the event is from us
       p = event.getProperty();
     } catch (e) {
@@ -334,7 +340,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
         // primitive visibility below.
         if (!source.getTimeEnabled() || !source.getAnimationEnabled()) {
           // handle visibility toggled via the list tool or other means
-          const features = /** @type {Array<!ol.Feature>} */ (event.getNewValue());
+          const features = /** @type {Array<!Feature>} */ (event.getNewValue());
           if (features) {
             for (let i = 0, n = features.length; i < n; i++) {
               const feature = features[i];
@@ -346,10 +352,10 @@ class VectorSynchronizer extends CesiumSynchronizer {
           }
         }
         break;
-      case os.source.PropertyChange.ANIMATION_FRAME:
+      case SourcePropertyChange.ANIMATION_FRAME:
         // each frame fires a map of features that changed visibility
-        const toHide = /** @type {?Array<!ol.Feature>} */ (event.getOldValue());
-        const toShow = /** @type {?Array<!ol.Feature>} */ (event.getNewValue());
+        const toHide = /** @type {?Array<!Feature>} */ (event.getOldValue());
+        const toShow = /** @type {?Array<!Feature>} */ (event.getNewValue());
 
         if (toHide) {
           for (let i = 0, n = toHide.length; i < n; i++) {
@@ -376,7 +382,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
         break;
       case SourcePropertyChange.FEATURES:
         // handle new features added to the source
-        const added = /** @type {Array<!ol.Feature>} */ (event.getNewValue());
+        const added = /** @type {Array<!Feature>} */ (event.getNewValue());
         if (added) {
           for (let i = 0, n = added.length; i < n; i++) {
             this.addFeature(added[i]);
@@ -384,7 +390,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
         }
 
         // handle features removed from the source
-        const removed = /** @type {Array<!ol.Feature>} */ (event.getOldValue());
+        const removed = /** @type {Array<!Feature>} */ (event.getOldValue());
         if (removed) {
           for (let i = 0, n = removed.length; i < n; i++) {
             this.removeFeature(removed[i]);
@@ -394,12 +400,12 @@ class VectorSynchronizer extends CesiumSynchronizer {
         }
         break;
       case SourcePropertyChange.HIGHLIGHTED_ITEMS:
-        oldVal = /** @type {Array<!ol.Feature>} */ (event.getOldValue());
+        oldVal = /** @type {Array<!Feature>} */ (event.getOldValue());
         if (oldVal) {
           this.updateHighlightedItems_(oldVal, false);
         }
 
-        newVal = /** @type {Array<!ol.Feature>} */ (event.getNewValue());
+        newVal = /** @type {Array<!Feature>} */ (event.getNewValue());
         if (newVal) {
           this.updateHighlightedItems_(newVal, true);
         }
@@ -410,7 +416,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
         const shape = source.getGeometryShape();
         const isSelectedShape = shape.match(styleUtils.SELECTED_REGEXP);
 
-        let features = /** @type {Array<!ol.Feature>} */ (event.getNewValue());
+        let features = /** @type {Array<!Feature>} */ (event.getNewValue());
         if (isSelectedShape) {
           this.resetFeatures_(features);
         } else {
@@ -418,7 +424,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
         }
 
         if (p == SelectionType.CHANGED) {
-          features = /** @type {Array<!ol.Feature>} */ (event.getOldValue());
+          features = /** @type {Array<!Feature>} */ (event.getOldValue());
           if (isSelectedShape) {
             this.resetFeatures_(features);
           } else {
@@ -445,7 +451,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
   /**
    * Refreshes the Cesium primitive style for a set of features.
    *
-   * @param {!ol.Feature} feature The features to refresh
+   * @param {!Feature} feature The features to refresh
    * @private
    *
    * @suppress {accessControls} To allow checking if the feature exists on the source without a function call.
@@ -474,7 +480,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
   /**
    * Refreshes the Cesium primitive style for a set of features.
    *
-   * @param {Array<!ol.Feature>} features The features to refresh
+   * @param {Array<!Feature>} features The features to refresh
    * @private
    */
   refreshFeatures_(features) {
@@ -489,17 +495,17 @@ class VectorSynchronizer extends CesiumSynchronizer {
   /**
    * Removes and adds features so their Cesium objects are recreated.
    *
-   * @param {Array<ol.Feature>} features The features to reset
+   * @param {Array<Feature>} features The features to reset
    * @param {boolean=} opt_force If the reset should be forced
    * @private
    */
   resetFeatures_(features, opt_force) {
-    goog.asserts.assert(this.csContext !== null);
+    asserts.assert(this.csContext !== null);
 
     if (this.active || opt_force) {
       for (let i = 0, n = features.length; i < n; i++) {
         const feature = features[i];
-        goog.asserts.assert(feature !== null);
+        asserts.assert(feature !== null);
 
         const prims = this.csContext.featureToCesiumMap[feature.getUid()];
         const shown = prims && prims.length > 0 && isPrimitiveShown(prims[0]);
@@ -516,12 +522,12 @@ class VectorSynchronizer extends CesiumSynchronizer {
 
 
   /**
-   * @param {!ol.Feature} feature
+   * @param {!Feature} feature
    * @protected
    */
   addFeature(feature) {
-    goog.asserts.assert(this.view !== null);
-    goog.asserts.assert(this.csContext !== null);
+    asserts.assert(this.view !== null);
+    asserts.assert(this.csContext !== null);
 
     this.updateFeature_(feature);
 
@@ -542,7 +548,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
 
 
   /**
-   * @param {ol.Feature|number|string} feature Feature or feature id.
+   * @param {Feature|number|string} feature Feature or feature id.
    * @protected
    */
   removeFeature(feature) {
@@ -560,7 +566,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
   /**
    * Check if a feature is hidden on the source.
    *
-   * @param {!ol.Feature} feature The OpenLayers feature
+   * @param {!Feature} feature The OpenLayers feature
    * @return {boolean} If the feature is hidden on the source.
    * @protected
    */
@@ -585,7 +591,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
    * Performs initialization actions on a Cesium primitive.
    *
    * @param {!Cesium.PrimitiveLike} primitive The Cesium primitive
-   * @param {!ol.Feature} feature The OpenLayers feature
+   * @param {!Feature} feature The OpenLayers feature
    * @protected
    */
   initializePrimitive(primitive, feature) {
@@ -604,7 +610,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
   /**
    * Refreshes the Cesium primitive style for a set of features.
    *
-   * @param {Array<!ol.Feature>} features The features to refresh
+   * @param {Array<!Feature>} features The features to refresh
    * @private
    */
   initializePrimitives_(features) {
@@ -625,7 +631,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
 
 
   /**
-   * @param {Array<!ol.Feature>} features
+   * @param {Array<!Feature>} features
    * @param {boolean} value
    * @private
    */
@@ -663,7 +669,7 @@ class VectorSynchronizer extends CesiumSynchronizer {
 
 
   /**
-   * @param {!ol.Feature} feature The OpenLayers feature or feature id to update
+   * @param {!Feature} feature The OpenLayers feature or feature id to update
    * @param {boolean} shown If the feature is shown
    * @private
    */

--- a/src/plugin/cesium/terrainlayer.js
+++ b/src/plugin/cesium/terrainlayer.js
@@ -1,204 +1,203 @@
-goog.provide('plugin.cesium.TerrainLayer');
+goog.module('plugin.cesium.TerrainLayer');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.log');
-goog.require('os.data.LayerNode');
-goog.require('os.layer.LayerType');
-goog.require('os.structs.ITreeNodeSupplier');
-goog.require('os.ui.Icons');
 goog.require('plugin.basemap.terrainNodeUIDirective');
-goog.require('plugin.cesium.Layer');
+
+const dispatcher = goog.require('os.Dispatcher');
+const log = goog.require('goog.log');
+const MapEvent = goog.require('os.MapEvent');
+const LayerNode = goog.require('os.data.LayerNode');
+const LayerType = goog.require('os.layer.LayerType');
+const Icons = goog.require('os.ui.Icons');
+const {CESIUM_ONLY_LAYER} = goog.require('plugin.cesium');
+const Layer = goog.require('plugin.cesium.Layer');
+
+const ITreeNodeSupplier = goog.requireType('os.structs.ITreeNodeSupplier');
+
+
+/**
+ * The logger.
+ * @type {log.Logger}
+ */
+const logger = log.getLogger('plugin.cesium.TerrainLayer');
 
 
 /**
  * An OpenLayers layer that manages a Cesium terrain provider.
  *
- * @param {Cesium.TerrainProvider|undefined} provider The terrain provider.
- * @extends {plugin.cesium.Layer}
- * @implements {os.structs.ITreeNodeSupplier}
- * @constructor
+ * @implements {ITreeNodeSupplier}
  */
-plugin.cesium.TerrainLayer = function(provider) {
-  plugin.cesium.TerrainLayer.base(this, 'constructor');
+class TerrainLayer extends Layer {
+  /**
+   * Constructor.
+   * @param {Cesium.TerrainProvider|undefined} provider The terrain provider.
+   */
+  constructor(provider) {
+    super();
 
-  this.setOSType(plugin.cesium.CESIUM_ONLY_LAYER);
-  this.setIcons(os.ui.Icons.TERRAIN);
-  this.setExplicitType(os.layer.LayerType.TERRAIN);
-  this.setNodeUI('<terrainnodeui></terrainnodeui>');
-  this.log = plugin.cesium.TerrainLayer.LOGGER_;
+    this.setOSType(CESIUM_ONLY_LAYER);
+    this.setIcons(Icons.TERRAIN);
+    this.setExplicitType(LayerType.TERRAIN);
+    this.setNodeUI('<terrainnodeui></terrainnodeui>');
+    this.log = logger;
+
+    /**
+     * Cesium terrain provider.
+     * @type {Cesium.TerrainProvider|undefined}
+     * @private
+     */
+    this.terrainProvider_ = undefined;
+
+    /**
+     * If the terrain provider encountered an error.
+     * @type {boolean}
+     * @private
+     */
+    this.terrainError_ = false;
+
+    /**
+     * The original `requestTileGeometry` function for the terrain provider.
+     * @type {Cesium.RequestTileGeometryFn|undefined}
+     */
+    this.origRequestTileGeometry_ = undefined;
+
+    this.setTerrainProvider(provider);
+  }
 
   /**
-   * Cesium terrain provider.
-   * @type {Cesium.TerrainProvider|undefined}
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
+
+    this.setTerrainProvider(undefined);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getErrorMessage() {
+    var error = super.getErrorMessage();
+    if (!error) {
+      if (this.terrainError_) {
+        error = 'Terrain provider encountered an error, so terrain may not be displayed.';
+      } else if (!this.terrainProvider_) {
+        error = 'Terrain provider has not been configured.';
+      }
+    }
+
+    return error;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getTreeNode() {
+    var node = new LayerNode();
+    node.setLayer(this);
+    node.setCheckboxVisible(false);
+    return node;
+  }
+
+  /**
+   * Set the Cesium terrain provider managed by the layer.
+   *
+   * @param {Cesium.TerrainProvider|undefined} provider The terrain provider.
+   */
+  setTerrainProvider(provider) {
+    if (this.terrainProvider_) {
+      this.terrainProvider_.errorEvent.removeEventListener(this.onTerrainError_, this);
+
+      // restore the original requestTileGeometry function
+      if (this.origRequestTileGeometry_) {
+        this.terrainProvider_.requestTileGeometry = this.origRequestTileGeometry_;
+        this.origRequestTileGeometry_ = undefined;
+      }
+    }
+
+    this.terrainProvider_ = provider;
+
+    if (this.terrainProvider_) {
+      this.terrainProvider_.errorEvent.addEventListener(this.onTerrainError_, this);
+
+      // wrap requestTileGeometry to update loading state
+      this.origRequestTileGeometry_ = this.terrainProvider_.requestTileGeometry;
+      this.terrainProvider_.requestTileGeometry = this.requestTileGeometry_.bind(this);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  synchronize() {
+    super.synchronize();
+
+    if (!this.hasError()) {
+      var scene = this.getScene();
+      if (scene && this.terrainProvider_ && scene.terrainProvider != this.terrainProvider_) {
+        scene.terrainProvider = this.terrainProvider_;
+        dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
+      }
+    }
+  }
+
+  /**
+   * Wrap the terrain provider's `requestTileGeometry` to display loading status.
+   *
+   * @param {number} x The tile x value.
+   * @param {number} y The tile y value.
+   * @param {number} level The tile level.
+   * @param {Cesium.Request=} opt_request The Cesium request.
+   * @return {Cesium.Promise<Cesium.TerrainData>|undefined}
    * @private
    */
-  this.terrainProvider_ = undefined;
+  requestTileGeometry_(x, y, level, opt_request) {
+    if (this.origRequestTileGeometry_ && this.terrainProvider_) {
+      var promise = this.origRequestTileGeometry_.call(this.terrainProvider_, x, y, level, opt_request);
+      if (promise) {
+        this.incrementLoading();
+        promise.then(this.onTileSuccess_.bind(this), this.onTileError_.bind(this));
+      }
+
+      return promise;
+    }
+
+    return undefined;
+  }
 
   /**
-   * If the terrain provider encountered an error.
-   * @type {boolean}
+   * Handle error raised from a Cesium terrain provider.
+   *
+   * @param {Cesium.TileProviderError} error The tile provider error.
    * @private
    */
-  this.terrainError_ = false;
+  onTerrainError_(error) {
+    this.terrainError_ = true;
+    log.error(this.log, 'Terrain provider error: ' + error.message);
+    this.synchronize();
+  }
 
   /**
-   * The original `requestTileGeometry` function for the terrain provider.
-   * @type {Cesium.RequestTileGeometryFn|undefined}
+   * Handle successful tile load.
+   *
+   * @private
    */
-  this.origRequestTileGeometry_ = undefined;
-
-  this.setTerrainProvider(provider);
-};
-goog.inherits(plugin.cesium.TerrainLayer, plugin.cesium.Layer);
-
-
-/**
- * The logger.
- * @type {goog.log.Logger}
- * @private
- * @const
- */
-plugin.cesium.TerrainLayer.LOGGER_ = goog.log.getLogger('plugin.cesium.TerrainLayer');
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.TerrainLayer.prototype.disposeInternal = function() {
-  plugin.cesium.TerrainLayer.base(this, 'disposeInternal');
-
-  this.setTerrainProvider(undefined);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.TerrainLayer.prototype.getErrorMessage = function() {
-  var error = plugin.cesium.TerrainLayer.base(this, 'getErrorMessage');
-  if (!error) {
-    if (this.terrainError_) {
-      error = 'Terrain provider encountered an error, so terrain may not be displayed.';
-    } else if (!this.terrainProvider_) {
-      error = 'Terrain provider has not been configured.';
-    }
+  onTileSuccess_() {
+    this.terrainError_ = false;
+    this.decrementLoading();
+    this.synchronize();
   }
 
-  return error;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.TerrainLayer.prototype.getTreeNode = function() {
-  var node = new os.data.LayerNode();
-  node.setLayer(this);
-  node.setCheckboxVisible(false);
-  return node;
-};
-
-
-/**
- * Set the Cesium terrain provider managed by the layer.
- *
- * @param {Cesium.TerrainProvider|undefined} provider The terrain provider.
- */
-plugin.cesium.TerrainLayer.prototype.setTerrainProvider = function(provider) {
-  if (this.terrainProvider_) {
-    this.terrainProvider_.errorEvent.removeEventListener(this.onTerrainError_, this);
-
-    // restore the original requestTileGeometry function
-    if (this.origRequestTileGeometry_) {
-      this.terrainProvider_.requestTileGeometry = this.origRequestTileGeometry_;
-      this.origRequestTileGeometry_ = undefined;
-    }
+  /**
+   * Handle failed tile load.
+   *
+   * @private
+   */
+  onTileError_() {
+    this.terrainError_ = true;
+    this.decrementLoading();
+    this.synchronize();
   }
+}
 
-  this.terrainProvider_ = provider;
-
-  if (this.terrainProvider_) {
-    this.terrainProvider_.errorEvent.addEventListener(this.onTerrainError_, this);
-
-    // wrap requestTileGeometry to update loading state
-    this.origRequestTileGeometry_ = this.terrainProvider_.requestTileGeometry;
-    this.terrainProvider_.requestTileGeometry = this.requestTileGeometry_.bind(this);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.TerrainLayer.prototype.synchronize = function() {
-  plugin.cesium.TerrainLayer.base(this, 'synchronize');
-
-  if (!this.hasError()) {
-    var scene = this.getScene();
-    if (scene && this.terrainProvider_ && scene.terrainProvider != this.terrainProvider_) {
-      scene.terrainProvider = this.terrainProvider_;
-      os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
-    }
-  }
-};
-
-
-/**
- * Wrap the terrain provider's `requestTileGeometry` to display loading status.
- *
- * @param {number} x The tile x value.
- * @param {number} y The tile y value.
- * @param {number} level The tile level.
- * @param {Cesium.Request=} opt_request The Cesium request.
- * @return {Cesium.Promise<Cesium.TerrainData>|undefined}
- * @private
- */
-plugin.cesium.TerrainLayer.prototype.requestTileGeometry_ = function(x, y, level, opt_request) {
-  if (this.origRequestTileGeometry_ && this.terrainProvider_) {
-    var promise = this.origRequestTileGeometry_.call(this.terrainProvider_, x, y, level, opt_request);
-    if (promise) {
-      this.incrementLoading();
-      promise.then(this.onTileSuccess_.bind(this), this.onTileError_.bind(this));
-    }
-
-    return promise;
-  }
-
-  return undefined;
-};
-
-
-/**
- * Handle error raised from a Cesium terrain provider.
- *
- * @param {Cesium.TileProviderError} error The tile provider error.
- * @private
- */
-plugin.cesium.TerrainLayer.prototype.onTerrainError_ = function(error) {
-  this.terrainError_ = true;
-  goog.log.error(this.log, 'Terrain provider error: ' + error.message);
-  this.synchronize();
-};
-
-
-/**
- * Handle successful tile load.
- *
- * @private
- */
-plugin.cesium.TerrainLayer.prototype.onTileSuccess_ = function() {
-  this.terrainError_ = false;
-  this.decrementLoading();
-  this.synchronize();
-};
-
-
-/**
- * Handle failed tile load.
- *
- * @private
- */
-plugin.cesium.TerrainLayer.prototype.onTileError_ = function() {
-  this.terrainError_ = true;
-  this.decrementLoading();
-  this.synchronize();
-};
+exports = TerrainLayer;

--- a/src/plugin/cesium/terrainlayer.js
+++ b/src/plugin/cesium/terrainlayer.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.TerrainLayer');
-goog.module.declareLegacyNamespace();
 
 goog.require('plugin.basemap.terrainNodeUIDirective');
 

--- a/src/plugin/cesium/tilegridtilingscheme.js
+++ b/src/plugin/cesium/tilegridtilingscheme.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.TileGridTilingScheme');
-goog.module.declareLegacyNamespace();
 
 const geo = goog.require('os.geo');
 const asserts = goog.require('goog.asserts');

--- a/src/plugin/cesium/tilegridtilingscheme.js
+++ b/src/plugin/cesium/tilegridtilingscheme.js
@@ -1,10 +1,15 @@
 goog.module('plugin.cesium.TileGridTilingScheme');
 
+const ol = goog.require('ol');
+const {toSize} = goog.require('ol.size');
 const geo = goog.require('os.geo');
 const asserts = goog.require('goog.asserts');
 const olProj = goog.require('ol.proj');
 const map = goog.require('os.map');
 const osProj = goog.require('os.proj');
+
+const TileImageSource = goog.requireType('ol.source.TileImage');
+const TileGrid = goog.requireType('ol.tilegrid.TileGrid');
 
 
 /**
@@ -13,15 +18,15 @@ const osProj = goog.require('os.proj');
 class TileGridTilingScheme {
   /**
    * Constructor.
-   * @param {!ol.source.TileImage} source The source.
-   * @param {ol.tilegrid.TileGrid=} opt_tileGrid The tile grid. If not provided, the source's tile grid will be used.
+   * @param {!TileImageSource} source The source.
+   * @param {TileGrid=} opt_tileGrid The tile grid. If not provided, the source's tile grid will be used.
    */
   constructor(source, opt_tileGrid) {
     var tg = opt_tileGrid || source.getTileGrid();
     asserts.assert(tg);
 
     /**
-     * @type {!ol.tilegrid.TileGrid}
+     * @type {!TileGrid}
      * @private
      */
     this.tilegrid_ = tg;
@@ -194,7 +199,7 @@ class TileGridTilingScheme {
 
     var origin = this.tilegrid_.getOrigin(level);
     var resolution = this.tilegrid_.getResolution(level);
-    var tileSize = ol.size.toSize(this.tilegrid_.getTileSize(level), this.tilegrid_.tmpSize_);
+    var tileSize = toSize(this.tilegrid_.getTileSize(level), this.tilegrid_.tmpSize_);
 
     var x = ((coord[0] - origin[0]) / resolution) / tileSize[0];
     var y = ((origin[1] - coord[1]) / resolution) / tileSize[1];

--- a/src/plugin/cesium/tilegridtilingscheme.js
+++ b/src/plugin/cesium/tilegridtilingscheme.js
@@ -1,36 +1,25 @@
-goog.provide('plugin.cesium.TileGridTilingScheme');
+goog.module('plugin.cesium.TileGridTilingScheme');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
-goog.require('ol.proj');
-goog.require('os.geo');
-goog.require('os.map');
-goog.require('os.proj');
-
-
-/**
- * @param {!ol.source.TileImage} source The source.
- * @param {ol.tilegrid.TileGrid=} opt_tileGrid The tile grid. If not provided, the source's tile grid will be used.
- * @extends {Cesium.TilingScheme}
- * @constructor
- */
-plugin.cesium.TileGridTilingScheme = function(source, opt_tileGrid) {
-  throw new Error('TileGridTilingScheme created before initialization!');
-};
+const geo = goog.require('os.geo');
+const asserts = goog.require('goog.asserts');
+const olProj = goog.require('ol.proj');
+const map = goog.require('os.map');
+const osProj = goog.require('os.proj');
 
 
 /**
- * Initialize the class. This must be done asynchronously after Cesium has been loaded
+ * @implements {Cesium.TilingScheme}
  */
-plugin.cesium.TileGridTilingScheme.init = function() {
+class TileGridTilingScheme {
   /**
+   * Constructor.
    * @param {!ol.source.TileImage} source The source.
    * @param {ol.tilegrid.TileGrid=} opt_tileGrid The tile grid. If not provided, the source's tile grid will be used.
-   * @extends {Cesium.TilingScheme}
-   * @constructor
    */
-  plugin.cesium.TileGridTilingScheme = function(source, opt_tileGrid) {
+  constructor(source, opt_tileGrid) {
     var tg = opt_tileGrid || source.getTileGrid();
-    goog.asserts.assert(tg);
+    asserts.assert(tg);
 
     /**
      * @type {!ol.tilegrid.TileGrid}
@@ -38,10 +27,10 @@ plugin.cesium.TileGridTilingScheme.init = function() {
      */
     this.tilegrid_ = tg;
 
-    var proj = source.getProjection() || os.map.PROJECTION;
-    goog.asserts.assert(proj);
-    var isGeographic = ol.proj.equivalent(proj, ol.proj.get(os.proj.EPSG4326));
-    var isWebMercator = ol.proj.equivalent(proj, ol.proj.get(os.proj.EPSG3857));
+    var proj = source.getProjection() || map.PROJECTION;
+    asserts.assert(proj);
+    var isGeographic = olProj.equivalent(proj, olProj.get(osProj.EPSG4326));
+    var isWebMercator = olProj.equivalent(proj, olProj.get(osProj.EPSG3857));
 
     if (!isGeographic && !isWebMercator && !ol.ENABLE_RASTER_REPROJECTION) {
       throw new Error('Cesium only supports EPSG:4326 and EPSG:3857 projections');
@@ -60,14 +49,14 @@ plugin.cesium.TileGridTilingScheme.init = function() {
       new Cesium.WebMercatorProjection(this.ellipsoid_);
 
     /**
-     * @type {!ol.proj.Projection}
+     * @type {!olProj.Projection}
      * @private
      */
-    this.projection_ = /** @type {!ol.proj.Projection} */ (proj);
+    this.projection_ = /** @type {!olProj.Projection} */ (proj);
 
-    var extent = ol.proj.transformExtent(this.tilegrid_.getExtent(), this.projection_, os.proj.EPSG4326);
+    var extent = olProj.transformExtent(this.tilegrid_.getExtent(), this.projection_, osProj.EPSG4326);
     extent = extent.map(function(deg) {
-      return deg * os.geo.D2R;
+      return deg * geo.D2R;
     });
 
     /**
@@ -75,54 +64,34 @@ plugin.cesium.TileGridTilingScheme.init = function() {
      * @private
      */
     this.rectangle_ = new Cesium.Rectangle(extent[0], extent[1], extent[2], extent[3]);
-  };
-  goog.inherits(plugin.cesium.TileGridTilingScheme, Cesium.TilingScheme);
-
-  // after creating the class, ensure this function can still be called without consequence.
-  plugin.cesium.TileGridTilingScheme.init = goog.nullFunction;
-
-
-  Object.defineProperties(plugin.cesium.TileGridTilingScheme.prototype, {
-    'ellipsoid': {
-      get:
-        /**
-         * @return {!Cesium.Ellipsoid}
-         * @this plugin.cesium.TileGridTilingScheme
-         */
-        function() {
-          return this.ellipsoid_;
-        }
-    },
-
-    'rectangle': {
-      get:
-        /**
-         * @return {!Cesium.Rectangle} rectangle in radians covered by the tiling scheme
-         * @this plugin.cesium.TileGridTilingScheme
-         */
-        function() {
-          return this.rectangle_;
-        }
-    },
-
-    'projection': {
-      get:
-        /**
-         * @return {!(Cesium.GeographicProjection|Cesium.WebMercatorProjection)}
-         * @this plugin.cesium.TileGridTilingScheme
-         */
-        function() {
-          return this.cesiumProjection_;
-        }
-    }
-  });
-
+  }
 
   /**
    * @inheritDoc
-   * @suppress {accessControls}
    */
-  plugin.cesium.TileGridTilingScheme.prototype.getNumberOfXTilesAtLevel = function(level) {
+  get ellipsoid() {
+    return this.ellipsoid_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  get rectangle() {
+    return this.rectangle_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  get projection() {
+    return this.cesiumProjection_;
+  }
+
+  /**
+   * @inheritDoc
+   * @suppress {accessControls} To allow access to tilegrid private properties.
+   */
+  getNumberOfXTilesAtLevel(level) {
     var tileRange = this.tilegrid_.getFullTileRange(level);
     if (tileRange) {
       return tileRange.maxX - tileRange.minX + 1;
@@ -140,14 +109,13 @@ plugin.cesium.TileGridTilingScheme.init = function() {
     }
 
     return 0;
-  };
-
+  }
 
   /**
    * @inheritDoc
-   * @suppress {accessControls}
+   * @suppress {accessControls} To allow access to tilegrid private properties.
    */
-  plugin.cesium.TileGridTilingScheme.prototype.getNumberOfYTilesAtLevel = function(level) {
+  getNumberOfYTilesAtLevel(level) {
     var tileRange = this.tilegrid_.getFullTileRange(level);
     if (tileRange) {
       return tileRange.maxY - tileRange.minY + 1;
@@ -164,22 +132,21 @@ plugin.cesium.TileGridTilingScheme.init = function() {
     }
 
     return 0;
-  };
-
+  }
 
   /**
    * @inheritDoc
    */
-  plugin.cesium.TileGridTilingScheme.prototype.rectangleToNativeRectangle = function(rectangle, opt_result) {
-    goog.asserts.assert(rectangle);
+  rectangleToNativeRectangle(rectangle, opt_result) {
+    asserts.assert(rectangle);
 
     var extent = [
-      rectangle.west * os.geo.R2D,
-      rectangle.south * os.geo.R2D,
-      rectangle.east * os.geo.R2D,
-      rectangle.north * os.geo.R2D];
+      rectangle.west * geo.R2D,
+      rectangle.south * geo.R2D,
+      rectangle.east * geo.R2D,
+      rectangle.north * geo.R2D];
 
-    extent = ol.proj.transformExtent(extent, os.proj.EPSG4326, this.projection_);
+    extent = olProj.transformExtent(extent, osProj.EPSG4326, this.projection_);
 
     var result = opt_result || new Cesium.Rectangle();
     result.west = extent[0];
@@ -188,44 +155,43 @@ plugin.cesium.TileGridTilingScheme.init = function() {
     result.north = extent[3];
 
     return result;
-  };
+  }
 
   /**
    * @inheritDoc
    */
-  plugin.cesium.TileGridTilingScheme.prototype.tileXYToNativeRectangle = function(x, y, level, opt_result) {
+  tileXYToNativeRectangle(x, y, level, opt_result) {
     var rectangle = this.tileXYToRectangle(x, y, level, opt_result);
     return this.rectangleToNativeRectangle(rectangle, opt_result);
-  };
-
+  }
 
   /**
    * @inheritDoc
    */
-  plugin.cesium.TileGridTilingScheme.prototype.tileXYToRectangle = function(x, y, level, opt_result) {
+  tileXYToRectangle(x, y, level, opt_result) {
     var extent = this.tilegrid_.getTileCoordExtent([level, x, -y - 1]);
-    extent = ol.proj.transformExtent(extent, this.projection_, os.proj.EPSG4326);
+    extent = olProj.transformExtent(extent, this.projection_, osProj.EPSG4326);
 
     var result = opt_result || new Cesium.Rectangle();
-    result.west = extent[0] * os.geo.D2R;
-    result.south = extent[1] * os.geo.D2R;
-    result.east = extent[2] * os.geo.D2R;
-    result.north = extent[3] * os.geo.D2R;
+    result.west = extent[0] * geo.D2R;
+    result.south = extent[1] * geo.D2R;
+    result.east = extent[2] * geo.D2R;
+    result.north = extent[3] * geo.D2R;
 
     return result;
-  };
+  }
 
   /**
    * @inheritDoc
-   * @suppress {accessControls}
+   * @suppress {accessControls} To allow access to tilegrid private properties.
    */
-  plugin.cesium.TileGridTilingScheme.prototype.positionToTileXY = function(position, level, opt_result) {
+  positionToTileXY(position, level, opt_result) {
     if (!this.contains(position)) {
       // outside bounds of tiling scheme
       return undefined;
     }
 
-    var coord = ol.proj.fromLonLat([position.longitude * os.geo.R2D, position.latitude * os.geo.R2D], this.projection_);
+    var coord = olProj.fromLonLat([position.longitude * geo.R2D, position.latitude * geo.R2D], this.projection_);
 
     var origin = this.tilegrid_.getOrigin(level);
     var resolution = this.tilegrid_.getResolution(level);
@@ -239,13 +205,13 @@ plugin.cesium.TileGridTilingScheme.init = function() {
     result.y = Math.floor(y);
 
     return result;
-  };
+  }
 
   /**
    * @param {Cesium.Cartographic} position The lon/lat in radians
    * @return {boolean} Whether or not the position is within the tiling scheme
    */
-  plugin.cesium.TileGridTilingScheme.prototype.contains = function(position) {
+  contains(position) {
     var epsilon = 1E-12;
     var rectangle = this.rectangle_;
 
@@ -253,5 +219,7 @@ plugin.cesium.TileGridTilingScheme.init = function() {
         position.latitude - rectangle.south < -epsilon ||
         position.longitude - rectangle.west < -epsilon ||
         position.longitude - rectangle.east > epsilon);
-  };
-};
+  }
+}
+
+exports = TileGridTilingScheme;

--- a/src/plugin/cesium/tiles/cesium3dtilelayerui.js
+++ b/src/plugin/cesium/tiles/cesium3dtilelayerui.js
@@ -3,10 +3,16 @@ goog.module('plugin.cesium.tiles.Cesium3DTileLayerUI');
 goog.require('os.ui.sliderDirective');
 
 const {ROOT} = goog.require('os');
+const {toHexString} = goog.require('os.color');
 const LayerColor = goog.require('os.command.LayerColor');
 const osImplements = goog.require('os.implements');
+const IColorableLayer = goog.require('os.layer.IColorableLayer');
 const Module = goog.require('os.ui.Module');
 const DefaultLayerUICtrl = goog.require('os.ui.layer.DefaultLayerUICtrl');
+
+const ICommand = goog.requireType('os.command.ICommand');
+const LayerNode = goog.requireType('os.data.LayerNode');
+const ILayer = goog.requireType('os.layer.ILayer');
 
 
 /**
@@ -74,15 +80,15 @@ class Controller extends DefaultLayerUICtrl {
    * @private
    */
   getColor_() {
-    var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+    var items = /** @type {Array<!LayerNode>} */ (this.scope['items']);
 
     if (items) {
       for (var i = 0, n = items.length; i < n; i++) {
         try {
           var layer = items[i].getLayer();
-          if (osImplements(layer, os.layer.IColorableLayer.ID)) {
-            var color = /** @type {os.layer.IColorableLayer} */ (layer).getColor();
-            return color ? os.color.toHexString(color) : color;
+          if (osImplements(layer, IColorableLayer.ID)) {
+            var color = /** @type {IColorableLayer} */ (layer).getColor();
+            return color ? toHexString(color) : color;
           }
         } catch (e) {
         }
@@ -102,8 +108,8 @@ class Controller extends DefaultLayerUICtrl {
   onColorChange(event, value) {
     var fn =
         /**
-         * @param {os.layer.ILayer} layer
-         * @return {os.command.ICommand}
+         * @param {ILayer} layer
+         * @return {ICommand}
          */
         function(layer) {
           return new LayerColor(layer.getId(), value);

--- a/src/plugin/cesium/tiles/cesium3dtilelayerui.js
+++ b/src/plugin/cesium/tiles/cesium3dtilelayerui.js
@@ -1,13 +1,12 @@
-goog.provide('plugin.cesium.tiles.Cesium3DTileLayerUICtrl');
-goog.provide('plugin.cesium.tiles.cesium3DTileLayerUIDirective');
+goog.module('plugin.cesium.tiles.Cesium3DTileLayerUI');
 
-goog.require('os');
-goog.require('os.command.LayerColor');
-goog.require('os.implements');
-goog.require('os.ui.Module');
-goog.require('os.ui.layer');
-goog.require('os.ui.layer.DefaultLayerUICtrl');
 goog.require('os.ui.sliderDirective');
+
+const os = goog.require('os');
+const LayerColor = goog.require('os.command.LayerColor');
+const osImplements = goog.require('os.implements');
+const Module = goog.require('os.ui.Module');
+const DefaultLayerUICtrl = goog.require('os.ui.layer.DefaultLayerUICtrl');
 
 
 /**
@@ -15,112 +14,121 @@ goog.require('os.ui.sliderDirective');
  *
  * @return {angular.Directive}
  */
-plugin.cesium.tiles.cesium3DTileLayerUIDirective = function() {
-  return {
-    restrict: 'AE',
-    replace: true,
-    templateUrl: os.ROOT + 'views/plugin/cesium/cesium3dtile.html',
-    controller: plugin.cesium.tiles.Cesium3DTileLayerUICtrl,
-    controllerAs: 'ctrl'
-  };
-};
+const directive = () => ({
+  restrict: 'AE',
+  replace: true,
+  templateUrl: os.ROOT + 'views/plugin/cesium/cesium3dtile.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'cesium3dtilelayerui';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('cesium3dtilelayerui', [plugin.cesium.tiles.cesium3DTileLayerUIDirective]);
+Module.directive(directiveTag, [directive]);
 
 
 
 /**
  * Controller for the Cesium 3D tile layer UI.
- *
- * @param {!angular.Scope} $scope The Angular scope.
- * @param {!angular.JQLite} $element The root DOM element.
- * @param {!angular.$timeout} $timeout The Angular $timeout service.
- * @extends {os.ui.layer.DefaultLayerUICtrl}
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.cesium.tiles.Cesium3DTileLayerUICtrl = function($scope, $element, $timeout) {
-  plugin.cesium.tiles.Cesium3DTileLayerUICtrl.base(this, 'constructor', $scope, $element, $timeout);
+class Controller extends DefaultLayerUICtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope The Angular scope.
+   * @param {!angular.JQLite} $element The root DOM element.
+   * @param {!angular.$timeout} $timeout The Angular $timeout service.
+   * @ngInject
+   */
+  constructor($scope, $element, $timeout) {
+    super($scope, $element, $timeout);
 
-  $scope.$on('color.change', this.onColorChange.bind(this));
-  $scope.$on('color.reset', this.onColorReset.bind(this));
-};
-goog.inherits(plugin.cesium.tiles.Cesium3DTileLayerUICtrl, os.ui.layer.DefaultLayerUICtrl);
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Cesium3DTileLayerUICtrl.prototype.initUI = function() {
-  plugin.cesium.tiles.Cesium3DTileLayerUICtrl.base(this, 'initUI');
-
-  if (this.scope) {
-    this.scope['color'] = this.getColor_();
+    $scope.$on('color.change', this.onColorChange.bind(this));
+    $scope.$on('color.reset', this.onColorReset.bind(this));
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  initUI() {
+    super.initUI();
 
-/**
- * Gets the color from the item(s)
- *
- * @return {?string} a hex color string
- * @private
- */
-plugin.cesium.tiles.Cesium3DTileLayerUICtrl.prototype.getColor_ = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
-
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      try {
-        var layer = items[i].getLayer();
-        if (os.implements(layer, os.layer.IColorableLayer.ID)) {
-          var color = /** @type {os.layer.IColorableLayer} */ (layer).getColor();
-          return color ? os.color.toHexString(color) : color;
-        }
-      } catch (e) {
-      }
+    if (this.scope) {
+      this.scope['color'] = this.getColor_();
     }
   }
 
-  return null;
-};
+  /**
+   * Gets the color from the item(s)
+   *
+   * @return {?string} a hex color string
+   * @private
+   */
+  getColor_() {
+    var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
 
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        try {
+          var layer = items[i].getLayer();
+          if (osImplements(layer, os.layer.IColorableLayer.ID)) {
+            var color = /** @type {os.layer.IColorableLayer} */ (layer).getColor();
+            return color ? os.color.toHexString(color) : color;
+          }
+        } catch (e) {
+        }
+      }
+    }
 
-/**
- * Handles changes to color
- *
- * @param {angular.Scope.Event} event
- * @param {string} value
- * @protected
- */
-plugin.cesium.tiles.Cesium3DTileLayerUICtrl.prototype.onColorChange = function(event, value) {
-  var fn =
-      /**
-       * @param {os.layer.ILayer} layer
-       * @return {os.command.ICommand}
-       */
-      function(layer) {
-        return new os.command.LayerColor(layer.getId(), value);
-      };
+    return null;
+  }
 
-  this.createCommand(fn);
-};
+  /**
+   * Handles changes to color
+   *
+   * @param {angular.Scope.Event} event
+   * @param {string} value
+   * @protected
+   */
+  onColorChange(event, value) {
+    var fn =
+        /**
+         * @param {os.layer.ILayer} layer
+         * @return {os.command.ICommand}
+         */
+        function(layer) {
+          return new LayerColor(layer.getId(), value);
+        };
 
+    this.createCommand(fn);
+  }
 
-/**
- * Handles color reset
- *
- * @param {angular.Scope.Event} event
- * @protected
- */
-plugin.cesium.tiles.Cesium3DTileLayerUICtrl.prototype.onColorReset = function(event) {
-  // clear the label color config value
-  this.onColorChange(event, '');
+  /**
+   * Handles color reset
+   *
+   * @param {angular.Scope.Event} event
+   * @protected
+   */
+  onColorReset(event) {
+    // clear the label color config value
+    this.onColorChange(event, '');
 
-  // reset to the layer color
-  this.scope['color'] = this.getColor_();
+    // reset to the layer color
+    this.scope['color'] = this.getColor_();
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/cesium/tiles/cesium3dtilelayerui.js
+++ b/src/plugin/cesium/tiles/cesium3dtilelayerui.js
@@ -2,7 +2,7 @@ goog.module('plugin.cesium.tiles.Cesium3DTileLayerUI');
 
 goog.require('os.ui.sliderDirective');
 
-const os = goog.require('os');
+const {ROOT} = goog.require('os');
 const LayerColor = goog.require('os.command.LayerColor');
 const osImplements = goog.require('os.implements');
 const Module = goog.require('os.ui.Module');
@@ -17,7 +17,7 @@ const DefaultLayerUICtrl = goog.require('os.ui.layer.DefaultLayerUICtrl');
 const directive = () => ({
   restrict: 'AE',
   replace: true,
-  templateUrl: os.ROOT + 'views/plugin/cesium/cesium3dtile.html',
+  templateUrl: ROOT + 'views/plugin/cesium/cesium3dtile.html',
   controller: Controller,
   controllerAs: 'ctrl'
 });

--- a/src/plugin/cesium/tiles/cesium3dtiles.js
+++ b/src/plugin/cesium/tiles/cesium3dtiles.js
@@ -1,25 +1,26 @@
-goog.provide('plugin.cesium.tiles');
+goog.module('plugin.cesium.tiles');
 
 
 /**
  * ID for Cesium 3D tile objects.
  * @type {string}
- * @const
  */
-plugin.cesium.tiles.ID = '3dtiles';
-
+const ID = '3dtiles';
 
 /**
  * Type for Cesium 3D tile objects.
  * @type {string}
- * @const
  */
-plugin.cesium.tiles.TYPE = '3D Tiles';
-
+const TYPE = '3D Tiles';
 
 /**
  * Type for Cesium 3D tile objects.
  * @type {string}
- * @const
  */
-plugin.cesium.tiles.ICON = '<i class="fa fa-cubes" title="3D tile layer"></i>';
+const ICON = '<i class="fa fa-cubes" title="3D tile layer"></i>';
+
+exports = {
+  ID,
+  TYPE,
+  ICON
+};

--- a/src/plugin/cesium/tiles/cesium3dtilesdescriptor.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesdescriptor.js
@@ -1,164 +1,164 @@
-goog.provide('plugin.cesium.tiles.Descriptor');
+goog.module('plugin.cesium.tiles.Descriptor');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.FileDescriptor');
-goog.require('plugin.cesium');
-goog.require('plugin.cesium.tiles');
-goog.require('plugin.cesium.tiles.Provider');
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const ColorControlType = goog.require('os.ui.ColorControlType');
+const ControlType = goog.require('os.ui.ControlType');
+const cesium = goog.require('plugin.cesium');
+const {ID, ICON} = goog.require('plugin.cesium.tiles');
+const Provider = goog.require('plugin.cesium.tiles.Provider');
+
+const FileParserConfig = goog.requireType('os.parse.FileParserConfig');
 
 
 /**
  * Cesium 3D tiles descriptor.
- *
- * @extends {os.data.FileDescriptor}
- * @constructor
  */
-plugin.cesium.tiles.Descriptor = function() {
-  plugin.cesium.tiles.Descriptor.base(this, 'constructor');
-  this.descriptorType = plugin.cesium.tiles.ID;
+class Descriptor extends FileDescriptor {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.descriptorType = ID;
+
+    /**
+     * Cesium Ion asset id.
+     * @type {number}
+     * @protected
+     */
+    this.assetId = NaN;
+
+    /**
+     * Cesium Ion access token.
+     * @type {string}
+     * @protected
+     */
+    this.accessToken = '';
+
+    /**
+     * Cesium 3D tiles style.
+     * @type {Object|string}
+     * @protected
+     */
+    this.tileStyle = null;
+
+    /**
+     * If Cesium World Terrain should be activated with this layer.
+     * @type {boolean}
+     * @protected
+     */
+    this.useWorldTerrain = false;
+  }
 
   /**
-   * Cesium Ion asset id.
-   * @type {number}
-   * @protected
+   * @inheritDoc
    */
-  this.assetId = NaN;
+  getIcons() {
+    return ICON;
+  }
 
   /**
-   * Cesium Ion access token.
-   * @type {string}
-   * @protected
+   * @inheritDoc
    */
-  this.accessToken = '';
+  getLayerOptions() {
+    var options = super.getLayerOptions();
+    options['type'] = ID;
+
+    // allow resetting the layer color to the default
+    options[ControlType.COLOR] = ColorControlType.PICKER_RESET;
+
+    // add Ion config
+    if (!isNaN(this.assetId)) {
+      options['assetId'] = this.assetId;
+      options['accessToken'] = this.accessToken;
+    }
+
+    if (this.tileStyle) {
+      options['tileStyle'] = this.tileStyle;
+    }
+
+    options['useWorldTerrain'] = this.useWorldTerrain;
+
+    return options;
+  }
 
   /**
-   * Cesium 3D tiles style.
-   * @type {Object|string}
-   * @protected
+   * Set the Ion asset configuration.
+   *
+   * @param {number} assetId The asset id.
+   * @param {string=} opt_accessToken The access token.
    */
-  this.tileStyle = null;
+  setIonConfig(assetId, opt_accessToken) {
+    this.assetId = assetId;
+
+    if (opt_accessToken) {
+      this.accessToken = opt_accessToken;
+    }
+
+    // set a URL so the descriptor gets persisted
+    this.setUrl(cesium.getIonUrl());
+  }
 
   /**
-   * If Cesium World Terrain should be activated with this layer.
-   * @type {boolean}
-   * @protected
+   * @inheritDoc
    */
-  this.useWorldTerrain = false;
-};
-goog.inherits(plugin.cesium.tiles.Descriptor, os.data.FileDescriptor);
+  persist(opt_obj) {
+    var obj = super.persist(opt_obj);
+    obj['assetId'] = this.assetId;
+    obj['accessToken'] = this.accessToken;
 
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Descriptor.prototype.getIcons = function() {
-  return plugin.cesium.tiles.ICON;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Descriptor.prototype.getLayerOptions = function() {
-  var options = plugin.cesium.tiles.Descriptor.base(this, 'getLayerOptions');
-  options['type'] = plugin.cesium.tiles.ID;
-
-  // allow resetting the layer color to the default
-  options[os.ui.ControlType.COLOR] = os.ui.ColorControlType.PICKER_RESET;
-
-  // add Ion config
-  if (!isNaN(this.assetId)) {
-    options['assetId'] = this.assetId;
-    options['accessToken'] = this.accessToken;
+    return obj;
   }
 
-  if (this.tileStyle) {
-    options['tileStyle'] = this.tileStyle;
+  /**
+   * @inheritDoc
+   */
+  restore(conf) {
+    if (typeof conf['assetId'] == 'number') {
+      this.assetId = /** @type {number} */ (conf['assetId']);
+    }
+
+    if (conf['accessToken']) {
+      this.accessToken = /** @type {string} */ (conf['accessToken']);
+    }
+
+    super.restore(conf);
   }
 
-  options['useWorldTerrain'] = this.useWorldTerrain;
+  /**
+   * @inheritDoc
+   */
+  updateFromConfig(config, opt_useConfigForParser) {
+    super.updateFromConfig(config, true);
 
-  return options;
-};
+    if (typeof config['assetId'] == 'number') {
+      this.setIonConfig(
+          /** @type {number} */ (config['assetId']),
+          /** @type {string|undefined} */ (config['accessToken']));
+    }
 
+    if (config['tileStyle'] != null) {
+      this.tileStyle = /** @type {Object|string} */ (config['tileStyle']);
+    }
 
-/**
- * Set the Ion asset configuration.
- *
- * @param {number} assetId The asset id.
- * @param {string=} opt_accessToken The access token.
- */
-plugin.cesium.tiles.Descriptor.prototype.setIonConfig = function(assetId, opt_accessToken) {
-  this.assetId = assetId;
-
-  if (opt_accessToken) {
-    this.accessToken = opt_accessToken;
+    if (config['useWorldTerrain'] != null) {
+      this.useWorldTerrain = !!config['useWorldTerrain'];
+    }
   }
 
-  // set a URL so the descriptor gets persisted
-  this.setUrl(plugin.cesium.ionUrl);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Descriptor.prototype.persist = function(opt_obj) {
-  var obj = plugin.cesium.tiles.Descriptor.base(this, 'persist', opt_obj);
-  obj['assetId'] = this.assetId;
-  obj['accessToken'] = this.accessToken;
-
-  return obj;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Descriptor.prototype.restore = function(conf) {
-  if (typeof conf['assetId'] == 'number') {
-    this.assetId = /** @type {number} */ (conf['assetId']);
+  /**
+   * Creates a new descriptor from a parser configuration.
+   *
+   * @param {!Object} config
+   * @return {!Descriptor}
+   */
+  static create(config) {
+    var descriptor = new Descriptor();
+    var provider = Provider.getInstance();
+    FileDescriptor.createFromConfig(descriptor, provider, /** @type {!FileParserConfig} */ (config));
+    return descriptor;
   }
+}
 
-  if (conf['accessToken']) {
-    this.accessToken = /** @type {string} */ (conf['accessToken']);
-  }
-
-  plugin.cesium.tiles.Descriptor.base(this, 'restore', conf);
-};
-
-
-/**
- * Creates a new descriptor from a parser configuration.
- *
- * @param {!Object} config
- * @return {!plugin.cesium.tiles.Descriptor}
- */
-plugin.cesium.tiles.Descriptor.createFromConfig = function(config) {
-  var descriptor = new plugin.cesium.tiles.Descriptor();
-  var provider = plugin.cesium.tiles.Provider.getInstance();
-  os.data.FileDescriptor.createFromConfig(descriptor, provider, /** @type {!os.parse.FileParserConfig} */ (config));
-  return descriptor;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Descriptor.prototype.updateFromConfig = function(config, opt_useConfigForParser) {
-  plugin.cesium.tiles.Descriptor.base(this, 'updateFromConfig',
-      /** @type {!os.parse.FileParserConfig} */ (config), true);
-
-  if (typeof config['assetId'] == 'number') {
-    this.setIonConfig(
-        /** @type {number} */ (config['assetId']),
-        /** @type {string|undefined} */ (config['accessToken']));
-  }
-
-  if (config['tileStyle'] != null) {
-    this.tileStyle = /** @type {Object|string} */ (config['tileStyle']);
-  }
-
-  if (config['useWorldTerrain'] != null) {
-    this.useWorldTerrain = !!config['useWorldTerrain'];
-  }
-};
+exports = Descriptor;

--- a/src/plugin/cesium/tiles/cesium3dtilesdescriptor.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesdescriptor.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.tiles.Descriptor');
-goog.module.declareLegacyNamespace();
 
 const FileDescriptor = goog.require('os.data.FileDescriptor');
 const ColorControlType = goog.require('os.ui.ColorControlType');

--- a/src/plugin/cesium/tiles/cesium3dtilesimport.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesimport.js
@@ -6,6 +6,8 @@ const AbstractFileImportCtrl = goog.require('os.ui.file.ui.AbstractFileImportCtr
 const Descriptor = goog.require('plugin.cesium.tiles.Descriptor');
 const Provider = goog.require('plugin.cesium.tiles.Provider');
 
+const FileParserConfig = goog.requireType('os.parse.FileParserConfig');
+
 
 /**
  * The 3D tiles import directive
@@ -61,7 +63,7 @@ class Controller extends AbstractFileImportCtrl {
     if (this.config['descriptor']) {
       // existing descriptor, update it
       descriptor = /** @type {!Descriptor} */ (this.config['descriptor']);
-      descriptor.updateFromConfig(/** @type {!os.parse.FileParserConfig} */ (this.config));
+      descriptor.updateFromConfig(/** @type {!FileParserConfig} */ (this.config));
     } else {
       // this is a new import
       descriptor = Descriptor.create(this.config);

--- a/src/plugin/cesium/tiles/cesium3dtilesimport.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesimport.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.tiles.TilesetImport');
-goog.module.declareLegacyNamespace();
 
 const os = goog.require('os');
 const Module = goog.require('os.ui.Module');

--- a/src/plugin/cesium/tiles/cesium3dtilesimport.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesimport.js
@@ -1,6 +1,6 @@
 goog.module('plugin.cesium.tiles.TilesetImport');
 
-const os = goog.require('os');
+const {ROOT} = goog.require('os');
 const Module = goog.require('os.ui.Module');
 const AbstractFileImportCtrl = goog.require('os.ui.file.ui.AbstractFileImportCtrl');
 const Descriptor = goog.require('plugin.cesium.tiles.Descriptor');
@@ -16,7 +16,7 @@ const directive = () => ({
   restrict: 'E',
   replace: true,
   scope: true,
-  templateUrl: os.ROOT + 'views/file/genericfileimport.html',
+  templateUrl: ROOT + 'views/file/genericfileimport.html',
   controller: Controller,
   controllerAs: 'ctrl'
 });

--- a/src/plugin/cesium/tiles/cesium3dtilesimport.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesimport.js
@@ -1,11 +1,11 @@
-goog.provide('plugin.cesium.tiles.TilesetImportCtrl');
-goog.provide('plugin.cesium.tiles.tilesetImportDirective');
+goog.module('plugin.cesium.tiles.TilesetImport');
+goog.module.declareLegacyNamespace();
 
-goog.require('os');
-goog.require('os.ui.Module');
-goog.require('os.ui.file.ui.AbstractFileImportCtrl');
-goog.require('plugin.cesium.tiles.Descriptor');
-goog.require('plugin.cesium.tiles.Provider');
+const os = goog.require('os');
+const Module = goog.require('os.ui.Module');
+const AbstractFileImportCtrl = goog.require('os.ui.file.ui.AbstractFileImportCtrl');
+const Descriptor = goog.require('plugin.cesium.tiles.Descriptor');
+const Provider = goog.require('plugin.cesium.tiles.Provider');
 
 
 /**
@@ -13,61 +13,74 @@ goog.require('plugin.cesium.tiles.Provider');
  *
  * @return {angular.Directive}
  */
-plugin.cesium.tiles.tilesetImportDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    scope: true,
-    templateUrl: os.ROOT + 'views/file/genericfileimport.html',
-    controller: plugin.cesium.tiles.TilesetImportCtrl,
-    controllerAs: 'ctrl'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  scope: true,
+  templateUrl: os.ROOT + 'views/file/genericfileimport.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'tilesetimport';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('tilesetimport', [plugin.cesium.tiles.tilesetImportDirective]);
+Module.directive(directiveTag, [directive]);
 
 
 
 /**
  * Controller for the 3D tiles import dialog
  *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @extends {os.ui.file.ui.AbstractFileImportCtrl<!Object,!plugin.cesium.tiles.Descriptor>}
- * @constructor
- * @ngInject
+ * @extends {AbstractFileImportCtrl<!Object,!Descriptor>}
+ * @unrestricted
  */
-plugin.cesium.tiles.TilesetImportCtrl = function($scope, $element) {
-  plugin.cesium.tiles.TilesetImportCtrl.base(this, 'constructor', $scope, $element);
-};
-goog.inherits(plugin.cesium.tiles.TilesetImportCtrl, os.ui.file.ui.AbstractFileImportCtrl);
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.TilesetImportCtrl.prototype.createDescriptor = function() {
-  var descriptor = null;
-  if (this.config['descriptor']) {
-    // existing descriptor, update it
-    descriptor = /** @type {!plugin.cesium.tiles.Descriptor} */ (this.config['descriptor']);
-    descriptor.updateFromConfig(/** @type {!os.parse.FileParserConfig} */ (this.config));
-  } else {
-    // this is a new import
-    descriptor = plugin.cesium.tiles.Descriptor.createFromConfig(this.config);
+class Controller extends AbstractFileImportCtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    super($scope, $element);
   }
 
-  return descriptor;
-};
+  /**
+   * @inheritDoc
+   */
+  createDescriptor() {
+    var descriptor = null;
+    if (this.config['descriptor']) {
+      // existing descriptor, update it
+      descriptor = /** @type {!Descriptor} */ (this.config['descriptor']);
+      descriptor.updateFromConfig(/** @type {!os.parse.FileParserConfig} */ (this.config));
+    } else {
+      // this is a new import
+      descriptor = Descriptor.create(this.config);
+    }
 
+    return descriptor;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.TilesetImportCtrl.prototype.getProvider = function() {
-  return plugin.cesium.tiles.Provider.getInstance();
+  /**
+   * @inheritDoc
+   */
+  getProvider() {
+    return Provider.getInstance();
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/cesium/tiles/cesium3dtilesimportui.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesimportui.js
@@ -1,10 +1,9 @@
 goog.module('plugin.cesium.tiles.TilesetImportUI');
-goog.module.declareLegacyNamespace();
 
 const {directiveTag} = goog.require('plugin.cesium.tiles.TilesetImport');
 const FileImportUI = goog.require('os.ui.im.FileImportUI');
-const window = goog.require('os.ui.window');
-const tiles = goog.require('plugin.cesium.tiles');
+const osWindow = goog.require('os.ui.window');
+const {TYPE} = goog.require('plugin.cesium.tiles');
 
 
 /**
@@ -24,7 +23,7 @@ class TilesetImportUI extends FileImportUI {
    * @inheritDoc
    */
   getTitle() {
-    return tiles.TYPE;
+    return TYPE;
   }
 
   /**
@@ -45,7 +44,7 @@ class TilesetImportUI extends FileImportUI {
       'config': config
     };
     var windowOptions = {
-      'label': 'Import ' + tiles.TYPE,
+      'label': 'Import ' + TYPE,
       'icon': 'fa fa-sign-in',
       'x': 'center',
       'y': 'center',
@@ -57,7 +56,7 @@ class TilesetImportUI extends FileImportUI {
       'show-close': true
     };
     var template = `<${directiveTag}></${directiveTag}>`;
-    window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+    osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
   }
 }
 

--- a/src/plugin/cesium/tiles/cesium3dtilesimportui.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesimportui.js
@@ -1,61 +1,64 @@
-goog.provide('plugin.cesium.tiles.TilesetImportUI');
+goog.module('plugin.cesium.tiles.TilesetImportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.ui.im.FileImportUI');
-goog.require('os.ui.window');
-goog.require('plugin.cesium.tiles');
-goog.require('plugin.cesium.tiles.tilesetImportDirective');
-
+const {directiveTag} = goog.require('plugin.cesium.tiles.TilesetImport');
+const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const window = goog.require('os.ui.window');
+const tiles = goog.require('plugin.cesium.tiles');
 
 
 /**
  * Import UI for 3D tiles.
  *
- * @extends {os.ui.im.FileImportUI<Object>}
- * @constructor
+ * @extends {FileImportUI<Object>}
  */
-plugin.cesium.tiles.TilesetImportUI = function() {
-  plugin.cesium.tiles.TilesetImportUI.base(this, 'constructor');
-};
-goog.inherits(plugin.cesium.tiles.TilesetImportUI, os.ui.im.FileImportUI);
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.TilesetImportUI.prototype.getTitle = function() {
-  return plugin.cesium.tiles.TYPE;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.TilesetImportUI.prototype.launchUI = function(file, opt_config) {
-  var config = {};
-
-  // if a configuration was provided, merge it in
-  if (opt_config) {
-    this.mergeConfig(opt_config, config);
+class TilesetImportUI extends FileImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
 
-  config['file'] = file;
-  config['title'] = 'New 3D Tile Layer';
+  /**
+   * @inheritDoc
+   */
+  getTitle() {
+    return tiles.TYPE;
+  }
 
-  var scopeOptions = {
-    'config': config
-  };
-  var windowOptions = {
-    'label': 'Import ' + plugin.cesium.tiles.TYPE,
-    'icon': 'fa fa-sign-in',
-    'x': 'center',
-    'y': 'center',
-    'width': 400,
-    'min-width': 400,
-    'max-width': 800,
-    'height': 'auto',
-    'modal': true,
-    'show-close': true
-  };
-  var template = '<tilesetimport></tilesetimport>';
-  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
-};
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    var config = {};
+
+    // if a configuration was provided, merge it in
+    if (opt_config) {
+      this.mergeConfig(opt_config, config);
+    }
+
+    config['file'] = file;
+    config['title'] = 'New 3D Tile Layer';
+
+    var scopeOptions = {
+      'config': config
+    };
+    var windowOptions = {
+      'label': 'Import ' + tiles.TYPE,
+      'icon': 'fa fa-sign-in',
+      'x': 'center',
+      'y': 'center',
+      'width': 400,
+      'min-width': 400,
+      'max-width': 800,
+      'height': 'auto',
+      'modal': true,
+      'show-close': true
+    };
+    var template = `<${directiveTag}></${directiveTag}>`;
+    window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+  }
+}
+
+exports = TilesetImportUI;

--- a/src/plugin/cesium/tiles/cesium3dtileslayer.js
+++ b/src/plugin/cesium/tiles/cesium3dtileslayer.js
@@ -2,11 +2,14 @@ goog.module('plugin.cesium.tiles.Layer');
 
 const log = goog.require('goog.log');
 const {transformExtent} = goog.require('ol.proj');
-const settings = goog.require('os.config.Settings');
 const dispatcher = goog.require('os.Dispatcher');
+const MapEvent = goog.require('os.MapEvent');
 const ActionEventType = goog.require('os.action.EventType');
+const settings = goog.require('os.config.Settings');
 const {PROJECTION} = goog.require('os.map');
 const {EPSG4326} = goog.require('os.proj');
+const osStyle = goog.require('os.style');
+
 const {
   CESIUM_ONLY_LAYER,
   promptForAccessToken,
@@ -182,7 +185,7 @@ class Layer extends PrimitiveLayer {
    * @return {Cesium.Color} The color.
    */
   getFeatureColor(feature, result) {
-    var cssColor = this.getColor() || os.style.DEFAULT_LAYER_COLOR;
+    var cssColor = this.getColor() || osStyle.DEFAULT_LAYER_COLOR;
     var cesiumColor = Cesium.Color.fromCssColorString(cssColor, result);
     cesiumColor.alpha = this.getOpacity();
 
@@ -198,7 +201,7 @@ class Layer extends PrimitiveLayer {
     var tileset = /** @type {Cesium.Cesium3DTileset} */ (this.getPrimitive());
     if (tileset) {
       tileset.makeStyleDirty();
-      dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
+      dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
     }
   }
 
@@ -211,7 +214,7 @@ class Layer extends PrimitiveLayer {
     var tileset = /** @type {Cesium.Cesium3DTileset} */ (this.getPrimitive());
     if (tileset) {
       tileset.makeStyleDirty();
-      dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
+      dispatcher.getInstance().dispatchEvent(MapEvent.GL_REPAINT);
     }
   }
 
@@ -285,13 +288,11 @@ class Layer extends PrimitiveLayer {
    * @inheritDoc
    */
   supportsAction(type, opt_actionArgs) {
-    if (os.action) {
-      switch (type) {
-        case ActionEventType.GOTO:
-          return this.getExtent() != null;
-        default:
-          break;
-      }
+    switch (type) {
+      case ActionEventType.GOTO:
+        return this.getExtent() != null;
+      default:
+        break;
     }
     return super.supportsAction(type, opt_actionArgs);
   }

--- a/src/plugin/cesium/tiles/cesium3dtileslayer.js
+++ b/src/plugin/cesium/tiles/cesium3dtileslayer.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.tiles.Layer');
-goog.module.declareLegacyNamespace();
 
 const log = goog.require('goog.log');
 const {transformExtent} = goog.require('ol.proj');

--- a/src/plugin/cesium/tiles/cesium3dtileslayer.js
+++ b/src/plugin/cesium/tiles/cesium3dtileslayer.js
@@ -1,299 +1,301 @@
-goog.provide('plugin.cesium.tiles.Layer');
+goog.module('plugin.cesium.tiles.Layer');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.log');
-goog.require('goog.log.Logger');
-goog.require('os.config.DisplaySetting');
-goog.require('os.events.PropertyChangeEvent');
-goog.require('os.layer.PropertyChange');
-goog.require('plugin.cesium');
-goog.require('plugin.cesium.PrimitiveLayer');
-goog.require('plugin.cesium.tiles.cesium3DTileLayerUIDirective');
+const log = goog.require('goog.log');
+const {transformExtent} = goog.require('ol.proj');
+const settings = goog.require('os.config.Settings');
+const dispatcher = goog.require('os.Dispatcher');
+const ActionEventType = goog.require('os.action.EventType');
+const {PROJECTION} = goog.require('os.map');
+const {EPSG4326} = goog.require('os.proj');
+const {
+  CESIUM_ONLY_LAYER,
+  promptForAccessToken,
+  createIonAssetUrl,
+  promptForWorldTerrain,
+  SettingsKey,
+  rectangleToExtent
+} = goog.require('plugin.cesium');
+const {ICON, TYPE} = goog.require('plugin.cesium.tiles');
+const PrimitiveLayer = goog.require('plugin.cesium.PrimitiveLayer');
+const {directiveTag: layerUITag} = goog.require('plugin.cesium.tiles.Cesium3DTileLayerUI');
 
-goog.requireType('plugin.cesium.CesiumRenderer');
-
-
-/**
- * @extends {plugin.cesium.PrimitiveLayer}
- * @constructor
- */
-plugin.cesium.tiles.Layer = function() {
-  plugin.cesium.tiles.Layer.base(this, 'constructor');
-
-  /**
-   * Cesium Ion asset id.
-   * @type {number}
-   * @protected
-   */
-  this.assetId = NaN;
-
-  /**
-   * Cesium Ion access token.
-   * @type {string}
-   * @protected
-   */
-  this.accessToken = '';
-
-  /**
-   * Error message for access token issues
-   * @type {string}
-   * @private
-   */
-  this.tokenError_ = '';
-
-  /**
-   * @type {Cesium.Resource|Object|string}
-   * @protected
-   */
-  this.tileStyle = null;
-
-  /**
-   * @type {string}
-   * @protected
-   */
-  this.url = '';
-
-  /**
-   * If Cesium World Terrain should be activated with this layer.
-   * @type {boolean}
-   * @protected
-   */
-  this.useWorldTerrain = false;
-
-  this.setOSType(plugin.cesium.CESIUM_ONLY_LAYER);
-  this.setIcons(plugin.cesium.tiles.ICON);
-  this.setExplicitType(plugin.cesium.tiles.TYPE);
-  this.setLayerUI('cesium3dtilelayerui');
-};
-goog.inherits(plugin.cesium.tiles.Layer, plugin.cesium.PrimitiveLayer);
+const Logger = goog.requireType('goog.log.Logger');
 
 
 /**
  * Logger
- * @type {goog.log.Logger}
- * @private
- * @const
+ * @type {Logger}
  */
-plugin.cesium.tiles.Layer.LOGGER_ = goog.log.getLogger('plugin.cesium.tiles.Layer');
+const logger = log.getLogger('plugin.cesium.tiles.Layer');
 
 
 /**
- * @inheritDoc
+ * Cesium 3D tiles layer.
  */
-plugin.cesium.tiles.Layer.prototype.removePrimitive = function() {
-  var tileset = /** @type {Cesium.Cesium3DTileset} */ (this.getPrimitive());
+class Layer extends PrimitiveLayer {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
 
-  if (tileset) {
-    tileset.loadProgress.removeEventListener(this.onTileProgress, this);
+    /**
+     * Cesium Ion asset id.
+     * @type {number}
+     * @protected
+     */
+    this.assetId = NaN;
+
+    /**
+     * Cesium Ion access token.
+     * @type {string}
+     * @protected
+     */
+    this.accessToken = '';
+
+    /**
+     * Error message for access token issues
+     * @type {string}
+     * @private
+     */
+    this.tokenError_ = '';
+
+    /**
+     * @type {Cesium.Resource|Object|string}
+     * @protected
+     */
+    this.tileStyle = null;
+
+    /**
+     * @type {string}
+     * @protected
+     */
+    this.url = '';
+
+    /**
+     * If Cesium World Terrain should be activated with this layer.
+     * @type {boolean}
+     * @protected
+     */
+    this.useWorldTerrain = false;
+
+    this.setOSType(CESIUM_ONLY_LAYER);
+    this.setIcons(ICON);
+    this.setExplicitType(TYPE);
+    this.setLayerUI(layerUITag);
   }
 
-  plugin.cesium.tiles.Layer.base(this, 'removePrimitive');
-};
+  /**
+   * @inheritDoc
+   */
+  removePrimitive() {
+    var tileset = /** @type {Cesium.Cesium3DTileset} */ (this.getPrimitive());
 
+    if (tileset) {
+      tileset.loadProgress.removeEventListener(this.onTileProgress, this);
+    }
 
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Layer.prototype.synchronize = function() {
-  plugin.cesium.tiles.Layer.base(this, 'synchronize');
+    super.removePrimitive();
+  }
 
-  if (!this.hasError()) {
-    var tilesetUrl = '';
-    if (!isNaN(this.assetId)) {
-      if (!this.accessToken) {
-        plugin.cesium.promptForAccessToken().then((accessToken) => {
-          this.accessToken = accessToken;
-          this.synchronize();
-        }, () => {
-          this.setTokenError_('An access token is required to enable this layer, but one was not provided.');
-        });
+  /**
+   * @inheritDoc
+   */
+  synchronize() {
+    super.synchronize();
+
+    if (!this.hasError()) {
+      var tilesetUrl = '';
+      if (!isNaN(this.assetId)) {
+        if (!this.accessToken) {
+          promptForAccessToken().then((accessToken) => {
+            this.accessToken = accessToken;
+            this.synchronize();
+          }, () => {
+            this.setTokenError_('An access token is required to enable this layer, but one was not provided.');
+          });
+        } else {
+          tilesetUrl = createIonAssetUrl(this.assetId, this.accessToken);
+
+          tilesetUrl.then(() => {
+            // Access token is valid, prompt the user to enable Cesium World Terrain if configured.
+            this.checkWorldTerrain();
+          }, () => {
+            // Access token is invalid. Notify the user.
+            this.setTokenError_('The provided Cesium Ion access token is invalid.');
+          });
+        }
       } else {
-        tilesetUrl = plugin.cesium.createIonAssetUrl(this.assetId, this.accessToken);
-
-        tilesetUrl.then(() => {
-          // Access token is valid, prompt the user to enable Cesium World Terrain if configured.
-          this.checkWorldTerrain();
-        }, () => {
-          // Access token is invalid. Notify the user.
-          this.setTokenError_('The provided Cesium Ion access token is invalid.');
-        });
+        tilesetUrl = this.url;
       }
+
+      if (tilesetUrl) {
+        var tileset = new Cesium.Cesium3DTileset({
+          url: tilesetUrl
+        });
+
+        if (this.tileStyle != null) {
+          tileset.style = new Cesium.Cesium3DTileStyle(this.tileStyle);
+        } else {
+          tileset.style = new Cesium.Cesium3DTileStyle({
+            'color': {
+              'evaluateColor': this.getFeatureColor.bind(this)
+            }
+          });
+        }
+
+        this.setPrimitive(tileset);
+        tileset.loadProgress.addEventListener(this.onTileProgress, this);
+      }
+    }
+  }
+
+  /**
+   * Prompt the user to enable Cesium World Terrain if configured.
+   * @protected
+   */
+  checkWorldTerrain() {
+    if (this.useWorldTerrain) {
+      const layerTitle = this.getTitle() || 'The activated layer';
+      promptForWorldTerrain(`
+        ${layerTitle} is best displayed with Cesium World Terrain. Would you like to activate it now?
+      `);
+    }
+  }
+
+  /**
+   * @param {string} errorMsg The message of the error
+   * @protected
+   */
+  setTokenError_(errorMsg) {
+    if (this.tokenError_ !== errorMsg) {
+      this.tokenError_ = errorMsg;
+      this.updateError();
+    }
+  }
+
+  /**
+   * Get the color for a 3D tile feature.
+   *
+   * @param {Cesium.Cesium3DTileFeature} feature The feature.
+   * @param {Cesium.Color} result The object to store the result.
+   * @return {Cesium.Color} The color.
+   */
+  getFeatureColor(feature, result) {
+    var cssColor = this.getColor() || os.style.DEFAULT_LAYER_COLOR;
+    var cesiumColor = Cesium.Color.fromCssColorString(cssColor, result);
+    cesiumColor.alpha = this.getOpacity();
+
+    return cesiumColor;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setColor(value) {
+    super.setColor(value);
+
+    var tileset = /** @type {Cesium.Cesium3DTileset} */ (this.getPrimitive());
+    if (tileset) {
+      tileset.makeStyleDirty();
+      dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setOpacity(value) {
+    super.setOpacity(value);
+
+    var tileset = /** @type {Cesium.Cesium3DTileset} */ (this.getPrimitive());
+    if (tileset) {
+      tileset.makeStyleDirty();
+      dispatcher.getInstance().dispatchEvent(os.MapEvent.GL_REPAINT);
+    }
+  }
+
+  /**
+   * @param {number} pendingRequests The number of pending requests
+   * @param {number} tilesProcessing The number of tiles currently being processed
+   * @protected
+   */
+  onTileProgress(pendingRequests, tilesProcessing) {
+    this.setLoading(pendingRequests > 0);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  restore(config) {
+    super.restore(config);
+
+    if (typeof config['assetId'] == 'number') {
+      this.assetId = /** @type {number} */ (config['assetId']);
+    }
+
+    if (config['accessToken']) {
+      this.accessToken = /** @type {string} */ (config['accessToken']);
     } else {
-      tilesetUrl = this.url;
+      this.accessToken = /** @type {string} */ (settings.getInstance().get(SettingsKey.ACCESS_TOKEN, ''));
     }
 
-    if (tilesetUrl) {
-      var tileset = new Cesium.Cesium3DTileset({
-        url: tilesetUrl
-      });
+    if (config['tileStyle']) {
+      this.tileStyle = /** @type {Object|string} */ (config['tileStyle']);
+    }
 
-      if (this.tileStyle != null) {
-        tileset.style = new Cesium.Cesium3DTileStyle(this.tileStyle);
-      } else {
-        tileset.style = new Cesium.Cesium3DTileStyle({
-          'color': {
-            'evaluateColor': this.getFeatureColor.bind(this)
-          }
-        });
+    if (config['url']) {
+      this.url = /** @type {string} */ (config['url']);
+    }
+
+    this.useWorldTerrain = !!config['useWorldTerrain'];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getErrorMessage() {
+    var error = super.getErrorMessage();
+    if (!error) {
+      error = this.tokenError_;
+    }
+
+    return error;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getExtent() {
+    try {
+      var tileset = /** @type {Cesium.Cesium3DTileset} */ (this.primitive);
+      if (tileset && tileset.root && tileset.root.contentBoundingVolume) {
+        var extent = rectangleToExtent(tileset.root.contentBoundingVolume.rectangle);
+        if (extent) {
+          return transformExtent(extent, EPSG4326, PROJECTION);
+        }
       }
-
-      this.setPrimitive(tileset);
-      tileset.loadProgress.addEventListener(this.onTileProgress, this);
+    } catch (e) {
+      log.error(logger, e);
     }
-  }
-};
-
-
-/**
- * Prompt the user to enable Cesium World Terrain if configured.
- * @protected
- */
-plugin.cesium.tiles.Layer.prototype.checkWorldTerrain = function() {
-  if (this.useWorldTerrain) {
-    const layerTitle = this.getTitle() || 'The activated layer';
-    plugin.cesium.promptForWorldTerrain(`
-      ${layerTitle} is best displayed with Cesium World Terrain. Would you like to activate it now?
-    `);
-  }
-};
-
-
-/**
- * @param {string} errorMsg The message of the error
- * @protected
- */
-plugin.cesium.tiles.Layer.prototype.setTokenError_ = function(errorMsg) {
-  if (this.tokenError_ !== errorMsg) {
-    this.tokenError_ = errorMsg;
-    this.updateError();
-  }
-};
-
-
-/**
- * Get the color for a 3D tile feature.
- *
- * @param {Cesium.Cesium3DTileFeature} feature The feature.
- * @param {Cesium.Color} result The object to store the result.
- * @return {Cesium.Color} The color.
- */
-plugin.cesium.tiles.Layer.prototype.getFeatureColor = function(feature, result) {
-  var cssColor = this.getColor() || os.style.DEFAULT_LAYER_COLOR;
-  var cesiumColor = Cesium.Color.fromCssColorString(cssColor, result);
-  cesiumColor.alpha = this.getOpacity();
-
-  return cesiumColor;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Layer.prototype.setColor = function(value) {
-  plugin.cesium.tiles.Layer.base(this, 'setColor', value);
-
-  var tileset = /** @type {Cesium.Cesium3DTileset} */ (this.getPrimitive());
-  if (tileset) {
-    tileset.makeStyleDirty();
-    os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Layer.prototype.setOpacity = function(value) {
-  plugin.cesium.tiles.Layer.base(this, 'setOpacity', value);
-
-  var tileset = /** @type {Cesium.Cesium3DTileset} */ (this.getPrimitive());
-  if (tileset) {
-    tileset.makeStyleDirty();
-    os.dispatcher.dispatchEvent(os.MapEvent.GL_REPAINT);
-  }
-};
-
-
-/**
- * @param {number} pendingRequests The number of pending requests
- * @param {number} tilesProcessing The number of tiles currently being processed
- * @protected
- */
-plugin.cesium.tiles.Layer.prototype.onTileProgress = function(pendingRequests, tilesProcessing) {
-  this.setLoading(pendingRequests > 0);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Layer.prototype.restore = function(config) {
-  plugin.cesium.tiles.Layer.base(this, 'restore', config);
-
-  if (typeof config['assetId'] == 'number') {
-    this.assetId = /** @type {number} */ (config['assetId']);
+    return super.getExtent();
   }
 
-  if (config['accessToken']) {
-    this.accessToken = /** @type {string} */ (config['accessToken']);
-  } else {
-    this.accessToken = /** @type {string} */ (os.settings.get(plugin.cesium.SettingsKey.ACCESS_TOKEN, ''));
-  }
-
-  if (config['tileStyle']) {
-    this.tileStyle = /** @type {Object|string} */ (config['tileStyle']);
-  }
-
-  if (config['url']) {
-    this.url = /** @type {string} */ (config['url']);
-  }
-
-  this.useWorldTerrain = !!config['useWorldTerrain'];
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Layer.prototype.getErrorMessage = function() {
-  var error = plugin.cesium.tiles.Layer.base(this, 'getErrorMessage');
-  if (!error) {
-    error = this.tokenError_;
-  }
-
-  return error;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Layer.prototype.getExtent = function() {
-  try {
-    var tileset = /** @type {Cesium.Cesium3DTileset} */ (this.primitive);
-    if (tileset && tileset.root && tileset.root.contentBoundingVolume) {
-      var extent = plugin.cesium.rectangleToExtent(tileset.root.contentBoundingVolume.rectangle);
-      if (extent) {
-        return ol.proj.transformExtent(extent, os.proj.EPSG4326, os.map.PROJECTION);
+  /**
+   * @inheritDoc
+   */
+  supportsAction(type, opt_actionArgs) {
+    if (os.action) {
+      switch (type) {
+        case ActionEventType.GOTO:
+          return this.getExtent() != null;
+        default:
+          break;
       }
     }
-  } catch (e) {
-    goog.log.error(plugin.cesium.tiles.Layer.LOGGER_, e);
+    return super.supportsAction(type, opt_actionArgs);
   }
-  return plugin.cesium.tiles.Layer.base(this, 'getExtent');
-};
+}
 
-
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Layer.prototype.supportsAction = function(type, opt_actionArgs) {
-  if (os.action) {
-    switch (type) {
-      case os.action.EventType.GOTO:
-        return this.getExtent() != null;
-      default:
-        break;
-    }
-  }
-  return plugin.cesium.tiles.Layer.base(this, 'supportsAction', type, opt_actionArgs);
-};
+exports = Layer;

--- a/src/plugin/cesium/tiles/cesium3dtileslayerconfig.js
+++ b/src/plugin/cesium/tiles/cesium3dtileslayerconfig.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.tiles.LayerConfig');
-goog.module.declareLegacyNamespace();
 
 const AbstractLayerConfig = goog.require('os.layer.config.AbstractLayerConfig');
 const Layer = goog.require('plugin.cesium.tiles.Layer');

--- a/src/plugin/cesium/tiles/cesium3dtileslayerconfig.js
+++ b/src/plugin/cesium/tiles/cesium3dtileslayerconfig.js
@@ -1,32 +1,35 @@
-goog.provide('plugin.cesium.tiles.LayerConfig');
+goog.module('plugin.cesium.tiles.LayerConfig');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.layer.LayerType');
-goog.require('os.layer.config.AbstractLayerConfig');
-goog.require('plugin.cesium.tiles.Layer');
-
-
-/**
- * @extends {os.layer.config.AbstractLayerConfig}
- * @constructor
- */
-plugin.cesium.tiles.LayerConfig = function() {
-  plugin.cesium.tiles.LayerConfig.base(this, 'constructor');
-};
-goog.inherits(plugin.cesium.tiles.LayerConfig, os.layer.config.AbstractLayerConfig);
+const AbstractLayerConfig = goog.require('os.layer.config.AbstractLayerConfig');
+const Layer = goog.require('plugin.cesium.tiles.Layer');
 
 
 /**
- * @inheritDoc
  */
-plugin.cesium.tiles.LayerConfig.prototype.createLayer = function(options) {
-  this.initializeConfig(options);
-
-  if (!options['url'] && options['assetId'] == null) {
-    throw new Error('3D Tile layers must have a URL to the tileset.json or an Ion asset id');
+class LayerConfig extends AbstractLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
 
-  var layer = new plugin.cesium.tiles.Layer();
-  layer.restore(options);
+  /**
+   * @inheritDoc
+   */
+  createLayer(options) {
+    this.initializeConfig(options);
 
-  return layer;
-};
+    if (!options['url'] && options['assetId'] == null) {
+      throw new Error('3D Tile layers must have a URL to the tileset.json or an Ion asset id');
+    }
+
+    var layer = new Layer();
+    layer.restore(options);
+
+    return layer;
+  }
+}
+
+exports = LayerConfig;

--- a/src/plugin/cesium/tiles/cesium3dtilesprovider.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesprovider.js
@@ -1,6 +1,7 @@
 goog.module('plugin.cesium.tiles.Provider');
 
 const BaseDescriptor = goog.require('os.data.BaseDescriptor');
+const DataManager = goog.require('os.data.DataManager');
 const FileProvider = goog.require('os.data.FileProvider');
 const tiles = goog.require('plugin.cesium.tiles');
 
@@ -26,7 +27,7 @@ class Provider extends FileProvider {
 
     var layers = config['layers'];
     if (layers) {
-      var dm = os.dataManager;
+      var dm = DataManager.getInstance();
       for (var key in layers) {
         var id = this.getId() + BaseDescriptor.ID_DELIMITER + key;
         var d = dm.getDescriptor(id);

--- a/src/plugin/cesium/tiles/cesium3dtilesprovider.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesprovider.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.tiles.Provider');
-goog.module.declareLegacyNamespace();
 
 const BaseDescriptor = goog.require('os.data.BaseDescriptor');
 const FileProvider = goog.require('os.data.FileProvider');

--- a/src/plugin/cesium/tiles/cesium3dtilesprovider.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesprovider.js
@@ -7,6 +7,13 @@ const tiles = goog.require('plugin.cesium.tiles');
 
 
 /**
+ * The global instance.
+ * @type {Provider|undefined}
+ */
+let instance;
+
+
+/**
  * Cesium 3D tiles provider.
  */
 class Provider extends FileProvider {
@@ -43,9 +50,26 @@ class Provider extends FileProvider {
       }
     }
   }
+
+  /**
+   * Get the global instance.
+   * @return {!Provider} The instance.
+   */
+  static getInstance() {
+    if (!instance) {
+      instance = new Provider();
+    }
+
+    return instance;
+  }
+
+  /**
+   * Set the global instance.
+   * @param {Provider|undefined} value The instance.
+   */
+  static setInstance(value) {
+    instance = value;
+  }
 }
-
-goog.addSingletonGetter(Provider);
-
 
 exports = Provider;

--- a/src/plugin/cesium/tiles/cesium3dtilesprovider.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesprovider.js
@@ -1,47 +1,51 @@
-goog.provide('plugin.cesium.tiles.Provider');
+goog.module('plugin.cesium.tiles.Provider');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.BaseDescriptor');
-goog.require('os.data.FileProvider');
-goog.require('plugin.cesium.tiles');
-
+const BaseDescriptor = goog.require('os.data.BaseDescriptor');
+const FileProvider = goog.require('os.data.FileProvider');
+const tiles = goog.require('plugin.cesium.tiles');
 
 
 /**
  * Cesium 3D tiles provider.
- *
- * @extends {os.data.FileProvider}
- * @constructor
  */
-plugin.cesium.tiles.Provider = function() {
-  plugin.cesium.tiles.Provider.base(this, 'constructor');
-};
-goog.inherits(plugin.cesium.tiles.Provider, os.data.FileProvider);
-goog.addSingletonGetter(plugin.cesium.tiles.Provider);
+class Provider extends FileProvider {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
 
+  /**
+   * @inheritDoc
+   */
+  configure(config) {
+    super.configure(config);
+    this.setId(tiles.ID);
+    this.setLabel(tiles.TYPE);
 
-/**
- * @inheritDoc
- */
-plugin.cesium.tiles.Provider.prototype.configure = function(config) {
-  plugin.cesium.tiles.Provider.base(this, 'configure', config);
-  this.setId(plugin.cesium.tiles.ID);
-  this.setLabel(plugin.cesium.tiles.TYPE);
+    var layers = config['layers'];
+    if (layers) {
+      var dm = os.dataManager;
+      for (var key in layers) {
+        var id = this.getId() + BaseDescriptor.ID_DELIMITER + key;
+        var d = dm.getDescriptor(id);
 
-  var layers = config['layers'];
-  if (layers) {
-    var dm = os.dataManager;
-    for (var key in layers) {
-      var id = this.getId() + os.data.BaseDescriptor.ID_DELIMITER + key;
-      var d = dm.getDescriptor(id);
+        if (!d) {
+          d = dm.createDescriptor(tiles.ID);
+          d.setId(id);
+          dm.addDescriptor(d);
+        }
 
-      if (!d) {
-        d = dm.createDescriptor(plugin.cesium.tiles.ID);
-        d.setId(id);
-        dm.addDescriptor(d);
+        d.updateFromConfig(layers[key]);
+        d.updateActiveFromTemp();
       }
-
-      d.updateFromConfig(layers[key]);
-      d.updateActiveFromTemp();
     }
   }
-};
+}
+
+goog.addSingletonGetter(Provider);
+
+
+exports = Provider;

--- a/src/plugin/cesium/tiles/mime.js
+++ b/src/plugin/cesium/tiles/mime.js
@@ -1,45 +1,45 @@
-goog.provide('plugin.cesium.tiles.mime');
+goog.module('plugin.cesium.tiles.mime');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Promise');
-goog.require('os.file.mime.json');
+const Promise = goog.require('goog.Promise');
+const {register} = goog.require('os.file.mime');
+const json = goog.require('os.file.mime.json');
+
 
 /**
- * @const
  * @type {string}
  */
-plugin.cesium.tiles.mime.TYPE = 'application/vnd.tileset+json';
-
+const TYPE = 'application/vnd.tileset+json';
 
 /**
  * @param {ArrayBuffer} buffer
  * @param {os.file.File=} opt_file
  * @param {*=} opt_context
- * @return {!goog.Promise<*|undefined>}
+ * @return {!Promise<*|undefined>}
  */
-plugin.cesium.tiles.mime.isTilesetJSON = function(buffer, opt_file, opt_context) {
+const isTilesetJSON = function(buffer, opt_file, opt_context) {
   var retVal;
 
-  if (opt_context && plugin.cesium.tiles.mime.find_(/** @type {Object|null} */ (opt_context))) {
+  if (opt_context && testContext(/** @type {Object|null} */ (opt_context))) {
     retVal = opt_context;
   }
 
-  return goog.Promise.resolve(retVal);
+  return Promise.resolve(retVal);
 };
-
 
 /**
  * @param {Array|Object} obj
  * @return {boolean}
- * @private
  */
-plugin.cesium.tiles.mime.find_ = function(obj) {
+const testContext = function(obj) {
   // geometricError is the only required property by spec, but also require a root tile
   return typeof obj['geometricError'] === 'number' &&
       obj['root'] && typeof obj['root']['geometricError'] === 'number';
 };
 
-os.file.mime.register(
-    plugin.cesium.tiles.mime.TYPE,
-    plugin.cesium.tiles.mime.isTilesetJSON,
-    1000,
-    os.file.mime.json.TYPE);
+register(TYPE, isTilesetJSON, 1000, json.TYPE);
+
+exports = {
+  TYPE,
+  isTilesetJSON
+};

--- a/src/plugin/cesium/tiles/mime.js
+++ b/src/plugin/cesium/tiles/mime.js
@@ -4,6 +4,8 @@ const Promise = goog.require('goog.Promise');
 const {register} = goog.require('os.file.mime');
 const json = goog.require('os.file.mime.json');
 
+const OSFile = goog.requireType('os.file.File');
+
 
 /**
  * @type {string}
@@ -12,7 +14,7 @@ const TYPE = 'application/vnd.tileset+json';
 
 /**
  * @param {ArrayBuffer} buffer
- * @param {os.file.File=} opt_file
+ * @param {OSFile=} opt_file
  * @param {*=} opt_context
  * @return {!Promise<*|undefined>}
  */

--- a/src/plugin/cesium/tiles/mime.js
+++ b/src/plugin/cesium/tiles/mime.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.tiles.mime');
-goog.module.declareLegacyNamespace();
 
 const Promise = goog.require('goog.Promise');
 const {register} = goog.require('os.file.mime');

--- a/src/plugin/cesium/vectorcontext.js
+++ b/src/plugin/cesium/vectorcontext.js
@@ -14,7 +14,6 @@ const OLVectorLayer = goog.requireType('ol.layer.Vector');
 const IDisposable = goog.requireType('goog.disposable.IDisposable');
 
 
-
 /**
  * Logger for plugin.cesium.VectorContext
  * @type {log.Logger}

--- a/src/plugin/cesium/vectorcontext.js
+++ b/src/plugin/cesium/vectorcontext.js
@@ -10,6 +10,7 @@ const {isGroundPrimitive, isPrimitiveShown, setPrimitiveShown} = goog.require('p
 const Feature = goog.requireType('ol.Feature');
 const Geometry = goog.requireType('ol.geom.Geometry');
 const OLVectorLayer = goog.requireType('ol.layer.Vector');
+const Projection = goog.requireType('ol.proj.Projection');
 const IDisposable = goog.requireType('goog.disposable.IDisposable');
 
 
@@ -28,8 +29,8 @@ const LOGGER = log.getLogger('plugin.cesium.VectorContext');
 class VectorContext {
   /**
    * @param {!Cesium.Scene} scene The Cesium scene
-   * @param {!ol.layer.Vector} layer The OL3 layer
-   * @param {!(ol.proj.Projection|string)} projection The map projection
+   * @param {!OLVectorLayer} layer The OL3 layer
+   * @param {!(Projection|string)} projection The map projection
    */
   constructor(scene, layer, projection) {
     /**
@@ -62,13 +63,13 @@ class VectorContext {
 
     /**
      * The OL3 vector layer
-     * @type {!ol.layer.Vector}
+     * @type {!OLVectorLayer}
      */
     this.layer = layer;
 
     /**
      * The map projection
-     * @type {!(ol.proj.Projection|string)}
+     * @type {!(Projection|string)}
      */
     this.projection = projection;
 

--- a/src/plugin/cesium/vectorcontext.js
+++ b/src/plugin/cesium/vectorcontext.js
@@ -1,5 +1,4 @@
 goog.module('plugin.cesium.VectorContext');
-goog.module.declareLegacyNamespace();
 
 const Throttle = goog.require('goog.async.Throttle');
 const arrayUtils = goog.require('ol.array');

--- a/src/plugin/cesium/wmsterrainprovider.js
+++ b/src/plugin/cesium/wmsterrainprovider.js
@@ -1,9 +1,18 @@
 goog.module('plugin.cesium.WMSTerrainProvider');
-goog.module.declareLegacyNamespace();
 
+const Promise = goog.require('goog.Promise');
 const asserts = goog.require('goog.asserts');
 const ProxyHandler = goog.require('os.net.ProxyHandler');
 const AbstractTerrainProvider = goog.require('plugin.cesium.AbstractTerrainProvider');
+
+
+/**
+ * Compare WMS terrain layer options in order of descending max level.
+ * @param {osx.cesium.WMSTerrainLayerOptions} a First layer options.
+ * @param {osx.cesium.WMSTerrainLayerOptions} b Second layer options.
+ * @return {number}
+ */
+const wmsTerrainLayerCompare = (a, b) => b.maxLevel - a.maxLevel;
 
 
 /**
@@ -25,7 +34,7 @@ class WMSTerrainProvider extends AbstractTerrainProvider {
      * @private
      */
     this.layers_ = options.layers;
-    this.layers_.sort(plugin.cesium.wmsTerrainLayerCompare);
+    this.layers_.sort(wmsTerrainLayerCompare);
 
     // for now, name the provider based on the first layer name so it can be of use in the layers window
     // we could change name based on zoom level but it's problematic because tiles are requested for multiple zoom levels
@@ -193,16 +202,15 @@ class WMSTerrainProvider extends AbstractTerrainProvider {
     }
     return result;
   }
+
+  /**
+   * Create a Cesium WMS terrain provider instance.
+   * @param {!osx.cesium.WMSTerrainProviderOptions} options The WMS terrain options.
+   * @return {!Promise<!WMSTerrainProvider>}
+   */
+  static create(options) {
+    return Promise.resolve(new WMSTerrainProvider(options));
+  }
 }
 
-
-/**
- * @param {Object} a
- * @param {Object} b
- * @return {number}
- */
-plugin.cesium.wmsTerrainLayerCompare = function(a, b) {
-  // sort in order of descending maxLevel
-  return goog.array.defaultCompare(b.maxLevel, a.maxLevel);
-};
 exports = WMSTerrainProvider;

--- a/src/plugin/cesium/wmsterrainprovider.js
+++ b/src/plugin/cesium/wmsterrainprovider.js
@@ -1,205 +1,199 @@
-goog.provide('plugin.cesium.WMSTerrainProvider');
+goog.module('plugin.cesium.WMSTerrainProvider');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
-goog.require('ol.proj');
-goog.require('os.net.ProxyHandler');
-goog.require('plugin.cesium.AbstractTerrainProvider');
-
+const asserts = goog.require('goog.asserts');
+const ProxyHandler = goog.require('os.net.ProxyHandler');
+const AbstractTerrainProvider = goog.require('plugin.cesium.AbstractTerrainProvider');
 
 
 /**
  * WMS Cesium terrain provider.
- *
- * @param {!osx.cesium.WMSTerrainProviderOptions} options
- * @extends {plugin.cesium.AbstractTerrainProvider}
- * @constructor
  */
-plugin.cesium.WMSTerrainProvider = function(options) {
-  plugin.cesium.WMSTerrainProvider.base(this, 'constructor', /** @type {!osx.map.TerrainProviderOptions} */ (options));
+class WMSTerrainProvider extends AbstractTerrainProvider {
+  /**
+   * Constructor.
+   * @param {!osx.cesium.WMSTerrainProviderOptions} options
+   */
+  constructor(options) {
+    super(options);
 
-  goog.asserts.assert(options.layers != null && options.layers.length > 0, 'layers not defined');
+    asserts.assert(options.layers != null && options.layers.length > 0, 'layers not defined');
+
+    /**
+     * Configured WMS layers to use for terrain.
+     * @type {!Array<!osx.cesium.WMSTerrainLayerOptions>}
+     * @private
+     */
+    this.layers_ = options.layers;
+    this.layers_.sort(plugin.cesium.wmsTerrainLayerCompare);
+
+    // for now, name the provider based on the first layer name so it can be of use in the layers window
+    // we could change name based on zoom level but it's problematic because tiles are requested for multiple zoom levels
+    if (this.layers_.length > 0) {
+      this.setName(this.layers_[this.layers_.length - 1].layerName);
+    }
+
+    // set min/max level based on the configured layers
+    this.maxLevel = this.layers_[0].maxLevel;
+    this.minLevel = this.layers_[this.layers_.length - 1].minLevel;
+
+    // mark as ready so Cesium will start requesting terrain
+    this.ready = true;
+  }
 
   /**
-   * Configured WMS layers to use for terrain.
-   * @type {!Array<!osx.cesium.WMSTerrainLayerOptions>}
+   * @inheritDoc
+   */
+  getTileDataAvailable(x, y, level) {
+    return super.getTileDataAvailable(x, y, level) && level < this.maxLevel;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  requestTileGeometry(x, y, level, opt_request) {
+    var layerName = this.getLayerForLevel_(level);
+    if (!layerName) {
+      // no terrain at this zoom level
+      var terrainData = new Cesium.HeightmapTerrainData({
+        buffer: new Uint8Array(this.tileSize * this.tileSize),
+        width: this.tileSize,
+        height: this.tileSize
+      });
+      return Cesium.when.resolve(terrainData);
+    }
+
+    var url = this.getRequestUrl_(x, y, level, layerName);
+    if (this.useProxy) {
+      url = ProxyHandler.getProxyUri(url);
+    }
+
+    var promise = Cesium.Resource.fetchArrayBuffer({
+      url: url,
+      request: opt_request
+    });
+
+    if (!promise) {
+      return undefined;
+    }
+
+    var childMask = this.getTerrainChildMask(x, y, level);
+    return Cesium.when(promise, this.arrayToHeightmap_.bind(this, childMask));
+  }
+
+  /**
+   * @param {number} level
+   * @return {string|undefined}
    * @private
    */
-  this.layers_ = options.layers;
-  this.layers_.sort(plugin.cesium.wmsTerrainLayerCompare);
+  getLayerForLevel_(level) {
+    var layerName = undefined;
+    if (level < this.maxLevel && level >= this.minLevel) {
+      for (var i = 0, n = this.layers_.length; i < n; i++) {
+        var layer = this.layers_[i];
+        if (level < layer.maxLevel && level >= layer.minLevel) {
+          layerName = layer.layerName;
+          break;
+        }
+      }
+    }
 
-  // for now, name the provider based on the first layer name so it can be of use in the layers window
-  // we could change name based on zoom level but it's problematic because tiles are requested for multiple zoom levels
-  if (this.layers_.length > 0) {
-    this.setName(this.layers_[this.layers_.length - 1].layerName);
+    return layerName;
   }
 
-  // set min/max level based on the configured layers
-  this.maxLevel = this.layers_[0].maxLevel;
-  this.minLevel = this.layers_[this.layers_.length - 1].minLevel;
+  /**
+   * Get the URL for an elevation tile
+   *
+   * @param {number} x
+   * @param {number} y
+   * @param {number} level
+   * @param {string} layerName
+   * @return {string}
+   * @private
+   */
+  getRequestUrl_(x, y, level, layerName) {
+    var url = this.url + '?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS=EPSG%3A4326&STYLES=';
 
-  // mark as ready so Cesium will start requesting terrain
-  this.ready = true;
-};
-goog.inherits(plugin.cesium.WMSTerrainProvider, plugin.cesium.AbstractTerrainProvider);
+    // add the elevation layer
+    url += '&LAYERS=' + layerName;
 
+    // add the format
+    url += '&FORMAT=image%2Fbil';
 
-/**
- * @inheritDoc
- */
-plugin.cesium.WMSTerrainProvider.prototype.getTileDataAvailable = function(x, y, level) {
-  return plugin.cesium.WMSTerrainProvider.base(this, 'getTileDataAvailable', x, y, level) && level < this.maxLevel;
-};
+    // add the tile size
+    url += '&WIDTH=' + this.tileSize + '&HEIGHT=' + this.tileSize;
 
+    // add the bounding box
+    var rect = this.tilingScheme.tileXYToNativeRectangle(x, y, level);
+    var xSpacing = (rect.east - rect.west) / this.tileSize;
+    var ySpacing = (rect.north - rect.south) / this.tileSize;
+    rect.west -= xSpacing * 0.5;
+    rect.east += xSpacing * 0.5;
+    rect.south -= ySpacing * 0.5;
+    rect.north += ySpacing * 0.5;
+    url += '&BBOX=' + rect.south + ',' + rect.west + ',' + rect.north + ',' + rect.east;
 
-/**
- * @inheritDoc
- */
-plugin.cesium.WMSTerrainProvider.prototype.requestTileGeometry = function(x, y, level, opt_request) {
-  var layerName = this.getLayerForLevel_(level);
-  if (!layerName) {
-    // no terrain at this zoom level
-    var terrainData = new Cesium.HeightmapTerrainData({
-      buffer: new Uint8Array(this.tileSize * this.tileSize),
+    return url;
+  }
+
+  /**
+   * @param {number} childTileMask
+   * @param {ArrayBuffer} buffer
+   * @return {Cesium.HeightmapTerrainData}
+   * @private
+   */
+  arrayToHeightmap_(childTileMask, buffer) {
+    var heightBuffer = this.postProcessArray_(buffer);
+    if (heightBuffer === undefined) {
+      throw new Cesium.DeveloperError('unexpected height buffer size');
+    }
+
+    var optionsHeightmapTerrainData = {
+      buffer: heightBuffer,
       width: this.tileSize,
-      height: this.tileSize
-    });
-    return Cesium.when.resolve(terrainData);
+      height: this.tileSize,
+      childTileMask: childTileMask,
+      structure: this.terrainDataStructure
+    };
+
+    return new Cesium.HeightmapTerrainData(optionsHeightmapTerrainData);
   }
 
-  var url = this.getRequestUrl_(x, y, level, layerName);
-  if (this.useProxy) {
-    url = os.net.ProxyHandler.getProxyUri(url);
-  }
+  /**
+   * @param {ArrayBuffer} buffer
+   * @return {Int16Array|undefined}
+   * @private
+   */
+  postProcessArray_(buffer) {
+    var result;
+    var viewerIn = new DataView(buffer);
+    var littleEndianBuffer = new ArrayBuffer(this.tileSize * this.tileSize * 2);
+    var littleEndianView = new DataView(littleEndianBuffer);
+    if (littleEndianBuffer.byteLength === buffer.byteLength) {
+      // switch from big to little endian
+      var current = 0;
+      var goodCell = 0;
+      var sum = 0;
+      for (var i = 0; i < littleEndianBuffer.byteLength; i += 2) {
+        current = viewerIn.getInt16(i, false);
 
-  var promise = Cesium.Resource.fetchArrayBuffer({
-    url: url,
-    request: opt_request
-  });
-
-  if (!promise) {
-    return undefined;
-  }
-
-  var childMask = this.getTerrainChildMask(x, y, level);
-  return Cesium.when(promise, this.arrayToHeightmap_.bind(this, childMask));
-};
-
-
-/**
- * @param {number} level
- * @return {string|undefined}
- * @private
- */
-plugin.cesium.WMSTerrainProvider.prototype.getLayerForLevel_ = function(level) {
-  var layerName = undefined;
-  if (level < this.maxLevel && level >= this.minLevel) {
-    for (var i = 0, n = this.layers_.length; i < n; i++) {
-      var layer = this.layers_[i];
-      if (level < layer.maxLevel && level >= layer.minLevel) {
-        layerName = layer.layerName;
-        break;
+        // don't allow values outside acceptable ranges (in meters) for the Earth.
+        if (current > -500 && current < 9000) {
+          littleEndianView.setInt16(i, current, true);
+          sum += current;
+          goodCell++;
+        } else {
+          // elevation is outside the acceptable range, so use an average
+          var average = goodCell > 0 ? (sum / goodCell) : 0;
+          littleEndianView.setInt16(i, average, true);
+        }
       }
+
+      result = new Int16Array(littleEndianBuffer);
     }
+    return result;
   }
-
-  return layerName;
-};
-
-
-/**
- * Get the URL for an elevation tile
- *
- * @param {number} x
- * @param {number} y
- * @param {number} level
- * @param {string} layerName
- * @return {string}
- * @private
- */
-plugin.cesium.WMSTerrainProvider.prototype.getRequestUrl_ = function(x, y, level, layerName) {
-  var url = this.url + '?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&CRS=EPSG%3A4326&STYLES=';
-
-  // add the elevation layer
-  url += '&LAYERS=' + layerName;
-
-  // add the format
-  url += '&FORMAT=image%2Fbil';
-
-  // add the tile size
-  url += '&WIDTH=' + this.tileSize + '&HEIGHT=' + this.tileSize;
-
-  // add the bounding box
-  var rect = this.tilingScheme.tileXYToNativeRectangle(x, y, level);
-  var xSpacing = (rect.east - rect.west) / this.tileSize;
-  var ySpacing = (rect.north - rect.south) / this.tileSize;
-  rect.west -= xSpacing * 0.5;
-  rect.east += xSpacing * 0.5;
-  rect.south -= ySpacing * 0.5;
-  rect.north += ySpacing * 0.5;
-  url += '&BBOX=' + rect.south + ',' + rect.west + ',' + rect.north + ',' + rect.east;
-
-  return url;
-};
-
-
-/**
- * @param {number} childTileMask
- * @param {ArrayBuffer} buffer
- * @return {Cesium.HeightmapTerrainData}
- * @private
- */
-plugin.cesium.WMSTerrainProvider.prototype.arrayToHeightmap_ = function(childTileMask, buffer) {
-  var heightBuffer = this.postProcessArray_(buffer);
-  if (heightBuffer === undefined) {
-    throw new Cesium.DeveloperError('unexpected height buffer size');
-  }
-
-  var optionsHeightmapTerrainData = {
-    buffer: heightBuffer,
-    width: this.tileSize,
-    height: this.tileSize,
-    childTileMask: childTileMask,
-    structure: this.terrainDataStructure
-  };
-
-  return new Cesium.HeightmapTerrainData(optionsHeightmapTerrainData);
-};
-
-
-/**
- * @param {ArrayBuffer} buffer
- * @return {Int16Array|undefined}
- * @private
- */
-plugin.cesium.WMSTerrainProvider.prototype.postProcessArray_ = function(buffer) {
-  var result;
-  var viewerIn = new DataView(buffer);
-  var littleEndianBuffer = new ArrayBuffer(this.tileSize * this.tileSize * 2);
-  var littleEndianView = new DataView(littleEndianBuffer);
-  if (littleEndianBuffer.byteLength === buffer.byteLength) {
-    // switch from big to little endian
-    var current = 0;
-    var goodCell = 0;
-    var sum = 0;
-    for (var i = 0; i < littleEndianBuffer.byteLength; i += 2) {
-      current = viewerIn.getInt16(i, false);
-
-      // don't allow values outside acceptable ranges (in meters) for the Earth.
-      if (current > -500 && current < 9000) {
-        littleEndianView.setInt16(i, current, true);
-        sum += current;
-        goodCell++;
-      } else {
-        // elevation is outside the acceptable range, so use an average
-        var average = goodCell > 0 ? (sum / goodCell) : 0;
-        littleEndianView.setInt16(i, average, true);
-      }
-    }
-
-    result = new Int16Array(littleEndianBuffer);
-  }
-  return result;
-};
+}
 
 
 /**
@@ -211,3 +205,4 @@ plugin.cesium.wmsTerrainLayerCompare = function(a, b) {
   // sort in order of descending maxLevel
   return goog.array.defaultCompare(b.maxLevel, a.maxLevel);
 };
+exports = WMSTerrainProvider;

--- a/src/plugin/ogc/ogclayerdescriptor.js
+++ b/src/plugin/ogc/ogclayerdescriptor.js
@@ -21,7 +21,9 @@ goog.require('os.ogc.wfs.DescribeFeatureLoader');
 goog.require('os.ogc.wmts');
 goog.require('os.ui.ControlType');
 goog.require('os.ui.Icons');
+goog.require('os.ui.IconsSVG');
 goog.require('os.ui.filter.ui.filterableDescriptorNodeUIDirective');
+goog.require('os.ui.icons');
 goog.require('os.ui.ogc.IOGCDescriptor');
 goog.require('os.ui.query.BaseCombinatorCtrl');
 goog.require('os.ui.query.CombinatorCtrl');
@@ -282,7 +284,7 @@ plugin.ogc.OGCLayerDescriptor.prototype.getIcons = function() {
     s += os.ui.Icons.DEPRECATED;
   }
 
-  s += os.ui.createIconSet(goog.string.getRandomString(), iconsSVG, [], color);
+  s += os.ui.icons.createIconSet(goog.string.getRandomString(), iconsSVG, [], color);
 
   return s;
 };

--- a/test/os/ui/icons.test.js
+++ b/test/os/ui/icons.test.js
@@ -1,15 +1,17 @@
-goog.require('os.ui.Icons');
+goog.require('os.ui.icons');
 
 
-describe('os.ui.Icons', function() {
+describe('os.ui.icons', function() {
   it('should not create iconSets with quotes in them', function() {
     var id = 'QUOTE\'S BOY\'S';
-    var svgIcons = ['<image xlink:href="features-base.png" width="16px" height="16px"><title>Feature layer</title></image>',
-        '<image class="time-icon" xlink:href="time-base.png" width="16px" height="16px"><title>This layer supports animation over time</title></image>'
+    var svgIcons = [
+      '<image xlink:href="features-base.png" width="16px" height="16px"><title>Feature layer</title></image>',
+      '<image class="time-icon" xlink:href="time-base.png" width="16px" height="16px">' +
+        '<title>This layer supports animation over time</title></image>'
     ];
     var faIcons = [];
     var color = '#fa0';
-    var result = os.ui.createIconSet(id, svgIcons, faIcons, color);
+    var result = os.ui.icons.createIconSet(id, svgIcons, faIcons, color);
 
     // it should hash the ID, so the original value should be nowhere to be found in the result
     expect(result.indexOf(id)).toBe(-1);

--- a/test/plugin/cesium/primitive.test.js
+++ b/test/plugin/cesium/primitive.test.js
@@ -13,6 +13,7 @@ goog.require('test.plugin.cesium.primitive');
 goog.require('test.plugin.cesium.scene');
 
 describe('plugin.cesium.primitive', () => {
+  const {GeometryInstanceId} = goog.module.get('plugin.cesium');
   const syncUtils = goog.module.get('plugin.cesium.primitive');
   const primitiveUtils = goog.module.get('test.plugin.cesium.primitive');
   const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
@@ -234,12 +235,12 @@ describe('plugin.cesium.primitive', () => {
 
     it('should assume a geometry ID rather than an outline', () => {
       const result = syncUtils.createColoredPrimitive(geometry, color, undefined, undefined, MockPrimitive);
-      expect(result.options.geometryInstances.id).toBe(plugin.cesium.GeometryInstanceId.GEOM);
+      expect(result.options.geometryInstances.id).toBe(GeometryInstanceId.GEOM);
     });
 
     it('should use an outline ID when an outline is provided', () => {
       const result = syncUtils.createColoredPrimitive(geometry, color, 3, undefined, MockPrimitive);
-      expect(result.options.geometryInstances.id).toBe(plugin.cesium.GeometryInstanceId.GEOM_OUTLINE);
+      expect(result.options.geometryInstances.id).toBe(GeometryInstanceId.GEOM_OUTLINE);
     });
 
     it('should add the line width to the appearance renderState', () => {
@@ -266,7 +267,7 @@ describe('plugin.cesium.primitive', () => {
       const customCreate = (id, geometry, color) => ({id, geometry, color});
       const result = syncUtils.createColoredPrimitive(geometry, color, undefined, customCreate, MockPrimitive);
       expect(result.options.geometryInstances).toEqual({
-        id: plugin.cesium.GeometryInstanceId.GEOM,
+        id: GeometryInstanceId.GEOM,
         geometry,
         color
       });

--- a/test/plugin/cesium/primitive.test.js
+++ b/test/plugin/cesium/primitive.test.js
@@ -1,3 +1,4 @@
+goog.require('goog.async.Delay');
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');
 goog.require('ol.proj');
@@ -5,7 +6,7 @@ goog.require('ol.style.Style');
 goog.require('os.data.RecordField');
 goog.require('os.layer.Vector');
 goog.require('os.proj');
-goog.require('os.webgl');
+goog.require('os.webgl.AltitudeMode');
 goog.require('plugin.cesium');
 goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.primitive');
@@ -13,20 +14,31 @@ goog.require('test.plugin.cesium.primitive');
 goog.require('test.plugin.cesium.scene');
 
 describe('plugin.cesium.primitive', () => {
+  const Delay = goog.module.get('goog.async.Delay');
+
+  const Feature = goog.module.get('ol.Feature');
+  const Point = goog.module.get('ol.geom.Point');
+  const olProj = goog.module.get('ol.proj');
+  const Style = goog.module.get('ol.style.Style');
+  const RecordField = goog.module.get('os.data.RecordField');
+  const VectorLayer = goog.module.get('os.layer.Vector');
+  const osProj = goog.module.get('os.proj');
+  const AltitudeMode = goog.module.get('os.webgl.AltitudeMode');
+
   const {GeometryInstanceId} = goog.module.get('plugin.cesium');
+  const VectorContext = goog.module.get('plugin.cesium.VectorContext');
   const syncUtils = goog.module.get('plugin.cesium.primitive');
   const primitiveUtils = goog.module.get('test.plugin.cesium.primitive');
   const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
-  const VectorContext = goog.module.get('plugin.cesium.VectorContext');
 
   describe('getPrimitive', () => {
     it('should retrieve the primitive', () => {
       const scene = getFakeScene();
-      const layer = new os.layer.Vector();
-      const context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+      const layer = new VectorLayer();
+      const context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
 
-      const geometry = new ol.geom.Point([0, 0]);
-      const feature = new ol.Feature(geometry);
+      const geometry = new Point([0, 0]);
+      const feature = new Feature(geometry);
       const billboard = primitiveUtils.createBillboard([0, 0, 0]);
 
       context.geometryToCesiumMap[ol.getUid(geometry)] = billboard;
@@ -46,12 +58,12 @@ describe('plugin.cesium.primitive', () => {
     let scene;
 
     beforeEach(() => {
-      geometry = new ol.geom.Point([0, 0]);
-      feature = new ol.Feature(geometry);
-      style = new ol.style.Style();
-      layer = new os.layer.Vector();
+      geometry = new Point([0, 0]);
+      feature = new Feature(geometry);
+      style = new Style();
+      layer = new VectorLayer();
       scene = getFakeScene();
-      context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+      context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
     });
 
     it('should allow updates on everything for unchanged altitude modes', () => {
@@ -66,7 +78,7 @@ describe('plugin.cesium.primitive', () => {
 
     it('should allow updates on billboards changing altitude modes', () => {
       const billboard = primitiveUtils.createBillboard([0, 0, 0]);
-      geometry.set(os.data.RecordField.ALTITUDE_MODE, os.webgl.AltitudeMode.CLAMP_TO_GROUND);
+      geometry.set(RecordField.ALTITUDE_MODE, AltitudeMode.CLAMP_TO_GROUND);
       expect(syncUtils.shouldUpdatePrimitive(feature, geometry, style, context, billboard)).toBe(true);
     });
 
@@ -74,7 +86,7 @@ describe('plugin.cesium.primitive', () => {
       const primitive = primitiveUtils.createPrimitive([-5, -5, 5, 5]);
       const polyline = primitiveUtils.createPolyline([[0, 0], [10, 10]]);
 
-      geometry.set(os.data.RecordField.ALTITUDE_MODE, os.webgl.AltitudeMode.CLAMP_TO_GROUND);
+      geometry.set(RecordField.ALTITUDE_MODE, AltitudeMode.CLAMP_TO_GROUND);
       [primitive, polyline].forEach((item) =>
         expect(syncUtils.shouldUpdatePrimitive(feature, geometry, style, context, item)).toBe(false));
     });
@@ -94,17 +106,17 @@ describe('plugin.cesium.primitive', () => {
     let material;
 
     beforeEach(() => {
-      geometry = new ol.geom.Point([0, 0]);
-      feature = new ol.Feature(geometry);
-      style = new ol.style.Style();
-      layer = new os.layer.Vector();
+      geometry = new Point([0, 0]);
+      feature = new Feature(geometry);
+      style = new Style();
+      layer = new VectorLayer();
       scene = getFakeScene();
-      context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+      context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
 
       // switch the delay to 1ms so that we don't have to wait so long to test
       // multiple tries
-      const oldStart = goog.async.Delay.prototype.start;
-      spyOn(goog.async.Delay.prototype, 'start').andCallFake(function(interval) {
+      const oldStart = Delay.prototype.start;
+      spyOn(Delay.prototype, 'start').andCallFake(function(interval) {
         oldStart.call(this, 1);
       });
 
@@ -126,7 +138,7 @@ describe('plugin.cesium.primitive', () => {
       const primitive = primitiveUtils.createPrimitive([-5, -5, 5, 5]);
       const polyline = primitiveUtils.createPolyline([[0, 0], [10, 10]]);
 
-      geometry.set(os.data.RecordField.ALTITUDE_MODE, os.webgl.AltitudeMode.CLAMP_TO_GROUND);
+      geometry.set(RecordField.ALTITUDE_MODE, AltitudeMode.CLAMP_TO_GROUND);
       [primitive, polyline].forEach((item) =>
         expect(syncUtils.updatePrimitive(feature, geometry, style, context, item)).toBe(false));
     });
@@ -194,11 +206,11 @@ describe('plugin.cesium.primitive', () => {
   describe('deletePrimitive', () => {
     it('should delete the primitive', () => {
       const scene = getFakeScene();
-      const layer = new os.layer.Vector();
-      const context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+      const layer = new VectorLayer();
+      const context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
 
-      const geometry = new ol.geom.Point([0, 0]);
-      const feature = new ol.Feature(geometry);
+      const geometry = new Point([0, 0]);
+      const feature = new Feature(geometry);
       const billboard = primitiveUtils.createBillboard([0, 0, 0]);
 
       context.geometryToCesiumMap[ol.getUid(geometry)] = billboard;

--- a/test/plugin/cesium/scene.mock.js
+++ b/test/plugin/cesium/scene.mock.js
@@ -1,6 +1,6 @@
 goog.module('test.plugin.cesium.scene');
 
-goog.require('plugin.cesium');
+const {getJulianDate} = goog.require('plugin.cesium');
 const {fixContextLimits} = goog.require('test.plugin.cesium');
 
 const getFakeScene = () => ({
@@ -43,7 +43,7 @@ const getRealScene = () => {
 const renderScene = (scene) => {
   if (scene instanceof Cesium.Scene) {
     scene.initializeFrame();
-    scene.forceRender(plugin.cesium.getJulianDate());
+    scene.forceRender(getJulianDate());
   } else {
     throw new Error('Only real Cesium scenes can be rendered. Did you mean to use getRealScene()?');
   }

--- a/test/plugin/cesium/sync/converter.test.js
+++ b/test/plugin/cesium/sync/converter.test.js
@@ -1,5 +1,6 @@
 goog.require('ol.geom.GeometryType');
 goog.require('ol.geom.Point');
+goog.require('ol.proj');
 goog.require('ol.style.Style');
 goog.require('ol.style.Text');
 goog.require('os.feature.DynamicFeature');
@@ -25,12 +26,20 @@ goog.require('plugin.cesium.sync.converter');
 goog.require('test.plugin.cesium.scene');
 
 describe('plugin.cesium.sync.converter', () => {
+  const Feature = goog.module.get('ol.Feature');
+  const GeometryType = goog.module.get('ol.geom.GeometryType');
+  const Point = goog.module.get('ol.geom.Point');
+  const olProj = goog.module.get('ol.proj');
+  const Style = goog.module.get('ol.style.Style');
+
   const {convertGeometry, getConverter} = goog.module.get('plugin.cesium.sync.converter');
   const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
   const DynamicFeature = goog.module.get('os.feature.DynamicFeature');
-  const GeometryType = goog.module.get('ol.geom.GeometryType');
   const DynamicLineStringConverter = goog.module.get('plugin.cesium.sync.DynamicLineStringConverter');
   const Ellipse = goog.module.get('os.geom.Ellipse');
+  const Vector = goog.module.get('os.layer.Vector');
+  const {EPSG4326} = goog.module.get('os.proj');
+
   const EllipseConverter = goog.module.get('plugin.cesium.sync.EllipseConverter');
   const GeometryCollectionConverter = goog.module.get('plugin.cesium.sync.GeometryCollectionConverter');
   const LabelConverter = goog.module.get('plugin.cesium.sync.LabelConverter');
@@ -53,12 +62,12 @@ describe('plugin.cesium.sync.converter', () => {
   let context;
 
   beforeEach(() => {
-    geometry = new ol.geom.Point([0, 0]);
-    feature = new ol.Feature(geometry);
-    style = new ol.style.Style();
-    layer = new os.layer.Vector();
+    geometry = new Point([0, 0]);
+    feature = new Feature(geometry);
+    style = new Style();
+    layer = new Vector();
     scene = getFakeScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(EPSG4326));
   });
 
   describe('converterGeometry', () => {

--- a/test/plugin/cesium/sync/dynamiclinestringconverter.test.js
+++ b/test/plugin/cesium/sync/dynamiclinestringconverter.test.js
@@ -4,7 +4,11 @@ goog.require('ol.proj');
 goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Image');
+goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
+goog.require('os.layer.Vector');
+goog.require('os.map');
+goog.require('os.proj');
 goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.sync.DynamicLineStringConverter');
 goog.require('test.plugin.cesium.scene');
@@ -14,9 +18,11 @@ describe('plugin.cesium.sync.DynamicLineStringConverter', () => {
   const Feature = goog.module.get('ol.Feature');
   const LineString = goog.module.get('ol.geom.LineString');
   const olProj = goog.module.get('ol.proj');
+  const Stroke = goog.module.get('ol.style.Stroke');
   const Style = goog.module.get('ol.style.Style');
 
   const Vector = goog.module.get('os.layer.Vector');
+  const osMap = goog.module.get('os.map');
   const {EPSG4326} = goog.module.get('os.proj');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
   const DynamicLineStringConverter = goog.module.get('plugin.cesium.sync.DynamicLineStringConverter');
@@ -41,10 +47,10 @@ describe('plugin.cesium.sync.DynamicLineStringConverter', () => {
     context = new VectorContext(scene, layer, olProj.get(EPSG4326));
   });
 
-  const originalProjection = os.map.PROJECTION;
+  const originalProjection = osMap.PROJECTION;
   afterEach(() => {
     disableWebGLMock();
-    os.map.PROJECTION = originalProjection;
+    osMap.PROJECTION = originalProjection;
   });
 
   const blue = 'rgba(0,0,255,1)';
@@ -59,7 +65,7 @@ describe('plugin.cesium.sync.DynamicLineStringConverter', () => {
     });
 
     it('should create a line with a given stroke style', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: green,
         width: 4
       }));
@@ -70,7 +76,7 @@ describe('plugin.cesium.sync.DynamicLineStringConverter', () => {
     });
 
     it('should create a dashed line if the stroke contains a dash', () => {
-      const stroke = new ol.style.Stroke({
+      const stroke = new Stroke({
         color: green,
         width: 1
       });
@@ -89,7 +95,7 @@ describe('plugin.cesium.sync.DynamicLineStringConverter', () => {
 
   describe('update', () => {
     it('should update changing line widths', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: blue,
         width: 3
       }));
@@ -98,7 +104,7 @@ describe('plugin.cesium.sync.DynamicLineStringConverter', () => {
 
       const linestring = context.polylines.get(0);
 
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: green,
         width: 4
       }));
@@ -108,7 +114,7 @@ describe('plugin.cesium.sync.DynamicLineStringConverter', () => {
     });
 
     it('should update changing dash patterns', () => {
-      const stroke = new ol.style.Stroke({
+      const stroke = new Stroke({
         color: green,
         width: 1
       });
@@ -125,7 +131,7 @@ describe('plugin.cesium.sync.DynamicLineStringConverter', () => {
     });
 
     it('should update lines with new colors', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: green,
         width: 4
       }));

--- a/test/plugin/cesium/sync/dynamiclinestringconverter.test.js
+++ b/test/plugin/cesium/sync/dynamiclinestringconverter.test.js
@@ -11,10 +11,19 @@ goog.require('test.plugin.cesium.scene');
 goog.require('test.plugin.cesium.sync.dynamiclinestring');
 
 describe('plugin.cesium.sync.DynamicLineStringConverter', () => {
+  const Feature = goog.module.get('ol.Feature');
+  const LineString = goog.module.get('ol.geom.LineString');
+  const olProj = goog.module.get('ol.proj');
+  const Style = goog.module.get('ol.style.Style');
+
+  const Vector = goog.module.get('os.layer.Vector');
+  const {EPSG4326} = goog.module.get('os.proj');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
+  const DynamicLineStringConverter = goog.module.get('plugin.cesium.sync.DynamicLineStringConverter');
+
   const {testLine} = goog.module.get('test.plugin.cesium.sync.dynamiclinestring');
   const {getRealScene, renderScene} = goog.module.get('test.plugin.cesium.scene');
-  const DynamicLineStringConverter = goog.module.get('plugin.cesium.sync.DynamicLineStringConverter');
+
   const lineStringConverter = new DynamicLineStringConverter();
 
   let feature;
@@ -24,12 +33,12 @@ describe('plugin.cesium.sync.DynamicLineStringConverter', () => {
 
   beforeEach(() => {
     enableWebGLMock();
-    geometry = new ol.geom.LineString([[0, 0], [5, 5]]);
-    feature = new ol.Feature(geometry);
-    style = new ol.style.Style();
-    layer = new os.layer.Vector();
+    geometry = new LineString([[0, 0], [5, 5]]);
+    feature = new Feature(geometry);
+    style = new Style();
+    layer = new Vector();
     scene = getRealScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(EPSG4326));
   });
 
   const originalProjection = os.map.PROJECTION;

--- a/test/plugin/cesium/sync/dynamicmultipolygonconverter.test.js
+++ b/test/plugin/cesium/sync/dynamicmultipolygonconverter.test.js
@@ -10,9 +10,18 @@ goog.require('plugin.cesium.sync.DynamicMultiPolygonConverter');
 goog.require('test.plugin.cesium.scene');
 
 describe('plugin.cesium.sync.DynamicMultiPolygonConverter', () => {
-  const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
+  const MultiPolygon = goog.module.get('ol.geom.MultiPolygon');
+  const Style = goog.module.get('ol.style.Style');
+  const olProj = goog.module.get('ol.proj');
+
+  const DynamicFeature = goog.module.get('os.feature.DynamicFeature');
+  const Vector = goog.module.get('os.layer.Vector');
+  const {EPSG4326} = goog.module.get('os.proj');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
   const DynamicMultiPolygonConverter = goog.module.get('plugin.cesium.sync.DynamicMultiPolygonConverter');
+
+  const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
+
   const converter = new DynamicMultiPolygonConverter();
 
   let feature;
@@ -29,12 +38,12 @@ describe('plugin.cesium.sync.DynamicMultiPolygonConverter', () => {
         [[10, 10], [10, 20], [20, 20], [20, 10], [10, 10]]
       ]
     ];
-    geometry = new ol.geom.MultiPolygon(coords);
-    feature = new os.feature.DynamicFeature(geometry);
-    style = new ol.style.Style();
-    layer = new os.layer.Vector();
+    geometry = new MultiPolygon(coords);
+    feature = new DynamicFeature(geometry);
+    style = new Style();
+    layer = new Vector();
     scene = getFakeScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(EPSG4326));
   });
 
   const originalProjection = os.map.PROJECTION;

--- a/test/plugin/cesium/sync/dynamicmultipolygonconverter.test.js
+++ b/test/plugin/cesium/sync/dynamicmultipolygonconverter.test.js
@@ -1,5 +1,6 @@
 goog.require('ol.geom.MultiPolygon');
 goog.require('ol.proj');
+goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('os.feature.DynamicFeature');
 goog.require('os.layer.Vector');
@@ -11,11 +12,13 @@ goog.require('test.plugin.cesium.scene');
 
 describe('plugin.cesium.sync.DynamicMultiPolygonConverter', () => {
   const MultiPolygon = goog.module.get('ol.geom.MultiPolygon');
+  const Stroke = goog.module.get('ol.style.Stroke');
   const Style = goog.module.get('ol.style.Style');
   const olProj = goog.module.get('ol.proj');
 
   const DynamicFeature = goog.module.get('os.feature.DynamicFeature');
   const Vector = goog.module.get('os.layer.Vector');
+  const osMap = goog.module.get('os.map');
   const {EPSG4326} = goog.module.get('os.proj');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
   const DynamicMultiPolygonConverter = goog.module.get('plugin.cesium.sync.DynamicMultiPolygonConverter');
@@ -46,9 +49,9 @@ describe('plugin.cesium.sync.DynamicMultiPolygonConverter', () => {
     context = new VectorContext(scene, layer, olProj.get(EPSG4326));
   });
 
-  const originalProjection = os.map.PROJECTION;
+  const originalProjection = osMap.PROJECTION;
   afterEach(() => {
-    os.map.PROJECTION = originalProjection;
+    osMap.PROJECTION = originalProjection;
   });
 
   const blue = 'rgba(0,0,255,1)';
@@ -70,8 +73,8 @@ describe('plugin.cesium.sync.DynamicMultiPolygonConverter', () => {
           [[12, 12], [12, 18], [18, 18], [18, 12], [12, 12]]
         ]
       ];
-      geometry = new ol.geom.MultiPolygon(coords);
-      feature = new os.feature.DynamicFeature(geometry);
+      geometry = new MultiPolygon(coords);
+      feature = new DynamicFeature(geometry);
 
       expect(converter.create(feature, geometry, style, context)).toBe(true);
       expect(context.polylines.length).toBe(4);
@@ -84,7 +87,7 @@ describe('plugin.cesium.sync.DynamicMultiPolygonConverter', () => {
       const primitives = converter.retrieve(feature, geometry, style, context);
       expect(context.polylines.length).toBe(2);
 
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: blue,
         width: 2
       }));

--- a/test/plugin/cesium/sync/dynamicpolygonconverter.test.js
+++ b/test/plugin/cesium/sync/dynamicpolygonconverter.test.js
@@ -5,6 +5,7 @@ goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Image');
 goog.require('ol.style.Style');
+goog.require('os.map');
 goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.sync.DynamicPolygonConverter');
 goog.require('test.plugin.cesium.scene');
@@ -17,6 +18,7 @@ describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
   const Style = goog.module.get('ol.style.Style');
 
   const Vector = goog.module.get('os.layer.Vector');
+  const osMap = goog.module.get('os.map');
   const {EPSG4326} = goog.module.get('os.proj');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
   const DynamicPolygonConverter = goog.module.get('plugin.cesium.sync.DynamicPolygonConverter');
@@ -41,10 +43,10 @@ describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
     context = new VectorContext(scene, layer, olProj.get(EPSG4326));
   });
 
-  const originalProjection = os.map.PROJECTION;
+  const originalProjection = osMap.PROJECTION;
   afterEach(() => {
     disableWebGLMock();
-    os.map.PROJECTION = originalProjection;
+    osMap.PROJECTION = originalProjection;
   });
 
   const bluish = 'rgba(20,50,255,1)';

--- a/test/plugin/cesium/sync/dynamicpolygonconverter.test.js
+++ b/test/plugin/cesium/sync/dynamicpolygonconverter.test.js
@@ -11,10 +11,19 @@ goog.require('test.plugin.cesium.scene');
 goog.require('test.plugin.cesium.sync.dynamiclinestring');
 
 describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
+  const Polygon = goog.module.get('ol.geom.Polygon');
+  const Feature = goog.module.get('ol.Feature');
+  const olProj = goog.module.get('ol.proj');
+  const Style = goog.module.get('ol.style.Style');
+
+  const Vector = goog.module.get('os.layer.Vector');
+  const {EPSG4326} = goog.module.get('os.proj');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
+  const DynamicPolygonConverter = goog.module.get('plugin.cesium.sync.DynamicPolygonConverter');
+
   const {testLine} = goog.module.get('test.plugin.cesium.sync.dynamiclinestring');
   const {getRealScene, renderScene} = goog.module.get('test.plugin.cesium.scene');
-  const DynamicPolygonConverter = goog.module.get('plugin.cesium.sync.DynamicPolygonConverter');
+
   const polygonConverter = new DynamicPolygonConverter();
 
   let feature;
@@ -24,12 +33,12 @@ describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
 
   beforeEach(() => {
     enableWebGLMock();
-    geometry = new ol.geom.Polygon([[[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]]]);
-    feature = new ol.Feature(geometry);
-    style = new ol.style.Style();
-    layer = new os.layer.Vector();
+    geometry = new Polygon([[[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]]]);
+    feature = new Feature(geometry);
+    style = new Style();
+    layer = new Vector();
     scene = getRealScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(EPSG4326));
   });
 
   const originalProjection = os.map.PROJECTION;

--- a/test/plugin/cesium/sync/ellipseconverter.test.js
+++ b/test/plugin/cesium/sync/ellipseconverter.test.js
@@ -6,7 +6,6 @@ goog.require('os.map');
 goog.require('os.proj');
 goog.require('os.style.StyleField');
 goog.require('os.style.StyleManager');
-goog.require('plugin.cesium');
 goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.sync.EllipseConverter');
 goog.require('test.plugin.cesium.scene');

--- a/test/plugin/cesium/sync/ellipsoidconverter.test.js
+++ b/test/plugin/cesium/sync/ellipsoidconverter.test.js
@@ -6,7 +6,6 @@ goog.require('os.map');
 goog.require('os.proj');
 goog.require('os.style.StyleField');
 goog.require('os.style.StyleManager');
-goog.require('plugin.cesium');
 goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.sync.EllipsoidConverter');
 goog.require('test.plugin.cesium.scene');

--- a/test/plugin/cesium/sync/geometrycollectionconverter.test.js
+++ b/test/plugin/cesium/sync/geometrycollectionconverter.test.js
@@ -10,7 +10,6 @@ goog.require('os.layer.Vector');
 goog.require('os.map');
 goog.require('os.proj');
 goog.require('os.webgl.AltitudeMode');
-goog.require('plugin.cesium');
 goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.sync.GeometryCollectionConverter');
 goog.require('test.plugin.cesium.scene');

--- a/test/plugin/cesium/sync/linestringconverter.test.js
+++ b/test/plugin/cesium/sync/linestringconverter.test.js
@@ -10,7 +10,6 @@ goog.require('os.layer.Vector');
 goog.require('os.map');
 goog.require('os.proj');
 goog.require('os.webgl.AltitudeMode');
-goog.require('plugin.cesium');
 goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.sync.LineStringConverter');
 goog.require('test.plugin.cesium.scene');

--- a/test/plugin/cesium/sync/polygon.mock.js
+++ b/test/plugin/cesium/sync/polygon.mock.js
@@ -12,7 +12,7 @@ const testPolygon = (polygon, options) => {
 
   if (!options.cleanedGeometryInstances) {
     expect(Array.isArray(polygon.geometryInstances)).toBe(false);
-    expect(polygon.geometryInstances.id).toBe(plugin.cesium.GeometryInstanceId.GEOM);
+    expect(polygon.geometryInstances.id).toBe(GeometryInstanceId.GEOM);
     expect(polygon.geometryInstances.geometry.constructor).toBe(Cesium.PolygonGeometry);
   }
 

--- a/test/plugin/cesium/sync/polygonconverter.test.js
+++ b/test/plugin/cesium/sync/polygonconverter.test.js
@@ -9,7 +9,6 @@ goog.require('os.layer.Vector');
 goog.require('os.map');
 goog.require('os.proj');
 goog.require('os.webgl.AltitudeMode');
-goog.require('plugin.cesium');
 goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.sync.PolygonConverter');
 goog.require('test.plugin.cesium.scene');

--- a/test/plugin/cesium/sync/style.test.js
+++ b/test/plugin/cesium/sync/style.test.js
@@ -6,6 +6,7 @@ goog.require('plugin.cesium');
 goog.require('plugin.cesium.sync.style');
 
 describe('plugin.cesium.sync.style', () => {
+  const {GeometryInstanceId} = goog.module.get('plugin.cesium');
   const {getColor, getLineWidthFromStyle} = goog.module.get('plugin.cesium.sync.style');
 
   describe('getColor', () => {
@@ -49,32 +50,32 @@ describe('plugin.cesium.sync.style', () => {
 
         it('should default to black', () => {
           const style = new ol.style.Style();
-          const color = getColor(style, context, plugin.cesium.GeometryInstanceId.GEOM);
+          const color = getColor(style, context, GeometryInstanceId.GEOM);
           compareColor(color, black);
         });
 
         it('should prefer the fill color for geometries', () => {
           const style = getStyle();
-          let color = getColor(style, context, plugin.cesium.GeometryInstanceId.GEOM);
+          let color = getColor(style, context, GeometryInstanceId.GEOM);
           compareColor(color, blue);
-          color = getColor(style, context, plugin.cesium.GeometryInstanceId.ELLIPSOID);
+          color = getColor(style, context, GeometryInstanceId.ELLIPSOID);
           compareColor(color, blue);
         });
 
         it('should prefer the stroke color for outline geometries', () => {
           const style = getStyle();
-          let color = getColor(style, context, plugin.cesium.GeometryInstanceId.GEOM_OUTLINE);
+          let color = getColor(style, context, GeometryInstanceId.GEOM_OUTLINE);
           compareColor(color, red);
-          color = getColor(style, context, plugin.cesium.GeometryInstanceId.ELLIPSOID_OUTLINE);
+          color = getColor(style, context, GeometryInstanceId.ELLIPSOID_OUTLINE);
           compareColor(color, red);
         });
 
         it('should use 0 alpha for non-highlight styles if the stroke is missing', () => {
           const style = getStyle();
           style.setStroke(null);
-          let color = getColor(style, context, plugin.cesium.GeometryInstanceId.GEOM_OUTLINE);
+          let color = getColor(style, context, GeometryInstanceId.GEOM_OUTLINE);
           compareColor(color, blue, 0);
-          color = getColor(style, context, plugin.cesium.GeometryInstanceId.ELLIPSOID_OUTLINE);
+          color = getColor(style, context, GeometryInstanceId.ELLIPSOID_OUTLINE);
           compareColor(color, blue, 0);
         });
       });

--- a/test/plugin/cesium/vectorcontext.test.js
+++ b/test/plugin/cesium/vectorcontext.test.js
@@ -2,6 +2,7 @@ goog.require('ol.Feature');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
+goog.require('ol.proj');
 goog.require('os.layer.Vector');
 goog.require('os.proj');
 goog.require('plugin.cesium.VectorContext');
@@ -10,19 +11,25 @@ goog.require('test.plugin.cesium.primitive');
 goog.require('test.plugin.cesium.scene');
 
 describe('plugin.cesium.VectorContext', () => {
-  const primitiveUtils = goog.module.get('test.plugin.cesium.primitive');
-  const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
+  const Feature = goog.module.get('ol.Feature');
+  const Point = goog.module.get('ol.geom.Point');
+  const Polygon = goog.module.get('ol.geom.Polygon');
+  const olProj = goog.module.get('ol.proj');
+  const VectorLayer = goog.module.get('os.layer.Vector');
+  const osProj = goog.module.get('os.proj');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
   const {isPrimitiveShown} = goog.module.get('plugin.cesium.primitive');
+  const primitiveUtils = goog.module.get('test.plugin.cesium.primitive');
+  const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
 
   let layer;
   let scene;
   let context;
 
   beforeEach(() => {
-    layer = new os.layer.Vector();
+    layer = new VectorLayer();
     scene = getFakeScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
   });
 
   describe('constructor', () => {
@@ -99,8 +106,8 @@ describe('plugin.cesium.VectorContext', () => {
     let geometry;
 
     beforeEach(() => {
-      geometry = new ol.geom.Point([0, 0]);
-      feature = new ol.Feature(geometry);
+      geometry = new Point([0, 0]);
+      feature = new Feature(geometry);
     });
 
     it('should handle undefined primitives', () => {
@@ -127,8 +134,8 @@ describe('plugin.cesium.VectorContext', () => {
     let geometry;
 
     beforeEach(() => {
-      geometry = new ol.geom.Point([0, 0]);
-      feature = new ol.Feature(geometry);
+      geometry = new Point([0, 0]);
+      feature = new Feature(geometry);
     });
 
     it('should handle undefined primitives', () => {
@@ -169,7 +176,7 @@ describe('plugin.cesium.VectorContext', () => {
   describe('markDirty', () => {
     let feature;
     beforeEach(() => {
-      feature = new ol.Feature(new ol.geom.Point([0, 0]));
+      feature = new Feature(new Point([0, 0]));
     });
 
     it('should handle no associated primitives', () => {
@@ -187,7 +194,7 @@ describe('plugin.cesium.VectorContext', () => {
   describe('removeDirty', () => {
     let feature;
     beforeEach(() => {
-      feature = new ol.Feature(new ol.geom.Point([0, 0]));
+      feature = new Feature(new Point([0, 0]));
     });
 
     it('should handle no associated primitives', () => {
@@ -209,7 +216,7 @@ describe('plugin.cesium.VectorContext', () => {
   describe('cleanup', () => {
     let feature;
     beforeEach(() => {
-      feature = new ol.Feature(new ol.geom.Point([0, 0]));
+      feature = new Feature(new Point([0, 0]));
     });
 
     it('should handle no associated primitives', () => {
@@ -236,8 +243,8 @@ describe('plugin.cesium.VectorContext', () => {
     let geometry;
 
     beforeEach(() => {
-      geometry = new ol.geom.Point([0, 0]);
-      feature = new ol.Feature(geometry);
+      geometry = new Point([0, 0]);
+      feature = new Feature(geometry);
     });
 
     it('should add a billboard properly', () => {
@@ -272,7 +279,7 @@ describe('plugin.cesium.VectorContext', () => {
 
     beforeEach(() => {
       geometry = new ol.geom.LineString([[0, 0], [5, 5]]);
-      feature = new ol.Feature(geometry);
+      feature = new Feature(geometry);
     });
 
     it('should add a polyline properly', () => {
@@ -306,8 +313,8 @@ describe('plugin.cesium.VectorContext', () => {
     let geometry;
 
     beforeEach(() => {
-      geometry = new ol.geom.Polygon.fromExtent([-5, -5, 5, 5]);
-      feature = new ol.Feature(geometry);
+      geometry = Polygon.fromExtent([-5, -5, 5, 5]);
+      feature = new Feature(geometry);
     });
 
     it('should add a primitive properly', () => {
@@ -355,8 +362,8 @@ describe('plugin.cesium.VectorContext', () => {
     let geometry;
 
     beforeEach(() => {
-      geometry = new ol.geom.Point([0, 0]);
-      feature = new ol.Feature(geometry);
+      geometry = new Point([0, 0]);
+      feature = new Feature(geometry);
     });
 
     it('should add a label properly', () => {
@@ -390,8 +397,8 @@ describe('plugin.cesium.VectorContext', () => {
     let geometry;
 
     beforeEach(() => {
-      geometry = new ol.geom.Point([0, 0]);
-      feature = new ol.Feature(geometry);
+      geometry = new Point([0, 0]);
+      feature = new Feature(geometry);
     });
 
     it('should remove each item type', () => {
@@ -432,14 +439,14 @@ describe('plugin.cesium.VectorContext', () => {
   });
 
   describe('getLabelForGeometry', () => {
-    const geometry = new ol.geom.Point([0, 0]);
+    const geometry = new Point([0, 0]);
 
     it('should return null by default', () => {
       expect(context.getLabelForGeometry(geometry)).toBe(null);
     });
 
     it('should return a label if one exists', () => {
-      const feature = new ol.Feature(geometry);
+      const feature = new Feature(geometry);
       const labelOptions = primitiveUtils.createLabelOptions();
       context.addLabel(labelOptions, feature, geometry);
 
@@ -450,7 +457,7 @@ describe('plugin.cesium.VectorContext', () => {
   });
 
   describe('getPrimitiveForGeometry', () => {
-    const geometry = new ol.geom.Point([0, 0]);
+    const geometry = new Point([0, 0]);
 
     it('should return undefined by default', () => {
       expect(context.getPrimitiveForGeometry(geometry)).toBe(undefined);
@@ -458,7 +465,7 @@ describe('plugin.cesium.VectorContext', () => {
 
     it('should return the primitive for the geometry if one exists', () => {
       const billboardOptions = primitiveUtils.createBillboard([0, 0, 0]);
-      const feature = new ol.Feature(geometry);
+      const feature = new Feature(geometry);
       context.addBillboard(billboardOptions, feature, geometry);
       const billboard = context.billboards.get(0);
 
@@ -532,7 +539,7 @@ describe('plugin.cesium.VectorContext', () => {
   });
 
   describe('isFeatureShown', () => {
-    const feature = new ol.Feature();
+    const feature = new Feature();
 
     it('should default to true', () => {
       expect(context.isFeatureShown(feature)).toBe(true);

--- a/test/plugin/heatmap/heatmapplugin.test.js
+++ b/test/plugin/heatmap/heatmapplugin.test.js
@@ -10,6 +10,8 @@ goog.require('plugin.heatmap.menu');
 
 
 describe('plugin.heatmap.HeatmapPlugin', function() {
+  const HeatmapSynchronizer = goog.module.get('plugin.cesium.sync.HeatmapSynchronizer');
+
   var createLayer = function() {
     var options = {
       'id': goog.string.getRandomString(),
@@ -41,12 +43,10 @@ describe('plugin.heatmap.HeatmapPlugin', function() {
     var sm = os.webgl.SynchronizerManager.getInstance();
 
     // now is registered by the WebGLRenderer (e.g. Cesium) plugin; spoof it
-    sm.registerSynchronizer(
-        plugin.heatmap.SynchronizerType.HEATMAP,
-        plugin.cesium.sync.HeatmapSynchronizer);
+    sm.registerSynchronizer(plugin.heatmap.SynchronizerType.HEATMAP, HeatmapSynchronizer);
 
     var synchronizer = sm.getSynchronizer(layer);
-    expect(synchronizer).toBe(plugin.cesium.sync.HeatmapSynchronizer);
+    expect(synchronizer).toBe(HeatmapSynchronizer);
     sm.synchronizers_ = {};
 
     var dm = os.dataManager;


### PR DESCRIPTION
The entire Cesium plugin has been converted to use `goog.module`. I cleaned up somethings we were doing in the plugin that resulted in compiler errors using ES classes.

- Some Cesium classes like `Cesium.TilingScheme` are really abstract classes and don't provide any functional code. The Cesium class/object is not available until the library is loaded, so we had code to defer creating extending classes until that happens. This was a little strange with modules/classes, so I changed the Cesium externs to make the original constructor an interface instead. This is much cleaner, and has no side effects given Cesium's implementations were all empty anyway.
- Some Cesium mixins also needed to load async after the library loaded, so I cleaned up those files to a more consistent and module-friendly pattern.
- We frequently used `Object.defineProperties` to add `get/set` functions to Cesium plugin classes. ES classes can use `get/set` directly, so I refactored all of those so the resulting code is much cleaner.
- We had some janky code to replace the OLCS camera class with our own, because we didn't want to use their view listener. We were using all of the other code, so I dropped the class replace and instead replaced `setView_` (the view change handler) on the OLCS class with an empty function. This has the same end result, but in a less janky manner.