### PR TITLE
test(cesium): replace global refs in tests

### DIFF
--- a/.jscodeshift.json
+++ b/.jscodeshift.json
@@ -8,7 +8,9 @@
     "os.ui.filterManager": {"require": "os.query.FilterManager", "singleton": true},
     "os.layerConfigManager": {"require": "os.layer.config.LayerConfigManager", "singleton": true},
     "os.settings": {"require": "os.config.Settings", "singleton": true},
-    "os.map.mapContainer": {"require": "os.MapContainer", "singleton": true}
+    "os.map.mapContainer": {"require": "os.MapContainer", "singleton": true},
+    "os.queryManager": {"require": "os.query.QueryManager", "singleton": true},
+    "os.ui.queryManager": {"require": "os.query.QueryManager", "singleton": true}
   },
   "globalRootNamespaces": [
     "plugin",

--- a/.jscodeshift.json
+++ b/.jscodeshift.json
@@ -4,15 +4,35 @@
     "os.areaManager": {"require": "os.query.AreaManager", "singleton": true},
     "os.ui.areaManager": {"require": "os.query.AreaManager", "singleton": true},
     "os.dispatcher": {"require": "os.Dispatcher", "singleton": true},
-    "os.feature": {},
     "os.filterManager": {"require": "os.query.FilterManager", "singleton": true},
     "os.ui.filterManager": {"require": "os.query.FilterManager", "singleton": true},
-    "os.geo": {},
     "os.layerConfigManager": {"require": "os.layer.config.LayerConfigManager", "singleton": true},
-    "os.layer.config.LayerConfigManager": {},
-    "os.ui": {},
     "os.settings": {"require": "os.config.Settings", "singleton": true},
-    "os.map.mapContainer": {"require": "os.MapContainer", "singleton": true},
-    "os.MapContainer": {}
+    "os.map.mapContainer": {"require": "os.MapContainer", "singleton": true}
+  },
+  "globalRootNamespaces": [
+    "plugin",
+    "os",
+    "olcs",
+    "ol",
+    "goog"
+  ],
+  "moduleBlacklist": [
+    "goog",
+    "goog.module"
+  ],
+  "moduleVarNames": {
+    "ol.extent": "olExtent",
+    "ol.layer.Vector": "OLVectorLayer",
+    "ol.proj": "olProj",
+    "ol.source.Vector": "OLVectorSource",
+
+    "os.extent": "osExtent",
+    "os.feature": "osFeature",
+    "os.layer.Vector": "VectorLayer",
+    "os.map": "osMap",
+    "os.proj": "osProj",
+    "os.source.Vector": "VectorSource",
+    "os.ui.window": "osWindow"
   }
 }

--- a/test/plugin/cesium/primitive.test.js
+++ b/test/plugin/cesium/primitive.test.js
@@ -1,4 +1,6 @@
 goog.require('goog.async.Delay');
+goog.require('goog.dispose');
+goog.require('ol');
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');
 goog.require('ol.proj');
@@ -13,7 +15,10 @@ goog.require('plugin.cesium.primitive');
 goog.require('test.plugin.cesium.primitive');
 goog.require('test.plugin.cesium.scene');
 
+
 describe('plugin.cesium.primitive', () => {
+  const dispose = goog.module.get('goog.dispose');
+  const ol = goog.module.get('ol');
   const Delay = goog.module.get('goog.async.Delay');
 
   const Feature = goog.module.get('ol.Feature');
@@ -190,7 +195,7 @@ describe('plugin.cesium.primitive', () => {
 
     it('should stop retrying disposed primitives and mark them for removal', () => {
       primitive.ready = true;
-      goog.dispose(feature);
+      dispose(feature);
       expect(syncUtils.updatePrimitive(feature, geometry, style, context, primitive)).toBe(true);
       expect(primitive.dirty).toBe(true);
     });

--- a/test/plugin/cesium/scene.mock.js
+++ b/test/plugin/cesium/scene.mock.js
@@ -3,6 +3,7 @@ goog.module('test.plugin.cesium.scene');
 const {getJulianDate} = goog.require('plugin.cesium');
 const {fixContextLimits} = goog.require('test.plugin.cesium');
 
+
 const getFakeScene = () => ({
   primitives: new Cesium.PrimitiveCollection(),
   groundPrimitives: new Cesium.PrimitiveCollection(),

--- a/test/plugin/cesium/sync/converter.test.js
+++ b/test/plugin/cesium/sync/converter.test.js
@@ -25,7 +25,9 @@ goog.require('plugin.cesium.sync.PolygonConverter');
 goog.require('plugin.cesium.sync.converter');
 goog.require('test.plugin.cesium.scene');
 
+
 describe('plugin.cesium.sync.converter', () => {
+  const Text = goog.module.get('ol.style.Text');
   const Feature = goog.module.get('ol.Feature');
   const GeometryType = goog.module.get('ol.geom.GeometryType');
   const Point = goog.module.get('ol.geom.Point');
@@ -132,7 +134,7 @@ describe('plugin.cesium.sync.converter', () => {
     });
 
     it('should return the label converter if the style contains a text style', () => {
-      style.setText(new ol.style.Text());
+      style.setText(new Text());
       runTests({
         [GeometryType.GEOMETRY_COLLECTION]: LabelConverter,
         [GeometryType.LINE_STRING]: LabelConverter,

--- a/test/plugin/cesium/sync/dynamiclinestring.mock.js
+++ b/test/plugin/cesium/sync/dynamiclinestring.mock.js
@@ -2,6 +2,7 @@ goog.module('test.plugin.cesium.sync.dynamiclinestring');
 
 const {testColor} = goog.require('test.plugin.cesium.sync.style');
 
+
 const testLine = (line, options) => {
   options = options || {};
   options.color = options.color || 'rgba(0,0,0,0)';

--- a/test/plugin/cesium/sync/dynamiclinestringconverter.test.js
+++ b/test/plugin/cesium/sync/dynamiclinestringconverter.test.js
@@ -14,6 +14,7 @@ goog.require('plugin.cesium.sync.DynamicLineStringConverter');
 goog.require('test.plugin.cesium.scene');
 goog.require('test.plugin.cesium.sync.dynamiclinestring');
 
+
 describe('plugin.cesium.sync.DynamicLineStringConverter', () => {
   const Feature = goog.module.get('ol.Feature');
   const LineString = goog.module.get('ol.geom.LineString');
@@ -165,4 +166,3 @@ describe('plugin.cesium.sync.DynamicLineStringConverter', () => {
     });
   });
 });
-

--- a/test/plugin/cesium/sync/dynamicmultipolygonconverter.test.js
+++ b/test/plugin/cesium/sync/dynamicmultipolygonconverter.test.js
@@ -10,6 +10,7 @@ goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.sync.DynamicMultiPolygonConverter');
 goog.require('test.plugin.cesium.scene');
 
+
 describe('plugin.cesium.sync.DynamicMultiPolygonConverter', () => {
   const MultiPolygon = goog.module.get('ol.geom.MultiPolygon');
   const Stroke = goog.module.get('ol.style.Stroke');

--- a/test/plugin/cesium/sync/dynamicpolygonconverter.test.js
+++ b/test/plugin/cesium/sync/dynamicpolygonconverter.test.js
@@ -4,6 +4,7 @@ goog.require('ol.proj');
 goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Image');
+goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('os.map');
 goog.require('plugin.cesium.VectorContext');
@@ -11,7 +12,9 @@ goog.require('plugin.cesium.sync.DynamicPolygonConverter');
 goog.require('test.plugin.cesium.scene');
 goog.require('test.plugin.cesium.sync.dynamiclinestring');
 
+
 describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
+  const Stroke = goog.module.get('ol.style.Stroke');
   const Polygon = goog.module.get('ol.geom.Polygon');
   const Feature = goog.module.get('ol.Feature');
   const olProj = goog.module.get('ol.proj');
@@ -61,7 +64,7 @@ describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
     });
 
     it('should create a polygon with a given stroke style', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: greenish,
         width: 4
       }));
@@ -72,7 +75,7 @@ describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
     });
 
     it('should create a dashed polygon if the stroke contains a dash', () => {
-      const stroke = new ol.style.Stroke({
+      const stroke = new Stroke({
         color: greenish,
         width: 1
       });
@@ -93,8 +96,8 @@ describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
         [[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]],
         [[1, 1], [1, 4], [4, 4], [4, 1], [1, 1]]
       ];
-      geometry = new ol.geom.Polygon(holeCoords);
-      feature = new ol.Feature(geometry);
+      geometry = new Polygon(holeCoords);
+      feature = new Feature(geometry);
 
       const result = polygonConverter.create(feature, geometry, style, context);
       expect(result).toBe(true);
@@ -106,7 +109,7 @@ describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
 
   describe('update', () => {
     it('should update changing line widths', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: bluish,
         width: 3
       }));
@@ -115,7 +118,7 @@ describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
 
       const polygon = context.polylines.get(0);
 
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: greenish,
         width: 4
       }));
@@ -125,7 +128,7 @@ describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
     });
 
     it('should update changing dash patterns', () => {
-      const stroke = new ol.style.Stroke({
+      const stroke = new Stroke({
         color: greenish,
         width: 1
       });
@@ -142,7 +145,7 @@ describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
     });
 
     it('should update lines with new colors', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: greenish,
         width: 4
       }));
@@ -176,4 +179,3 @@ describe('plugin.cesium.sync.DynamicPolygonConverter', () => {
     });
   });
 });
-

--- a/test/plugin/cesium/sync/ellipseconverter.test.js
+++ b/test/plugin/cesium/sync/ellipseconverter.test.js
@@ -1,5 +1,6 @@
 goog.require('ol.Feature');
 goog.require('ol.proj');
+goog.require('ol.style.Style');
 goog.require('os.geom.Ellipse');
 goog.require('os.layer.Vector');
 goog.require('os.map');
@@ -13,6 +14,14 @@ goog.require('test.plugin.cesium.sync.linestring');
 
 
 describe('plugin.cesium.sync.EllipseConverter', () => {
+  const Feature = goog.module.get('ol.Feature');
+  const olProj = goog.module.get('ol.proj');
+  const Style = goog.module.get('ol.style.Style');
+  const Ellipse = goog.module.get('os.geom.Ellipse');
+  const VectorLayer = goog.module.get('os.layer.Vector');
+  const osProj = goog.module.get('os.proj');
+  const StyleField = goog.module.get('os.style.StyleField');
+  const StyleManager = goog.module.get('os.style.StyleManager');
   const {getRealScene} = goog.module.get('test.plugin.cesium.scene');
   const {getLineRetriever, testLine} = goog.module.get('test.plugin.cesium.sync.linestring');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
@@ -29,12 +38,12 @@ describe('plugin.cesium.sync.EllipseConverter', () => {
 
   beforeEach(() => {
     enableWebGLMock();
-    geometry = new os.geom.Ellipse([-5, -5], 100000, 50000, 45);
-    feature = new ol.Feature(geometry);
-    style = new ol.style.Style();
-    layer = new os.layer.Vector();
+    geometry = new Ellipse([-5, -5], 100000, 50000, 45);
+    feature = new Feature(geometry);
+    style = new Style();
+    layer = new VectorLayer();
     scene = getRealScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
     getLine = getLineRetriever(context, scene);
   });
 
@@ -52,8 +61,8 @@ describe('plugin.cesium.sync.EllipseConverter', () => {
     });
 
     it('should not create a ground reference for ellipses without altitude', () => {
-      const config = os.style.StyleManager.getInstance().createLayerConfig(layer.getId());
-      config[os.style.StyleField.SHOW_GROUND_REF] = true;
+      const config = StyleManager.getInstance().createLayerConfig(layer.getId());
+      config[StyleField.SHOW_GROUND_REF] = true;
       const result = ellipseConverter.create(feature, geometry, style, context);
       expect(result).toBe(true);
       expect(context.primitives.length).toBe(1);
@@ -61,9 +70,9 @@ describe('plugin.cesium.sync.EllipseConverter', () => {
     });
 
     it('should create a ground reference for ellipses with altitude', () => {
-      geometry = new os.geom.Ellipse([-5, -5, 1000], 100000, 50000, 45);
-      const config = os.style.StyleManager.getInstance().createLayerConfig(layer.getId());
-      config[os.style.StyleField.SHOW_GROUND_REF] = true;
+      geometry = new Ellipse([-5, -5, 1000], 100000, 50000, 45);
+      const config = StyleManager.getInstance().createLayerConfig(layer.getId());
+      config[StyleField.SHOW_GROUND_REF] = true;
       const result = ellipseConverter.create(feature, geometry, style, context);
       expect(result).toBe(true);
       expect(context.primitives.length).toBe(1);
@@ -86,8 +95,8 @@ describe('plugin.cesium.sync.EllipseConverter', () => {
     });
 
     it('should not update a ground reference for ellipses without altitude', () => {
-      const config = os.style.StyleManager.getInstance().createLayerConfig(layer.getId());
-      config[os.style.StyleField.SHOW_GROUND_REF] = true;
+      const config = StyleManager.getInstance().createLayerConfig(layer.getId());
+      config[StyleField.SHOW_GROUND_REF] = true;
       ellipseConverter.create(feature, geometry, style, context);
 
       geometry.setCenter([0, 0]);
@@ -100,9 +109,9 @@ describe('plugin.cesium.sync.EllipseConverter', () => {
     });
 
     it('should create a ground reference for ellipses with altitude', () => {
-      geometry = new os.geom.Ellipse([-5, -5, 1000], 100000, 50000, 45);
-      const config = os.style.StyleManager.getInstance().createLayerConfig(layer.getId());
-      config[os.style.StyleField.SHOW_GROUND_REF] = true;
+      geometry = new Ellipse([-5, -5, 1000], 100000, 50000, 45);
+      const config = StyleManager.getInstance().createLayerConfig(layer.getId());
+      config[StyleField.SHOW_GROUND_REF] = true;
       ellipseConverter.create(feature, geometry, style, context);
 
       geometry.setCenter([0, 0, 1000]);

--- a/test/plugin/cesium/sync/ellipsoidconverter.test.js
+++ b/test/plugin/cesium/sync/ellipsoidconverter.test.js
@@ -1,5 +1,6 @@
 goog.require('ol.Feature');
 goog.require('ol.proj');
+goog.require('ol.style.Style');
 goog.require('os.geom.Ellipse');
 goog.require('os.layer.Vector');
 goog.require('os.map');
@@ -10,7 +11,14 @@ goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.sync.EllipsoidConverter');
 goog.require('test.plugin.cesium.scene');
 
+
 describe('plugin.cesium.sync.EllipsoidConverter', () => {
+  const Feature = goog.module.get('ol.Feature');
+  const olProj = goog.module.get('ol.proj');
+  const Style = goog.module.get('ol.style.Style');
+  const Ellipse = goog.module.get('os.geom.Ellipse');
+  const VectorLayer = goog.module.get('os.layer.Vector');
+  const osProj = goog.module.get('os.proj');
   const {getRealScene} = goog.module.get('test.plugin.cesium.scene');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
   const EllipsoidConverter = goog.module.get('plugin.cesium.sync.EllipsoidConverter');
@@ -25,12 +33,12 @@ describe('plugin.cesium.sync.EllipsoidConverter', () => {
 
   beforeEach(() => {
     enableWebGLMock();
-    geometry = new os.geom.Ellipse([-5, -5], 100000, 50000, 45);
-    feature = new ol.Feature(geometry);
-    style = new ol.style.Style();
-    layer = new os.layer.Vector();
+    geometry = new Ellipse([-5, -5], 100000, 50000, 45);
+    feature = new Feature(geometry);
+    style = new Style();
+    layer = new VectorLayer();
     scene = getRealScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
   });
 
   afterEach(() => {

--- a/test/plugin/cesium/sync/featureconverter.test.js
+++ b/test/plugin/cesium/sync/featureconverter.test.js
@@ -1,5 +1,7 @@
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');
+goog.require('ol.geom.Polygon');
+goog.require('ol.proj');
 goog.require('ol.style.Style');
 goog.require('os.layer.Vector');
 goog.require('os.proj');
@@ -8,7 +10,14 @@ goog.require('plugin.cesium.sync.convert');
 goog.require('plugin.cesium.sync.converter');
 goog.require('test.plugin.cesium.scene');
 
+
 describe('plugin.cesium.sync.convert', () => {
+  const Feature = goog.module.get('ol.Feature');
+  const Polygon = goog.module.get('ol.geom.Polygon');
+  const olProj = goog.module.get('ol.proj');
+  const Style = goog.module.get('ol.style.Style');
+  const VectorLayer = goog.module.get('os.layer.Vector');
+  const osProj = goog.module.get('os.proj');
   const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
   const converterExports = goog.module.get('plugin.cesium.sync.converter');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
@@ -21,11 +30,11 @@ describe('plugin.cesium.sync.convert', () => {
   let context;
 
   beforeEach(() => {
-    geometry = new ol.geom.Polygon.fromExtent([-5, -5, 5, 5]);
-    feature = new ol.Feature(geometry);
-    layer = new os.layer.Vector();
+    geometry = new Polygon.fromExtent([-5, -5, 5, 5]);
+    feature = new Feature(geometry);
+    layer = new VectorLayer();
     scene = getFakeScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
   });
 
   it('should not convert empty styles', () => {
@@ -38,7 +47,7 @@ describe('plugin.cesium.sync.convert', () => {
 
   it('should fall back on layer styles', () => {
     spyOn(converterExports, 'convertGeometry').andReturn(undefined);
-    layer.setStyle(new ol.style.Style());
+    layer.setStyle(new Style());
     convert(feature, 1, context);
     expect(converterExports.convertGeometry.calls.length).toBe(1);
   });
@@ -46,9 +55,9 @@ describe('plugin.cesium.sync.convert', () => {
   it('should convert each style on the feature', () => {
     spyOn(converterExports, 'convertGeometry').andReturn(undefined);
     feature.setStyle([
-      new ol.style.Style(),
+      new Style(),
       null,
-      new ol.style.Style()
+      new Style()
     ]);
 
     convert(feature, 1, context);
@@ -58,13 +67,13 @@ describe('plugin.cesium.sync.convert', () => {
   it('should not convert styles without geometries', () => {
     spyOn(converterExports, 'convertGeometry').andReturn(undefined);
 
-    const missingGeomStyle = new ol.style.Style();
+    const missingGeomStyle = new Style();
     missingGeomStyle.setGeometry(() => null);
 
     feature.setStyle([
       missingGeomStyle,
       undefined,
-      new ol.style.Style()
+      new Style()
     ]);
 
     convert(feature, 1, context);
@@ -73,7 +82,7 @@ describe('plugin.cesium.sync.convert', () => {
 
   it('should handle non-array styles', () => {
     spyOn(converterExports, 'convertGeometry').andReturn(undefined);
-    feature.setStyle(() => new ol.style.Style());
+    feature.setStyle(() => new Style());
     convert(feature, 1, context);
     expect(converterExports.convertGeometry.calls.length).toBe(1);
   });

--- a/test/plugin/cesium/sync/geometrycollectionconverter.test.js
+++ b/test/plugin/cesium/sync/geometrycollectionconverter.test.js
@@ -14,7 +14,16 @@ goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.sync.GeometryCollectionConverter');
 goog.require('test.plugin.cesium.scene');
 
+
 describe('plugin.cesium.sync.GeometryCollectionConverter', () => {
+  const Feature = goog.module.get('ol.Feature');
+  const GeometryCollection = goog.module.get('ol.geom.GeometryCollection');
+  const Point = goog.module.get('ol.geom.Point');
+  const Polygon = goog.module.get('ol.geom.Polygon');
+  const olProj = goog.module.get('ol.proj');
+  const Style = goog.module.get('ol.style.Style');
+  const VectorLayer = goog.module.get('os.layer.Vector');
+  const osProj = goog.module.get('os.proj');
   const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
   const GeometryCollectionConverter = goog.module.get('plugin.cesium.sync.GeometryCollectionConverter');
@@ -32,12 +41,12 @@ describe('plugin.cesium.sync.GeometryCollectionConverter', () => {
   };
 
   beforeEach(() => {
-    geometry = new ol.geom.GeometryCollection();
-    feature = new ol.Feature(geometry);
-    style = new ol.style.Style();
-    layer = new os.layer.Vector();
+    geometry = new GeometryCollection();
+    feature = new Feature(geometry);
+    style = new Style();
+    layer = new VectorLayer();
     scene = getFakeScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
   });
 
   describe('create', () => {
@@ -52,8 +61,8 @@ describe('plugin.cesium.sync.GeometryCollectionConverter', () => {
     });
 
     it('should recursively create geometries', () => {
-      const point = new ol.geom.Point([0, 0]);
-      const poly = new ol.geom.Polygon.fromExtent([-5, -5, 5, 5]);
+      const point = new Point([0, 0]);
+      const poly = new Polygon.fromExtent([-5, -5, 5, 5]);
       const geoms = [point, poly];
       geometry.setGeometriesArray(geoms);
 
@@ -72,8 +81,8 @@ describe('plugin.cesium.sync.GeometryCollectionConverter', () => {
     });
 
     it('should recursively update geometries', () => {
-      const point = new ol.geom.Point([0, 0]);
-      const poly = new ol.geom.Polygon.fromExtent([-5, -5, 5, 5]);
+      const point = new Point([0, 0]);
+      const poly = new Polygon.fromExtent([-5, -5, 5, 5]);
       const geoms = [point, poly];
       geometry.setGeometriesArray(geoms);
       GeometryCollectionConverter.setConvertFunction(mockConvert);

--- a/test/plugin/cesium/sync/gettransformfunction.test.js
+++ b/test/plugin/cesium/sync/gettransformfunction.test.js
@@ -3,21 +3,25 @@ goog.require('os.map');
 goog.require('os.proj');
 goog.require('plugin.cesium.sync.getTransformFunction');
 
+
 describe('plugin.cesium.sync.getTransformFunction', () => {
+  const olProj = goog.module.get('ol.proj');
+  const osMap = goog.module.get('os.map');
+  const osProj = goog.module.get('os.proj');
   const getTransformFunction = goog.module.get('plugin.cesium.sync.getTransformFunction');
-  const proj = os.map.PROJECTION;
+  const proj = osMap.PROJECTION;
 
   afterEach(() => {
-    os.map.PROJECTION = proj;
+    osMap.PROJECTION = proj;
   });
 
   it('should return null for projections equivalent to EPSG:4326', () => {
-    os.map.PROJECTION = ol.proj.get(os.proj.EPSG4326);
+    osMap.PROJECTION = olProj.get(osProj.EPSG4326);
     expect(getTransformFunction()).toBe(null);
   });
 
   it('should return a transform function for projections not equivalent to EPSG:4326', () => {
-    os.map.PROJECTION = ol.proj.get(os.proj.EPSG3857);
+    osMap.PROJECTION = olProj.get(osProj.EPSG3857);
     const result = getTransformFunction();
     expect(result).toBeTruthy();
 
@@ -26,7 +30,7 @@ describe('plugin.cesium.sync.getTransformFunction', () => {
   });
 
   it('should transform coordinates', () => {
-    os.map.PROJECTION = ol.proj.get(os.proj.EPSG3857);
+    osMap.PROJECTION = olProj.get(osProj.EPSG3857);
     const tx = getTransformFunction();
     const coord = [0, 0];
     const result = tx(coord);
@@ -36,7 +40,7 @@ describe('plugin.cesium.sync.getTransformFunction', () => {
   });
 
   it('should copy dimensions outside of x/y to the output', () => {
-    os.map.PROJECTION = ol.proj.get(os.proj.EPSG3857);
+    osMap.PROJECTION = olProj.get(osProj.EPSG3857);
     const tx = getTransformFunction();
     const coord = [0, 0, 100];
     const result = tx(coord);
@@ -50,7 +54,7 @@ describe('plugin.cesium.sync.getTransformFunction', () => {
   });
 
   it('should use the optional result', () => {
-    os.map.PROJECTION = ol.proj.get(os.proj.EPSG3857);
+    osMap.PROJECTION = olProj.get(osProj.EPSG3857);
     const tx = getTransformFunction();
     const coord = [0, 0, 100];
     const result = [];
@@ -62,7 +66,7 @@ describe('plugin.cesium.sync.getTransformFunction', () => {
   });
 
   it('should use the given dimensions size', () => {
-    os.map.PROJECTION = ol.proj.get(os.proj.EPSG3857);
+    osMap.PROJECTION = olProj.get(osProj.EPSG3857);
     const tx = getTransformFunction();
     const coord = [0, 0, 100];
     const result = [];

--- a/test/plugin/cesium/sync/heightreference.test.js
+++ b/test/plugin/cesium/sync/heightreference.test.js
@@ -6,24 +6,33 @@ goog.require('os.data.RecordField');
 goog.require('os.mock');
 goog.require('os.source.Vector');
 goog.require('os.webgl');
+goog.require('os.webgl.AltitudeMode');
 goog.require('plugin.cesium.sync.HeightReference');
 
+
 describe('plugin.cesium.sync.HeightReference', () => {
+  const Feature = goog.module.get('ol.Feature');
+  const Point = goog.module.get('ol.geom.Point');
+  const OLVectorLayer = goog.module.get('ol.layer.Vector');
+  const OLVectorSource = goog.module.get('ol.source.Vector');
+  const RecordField = goog.module.get('os.data.RecordField');
+  const VectorSource = goog.module.get('os.source.Vector');
+  const AltitudeMode = goog.module.get('os.webgl.AltitudeMode');
   const {getHeightReference, isPrimitiveClassTypeChanging} = goog.module.get('plugin.cesium.sync.HeightReference');
   const primitiveUtils = goog.module.get('test.plugin.cesium.primitive');
 
   describe('getHeightReference', () => {
-    const altModeField = os.data.RecordField.ALTITUDE_MODE;
+    const altModeField = RecordField.ALTITUDE_MODE;
     let geometry;
     let feature;
     let source;
     let layer;
 
     beforeEach(() => {
-      geometry = new ol.geom.Point([0, 0]);
-      feature = new ol.Feature(geometry);
-      source = new os.source.Vector();
-      layer = new ol.layer.Vector();
+      geometry = new Point([0, 0]);
+      feature = new Feature(geometry);
+      source = new VectorSource();
+      layer = new OLVectorLayer();
 
       layer.setSource(source);
       source.addFeature(feature);
@@ -34,51 +43,51 @@ describe('plugin.cesium.sync.HeightReference', () => {
     });
 
     it('should prefer altitude mode from the geometry', () => {
-      geometry.set(altModeField, os.webgl.AltitudeMode.RELATIVE_TO_GROUND);
-      feature.set(altModeField, os.webgl.AltitudeMode.ABSOLUTE);
-      layer.set(altModeField, os.webgl.AltitudeMode.ABSOLUTE);
-      source.setAltitudeMode(os.webgl.AltitudeMode.ABSOLUTE);
+      geometry.set(altModeField, AltitudeMode.RELATIVE_TO_GROUND);
+      feature.set(altModeField, AltitudeMode.ABSOLUTE);
+      layer.set(altModeField, AltitudeMode.ABSOLUTE);
+      source.setAltitudeMode(AltitudeMode.ABSOLUTE);
 
       expect(getHeightReference(layer, feature, geometry)).toBe(Cesium.HeightReference.RELATIVE_TO_GROUND);
     });
 
     it('should prefer altitude mode from the feature if not on the geometry', () => {
-      feature.set(altModeField, os.webgl.AltitudeMode.CLAMP_TO_GROUND);
-      layer.set(altModeField, os.webgl.AltitudeMode.ABSOLUTE);
-      source.setAltitudeMode(os.webgl.AltitudeMode.ABSOLUTE);
+      feature.set(altModeField, AltitudeMode.CLAMP_TO_GROUND);
+      layer.set(altModeField, AltitudeMode.ABSOLUTE);
+      source.setAltitudeMode(AltitudeMode.ABSOLUTE);
       expect(getHeightReference(layer, feature, geometry)).toBe(Cesium.HeightReference.CLAMP_TO_GROUND);
     });
 
     it('should prefer altitude mode the layer if not on the feature', () => {
-      layer.set(altModeField, os.webgl.AltitudeMode.RELATIVE_TO_GROUND);
-      source.setAltitudeMode(os.webgl.AltitudeMode.ABSOLUTE);
+      layer.set(altModeField, AltitudeMode.RELATIVE_TO_GROUND);
+      source.setAltitudeMode(AltitudeMode.ABSOLUTE);
       expect(getHeightReference(layer, feature, geometry)).toBe(Cesium.HeightReference.RELATIVE_TO_GROUND);
     });
 
     it('should prefer altitude mode from the source if not on the layer', () => {
-      source.setAltitudeMode(os.webgl.AltitudeMode.CLAMP_TO_GROUND);
+      source.setAltitudeMode(AltitudeMode.CLAMP_TO_GROUND);
       expect(getHeightReference(layer, feature, geometry)).toBe(Cesium.HeightReference.CLAMP_TO_GROUND);
     });
 
     it('should not check altitude mode from non-opensphere source implementations', () => {
-      const otherSource = new ol.source.Vector();
-      const otherLayer = new ol.layer.Vector();
+      const otherSource = new OLVectorSource();
+      const otherLayer = new OLVectorLayer();
       otherLayer.setSource(otherSource);
       expect(getHeightReference(otherLayer, feature, geometry)).toBe(Cesium.HeightReference.NONE);
     });
 
     it('should default to the first index in an altitude mode array', () => {
-      geometry.set(altModeField, [os.webgl.AltitudeMode.CLAMP_TO_GROUND, os.webgl.AltitudeMode.RELATIVE_TO_GROUND]);
+      geometry.set(altModeField, [AltitudeMode.CLAMP_TO_GROUND, AltitudeMode.RELATIVE_TO_GROUND]);
       expect(getHeightReference(layer, feature, geometry)).toBe(Cesium.HeightReference.CLAMP_TO_GROUND);
     });
 
     it('should get the altitude mode at the given index', () => {
-      geometry.set(altModeField, [os.webgl.AltitudeMode.CLAMP_TO_GROUND, os.webgl.AltitudeMode.RELATIVE_TO_GROUND]);
+      geometry.set(altModeField, [AltitudeMode.CLAMP_TO_GROUND, AltitudeMode.RELATIVE_TO_GROUND]);
       expect(getHeightReference(layer, feature, geometry, 1)).toBe(Cesium.HeightReference.RELATIVE_TO_GROUND);
     });
 
     it('should default out of range indexes to absolute', () => {
-      geometry.set(altModeField, [os.webgl.AltitudeMode.CLAMP_TO_GROUND, os.webgl.AltitudeMode.RELATIVE_TO_GROUND]);
+      geometry.set(altModeField, [AltitudeMode.CLAMP_TO_GROUND, AltitudeMode.RELATIVE_TO_GROUND]);
       expect(getHeightReference(layer, feature, geometry, 2)).toBe(Cesium.HeightReference.NONE);
       expect(getHeightReference(layer, feature, geometry, -1)).toBe(Cesium.HeightReference.NONE);
     });

--- a/test/plugin/cesium/sync/linestring.mock.js
+++ b/test/plugin/cesium/sync/linestring.mock.js
@@ -1,8 +1,11 @@
 goog.module('test.plugin.cesium.sync.linestring');
 
+const cesium = goog.require('plugin.cesium');
+
 const {GeometryInstanceId} = goog.require('plugin.cesium');
 const {testColor} = goog.require('test.plugin.cesium.sync.style');
 const {renderScene} = goog.require('test.plugin.cesium.scene');
+
 
 const testLine = (line, options) => {
   options = options || {};
@@ -25,7 +28,7 @@ const testLine = (line, options) => {
     const expectedColor = Cesium.Color.fromCssColorString(options.color);
 
     if (options.geometryClass === Cesium.PolylineGeometry || options.geometryClass === Cesium.GroundPolylineGeometry) {
-      expect(line.geometryInstances.id).toBe(plugin.cesium.GeometryInstanceId.GEOM_OUTLINE);
+      expect(line.geometryInstances.id).toBe(cesium.GeometryInstanceId.GEOM_OUTLINE);
       if (options.dashPattern) {
         expect(line.appearance.constructor).toBe(Cesium.PolylineMaterialAppearance);
         expect(line.appearance.material.type).toBe(Cesium.Material.PolylineDashType);

--- a/test/plugin/cesium/sync/linestringconverter.test.js
+++ b/test/plugin/cesium/sync/linestringconverter.test.js
@@ -2,10 +2,13 @@ goog.require('ol.Feature');
 goog.require('ol.geom.LineString');
 goog.require('ol.proj');
 goog.require('ol.style.Fill');
+goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('olcs.core');
+goog.require('os.data.RecordField');
 goog.require('os.geom.GeometryField');
 goog.require('os.interpolate');
+goog.require('os.interpolate.Method');
 goog.require('os.layer.Vector');
 goog.require('os.map');
 goog.require('os.proj');
@@ -17,6 +20,19 @@ goog.require('test.plugin.cesium.sync.linestring');
 
 
 describe('plugin.cesium.sync.LineStringConverter', () => {
+  const Feature = goog.module.get('ol.Feature');
+  const LineString = goog.module.get('ol.geom.LineString');
+  const olProj = goog.module.get('ol.proj');
+  const Fill = goog.module.get('ol.style.Fill');
+  const Stroke = goog.module.get('ol.style.Stroke');
+  const Style = goog.module.get('ol.style.Style');
+  const RecordField = goog.module.get('os.data.RecordField');
+  const interpolate = goog.module.get('os.interpolate');
+  const Method = goog.module.get('os.interpolate.Method');
+  const VectorLayer = goog.module.get('os.layer.Vector');
+  const osMap = goog.module.get('os.map');
+  const osProj = goog.module.get('os.proj');
+  const AltitudeMode = goog.module.get('os.webgl.AltitudeMode');
   const {getRealScene} = goog.module.get('test.plugin.cesium.scene');
   const {getLineRetriever, testLine} = goog.module.get('test.plugin.cesium.sync.linestring');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
@@ -32,19 +48,19 @@ describe('plugin.cesium.sync.LineStringConverter', () => {
 
   beforeEach(() => {
     enableWebGLMock();
-    geometry = new ol.geom.LineString([[0, 0], [5, 5]]);
-    feature = new ol.Feature(geometry);
-    style = new ol.style.Style();
-    layer = new os.layer.Vector();
+    geometry = new LineString([[0, 0], [5, 5]]);
+    feature = new Feature(geometry);
+    style = new Style();
+    layer = new VectorLayer();
     scene = getRealScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
     getLine = getLineRetriever(context, scene);
   });
 
-  const originalProjection = os.map.PROJECTION;
+  const originalProjection = osMap.PROJECTION;
   afterEach(() => {
     disableWebGLMock();
-    os.map.PROJECTION = originalProjection;
+    osMap.PROJECTION = originalProjection;
   });
 
   const blue = 'rgba(0,0,255,1)';
@@ -60,7 +76,7 @@ describe('plugin.cesium.sync.LineStringConverter', () => {
     });
 
     it('should create a line with a given stroke style', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: green,
         width: 4
       }));
@@ -71,7 +87,7 @@ describe('plugin.cesium.sync.LineStringConverter', () => {
     });
 
     it('should create a dashed line if the stroke contains a dash', () => {
-      const stroke = new ol.style.Stroke({
+      const stroke = new Stroke({
         color: green,
         width: 1
       });
@@ -93,9 +109,9 @@ describe('plugin.cesium.sync.LineStringConverter', () => {
       waitsFor(() => initialized, 'terrain heights to initialize');
 
       runs(() => {
-        geometry.set(os.data.RecordField.ALTITUDE_MODE, os.webgl.AltitudeMode.CLAMP_TO_GROUND);
+        geometry.set(RecordField.ALTITUDE_MODE, AltitudeMode.CLAMP_TO_GROUND);
 
-        style.setStroke(new ol.style.Stroke({
+        style.setStroke(new Stroke({
           color: green,
           width: 1
         }));
@@ -113,15 +129,15 @@ describe('plugin.cesium.sync.LineStringConverter', () => {
     });
 
     it('should use WallGeometry when extrude is set', () => {
-      feature.set(os.interpolate.METHOD_FIELD, os.interpolate.Method.RHUMB);
+      feature.set(interpolate.METHOD_FIELD, Method.RHUMB);
       geometry.set('extrude', true);
 
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: blue,
         width: 1
       }));
 
-      style.setFill(new ol.style.Fill({
+      style.setFill(new Fill({
         color: green
       }));
 
@@ -135,16 +151,16 @@ describe('plugin.cesium.sync.LineStringConverter', () => {
     });
 
     it('should prefer extrusion to clampToGround', () => {
-      feature.set(os.interpolate.METHOD_FIELD, os.interpolate.Method.RHUMB);
+      feature.set(interpolate.METHOD_FIELD, Method.RHUMB);
       geometry.set('extrude', true);
-      geometry.set(os.data.RecordField.ALTITUDE_MODE, os.webgl.AltitudeMode.CLAMP_TO_GROUND);
+      geometry.set(RecordField.ALTITUDE_MODE, AltitudeMode.CLAMP_TO_GROUND);
 
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: blue,
         width: 1
       }));
 
-      style.setFill(new ol.style.Fill({
+      style.setFill(new Fill({
         color: green
       }));
 
@@ -163,7 +179,7 @@ describe('plugin.cesium.sync.LineStringConverter', () => {
 
   describe('update', () => {
     it('should not update changing line widths', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: blue,
         width: 3
       }));
@@ -172,7 +188,7 @@ describe('plugin.cesium.sync.LineStringConverter', () => {
 
       const linestring = context.primitives.get(0);
 
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: green,
         width: 4
       }));
@@ -182,7 +198,7 @@ describe('plugin.cesium.sync.LineStringConverter', () => {
     });
 
     it('should not update changing dash patterns', () => {
-      const stroke = new ol.style.Stroke({
+      const stroke = new Stroke({
         color: green,
         width: 1
       });
@@ -199,7 +215,7 @@ describe('plugin.cesium.sync.LineStringConverter', () => {
     });
 
     it('should not update if adding a dash pattern', () => {
-      const stroke = new ol.style.Stroke({
+      const stroke = new Stroke({
         color: green,
         width: 1
       });
@@ -215,7 +231,7 @@ describe('plugin.cesium.sync.LineStringConverter', () => {
     });
 
     it('should not update if removing a dash pattern', () => {
-      const stroke = new ol.style.Stroke({
+      const stroke = new Stroke({
         color: green,
         width: 1
       });
@@ -231,7 +247,7 @@ describe('plugin.cesium.sync.LineStringConverter', () => {
     });
 
     it('should update lines with new colors', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: green,
         width: 4
       }));

--- a/test/plugin/cesium/sync/multidynamiclinestringconverter.test.js
+++ b/test/plugin/cesium/sync/multidynamiclinestringconverter.test.js
@@ -1,5 +1,6 @@
 goog.require('ol.geom.MultiLineString');
 goog.require('ol.proj');
+goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('os.feature.DynamicFeature');
 goog.require('os.layer.Vector');
@@ -9,7 +10,16 @@ goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.sync.MultiDynamicLineStringConverter');
 goog.require('test.plugin.cesium.scene');
 
+
 describe('plugin.cesium.sync.MultiDynamicLineStringConverter', () => {
+  const MultiLineString = goog.module.get('ol.geom.MultiLineString');
+  const olProj = goog.module.get('ol.proj');
+  const Stroke = goog.module.get('ol.style.Stroke');
+  const Style = goog.module.get('ol.style.Style');
+  const DynamicFeature = goog.module.get('os.feature.DynamicFeature');
+  const VectorLayer = goog.module.get('os.layer.Vector');
+  const osMap = goog.module.get('os.map');
+  const osProj = goog.module.get('os.proj');
   const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
   const MultiDynamicLineStringConverter = goog.module.get('plugin.cesium.sync.MultiDynamicLineStringConverter');
@@ -21,17 +31,17 @@ describe('plugin.cesium.sync.MultiDynamicLineStringConverter', () => {
   let context;
 
   beforeEach(() => {
-    geometry = new ol.geom.MultiLineString([[[0, 0], [2, 2]], [[4, 4], [6, 6]]]);
-    feature = new os.feature.DynamicFeature(geometry);
-    style = new ol.style.Style();
-    layer = new os.layer.Vector();
+    geometry = new MultiLineString([[[0, 0], [2, 2]], [[4, 4], [6, 6]]]);
+    feature = new DynamicFeature(geometry);
+    style = new Style();
+    layer = new VectorLayer();
     scene = getFakeScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
   });
 
-  const originalProjection = os.map.PROJECTION;
+  const originalProjection = osMap.PROJECTION;
   afterEach(() => {
-    os.map.PROJECTION = originalProjection;
+    osMap.PROJECTION = originalProjection;
   });
 
   const blue = 'rgba(0,0,255,1)';
@@ -49,7 +59,7 @@ describe('plugin.cesium.sync.MultiDynamicLineStringConverter', () => {
       const primitives = converter.retrieve(feature, geometry, style, context);
       expect(context.polylines.length).toBe(2);
 
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: blue,
         width: 2
       }));

--- a/test/plugin/cesium/sync/multilinestringconverter.test.js
+++ b/test/plugin/cesium/sync/multilinestringconverter.test.js
@@ -1,6 +1,7 @@
 goog.require('ol.Feature');
 goog.require('ol.geom.MultiLineString');
 goog.require('ol.proj');
+goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('os.layer.Vector');
 goog.require('os.map');
@@ -10,7 +11,17 @@ goog.require('plugin.cesium.VectorContext');
 goog.require('plugin.cesium.sync.MultiLineStringConverter');
 goog.require('test.plugin.cesium.scene');
 
+
 describe('plugin.cesium.sync.MultiLineStringConverter', () => {
+  const Feature = goog.module.get('ol.Feature');
+  const MultiLineString = goog.module.get('ol.geom.MultiLineString');
+  const olProj = goog.module.get('ol.proj');
+  const Stroke = goog.module.get('ol.style.Stroke');
+  const Style = goog.module.get('ol.style.Style');
+  const VectorLayer = goog.module.get('os.layer.Vector');
+  const osMap = goog.module.get('os.map');
+  const osProj = goog.module.get('os.proj');
+  const osStyle = goog.module.get('os.style');
   const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
   const MultiLineStringConverter = goog.module.get('plugin.cesium.sync.MultiLineStringConverter');
@@ -22,17 +33,17 @@ describe('plugin.cesium.sync.MultiLineStringConverter', () => {
   let context;
 
   beforeEach(() => {
-    geometry = new ol.geom.MultiLineString([[[0, 0], [2, 2]], [[4, 4], [6, 6]]]);
-    feature = new ol.Feature(geometry);
-    style = new ol.style.Style();
-    layer = new os.layer.Vector();
+    geometry = new MultiLineString([[[0, 0], [2, 2]], [[4, 4], [6, 6]]]);
+    feature = new Feature(geometry);
+    style = new Style();
+    layer = new VectorLayer();
     scene = getFakeScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
   });
 
-  const originalProjection = os.map.PROJECTION;
+  const originalProjection = osMap.PROJECTION;
   afterEach(() => {
-    os.map.PROJECTION = originalProjection;
+    osMap.PROJECTION = originalProjection;
   });
 
   const blue = 'rgba(0,0,255,1)';
@@ -47,7 +58,7 @@ describe('plugin.cesium.sync.MultiLineStringConverter', () => {
 
   describe('update', () => {
     it('should not update if the line width is changing', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: green,
         width: 2
       }));
@@ -55,7 +66,7 @@ describe('plugin.cesium.sync.MultiLineStringConverter', () => {
       expect(converter.create(feature, geometry, style, context)).toBe(true);
       const primitives = converter.retrieve(feature, geometry, style, context);
 
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: blue,
         width: 3
       }));
@@ -67,8 +78,8 @@ describe('plugin.cesium.sync.MultiLineStringConverter', () => {
       expect(converter.create(feature, geometry, style, context)).toBe(true);
       const primitives = converter.retrieve(feature, geometry, style, context);
 
-      style.setStroke(new ol.style.Stroke({
-        lineDash: os.style.LINE_STYLE_OPTIONS[1].pattern,
+      style.setStroke(new Stroke({
+        lineDash: osStyle.LINE_STYLE_OPTIONS[1].pattern,
         color: blue,
         width: 3
       }));
@@ -77,7 +88,7 @@ describe('plugin.cesium.sync.MultiLineStringConverter', () => {
     });
 
     it('should update polylines', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: green,
         width: 2
       }));
@@ -86,7 +97,7 @@ describe('plugin.cesium.sync.MultiLineStringConverter', () => {
       const primitives = converter.retrieve(feature, geometry, style, context);
       expect(context.primitives.length).toBe(2);
 
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: blue,
         width: 2
       }));

--- a/test/plugin/cesium/sync/pointconverter.test.js
+++ b/test/plugin/cesium/sync/pointconverter.test.js
@@ -3,6 +3,7 @@ goog.require('ol.geom.Point');
 goog.require('ol.proj');
 goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
+goog.require('ol.style.Icon');
 goog.require('ol.style.Image');
 goog.require('ol.style.Style');
 goog.require('os.layer.Vector');
@@ -13,6 +14,16 @@ goog.require('plugin.cesium.sync.PointConverter');
 
 
 describe('plugin.cesium.sync.PointConverter', () => {
+  const Feature = goog.module.get('ol.Feature');
+  const Point = goog.module.get('ol.geom.Point');
+  const olProj = goog.module.get('ol.proj');
+  const Circle = goog.module.get('ol.style.Circle');
+  const Fill = goog.module.get('ol.style.Fill');
+  const Icon = goog.module.get('ol.style.Icon');
+  const Style = goog.module.get('ol.style.Style');
+  const VectorLayer = goog.module.get('os.layer.Vector');
+  const osMap = goog.module.get('os.map');
+  const osProj = goog.module.get('os.proj');
   const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
   const VectorContext = goog.module.get('plugin.cesium.VectorContext');
   const PointConverter = goog.module.get('plugin.cesium.sync.PointConverter');
@@ -24,26 +35,26 @@ describe('plugin.cesium.sync.PointConverter', () => {
   let context;
 
   beforeEach(() => {
-    geometry = new ol.geom.Point([0, 0]);
-    feature = new ol.Feature(geometry);
-    style = new ol.style.Style();
-    layer = new os.layer.Vector();
+    geometry = new Point([0, 0]);
+    feature = new Feature(geometry);
+    style = new Style();
+    layer = new VectorLayer();
     scene = getFakeScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
   });
 
-  const originalProjection = os.map.PROJECTION;
+  const originalProjection = osMap.PROJECTION;
   afterEach(() => {
-    os.map.PROJECTION = originalProjection;
+    osMap.PROJECTION = originalProjection;
   });
 
   const blue = 'rgba(0,0,255,1)';
   const green = 'rgba(0,255,0,1)';
 
   setCircleStyle = (color) => {
-    style.setImage(new ol.style.Circle({
+    style.setImage(new Circle({
       radius: 3,
-      fill: new ol.style.Fill({
+      fill: new Fill({
         color: color
       })
     }));
@@ -81,7 +92,7 @@ describe('plugin.cesium.sync.PointConverter', () => {
   });
 
   it('should create a billboard for an icon style', () => {
-    style.setImage(new ol.style.Icon({
+    style.setImage(new Icon({
       anchor: [0.5, 1.0],
       crossOrigin: 'none',
       src: '/base/images/icons/pushpin/wht-pushpin.png',
@@ -117,7 +128,7 @@ describe('plugin.cesium.sync.PointConverter', () => {
   });
 
   it('should create a billboard for a colored icon style', () => {
-    style.setImage(new ol.style.Icon({
+    style.setImage(new Icon({
       anchor: [0.5, 1.0],
       crossOrigin: 'none',
       src: '/base/images/icons/pushpin/wht-pushpin.png',
@@ -155,9 +166,9 @@ describe('plugin.cesium.sync.PointConverter', () => {
 
   it('should create a billboard and transform other projection coordinates', () => {
     // pretend we swapped to EPSG:3857
-    os.map.PROJECTION = ol.proj.get(os.proj.EPSG3857);
+    osMap.PROJECTION = olProj.get(osProj.EPSG3857);
 
-    style.setImage(new ol.style.Icon({
+    style.setImage(new Icon({
       anchor: [0.5, 1.0],
       crossOrigin: 'none',
       src: '/base/images/icons/pushpin/wht-pushpin.png',
@@ -167,7 +178,7 @@ describe('plugin.cesium.sync.PointConverter', () => {
       rotation: 90
     }));
 
-    geometry.setCoordinates(ol.proj.transform([-105, 40], os.proj.EPSG4326, os.proj.EPSG3857));
+    geometry.setCoordinates(olProj.transform([-105, 40], osProj.EPSG4326, osProj.EPSG3857));
 
     const result = pointConverter.create(feature, geometry, style, context);
     expect(result).toBe(true);
@@ -207,13 +218,13 @@ describe('plugin.cesium.sync.PointConverter', () => {
   });
 
   it('should reuse image resources', () => {
-    style.setImage(new ol.style.Icon({
+    style.setImage(new Icon({
       src: '/base/images/icons/pushpin/wht-pushpin.png'
     }));
 
     const createBillboard = () => {
-      const geometry = new ol.geom.Point([0, 0]);
-      const feature = new ol.Feature(geometry);
+      const geometry = new Point([0, 0]);
+      const feature = new Feature(geometry);
       return pointConverter.create(feature, geometry, style, context);
     };
 
@@ -225,7 +236,7 @@ describe('plugin.cesium.sync.PointConverter', () => {
     expect(bb1._image).toBe(bb2._image);
     expect(bb1._imageId).toBe(bb2._imageId);
 
-    style.setImage(new ol.style.Icon({
+    style.setImage(new Icon({
       src: '/base/images/icons/pushpin/blue-pushpin.png'
     }));
 

--- a/test/plugin/cesium/sync/polygon.mock.js
+++ b/test/plugin/cesium/sync/polygon.mock.js
@@ -3,6 +3,7 @@ goog.module('test.plugin.cesium.sync.polygon');
 const {GeometryInstanceId} = goog.require('plugin.cesium');
 const {testColor} = goog.require('test.plugin.cesium.sync.style');
 
+
 const testPolygon = (polygon, options) => {
   options = options || {};
   options.primitiveClass = options.primitiveClass || Cesium.Primitive;

--- a/test/plugin/cesium/sync/polygonconverter.test.js
+++ b/test/plugin/cesium/sync/polygonconverter.test.js
@@ -2,6 +2,7 @@ goog.require('ol.Feature');
 goog.require('ol.geom.Polygon');
 goog.require('ol.proj');
 goog.require('ol.style.Fill');
+goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('olcs.core');
 goog.require('os.interpolate');
@@ -17,6 +18,14 @@ goog.require('test.plugin.cesium.sync.polygon');
 
 
 describe('plugin.cesium.sync.PolygonConverter', () => {
+  const Feature = goog.module.get('ol.Feature');
+  const Polygon = goog.module.get('ol.geom.Polygon');
+  const olProj = goog.module.get('ol.proj');
+  const Fill = goog.module.get('ol.style.Fill');
+  const Stroke = goog.module.get('ol.style.Stroke');
+  const Style = goog.module.get('ol.style.Style');
+  const VectorLayer = goog.module.get('os.layer.Vector');
+  const osProj = goog.module.get('os.proj');
   const {getRealScene} = goog.module.get('test.plugin.cesium.scene');
   const {getLineRetriever, testLine} = goog.module.get('test.plugin.cesium.sync.linestring');
   const {testPolygon} = goog.module.get('test.plugin.cesium.sync.polygon');
@@ -34,12 +43,12 @@ describe('plugin.cesium.sync.PolygonConverter', () => {
 
   beforeEach(() => {
     enableWebGLMock();
-    geometry = new ol.geom.Polygon.fromExtent([-5, -5, 5, 5]);
-    feature = new ol.Feature(geometry);
-    style = new ol.style.Style();
-    layer = new os.layer.Vector();
+    geometry = new Polygon.fromExtent([-5, -5, 5, 5]);
+    feature = new Feature(geometry);
+    style = new Style();
+    layer = new VectorLayer();
     scene = getRealScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
     getLine = getLineRetriever(context, scene);
   });
 
@@ -59,7 +68,7 @@ describe('plugin.cesium.sync.PolygonConverter', () => {
     });
 
     it('should create an outline with a given stroke style', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: green,
         width: 4
       }));
@@ -75,7 +84,7 @@ describe('plugin.cesium.sync.PolygonConverter', () => {
     });
 
     it('should create a dashed line if the stroke contains a dash', () => {
-      const stroke = new ol.style.Stroke({
+      const stroke = new Stroke({
         color: green,
         width: 1
       });
@@ -93,7 +102,7 @@ describe('plugin.cesium.sync.PolygonConverter', () => {
     });
 
     it('should create an outline for every ring of the polygon', () => {
-      const otherRing = ol.geom.Polygon.fromExtent([-2, -2, 2, 2]);
+      const otherRing = Polygon.fromExtent([-2, -2, 2, 2]);
       const coords = geometry.getCoordinates();
       coords.push(otherRing.getCoordinates()[0]);
       geometry.setCoordinates(coords);
@@ -109,12 +118,12 @@ describe('plugin.cesium.sync.PolygonConverter', () => {
     });
 
     it('should create a single fill if one exists on the style', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: green,
         width: 4
       }));
 
-      style.setFill(new ol.style.Fill({
+      style.setFill(new Fill({
         color: blue
       }));
 
@@ -141,7 +150,7 @@ describe('plugin.cesium.sync.PolygonConverter', () => {
 
   describe('update', () => {
     it('should not update if a fill is being added', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: green,
         width: 4
       }));
@@ -153,7 +162,7 @@ describe('plugin.cesium.sync.PolygonConverter', () => {
       expect(polygon).toBeTruthy();
       expect(context.primitives.length).toBe(1);
 
-      style.setFill(new ol.style.Fill({
+      style.setFill(new Fill({
         color: blue
       }));
 
@@ -161,12 +170,12 @@ describe('plugin.cesium.sync.PolygonConverter', () => {
     });
 
     it('should not update the dirty flag for the fill if the fill is being removed', () => {
-      style.setStroke(new ol.style.Stroke({
+      style.setStroke(new Stroke({
         color: green,
         width: 4
       }));
 
-      style.setFill(new ol.style.Fill({
+      style.setFill(new Fill({
         color: blue
       }));
 

--- a/test/plugin/cesium/sync/runconverter.test.js
+++ b/test/plugin/cesium/sync/runconverter.test.js
@@ -10,7 +10,14 @@ goog.require('plugin.cesium.sync.runConverter');
 goog.require('test.plugin.cesium.primitive');
 goog.require('test.plugin.cesium.scene');
 
+
 describe('plugin.cesium.sync.runConverter', () => {
+  const Feature = goog.module.get('ol.Feature');
+  const Point = goog.module.get('ol.geom.Point');
+  const olProj = goog.module.get('ol.proj');
+  const Style = goog.module.get('ol.style.Style');
+  const VectorLayer = goog.module.get('os.layer.Vector');
+  const osProj = goog.module.get('os.proj');
   const {runConverter} = goog.module.get('plugin.cesium.sync.runConverter');
   const primitiveUtils = goog.module.get('test.plugin.cesium.primitive');
   const {getFakeScene} = goog.module.get('test.plugin.cesium.scene');
@@ -24,12 +31,12 @@ describe('plugin.cesium.sync.runConverter', () => {
   let context;
 
   beforeEach(() => {
-    geometry = new ol.geom.Point([0, 0]);
-    feature = new ol.Feature(geometry);
-    style = new ol.style.Style();
-    layer = new os.layer.Vector();
+    geometry = new Point([0, 0]);
+    feature = new Feature(geometry);
+    style = new Style();
+    layer = new VectorLayer();
     scene = getFakeScene();
-    context = new VectorContext(scene, layer, ol.proj.get(os.proj.EPSG4326));
+    context = new VectorContext(scene, layer, olProj.get(osProj.EPSG4326));
   });
 
   it('should create the primitive if it does not exist', () => {

--- a/test/plugin/cesium/sync/style.test.js
+++ b/test/plugin/cesium/sync/style.test.js
@@ -5,7 +5,12 @@ goog.require('os.style');
 goog.require('plugin.cesium');
 goog.require('plugin.cesium.sync.style');
 
+
 describe('plugin.cesium.sync.style', () => {
+  const Fill = goog.module.get('ol.style.Fill');
+  const Stroke = goog.module.get('ol.style.Stroke');
+  const Style = goog.module.get('ol.style.Style');
+  const osStyle = goog.module.get('os.style');
   const {GeometryInstanceId} = goog.module.get('plugin.cesium');
   const {getColor, getLineWidthFromStyle} = goog.module.get('plugin.cesium.sync.style');
 
@@ -18,13 +23,13 @@ describe('plugin.cesium.sync.style', () => {
     };
 
     const getStyle = () => {
-      const stroke = new ol.style.Stroke();
+      const stroke = new Stroke();
       stroke.setColor('rgba(255,0,0,1)');
 
-      const fill = new ol.style.Fill();
+      const fill = new Fill();
       fill.setColor('rgba(0,0,255,1)');
 
-      const style = new ol.style.Style();
+      const style = new Style();
       style.setStroke(stroke);
       style.setFill(fill);
 
@@ -49,7 +54,7 @@ describe('plugin.cesium.sync.style', () => {
         const black = Cesium.Color.fromAlpha(Cesium.Color.BLACK, opacity);
 
         it('should default to black', () => {
-          const style = new ol.style.Style();
+          const style = new Style();
           const color = getColor(style, context, GeometryInstanceId.GEOM);
           compareColor(color, black);
         });
@@ -84,13 +89,13 @@ describe('plugin.cesium.sync.style', () => {
 
   describe('getLineWidthFromStyle', () => {
     it('should default to the default to the feature size', () => {
-      const style = new ol.style.Style();
-      expect(getLineWidthFromStyle(style)).toBe(os.style.DEFAULT_FEATURE_SIZE);
+      const style = new Style();
+      expect(getLineWidthFromStyle(style)).toBe(osStyle.DEFAULT_FEATURE_SIZE);
     });
 
     it('should return the stroke width', () => {
-      const style = new ol.style.Style();
-      const stroke = new ol.style.Stroke();
+      const style = new Style();
+      const stroke = new Stroke();
       stroke.setWidth(3);
       style.setStroke(stroke);
 

--- a/test/plugin/cesium/vectorcontext.test.js
+++ b/test/plugin/cesium/vectorcontext.test.js
@@ -1,3 +1,5 @@
+goog.require('goog.dispose');
+goog.require('ol');
 goog.require('ol.Feature');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.Point');
@@ -10,7 +12,11 @@ goog.require('plugin.cesium.primitive');
 goog.require('test.plugin.cesium.primitive');
 goog.require('test.plugin.cesium.scene');
 
+
 describe('plugin.cesium.VectorContext', () => {
+  const dispose = goog.module.get('goog.dispose');
+  const LineString = goog.module.get('ol.geom.LineString');
+  const ol = goog.module.get('ol');
   const Feature = goog.module.get('ol.Feature');
   const Point = goog.module.get('ol.geom.Point');
   const Polygon = goog.module.get('ol.geom.Polygon');
@@ -266,7 +272,7 @@ describe('plugin.cesium.VectorContext', () => {
 
     it('should not add a disposed feature', () => {
       const billboardOptions = primitiveUtils.createBillboard([0, 0, 0]);
-      goog.dispose(feature);
+      dispose(feature);
       context.addBillboard(billboardOptions, feature, geometry);
       expect(context.billboards.length).toBe(0);
       expect(context.geometryToCesiumMap[ol.getUid(geometry)]).toBe(undefined);
@@ -278,7 +284,7 @@ describe('plugin.cesium.VectorContext', () => {
     let geometry;
 
     beforeEach(() => {
-      geometry = new ol.geom.LineString([[0, 0], [5, 5]]);
+      geometry = new LineString([[0, 0], [5, 5]]);
       feature = new Feature(geometry);
     });
 
@@ -301,7 +307,7 @@ describe('plugin.cesium.VectorContext', () => {
 
     it('should not add a disposed feature', () => {
       const polylineOptions = primitiveUtils.createPolyline(geometry.getCoordinates());
-      goog.dispose(feature);
+      dispose(feature);
       context.addPolyline(polylineOptions, feature, geometry);
       expect(context.polylines.length).toBe(0);
       expect(context.geometryToCesiumMap[ol.getUid(geometry)]).toBe(undefined);
@@ -337,7 +343,7 @@ describe('plugin.cesium.VectorContext', () => {
 
     it('should not add a disposed feature', () => {
       const primitive = primitiveUtils.createPrimitive(geometry.getExtent());
-      goog.dispose(feature);
+      dispose(feature);
       context.addPrimitive(primitive, feature, geometry);
       expect(context.primitives.length).toBe(0);
       expect(context.geometryToCesiumMap[ol.getUid(geometry)]).toBe(undefined);
@@ -385,7 +391,7 @@ describe('plugin.cesium.VectorContext', () => {
 
     it('should not add a disposed feature', () => {
       const labelOptions = primitiveUtils.createLabelOptions();
-      goog.dispose(feature);
+      dispose(feature);
       context.addLabel(labelOptions, feature, geometry);
       expect(context.labels.length).toBe(0);
       expect(context.geometryToLabelMap[ol.getUid(geometry)]).toBe(undefined);


### PR DESCRIPTION
I added a new transform to [opensphere-jscodeshift](https://github.com/schmidtk/opensphere-jscodeshift) that finds/replaces global references in sources/tests. For source files, the transform simply adds a legacy `goog.require` then replaces it because the replace call already updates refs. For test files, a `goog.module.get` call is either found or added for each detected reference. The call is added directly to the root `describe()` call containing the reference, so subsequent references may reuse it.

To generate the changes in this PR, the transform was executed with:

```
yarn run shift -t src/transforms/es6/replaceglobals.js /path/to/opensphere/test/plugin/cesium
```

Global reference replacement is config driven by new config in `.jscodeshift.json`. The config defines the root namespaces to start from when searching for global refs, a list of modules to ignore (like `goog` which doesn't need to be required), and a map of module name to variable name for modules we want to specifically name instead of auto-generating the name.