### PR TITLE
fix: use consistent validation across all import forms

### DIFF
--- a/src/os/ui/providerimport.js
+++ b/src/os/ui/providerimport.js
@@ -188,13 +188,19 @@ os.ui.ProviderImportCtrl.prototype.onAccept_ = function() {
 
 
 /**
- * Launches help window
+ * Launches the import help window.
+ * @param {string=} opt_providerName The user-facing name for the provider.
  * @export
  */
-os.ui.ProviderImportCtrl.prototype.launchHelp = function() {
+os.ui.ProviderImportCtrl.prototype.launchHelp = function(opt_providerName) {
   if (!os.ui.window.exists(this.helpWindowId) && this['helpUi']) {
+    let label = 'URL Format Help';
+    if (opt_providerName) {
+      label = `${opt_providerName} ${label}`;
+    }
+
     os.ui.window.create({
-      'label': 'URL Format Help',
+      'label': label,
       'icon': 'fa fa-question-circle',
       'x': '-10',
       'y': 'center',

--- a/src/plugin/arc/arcserverimport.js
+++ b/src/plugin/arc/arcserverimport.js
@@ -48,6 +48,7 @@ plugin.arc.ArcImportCtrl = function($scope, $element) {
 
   var file = /** @type {os.file.File} */ ($scope['config']['file']);
   $scope['config']['url'] = file ? file.getUrl() : this.getUrl();
+  $scope['typeName'] = 'ArcGIS Server';
   $scope['urlExample'] = 'https://www.example.com/arcgis/rest/services';
   $scope['config']['type'] = 'arc';
   $scope['config']['label'] = this.getLabel() || 'ArcGIS Server';

--- a/src/plugin/ogc/ui/geoserverimport.js
+++ b/src/plugin/ogc/ui/geoserverimport.js
@@ -53,6 +53,7 @@ plugin.ogc.ui.GeoserverImportCtrl = function($scope, $element) {
   $scope['config']['url'] = file ? file.getUrl().replace(/(\/geoserver|\/.*?gs)(\/.*)(web|ows)[#?\/].*$/, '/geoserver$1ows') :
     this.getUrl();
   $scope['config']['type'] = 'geoserver';
+  $scope['typeName'] = 'GeoServer';
   $scope['urlExample'] = 'http://www.example.com/geoserver/ows';
 };
 goog.inherits(plugin.ogc.ui.GeoserverImportCtrl, os.ui.SingleUrlProviderImportCtrl);

--- a/src/plugin/ogc/ui/ogcserverimport.js
+++ b/src/plugin/ogc/ui/ogcserverimport.js
@@ -48,6 +48,8 @@ plugin.ogc.ui.OgcServerImportCtrl = function($scope, $element) {
   plugin.ogc.ui.OgcServerImportCtrl.base(this, 'constructor', $scope, $element);
   this['helpUi'] = plugin.ogc.ui.OgcServerHelpUI.directiveTag;
 
+  $scope['typeName'] = 'OGC Server';
+
   $scope['config']['type'] = 'ogc';
   var file = /** @type {os.file.File} */ ($scope['config']['file']);
 

--- a/views/file/addserver.html
+++ b/views/file/addserver.html
@@ -1,6 +1,6 @@
 <div class="flex-fill w-100 d-flex flex-column">
   <div class="modal-body container flex-fill">
-    <form>
+    <form name="addServerForm" ng-submit="ctrl.accept()">
       <div class="form-group m-0">
         <label for="serverType">Select a server type:</label>
         <select title="ServerType" class="custom-select w-50"
@@ -9,13 +9,12 @@
             ng-options="value.label for value in ctrl.items">
         </select>
       </div>
+      <uiswitch items="ctrl.serverType" directive-function="ctrl.getUi" scope-update-function="ctrl.updateUiScope">
+      </uiswitch>
     </form>
-    <div>
-      <uiswitch items="ctrl.serverType" directive-function="ctrl.getUi" scope-update-function="ctrl.updateUiScope"></uiswitch>
-    </div>
   </div>
   <div class="modal-footer d-flex">
-    <button class="btn btn-primary" ng-click="ctrl.accept()" ng-disabled="form.$invalid || testing">
+    <button class="btn btn-primary" ng-click="ctrl.accept()" ng-disabled="addServerForm.$invalid || testing">
       <i class="fa fa-check"></i>
       Save
     </button>

--- a/views/forms/multiurl.html
+++ b/views/forms/multiurl.html
@@ -4,13 +4,17 @@
       <div><i class="fa fa-4x fa-spin fa-smooth fa-spinner"></i></div>
       <div>Testing...</div>
     </div>
-    <form class="container-fluid" ng-show="!testing" name="form" ng-submit="ctrl.accept()" novalidate>
+    <div class="container-fluid" ng-form="form" ng-show="!testing" ng-submit="ctrl.accept()" novalidate>
       <div class="form-group row" title="The title for the server">
         <label class="col-3 col-form-label text-right" for="title">Title</label>
         <div class="col">
           <input unique-provider-title type="text" class="form-control" name="title" ng-disabled="!edit"
               ng-model="config.label" ng-required="true" ng-maxlength="1000">
-          <validation-message target="form.title"></validation-message>
+          <small class="form-text text-danger" ng-if="form.title.$error.maxlength">Title is too long!</small>
+          <small class="form-text text-danger" ng-if="form.title.$error.unique">Title is not unique!</small>
+          <small class="form-text text-muted" ng-if="form.title.$valid || form.title.$error.required">
+            Please enter a title <span ng-if="typeName">for the {{typeName}}</span>
+          </small>
         </div>
       </div>
 
@@ -18,10 +22,12 @@
       <div class="form-group row" title="The primary URL for the server">
         <label class="col-3 col-form-label text-right" for="url">URL</label>
         <div class="col">
-          <input type="text" name="url" class="form-control" ng-disabled="!edit" ng-model="config.url" ng-required="true"
-              ng-maxlength="1000">
-          <small class="form-text invalid-feedback" ng-if="urlExample && form.url.$valid">e.g. {{urlExample}}</small>
-          <validation-message target="form.url"></validation-message>
+          <input type="text" name="url" class="form-control" ng-disabled="!edit" ng-model="config.url"
+              ng-required="true" ng-maxlength="1000">
+          <small class="form-text text-danger" ng-if="form.url.$error.maxlength">URL is too long!</small>
+          <small class="form-text text-muted" ng-if="form.url.$valid || form.url.$error.required">
+            Please enter a URL <span ng-if="urlExample">(e.g. {{urlExample}})</span>
+          </small>
         </div>
       </div>
 
@@ -36,11 +42,12 @@
         </div>
       </div>
 
-      <input type="submit" hidden >
-    </form>
-    <div class="alert alert-danger" ng-if="error">
-      <h5>Error!</h5>
-      <p ng-bind-html="error"></p>
+      <input type="submit" hidden>
+
+      <div class="alert alert-danger" ng-if="error">
+        <h5>Error!</h5>
+        <p ng-bind-html="error"></p>
+      </div>
     </div>
   </div>
   <div class="modal-footer d-flex">

--- a/views/forms/singleurlform.html
+++ b/views/forms/singleurlform.html
@@ -3,34 +3,37 @@
     <div><i class="fa fa-4x fa-spin fa-smooth fa-spinner"></i></div>
     <div>Testing...</div>
   </div>
-  <form class="container-fluid" ng-show="!testing" name="form" ng-submit="ctrl.accept()" novalidate>
+  <div class="container-fluid" ng-form="form" ng-show="!testing" ng-submit="ctrl.accept()" novalidate>
     <div class="form-group" title="The title for the server">
       <label for="title">Title</label>
       <input unique-provider-title type="text" class="form-control" name="title" ng-disabled="!edit"
           ng-model="config.label" ng-required="true" ng-maxlength="1000">
-      <small class="form-text text-muted" data-ng-show="form.title.$error.maxlength">Title is too long!</small>
-      <small class="form-text text-muted" data-ng-show="form.title.$error.unique">Title is not unique!</small>
-      <small class="form-text text-muted" data-ng-show="!form.title.$error.maxlength && !form.title.$error.unique">Please enter a title</small>
+      <small class="form-text text-danger" ng-if="form.title.$error.maxlength">Title is too long!</small>
+      <small class="form-text text-danger" ng-if="form.title.$error.unique">Title is not unique!</small>
+      <small class="form-text text-muted" ng-if="form.title.$valid || form.title.$error.required">
+        Please enter a title <span ng-if="typeName">for the {{typeName}}</span>
+      </small>
     </div>
 
     <div class="form-group" title="The URL for the server">
       <label for="url" class="pr-2">URL</label>
       <button class="btn btn-primary" type="button"
-          ng-click="ctrl.launchHelp()"
+          ng-click="ctrl.launchHelp(typeName)"
           ng-if="ctrl.helpUi"
           title="Help for server specific URL formats">
         <i class="fa fa-fw fa-question-circle"></i>
       </button>
       <input type="text" name="url" class="form-control" ng-disabled="!edit" ng-model="config.url" ng-required="true"
           ng-maxlength="1000">
-      <small class="form-text text-muted" data-ng-show="form.wms.$error.maxlength">URL is too long!</small>
-      <small class="form-text text-muted" data-ng-show="!form.wms.$error.maxlength" ng-if="urlExample">Please enter a URL (e.g. {{urlExample}})</small>
-      <small class="form-text text-muted" data-ng-show="!form.wms.$error.maxlength" ng-if="!urlExample">Please enter a URL</small>
+      <small class="form-text text-danger" ng-if="form.url.$error.maxlength">URL is too long!</small>
+      <small class="form-text text-muted" ng-if="form.url.$valid || form.url.$error.required">
+        Please enter a URL <span ng-if="urlExample">(e.g. {{urlExample}})</span>
+      </small>
     </div>
     <input type="submit" hidden>
-  </form>
-  <div class="alert alert-danger" ng-if="error">
-    <h5>Error!</h5>
-    <p ng-bind-html="error" class="m-0"></p>
+    <div class="alert alert-danger" ng-if="error">
+      <h5>Error!</h5>
+      <p ng-bind-html="error" class="m-0"></p>
+    </div>
   </div>
 </div>

--- a/views/plugin/ogc/ui/ogcserverimportform.html
+++ b/views/plugin/ogc/ui/ogcserverimportform.html
@@ -3,49 +3,60 @@
     <div><i class="fa fa-4x fa-spin fa-smooth fa-spinner"></i></div>
     <div>Testing...</div>
   </div>
-  <form ng-show="!testing" name="form" ng-submit="ctrl.accept()">
+  <div ng-form="form" ng-show="!testing" ng-submit="ctrl.accept()">
     <div class="form-group">
       <label for="title">Title</label>
       <input unique-provider-title type="text" class="form-control" name="title" ng-disabled="!edit"
           ng-model="config.label" ng-required="true" ng-maxlength="1000">
-      <small class="form-text text-muted" data-ng-show="form.title.$error.maxlength">Title is too long!</small>
-      <small class="form-text text-muted" data-ng-show="form.title.$error.unique">Title is not unique!</small>
-      <small class="form-text text-muted" data-ng-show="!form.title.$error.maxlength && !form.title.$error.unique">Please enter a title</small>
+      <small class="form-text text-danger" ng-if="form.title.$error.maxlength">Title is too long!</small>
+      <small class="form-text text-danger" ng-if="form.title.$error.unique">Title is not unique!</small>
+      <small class="form-text text-muted" ng-if="form.title.$valid || form.title.$error.required">
+        Please enter a title <span ng-if="typeName">for the {{typeName}}</span>
+      </small>
     </div>
     <div class="form-group">
       <label for="wms" class="pr-1">WMS (Tile) Server URL</label>
-      <button class="btn btn-primary" type="button" ng-click="ctrl.launchHelp()" title="Help for server specific URL formats">
+      <button class="btn btn-primary" type="button" ng-click="ctrl.launchHelp(typeName)"
+          title="Help for server specific URL formats">
         <i class="fa fa-fw fa-question-circle"></i>
       </button>
       <input type="text" name="wms" class="form-control" ng-disabled="!edit" ng-model="config.wms"
           ng-required="!config.wms && !config.wmts && !config.wfs" ng-maxlength="1000">
-      <small class="form-text text-muted" data-ng-show="form.wms.$error.maxlength">URL is too long!</small>
-      <small class="form-text text-muted" data-ng-show="!form.wms.$error.maxlength">Please enter a URL (e.g. http://www.example.com/ogcserver/wms)</small>
+      <small class="form-text text-danger" ng-if="form.wms.$error.maxlength">URL is too long!</small>
+        <small class="form-text text-muted" ng-if="form.wms.$valid || form.wms.$error.required">
+          Please enter the WMS URL (e.g. https://www.example.com/ogcserver/wms)
+        </small>
     </div>
     <div class="form-group">
       <label for="wmts" class="pr-1">WMTS (Tile) Server URL</label>
-      <button class="btn btn-primary" type="button" ng-click="ctrl.launchHelp()" title="Help for server specific URL formats">
+      <button class="btn btn-primary" type="button" ng-click="ctrl.launchHelp(typeName)"
+          title="Help for server specific URL formats">
         <i class="fa fa-fw fa-question-circle"></i>
       </button>
       <input type="text" name="wmts" class="form-control" ng-disabled="!edit" ng-model="config.wmts"
           ng-required="!config.wms && !config.wmts && !config.wfs" ng-maxlength="1000">
-      <small class="form-text text-muted" data-ng-show="form.wmts.$error.maxlength">URL is too long!</small>
-      <small class="form-text text-muted" data-ng-show="!form.wmts.$error.maxlength">Please enter a URL (e.g. http://www.example.com/ogcserver/wmts)</small>
+      <small class="form-text text-danger" ng-if="form.wmts.$error.maxlength">URL is too long!</small>
+      <small class="form-text text-muted" ng-if="form.wmts.$valid || form.wmts.$error.required">
+        Please enter the WMTS URL (e.g. https://www.example.com/ogcserver/wmts)
+      </small>
     </div>
     <div class="form-group">
       <label for="wfs" class="pr-1">WFS (Features) Server URL</label>
-      <button class="btn btn-primary" type="button" ng-click="ctrl.launchHelp()" title="Help for server specific URL formats">
+      <button class="btn btn-primary" type="button" ng-click="ctrl.launchHelp(typeName)"
+          title="Help for server specific URL formats">
         <i class="fa fa-fw fa-question-circle"></i>
       </button>
       <input type="text" name="wfs" class="form-control" ng-disabled="!edit" ng-model="config.wfs"
           ng-required="!config.wms && !config.wmts && !config.wfs" ng-maxlength="1000">
-      <small class="form-text text-muted" data-ng-show="form.wfs.$error.maxlength">URL is too long!</small>
-      <small class="form-text text-muted" data-ng-show="!form.wfs.$error.maxlength">Please enter a URL (e.g. http://www.example.com/ogcserver/wfs)</small>
+      <small class="form-text text-danger" ng-if="form.wfs.$error.maxlength">URL is too long!</small>
+      <small class="form-text text-muted" ng-if="form.wfs.$valid || form.wfs.$error.required">
+        Please enter the WFS URL (e.g. https://www.example.com/ogcserver/wfs)
+      </small>
     </div>
     <input type="submit" hidden>
-  </form>
-  <div class="alert alert-danger" ng-if="error">
-    <h5>Error!</h5>
-    <p ng-bind-html="error" class="m-0"></p>
+    <div class="alert alert-danger" ng-if="error">
+      <h5>Error!</h5>
+      <p ng-bind-html="error" class="m-0"></p>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
The forms used to import servers had inconsistent validation logic, and also were no longer disabling the Save button appropriately when the form was invalid. I fixed the Save button for both the new Add Server UI and the Import Data route, and made validation consistent across all forms.

I also added some context-sensitive text to the forms and help UI's to make them a little less generic.