### PR TITLE
fix(cesium): fix clipping issues in image layers

### DIFF
--- a/src/plugin/cesium/sync/imagesynchronizer.js
+++ b/src/plugin/cesium/sync/imagesynchronizer.js
@@ -13,6 +13,7 @@ const mapContainer = goog.require('os.MapContainer');
 const MapEvent = goog.require('os.MapEvent');
 const osExtent = goog.require('os.extent');
 const geo = goog.require('os.geo');
+const {normalizeLongitude} = goog.require('os.geo2');
 const PropertyChange = goog.require('os.layer.PropertyChange');
 const osMap = goog.require('os.map');
 const osProj = goog.require('os.proj');
@@ -222,18 +223,15 @@ class ImageSynchronizer extends CesiumSynchronizer {
 
       if (url && extent) {
         if (changed) {
-          var minX = viewExtent[0];
+          var minX = normalizeLongitude(viewExtent[0]);
           var minY = viewExtent[1];
-          var maxX = viewExtent[2] - geo.EPSILON;
+          var maxX = normalizeLongitude(viewExtent[2] - geo.EPSILON);
           var maxY = viewExtent[3] - geo.EPSILON;
-          var flatCoordinates = [minX, minY, minX, maxY, maxX, maxY, maxX, minY, minX, minY];
 
           var primitive = new Cesium.GroundPrimitive({
             geometryInstances: new Cesium.GeometryInstance({
-              geometry: new Cesium.PolygonGeometry({
-                polygonHierarchy: new Cesium.PolygonHierarchy(Cesium.Cartesian3.fromDegreesArray(flatCoordinates)),
-                height: 5000,
-                arcType: Cesium.ArcType.RHUMB
+              geometry: new Cesium.RectangleGeometry({
+                rectangle: Cesium.Rectangle.fromDegrees(minX, minY, maxX, maxY)
               }),
               id: this.layer.getId() + '.' + (this.nextId_++)
             }),


### PR DESCRIPTION
Image layers are getting clipped by the globe above certain zoom levels. To reproduce, add this Arc layer and pan the globe to the US.

https://services.nationalmap.gov/arcgis/rest/services/USGSNAIPImagery/ImageServer

At zoom ~5.2 a partial image renders, but it's clipped by a diagonal line. This may have been caused by our last Cesium upgrade because they made a lot of changes with how things are rendered with respect to the globe when implementing globe translucency.

Changing the geometry to a rectangle instead of a polygon fixes the issue. We have noticed that rectangles render better at large scales, and it seems they also work better with GroundPrimitive and an image material. I did have to normalize the longitudes for the rectangle coords, because Cesium expects all rectangle coords to be in the range `[-180, 180]`. For rectangles crossing the AM, that's still expected but providing `west > east` will result in directionality across the AM.

**Outstanding issues:**

- There appears to be a timing issue when loading an image layer immediately after Cesium is initialized. If you refresh OpenSphere with the layer added, the Cesium renderer will sometimes break until you pan the globe to reload the image.
- If the pole is in view, Cesium doesn't render the image. I tried clamping rectangle coordinates but that doesn't appear to be the problem.