### PR TITLE
fix(addserver): match icon to other server ui's

### DIFF
--- a/src/os/ui/file/addserver.js
+++ b/src/os/ui/file/addserver.js
@@ -157,7 +157,7 @@ const launchAddServerWindow = function() {
     osWindow.create({
       'id': id,
       'label': 'Add Server',
-      'icon': 'fa fa-cloud-download',
+      'icon': 'fa fa-database',
       'x': 'center',
       'y': 'center',
       'width': '500',


### PR DESCRIPTION
The icon came from the Import Data dialog, but this dialog is more specific and should be consistent with other server UI's.