### PR TITLE
fix(cesium): don't destructure PROJECTION because it may change

### DIFF
--- a/src/plugin/cesium/command/flytospherecmd.js
+++ b/src/plugin/cesium/command/flytospherecmd.js
@@ -4,7 +4,7 @@ const MapContainer = goog.require('os.MapContainer');
 const AbstractSyncCommand = goog.require('os.command.AbstractSyncCommand');
 const FlyToExtent = goog.require('os.command.FlyToExtent');
 const State = goog.require('os.command.State');
-const {MAX_AUTO_ZOOM, PROJECTION, zoomToResolution} = goog.require('os.map');
+const osMap = goog.require('os.map');
 
 
 /**
@@ -34,7 +34,7 @@ class FlyToSphere extends AbstractSyncCommand {
 
     var cam = /** @type {plugin.cesium.Camera} */ (MapContainer.getInstance().getWebGLCamera());
     var minRange = cam.calcDistanceForResolution(
-        zoomToResolution(MAX_AUTO_ZOOM, PROJECTION), 0);
+        osMap.zoomToResolution(osMap.MAX_AUTO_ZOOM, osMap.PROJECTION), 0);
 
     sphere.radius = sphere.radius || 10;
 

--- a/src/plugin/cesium/interaction/cesiuminteraction.js
+++ b/src/plugin/cesium/interaction/cesiuminteraction.js
@@ -4,7 +4,7 @@ const DragBox = goog.require('os.interaction.DragBox');
 const DragCircle = goog.require('os.interaction.DragCircle');
 const DrawPolygon = goog.require('os.interaction.DrawPolygon');
 const Measure = goog.require('os.interaction.Measure');
-const {PROJECTION, zoomToResolution} = goog.require('os.map');
+const osMap = goog.require('os.map');
 const dragbox = goog.require('plugin.cesium.interaction.dragbox');
 const dragcircle = goog.require('plugin.cesium.interaction.dragcircle');
 const drawpolygon = goog.require('plugin.cesium.interaction.drawpolygon');
@@ -21,7 +21,7 @@ const Camera = goog.requireType('plugin.cesium.Camera');
  */
 const configureCesium = function(camera, sscc) {
   // allow zooming out further in the 3D view
-  var maxResolution = zoomToResolution(0, PROJECTION);
+  var maxResolution = osMap.zoomToResolution(0, osMap.PROJECTION);
   sscc.maximumZoomDistance = camera.calcDistanceForResolution(maxResolution, 0);
 
   // shift + right drag to change the camera direction

--- a/src/plugin/cesium/tiles/cesium3dtileslayer.js
+++ b/src/plugin/cesium/tiles/cesium3dtileslayer.js
@@ -8,7 +8,7 @@ const ActionEventType = goog.require('os.action.EventType');
 const settings = goog.require('os.config.Settings');
 const LayerEvent = goog.require('os.events.LayerEvent');
 const LayerEventType = goog.require('os.events.LayerEventType');
-const {PROJECTION} = goog.require('os.map');
+const osMap = goog.require('os.map');
 const {EPSG4326} = goog.require('os.proj');
 const osStyle = goog.require('os.style');
 
@@ -280,7 +280,7 @@ class Layer extends PrimitiveLayer {
       if (tileset && tileset.root && tileset.root.contentBoundingVolume) {
         var extent = rectangleToExtent(tileset.root.contentBoundingVolume.rectangle);
         if (extent) {
-          return transformExtent(extent, EPSG4326, PROJECTION);
+          return transformExtent(extent, EPSG4326, osMap.PROJECTION);
         }
       }
     } catch (e) {


### PR DESCRIPTION
The value of `os.map.PROJECTION` may change, so we shouldn't destructure the value when importing. Destructuring will get the _current_ value, and the reference will not update if the original changes.

Values like this will eventually need to be refactored because ES module exports cannot be reassigned, so we will need a getter/setter. For now, assign the exported object and reference the current `PROJECTION` value from there.