### PR TITLE
Feat save modify

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -58,7 +58,7 @@
       "basemap": {
         "type": "basemap",
         "defaults": {
-          "EPSG:4326": ["worldimagery-4326", "streetmap-4326"],
+          "EPSG:4326": ["streetmap-4326"],
           "EPSG:3857": ["worldimagery", "streetmap"]
         },
         "maps": {
@@ -95,6 +95,7 @@
             "zoomOffset": -1,
             "projection": "EPSG:4326",
             "tileSize": 256,
+            "opacity": 0.5,
             "description": "This worldwide street map presents highway-level data for the world and street-level data for the United States, Canada, Europe, Southern Africa and elsewhere. This comprehensive street map includes highways, major roads, minor roads, railways, water features, administrative boundaries, cities, parks, and landmarks, overlaid on shaded relief imagery for added context. The street map was developed by Esri using DeLorme data and NAVTEQ street data. Coverage for street-level data elsewhere in the world includes Mexico (Mexico City only), Russia (Moscow, St. Petersburg only), and Turkey (Istanbul, Ankara only). For more information on this map, including our terms of use, visit us online at http://goto.arcgisonline.com/maps/ESRI_StreetMap_World_2D\n\nSources: Esri, DeLorme, NAVTEQ, USGS, NRCAN, METI, iPC, TomTom",
             "attributions": [
               "Esri",

--- a/config/settings.json
+++ b/config/settings.json
@@ -58,7 +58,7 @@
       "basemap": {
         "type": "basemap",
         "defaults": {
-          "EPSG:4326": ["streetmap-4326"],
+          "EPSG:4326": ["worldimagery-4326", "streetmap-4326"],
           "EPSG:3857": ["worldimagery", "streetmap"]
         },
         "maps": {
@@ -95,7 +95,6 @@
             "zoomOffset": -1,
             "projection": "EPSG:4326",
             "tileSize": 256,
-            "opacity": 0.5,
             "description": "This worldwide street map presents highway-level data for the world and street-level data for the United States, Canada, Europe, Southern Africa and elsewhere. This comprehensive street map includes highways, major roads, minor roads, railways, water features, administrative boundaries, cities, parks, and landmarks, overlaid on shaded relief imagery for added context. The street map was developed by Esri using DeLorme data and NAVTEQ street data. Coverage for street-level data elsewhere in the world includes Mexico (Mexico City only), Russia (Moscow, St. Petersburg only), and Turkey (Istanbul, Ankara only). For more information on this map, including our terms of use, visit us online at http://goto.arcgisonline.com/maps/ESRI_StreetMap_World_2D\n\nSources: Esri, DeLorme, NAVTEQ, USGS, NRCAN, METI, iPC, TomTom",
             "attributions": [
               "Esri",

--- a/src/os/action/eventtype.js
+++ b/src/os/action/eventtype.js
@@ -81,6 +81,7 @@ os.action.EventType = {
 
   // export
   EXPORT: 'export',
+  SAVE_LAYER: 'saveLayer',
 
   // feature list
   INVERT: 'invert',

--- a/src/os/action/eventtype.js
+++ b/src/os/action/eventtype.js
@@ -82,6 +82,7 @@ os.action.EventType = {
   // export
   EXPORT: 'export',
   SAVE_LAYER: 'saveLayer',
+  SAVE_LAYER_AS: 'saveLayerAs',
 
   // feature list
   INVERT: 'invert',

--- a/src/os/data/filedescriptor.js
+++ b/src/os/data/filedescriptor.js
@@ -358,8 +358,9 @@ os.data.FileDescriptor.prototype.onLayerChange = function(e) {
   if (e instanceof os.events.PropertyChangeEvent) {
     const layer = /** @type {os.layer.Vector} */ (e.target);
     const p = e.getProperty() || '';
+    const newVal = e.getNewValue();
 
-    if (p == os.source.PropertyChange.HAS_MODIFICATIONS) {
+    if (p == os.source.PropertyChange.HAS_MODIFICATIONS && newVal) {
       if (layer instanceof os.layer.Vector) {
         const source = /** @type {os.source.Vector} */ (layer.getSource());
 
@@ -370,7 +371,7 @@ os.data.FileDescriptor.prototype.onLayerChange = function(e) {
             fields: null
           });
 
-          this.onDataChange(options);
+          this.updateFile(options);
         }
       }
     }
@@ -379,10 +380,10 @@ os.data.FileDescriptor.prototype.onLayerChange = function(e) {
 
 
 /**
- * Handles changes to the underlying layer data. Updates the file in storage.
+ * Updates to the underlying layer data. Updates the file in storage.
  * @param {os.ex.ExportOptions} options
  */
-os.data.FileDescriptor.prototype.onDataChange = function(options) {
+os.data.FileDescriptor.prototype.updateFile = function(options) {
   const source = /** @type {os.source.Vector} */ (options.sources[0]);
   const exporter = this.getExporter();
 
@@ -397,11 +398,23 @@ os.data.FileDescriptor.prototype.onDataChange = function(options) {
     // possible TODO: have this function return a promise that resolves/rejects if the export succeeds/fails
     os.ui.file.ExportManager.getInstance().exportItems(options);
 
-    // update this descriptor's URL to point to the file, set the source back to having no modifications
-    const url = os.file.getLocalUrl(name);
-    this.setUrl(url);
-    source.setHasModifications(false);
+    this.onFileChange(options);
   }
+};
+
+
+/**
+ * Handles changes to the underlying layer data. Updates the file in storage.
+ * @param {os.ex.ExportOptions} options
+ */
+os.data.FileDescriptor.prototype.onFileChange = function(options) {
+  // update this descriptor's URL to point to the file, set the source back to having no modifications
+  const name = this.getTitle() || 'New File';
+  const url = os.file.getLocalUrl(name);
+  this.setUrl(url);
+
+  const source = /** @type {os.source.Vector} */ (options.sources[0]);
+  source.setHasModifications(false);
 };
 
 

--- a/src/os/data/filedescriptor.js
+++ b/src/os/data/filedescriptor.js
@@ -2,10 +2,12 @@ goog.provide('os.data.FileDescriptor');
 
 goog.require('os.command.LayerAdd');
 goog.require('os.command.LayerRemove');
+goog.require('os.config.Settings');
 goog.require('os.data.IReimport');
 goog.require('os.data.IUrlDescriptor');
 goog.require('os.data.LayerSyncDescriptor');
 goog.require('os.ex.IExportMethod');
+goog.require('os.file');
 goog.require('os.file.File');
 goog.require('os.file.FileStorage');
 goog.require('os.im.ImportProcess');
@@ -363,8 +365,10 @@ os.data.FileDescriptor.prototype.onLayerChange = function(e) {
     if (p == os.source.PropertyChange.HAS_MODIFICATIONS && newVal) {
       if (layer instanceof os.layer.Vector) {
         const source = /** @type {os.source.Vector} */ (layer.getSource());
+        const settings = os.config.Settings.getInstance();
+        const key = os.file.FileSetting.AUTO_SAVE;
 
-        if (os.settings.get('os.file.autoSaveFiles', true) && source instanceof os.source.Vector) {
+        if (settings.get(key, os.file.FileSettingDefault[key]) && source instanceof os.source.Vector) {
           const options = /** @type {os.ex.ExportOptions} */ ({
             sources: [source],
             items: source.getFeatures(),

--- a/src/os/data/layernode.js
+++ b/src/os/data/layernode.js
@@ -356,7 +356,7 @@ os.data.LayerNode.prototype.formatValue = function(value) {
       var source = layer.getSource();
       if (source instanceof os.source.Vector && source.getHasModifications()) {
         s = `<span title="This layer has unsaved changes. Right click to save them." 
-            style="font-weight:900;">  •  </span>${s}`;
+            class="font-weight-bolder">  •  </span>${s}`;
       }
     } else if (layer instanceof os.layer.Tile) {
       s += ' <tileloading></tileloading>';

--- a/src/os/data/layernode.js
+++ b/src/os/data/layernode.js
@@ -290,6 +290,7 @@ os.data.LayerNode.prototype.onPropertyChange = function(e) {
         // update the label (styled differently when disabled/hidden)
         this.dispatchEvent(new os.events.PropertyChangeEvent('label'));
         break;
+      case os.source.PropertyChange.HAS_MODIFICATIONS:
       case os.layer.PropertyChange.TITLE:
         // change the label
         this.setLabel(this.layer_.getTitle());
@@ -351,6 +352,11 @@ os.data.LayerNode.prototype.formatValue = function(value) {
 
     if (layer instanceof os.layer.Vector) {
       s += ' <featurecount></featurecount>';
+
+      var source = layer.getSource();
+      if (source instanceof os.source.Vector && source.getHasModifications()) {
+        s = '<span title="This layer has unsaved changes. Right click to save them."> • </span>' + s;
+      }
     } else if (layer instanceof os.layer.Tile) {
       s += ' <tileloading></tileloading>';
     }

--- a/src/os/data/layernode.js
+++ b/src/os/data/layernode.js
@@ -355,7 +355,8 @@ os.data.LayerNode.prototype.formatValue = function(value) {
 
       var source = layer.getSource();
       if (source instanceof os.source.Vector && source.getHasModifications()) {
-        s = '<span title="This layer has unsaved changes. Right click to save them."> • </span>' + s;
+        s = `<span title="This layer has unsaved changes. Right click to save them." 
+            style="font-weight:900;">  •  </span>${s}`;
       }
     } else if (layer instanceof os.layer.Tile) {
       s += ' <tileloading></tileloading>';

--- a/src/os/data/osdatamanager.js
+++ b/src/os/data/osdatamanager.js
@@ -111,8 +111,7 @@ os.data.OSDataManager.prototype.disposeInternal = function() {
  */
 os.data.OSDataManager.prototype.init_ = function() {
   // restore time filter flag from settings
-  this.setTimeFilterEnabled(/** @type {boolean} */ (os.settings.get(
-      os.data.OSDataManagerSetting.FILTER_TIME, true)));
+  this.setTimeFilterEnabled(/** @type {boolean} */ (os.settings.get(os.data.OSDataManagerSetting.FILTER_TIME, true)));
 };
 
 

--- a/src/os/ex/export.js
+++ b/src/os/ex/export.js
@@ -13,7 +13,8 @@ goog.provide('os.ex.ExportOptions');
  *   persister: (os.ex.IPersistenceMethod|undefined),
  *   sources: (Array.<*>|undefined),
  *   title: (string|undefined),
- *   keepTitle: (boolean|undefined)
+ *   keepTitle: (boolean|undefined),
+ *   createDescriptor: (boolean|undefined)
  * }}
  */
 os.ex.ExportOptions;

--- a/src/os/ex/export.js
+++ b/src/os/ex/export.js
@@ -12,7 +12,8 @@ goog.provide('os.ex.ExportOptions');
  *   items: Array.<*>,
  *   persister: (os.ex.IPersistenceMethod|undefined),
  *   sources: (Array.<*>|undefined),
- *   title: (string|undefined)
+ *   title: (string|undefined),
+ *   keepTitle: (boolean|undefined)
  * }}
  */
 os.ex.ExportOptions;

--- a/src/os/file/file.js
+++ b/src/os/file/file.js
@@ -440,3 +440,28 @@ os.file.deserializeFile = function(data) {
 os.file.serializeFile = function(file) {
   return file ? file.persist() : undefined;
 };
+
+
+/**
+ * Base file setting key.
+ * @type {string}
+ */
+os.file.BaseSettingKey = 'os.file';
+
+
+/**
+ * File settings keys.
+ * @enum {string}
+ */
+os.file.FileSetting = {
+  AUTO_SAVE: os.file.BaseSettingKey + '.autoSaveFiles'
+};
+
+
+/**
+ * Default file setting values.
+ * @type {Object<string, *>}
+ */
+os.file.FileSettingDefault = {
+  [os.file.FileSetting.AUTO_SAVE]: false
+};

--- a/src/os/file/filesettings.js
+++ b/src/os/file/filesettings.js
@@ -1,0 +1,25 @@
+goog.module('os.file.FileSettings');
+goog.module.declareLegacyNamespace();
+
+const {directiveTag} = goog.require('os.file.FileSettingsUI');
+const SettingPlugin = goog.require('os.ui.config.SettingPlugin');
+
+
+/**
+ */
+class FileSettings extends SettingPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    this.setLabel('Files');
+    this.setDescription('Configure your file preferences.');
+    this.setTags(['files']);
+    this.setIcon('fa fa-file-text-o');
+    this.setUI(directiveTag);
+  }
+}
+
+exports = FileSettings;

--- a/src/os/file/filesettingsui.js
+++ b/src/os/file/filesettingsui.js
@@ -1,0 +1,93 @@
+goog.module('os.file.FileSettingsUI');
+
+const Settings = goog.require('os.config.Settings');
+const Module = goog.require('os.ui.Module');
+
+
+/**
+ * The column mapping settings UI directive
+ * @return {angular.Directive}
+ */
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  templateUrl: os.ROOT + 'views/file/filesettings.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'filesettings';
+
+
+Module.directive(directiveTag, [directive]);
+
+
+/**
+ * Base file setting key.
+ * @type {string}
+ */
+const BaseKey = 'os.file';
+
+
+/**
+ * File settings keys.
+ * @enum {string}
+ */
+const FileSetting = {
+  AUTO_SAVE: BaseKey + '.autoSaveFiles'
+};
+
+
+/**
+ * Controller for file settings.
+ * @unrestricted
+ */
+class Controller {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @ngInject
+   */
+  constructor($scope) {
+    /**
+     * @type {?angular.Scope}
+     * @protected
+     */
+    this.scope = $scope;
+
+    /**
+     * Setting value for auto saving files.
+     * @type {boolean}
+     */
+    this['autoSaveFiles'] = Settings.getInstance().get(FileSetting.AUTO_SAVE, true);
+  }
+
+  /**
+   * Clean up.
+   * @protected
+   */
+  $onDestroy() {
+    this.scope = null;
+  }
+
+  /**
+   * Toggles a file setting value.
+   * @param {string} type
+   * @export
+   */
+  toggle(type) {
+    const settingKey = BaseKey + '.' + type;
+    Settings.getInstance().set(settingKey, this['autoSaveFiles']);
+  }
+}
+
+exports = {
+  directive,
+  Controller,
+  directiveTag
+};

--- a/src/os/file/filesettingsui.js
+++ b/src/os/file/filesettingsui.js
@@ -1,7 +1,9 @@
 goog.module('os.file.FileSettingsUI');
 
-const Settings = goog.require('os.config.Settings');
 const Module = goog.require('os.ui.Module');
+const Settings = goog.require('os.config.Settings');
+const {BaseSettingKey, FileSetting, FileSettingDefault} = goog.require('os.file');
+const {ROOT} = goog.require('os');
 
 
 /**
@@ -11,7 +13,7 @@ const Module = goog.require('os.ui.Module');
 const directive = () => ({
   restrict: 'E',
   replace: true,
-  templateUrl: os.ROOT + 'views/file/filesettings.html',
+  templateUrl: ROOT + 'views/file/filesettings.html',
   controller: Controller,
   controllerAs: 'ctrl'
 });
@@ -25,22 +27,6 @@ const directiveTag = 'filesettings';
 
 
 Module.directive(directiveTag, [directive]);
-
-
-/**
- * Base file setting key.
- * @type {string}
- */
-const BaseKey = 'os.file';
-
-
-/**
- * File settings keys.
- * @enum {string}
- */
-const FileSetting = {
-  AUTO_SAVE: BaseKey + '.autoSaveFiles'
-};
 
 
 /**
@@ -64,12 +50,12 @@ class Controller {
      * Setting value for auto saving files.
      * @type {boolean}
      */
-    this['autoSaveFiles'] = Settings.getInstance().get(FileSetting.AUTO_SAVE, true);
+    this['autoSaveFiles'] = Settings.getInstance().get(FileSetting.AUTO_SAVE,
+        FileSettingDefault[FileSetting.AUTO_SAVE]);
   }
 
   /**
    * Clean up.
-   * @protected
    */
   $onDestroy() {
     this.scope = null;
@@ -81,7 +67,7 @@ class Controller {
    * @export
    */
   toggle(type) {
-    const settingKey = BaseKey + '.' + type;
+    const settingKey = BaseSettingKey + '.' + type;
     Settings.getInstance().set(settingKey, this['autoSaveFiles']);
   }
 }

--- a/src/os/layer/vector.js
+++ b/src/os/layer/vector.js
@@ -329,7 +329,7 @@ os.layer.Vector.prototype.onSourceChange = function(event) {
     case os.source.PropertyChange.HAS_MODIFICATIONS:
     case os.source.PropertyChange.COLUMNS:
     case os.source.PropertyChange.COLUMN_ADDED:
-      this.dispatchEvent(new os.events.PropertyChangeEvent(p));
+      this.dispatchEvent(new os.events.PropertyChangeEvent(p, event.getNewValue(), event.getOldValue()));
       break;
     case os.source.PropertyChange.ALTITUDE:
       // forward as a layer event
@@ -1098,6 +1098,7 @@ os.layer.Vector.prototype.supportsAction = function(type, opt_actionArgs) {
       case os.action.EventType.RESET_COLOR:
         return isVector && source.hasColors();
       case os.action.EventType.SAVE_LAYER:
+      case os.action.EventType.SAVE_LAYER_AS:
         return isVector && source.getHasModifications();
       default:
         // ask the source if it supports the action

--- a/src/os/layer/vector.js
+++ b/src/os/layer/vector.js
@@ -326,6 +326,7 @@ os.layer.Vector.prototype.onSourceChange = function(event) {
           event.getOldValue());
       this.dispatchEvent(e);
       break;
+    case os.source.PropertyChange.HAS_MODIFICATIONS:
     case os.source.PropertyChange.COLUMNS:
     case os.source.PropertyChange.COLUMN_ADDED:
       this.dispatchEvent(new os.events.PropertyChangeEvent(p));
@@ -1096,6 +1097,8 @@ os.layer.Vector.prototype.supportsAction = function(type, opt_actionArgs) {
         return isVector && source.isLockable() && source.isLocked();
       case os.action.EventType.RESET_COLOR:
         return isVector && source.hasColors();
+      case os.action.EventType.SAVE_LAYER:
+        return isVector && source.getHasModifications();
       default:
         // ask the source if it supports the action
         return isVector && source.getSupportsAction(type);

--- a/src/os/mainctrl.js
+++ b/src/os/mainctrl.js
@@ -38,6 +38,7 @@ goog.require('os.events.EventFactory');
 goog.require('os.events.LayerConfigEvent');
 goog.require('os.events.LayerConfigEventType');
 goog.require('os.file.FileManager');
+goog.require('os.file.FileSettings');
 goog.require('os.file.FileStorage');
 goog.require('os.file.FileUrlHandler');
 goog.require('os.file.mime.any');
@@ -676,6 +677,7 @@ os.MainCtrl.prototype.initializeSettings_ = function() {
   sm.addSettingPlugin(new os.ui.user.settings.LocationSettings());
   sm.addSettingPlugin(new os.ui.column.mapping.ColumnMappingSettings());
   sm.addSettingPlugin(new os.config.ThemeSettings());
+  sm.addSettingPlugin(new os.file.FileSettings());
 };
 
 

--- a/src/os/metrics/metricskeys.js
+++ b/src/os/metrics/metricskeys.js
@@ -304,7 +304,8 @@ os.metrics.Layer = {
   EXPORT: 'layers.contextMenu.export',
   CREATE_BUFFER: 'layers.contextMenu.createBuffer',
   SHOW_DESCRIPTION: 'layers.contextMenu.showDescription',
-  FEATURE_LIST: 'layers.contextMenu.featureList'
+  FEATURE_LIST: 'layers.contextMenu.featureList',
+  SAVE: 'layers.contextMenu.save'
 };
 
 

--- a/src/os/metrics/metricskeys.js
+++ b/src/os/metrics/metricskeys.js
@@ -305,7 +305,8 @@ os.metrics.Layer = {
   CREATE_BUFFER: 'layers.contextMenu.createBuffer',
   SHOW_DESCRIPTION: 'layers.contextMenu.showDescription',
   FEATURE_LIST: 'layers.contextMenu.featureList',
-  SAVE: 'layers.contextMenu.save'
+  SAVE: 'layers.contextMenu.save',
+  SAVE_AS: 'layers.contextMenu.saveAs'
 };
 
 

--- a/src/os/source/propertychange.js
+++ b/src/os/source/propertychange.js
@@ -16,16 +16,17 @@ os.source.PropertyChange = {
   DATA: 'data',
   ENABLED: 'enabled',
   FEATURES: 'features',
-  PREPROCESS_FEATURES: 'preprocessFeatures',
   FEATURE_VISIBILITY: 'featureVisibility',
-  GEOMETRY_SHAPE: 'geometryShape',
   GEOMETRY_CENTER_SHAPE: 'geometryCenterShape',
+  GEOMETRY_SHAPE: 'geometryShape',
+  HAS_MODIFICATIONS: 'hasModifications',
   HIGHLIGHTED_ITEMS: 'highlightedItems',
   ID: 'id',
   LABEL: 'label',
   LOADING: 'loading',
   LOADING_COUNT: 'loadingCount',
   LOCK: 'lock',
+  PREPROCESS_FEATURES: 'preprocessFeatures',
   REFRESH_INTERVAL: 'refreshInterval',
   REPLACE_STYLE: 'replaceStyle',
   STYLE: 'style',
@@ -33,6 +34,6 @@ os.source.PropertyChange = {
   TIME_FILTER: 'timeFilter',
   TIME_MODEL: 'timeModel',
   TITLE: 'title',
-  VISIBLE: 'visible',
-  UNIQUE_ID: 'uniqueId'
+  UNIQUE_ID: 'uniqueId',
+  VISIBLE: 'visible'
 };

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -403,11 +403,18 @@ os.source.Vector = function(opt_options) {
   this.detectColumnTypes_ = false;
 
   /**
-   * Flag for what this source supports modify
+   * Flag for whether this source supports modify.
    * @type {boolean}
    * @protected
    */
   this.canModify = true;
+
+  /**
+   * Flag for whether this source has pending modifications.
+   * @type {boolean}
+   * @protected
+   */
+  this.hasModifications = false;
 
   if (!options['disableAreaSelection']) {
     os.dispatcher.listen(os.action.EventType.SELECT, this.onFeatureAction_, false, this);
@@ -3725,19 +3732,31 @@ os.source.Vector.prototype.getModifyFunction = function() {
     // Notify that the feature/geometry changed, in case previous steps did not do this.
     originalFeature.changed();
 
+    this.setHasModifications(true);
     this.notifyDataChange();
-
-    const descriptor = os.dataManager.getDescriptor(this.getId());
-    if (descriptor instanceof os.data.FileDescriptor) {
-      const options = /** @type {os.ex.ExportOptions} */ ({
-        sources: [this],
-        items: this.getFeatures(),
-        fields: null
-      });
-
-      descriptor.onDataChange(options);
-    }
   };
+};
+
+
+/**
+ * Gets whether the source has pending changes.
+ * @return {boolean}
+ */
+os.source.Vector.prototype.getHasModifications = function() {
+  return this.hasModifications;
+};
+
+
+/**
+ * Gets whether the source has pending changes.
+ * @param {boolean} value
+ */
+os.source.Vector.prototype.setHasModifications = function(value) {
+  if (value != this.hasModifications) {
+    const old = this.hasModifications;
+    this.hasModifications = value;
+    this.dispatchEvent(new os.events.PropertyChangeEvent(os.source.PropertyChange.HAS_MODIFICATIONS, value, old));
+  }
 };
 
 

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -3726,6 +3726,17 @@ os.source.Vector.prototype.getModifyFunction = function() {
     originalFeature.changed();
 
     this.notifyDataChange();
+
+    const descriptor = os.dataManager.getDescriptor(this.getId());
+    if (descriptor instanceof os.data.FileDescriptor) {
+      const options = /** @type {os.ex.ExportOptions} */ ({
+        sources: [this],
+        items: this.getFeatures(),
+        fields: null
+      });
+
+      descriptor.onDataChange(options);
+    }
   };
 };
 

--- a/src/os/ui/ex/exportdialog.js
+++ b/src/os/ui/ex/exportdialog.js
@@ -3,6 +3,7 @@ goog.provide('os.ui.ex.ExportDirective');
 
 goog.require('goog.array');
 goog.require('ol.array');
+goog.require('os.config');
 goog.require('os.data.event.DataEvent');
 goog.require('os.data.event.DataEventType');
 goog.require('os.events.SelectionType');
@@ -51,6 +52,9 @@ os.ui.ex.ExportCtrl = function($scope, $element, $compile) {
 
   // call things features in !
   $scope['itemText'] = 'feature';
+
+  // Set the appname to support exporting into the tool.
+  this['appName'] = os.config.getAppName();
 
   /**
    * If multiple sources are allowed by the export method.

--- a/src/os/ui/file/csv/csv.js
+++ b/src/os/ui/file/csv/csv.js
@@ -21,3 +21,18 @@ os.ui.file.csv.configurePapaParse = function() {
     Papa.RemoteChunkSize = 1024 * 1024 * 1; // 1 MB (default 5MB)
   }
 };
+
+
+/**
+ * Default configuration options for the CSV parser.
+ * @type {Object<string, *>}
+ * @const
+ */
+os.ui.file.csv.DEFAULT_CONFIG = {
+  'color': '#ffffff',
+  'commentChar': '#',
+  'dataRow': 2,
+  'delimiter': ',',
+  'headerRow': 1,
+  'useHeader': true
+};

--- a/src/os/ui/file/exportdialog.js
+++ b/src/os/ui/file/exportdialog.js
@@ -74,6 +74,11 @@ os.ui.file.ExportDialogCtrl = function($scope, $element, $compile) {
    */
   this['exporters'] = {};
 
+  /**
+   * @type {string|undefined}
+   */
+  this['appName'] = undefined;
+
   $scope['exporter'] = this.options.exporter;
   $scope['initialExporter'] = !!$scope['exporter'];
   if (!$scope['exporter']) {
@@ -231,9 +236,7 @@ os.ui.file.ExportDialogCtrl.prototype.onExporterChange = function(opt_new, opt_o
  * @protected
  */
 os.ui.file.ExportDialogCtrl.prototype.onPersisterChange = function(opt_new, opt_old) {
-  if (opt_new) {
-    this.options.persister = opt_new;
-  }
+  this.options.persister = opt_new;
 };
 
 
@@ -254,7 +257,6 @@ os.ui.file.ExportDialogCtrl.prototype.cancel = function() {
  */
 os.ui.file.ExportDialogCtrl.prototype.confirm = function() {
   goog.asserts.assert(this.options.exporter != null, 'exporter is not defined');
-  goog.asserts.assert(this.options.persister != null, 'persister is not defined');
   goog.asserts.assert(this.options.title != null, 'export title is null');
   goog.asserts.assert(this.options.items.length > 0, 'no items to export');
   goog.asserts.assert(this.options.fields.length > 0, 'no fields defined on export');

--- a/src/os/ui/file/exportdialog.js
+++ b/src/os/ui/file/exportdialog.js
@@ -261,8 +261,7 @@ os.ui.file.ExportDialogCtrl.prototype.confirm = function() {
   goog.asserts.assert(this.options.items.length > 0, 'no items to export');
   goog.asserts.assert(this.options.fields.length > 0, 'no fields defined on export');
 
-  os.ui.exportManager.exportItems(this.options.items, this.options.fields, this.options.title,
-      this.options.exporter, this.options.persister);
+  os.ui.exportManager.exportItems(this.options);
   this.close_();
 };
 

--- a/src/os/ui/file/exportdialog.js
+++ b/src/os/ui/file/exportdialog.js
@@ -225,6 +225,8 @@ os.ui.file.ExportDialogCtrl.prototype.onExporterChange = function(opt_new, opt_o
       this.compile(uiContainer.contents())(this.scope);
     }
   }
+
+  this.options.createDescriptor = !!opt_new;
 };
 
 

--- a/src/os/ui/file/exportmanager.js
+++ b/src/os/ui/file/exportmanager.js
@@ -240,7 +240,7 @@ os.ui.file.ExportManager.prototype.onExportComplete_ = async function(options, o
         // always replace. if we got here the application should have done duplicate file detection already.
         fs.storeFile(file, true).addCallbacks(this.onFileSuccess_.bind(this, file, options), this.onFileError_, this);
       } catch (e) {
-        goog.log.error(this.log, 'Error exporting file to storage. Details: ' + e.message, e);
+        goog.log.error(os.ui.file.ExportManager.LOGGER_, 'Error exporting file to storage. Details: ' + e.message, e);
       }
     }
   } else {
@@ -287,7 +287,7 @@ os.ui.file.ExportManager.prototype.onFileSuccess_ = function(file, options) {
     if (importUI) {
       importUI.launchUI(file, options);
     } else {
-      goog.log.error(this.log, 'Failed to find import method for exported file.');
+      goog.log.error(os.ui.file.ExportManager.LOGGER_, 'Failed to find import method for exported file.');
     }
   }
 };
@@ -304,7 +304,7 @@ os.ui.file.ExportManager.prototype.onFileError_ = function(error) {
     msg += ' Error: ' + error;
   }
 
-  goog.log.error(this.log, msg);
+  goog.log.error(os.ui.file.ExportManager.LOGGER_, msg);
 };
 
 

--- a/src/os/ui/file/exportmanager.js
+++ b/src/os/ui/file/exportmanager.js
@@ -220,7 +220,7 @@ os.ui.file.ExportManager.prototype.onExportComplete_ = async function(options, o
     } else {
       try {
         if (result instanceof Blob) {
-          await result.arrayBuffer().then((arrayBuffer) => result = arrayBuffer);
+          result = await result.arrayBuffer();
         }
 
         const file = new os.file.File();
@@ -240,7 +240,7 @@ os.ui.file.ExportManager.prototype.onExportComplete_ = async function(options, o
         // always replace. if we got here the application should have done duplicate file detection already.
         fs.storeFile(file, true).addCallbacks(this.onFileSuccess_.bind(this, file, options), this.onFileError_, this);
       } catch (e) {
-        goog.log.error(this.log, 'error saving state file to local storage: ' + e.message, e);
+        goog.log.error(this.log, 'Error exporting file to storage. Details: ' + e.message, e);
       }
     }
   } else {

--- a/src/os/ui/file/exportmanager.js
+++ b/src/os/ui/file/exportmanager.js
@@ -8,6 +8,8 @@ goog.require('goog.log.Logger');
 goog.require('os.alert.AlertEventSeverity');
 goog.require('os.alert.AlertManager');
 goog.require('os.ex.ExportOptions');
+goog.require('os.file.File');
+goog.require('os.file.FileStorage');
 goog.require('os.ui.window');
 
 
@@ -134,22 +136,31 @@ os.ui.file.ExportManager.prototype.getPersistenceMethods = function(opt_getAll) 
 /**
  * Launches a dialog to export items from the application
  *
- * @param {Array.<*>} items The items to export
- * @param {Array.<string>} fields The fields to export from each item
+ * @param {Array<*>} items The items to export
+ * @param {Array<string>} fields The fields to export from each item
  * @param {string} title The title of the export source, or the file name when the methods are provided
  * @param {os.ex.IExportMethod=} opt_exporter The export method to use
  * @param {os.ex.IPersistenceMethod=} opt_persister The persistence method to use
  */
 os.ui.file.ExportManager.prototype.exportItems = function(items, fields, title, opt_exporter, opt_persister) {
+  // TODO: refactor the argument to this function to just be export options
+  const options = /** @type {os.ex.ExportOptions} */ ({
+    items: items,
+    fields: fields,
+    title: title,
+    exporter: opt_exporter,
+    persister: opt_persister
+  });
+
   if (items == null || items.length == 0) {
     goog.log.error(os.ui.file.ExportManager.LOGGER_, 'No data was supplied for the export.');
     return;
   }
 
-  if (opt_exporter != null && opt_persister != null) {
-    this.doExport_(items, fields, title, opt_exporter, opt_persister);
+  if (opt_exporter != null) {
+    this.doExport_(options);
   } else if (this.exporters_.length > 0 && this.persisters_.length > 0) {
-    this.launchExportDialog_(items, fields, title, opt_exporter, opt_persister);
+    this.launchExportDialog_(options);
   } else if (this.exporters_.length == 0) {
     goog.log.error(os.ui.file.ExportManager.LOGGER_,
         'There are no export methods defined. Can not export "' + title + '".');
@@ -163,32 +174,31 @@ os.ui.file.ExportManager.prototype.exportItems = function(items, fields, title, 
 /**
  * Exports the data.
  *
- * @param {Array.<*>} items The items to export
- * @param {Array.<string>} fields The fields to export from each item
- * @param {string} title The title of the export source, or the file name when the methods are provided
- * @param {os.ex.IExportMethod} exporter The export method to use
- * @param {os.ex.IPersistenceMethod} persister The persistence method to use
+ * @param {os.ex.ExportOptions} options The export options.
  * @private
+ *
+ * @suppress {checkTypes}
  */
-os.ui.file.ExportManager.prototype.doExport_ = function(items, fields, title, exporter, persister) {
-  exporter.setItems(items);
-  exporter.setFields(fields);
-  exporter.setName(title);
+os.ui.file.ExportManager.prototype.doExport_ = function(options) {
+  const exporter = options.exporter;
+  exporter.setItems(options.items);
+  exporter.setFields(options.fields);
+  exporter.setName(options.title || 'New Export');
 
   try {
     if (exporter.isAsync()) {
       // this typecast is entirely to make the compiler happy
       var et = /** @type {goog.events.EventTarget} */ (exporter);
-      et.listen(os.events.EventType.COMPLETE, goog.partial(this.onExportComplete_, exporter, persister), false, this);
+      et.listen(os.events.EventType.COMPLETE, this.onExportComplete_.bind(this, options), false, this);
       et.listen(os.events.EventType.ERROR, this.onExportError_, false, this);
 
       exporter.process();
     } else {
       exporter.process();
-      this.onExportComplete_(exporter, persister);
+      this.onExportComplete_(options);
     }
   } catch (e) {
-    var msg = 'Failed exporting "' + title + '" to ' + exporter.getLabel() + ': ' + e.message;
+    var msg = 'Failed exporting "' + options.title + '" to ' + exporter.getLabel() + ': ' + e.message;
     os.alertManager.sendAlert(msg, os.alert.AlertEventSeverity.ERROR, os.ui.file.ExportManager.LOGGER_);
     exporter.dispose();
   }
@@ -198,12 +208,12 @@ os.ui.file.ExportManager.prototype.doExport_ = function(items, fields, title, ex
 /**
  * Finishes the export when the exporter output is ready.
  *
- * @param {os.ex.IExportMethod} exporter The export method
- * @param {os.ex.IPersistenceMethod} persister The persistence method
+ * @param {os.ex.ExportOptions} options The export options.
  * @param {goog.events.Event=} opt_event The complete event
  * @private
  */
-os.ui.file.ExportManager.prototype.onExportComplete_ = function(exporter, persister, opt_event) {
+os.ui.file.ExportManager.prototype.onExportComplete_ = async function(options, opt_event) {
+  const exporter = options.exporter;
   var result = exporter.getOutput();
   var name = exporter.getName();
   var extension = '.' + exporter.getExtension();
@@ -215,10 +225,32 @@ os.ui.file.ExportManager.prototype.onExportComplete_ = function(exporter, persis
       name += extension;
     }
 
-    persister.save(name, result, exporter.getMimeType());
+    if (options.persister) {
+      options.persister.save(name, result, exporter.getMimeType());
+    } else {
+      try {
+        if (result instanceof Blob) {
+          await result.arrayBuffer().then((arrayBuffer) => result = arrayBuffer);
+        }
+
+        const file = new os.file.File();
+        file.setFileName(name);
+        file.setUrl(os.file.getLocalUrl(name));
+        file.setContent(result);
+        file.setContentType(exporter.getMimeType());
+
+        os.file.FileStorage.getInstance().setUniqueFileName(file);
+
+        // always replace. if we got here the application should have done duplicate file detection already.
+        const fs = os.file.FileStorage.getInstance();
+        fs.storeFile(file, true).addCallbacks(this.onFileSuccess_.bind(this, file, options),
+            this.onFileError_, this);
+      } catch (e) {
+        goog.log.error(this.log, 'error saving state file to local storage: ' + e.message, e);
+      }
+    }
   } else {
-    var msg = 'Failed exporting "' + exporter.getName() + '" to ' + exporter.getLabel() +
-        '. Exporter result was empty.';
+    var msg = `Failed exporting "${name}" to ${exporter.getLabel()}. Exporter result was empty.`;
     os.alertManager.sendAlert(msg, os.alert.AlertEventSeverity.ERROR, os.ui.file.ExportManager.LOGGER_);
   }
 };
@@ -237,37 +269,71 @@ os.ui.file.ExportManager.prototype.onExportError_ = function(event) {
 
 
 /**
+ * Handler for file storage success.
+ * @param {!os.file.File} file The file to store.
+ * @param {os.ex.ExportOptions} options The export options.
+ * @private
+ */
+os.ui.file.ExportManager.prototype.onFileSuccess_ = function(file, options) {
+  const dm = os.dataManager;
+  const descriptors = dm.getDescriptors();
+  const url = file.getUrl() || '';
+  let descriptor = null;
+
+  if (url) {
+    descriptor = descriptors.find((d) => d.matchesURL(url));
+    options['descriptor'] = descriptor;
+  }
+
+  options['defaultImport'] = true;
+
+  const importUI = os.ui.im.ImportManager.getInstance().getImportUI(options.exporter.getMimeType());
+
+  if (importUI) {
+    importUI.launchUI(file, options);
+  } else {
+    goog.log.error(this.log, 'Failed to find import method for exported file.');
+  }
+};
+
+
+/**
+ * Handler for file storage error.
+ * @param {*} error
+ * @private
+ */
+os.ui.file.ExportManager.prototype.onFileError_ = function(error) {
+  let msg = 'Unable to store state file locally.';
+  if (typeof error === 'string') {
+    msg += ' Error: ' + error;
+  }
+
+  goog.log.error(this.log, msg);
+};
+
+
+/**
  * Launches a dialog that allows the user to choose which export/persistence method to use. If the persister/exporter
  * is provided, the picker will not be present on the export dialog.
  *
- * @param {Array.<*>} items The items to export
- * @param {Array.<string>} fields The fields to export from each item
- * @param {string} title The title of the export source
- * @param {os.ex.IExportMethod=} opt_exporter The export method to use
- * @param {os.ex.IPersistenceMethod=} opt_persister The persistence method to use
+ * @param {os.ex.ExportOptions} options The export options.
  * @private
  */
-os.ui.file.ExportManager.prototype.launchExportDialog_ = function(items, fields, title, opt_exporter, opt_persister) {
-  if (items && items.length > 0) {
+os.ui.file.ExportManager.prototype.launchExportDialog_ = function(options) {
+  if (options.items && options.items.length > 0) {
     var windowId = 'exportDialog';
     if (os.ui.window.exists(windowId)) {
       os.ui.window.bringToFront(windowId);
     } else {
       var scopeOptions = {
-        'options': /** @type {os.ex.ExportOptions} */ ({
-          exporter: opt_exporter,
-          fields: fields,
-          items: items,
-          persister: opt_persister,
-          title: title
-        }),
+        'options': options,
         'exporters': this.getExportMethods(),
         'persisters': this.getPersistenceMethods()
       };
 
       var windowOptions = {
         'id': windowId,
-        'label': 'Export: ' + title,
+        'label': 'Export: ' + options.title,
         'icon': 'fa fa-download',
         'x': 'center',
         'y': 'center',

--- a/src/os/ui/file/exportmanager.js
+++ b/src/os/ui/file/exportmanager.js
@@ -238,8 +238,7 @@ os.ui.file.ExportManager.prototype.onExportComplete_ = async function(options, o
         }
 
         // always replace. if we got here the application should have done duplicate file detection already.
-        fs.storeFile(file, true).addCallbacks(this.onFileSuccess_.bind(this, file, options),
-            this.onFileError_, this);
+        fs.storeFile(file, true).addCallbacks(this.onFileSuccess_.bind(this, file, options), this.onFileError_, this);
       } catch (e) {
         goog.log.error(this.log, 'error saving state file to local storage: ' + e.message, e);
       }
@@ -270,7 +269,7 @@ os.ui.file.ExportManager.prototype.onExportError_ = function(event) {
  * @private
  */
 os.ui.file.ExportManager.prototype.onFileSuccess_ = function(file, options) {
-  if (!options.keepTitle) {
+  if (options.createDescriptor) {
     const dm = os.data.DataManager.getInstance();
     const descriptors = dm.getDescriptors();
     const url = file.getUrl() || '';

--- a/src/os/ui/im/abstractimportui.js
+++ b/src/os/ui/im/abstractimportui.js
@@ -30,7 +30,7 @@ os.ui.im.AbstractImportUI.prototype.getTitle = function() {
  * @abstract
  * @inheritDoc
  */
-os.ui.im.AbstractImportUI.prototype.launchUI = function(file, config) {};
+os.ui.im.AbstractImportUI.prototype.launchUI = function(file, opt_config) {};
 
 
 /**
@@ -44,4 +44,21 @@ os.ui.im.AbstractImportUI.prototype.mergeConfig = function(from, to) {
   to['mappings'] = from['mappings'];
   to['tags'] = from['tags'];
   to['title'] = from['title'];
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.im.AbstractImportUI.prototype.getDefaultConfig = function(file, config) {
+  // implement a good default config for the individual import types
+  return config;
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.im.AbstractImportUI.prototype.handleDefaultImport = function(file, config) {
+  // implemented by extending classes to support importing files with a known structure
 };

--- a/src/os/ui/im/iimportui.js
+++ b/src/os/ui/im/iimportui.js
@@ -40,3 +40,20 @@ os.ui.im.IImportUI.prototype.launchUI;
  * @param {T} to The import configuration to merge to
  */
 os.ui.im.IImportUI.prototype.mergeConfig;
+
+
+/**
+ * Gets the default config for the import UI.
+ * @param {os.file.File} file The file being imported by the UI
+ * @param {T} config The base import configuration
+ * @return {!T} config The default import config for the UI.
+ */
+os.ui.im.IImportUI.prototype.getDefaultConfig;
+
+
+/**
+ * Handles the default import path, skipping the UI.
+ * @param {os.file.File} file The file being imported by the UI
+ * @param {T} config The import configuration
+ */
+os.ui.im.IImportUI.prototype.handleDefaultImport;

--- a/src/os/ui/menu/layermenu.js
+++ b/src/os/ui/menu/layermenu.js
@@ -67,6 +67,15 @@ os.ui.menu.layer.setup = function() {
       type: os.ui.menu.MenuItemType.GROUP,
       sort: os.ui.menu.layer.GroupSort.GROUPS++,
       children: [{
+        label: 'Save',
+        eventType: os.action.EventType.SAVE_LAYER,
+        tooltip: 'Saves the changes to the layer',
+        icons: ['<i class="fa fa-fw fa-save"></i>'],
+        beforeRender: os.ui.menu.layer.visibleIfSupported,
+        handler: os.ui.menu.layer.onSave_,
+        metricKey: os.metrics.Layer.SAVE,
+        sort: -10000 // we want this to appear at the top when its available
+      }, {
         label: 'Go To',
         eventType: os.action.EventType.GOTO,
         tooltip: 'Repositions the map to show the layer',
@@ -324,6 +333,33 @@ os.ui.menu.layer.onDescription_ = function(event) {
   });
 
   os.ui.window.ConfirmUI.launchConfirm(confirmOptions);
+};
+
+
+/**
+ * Handle the "Save" menu event.
+ *
+ * @param {!os.ui.menu.MenuEvent<os.ui.menu.layer.Context>} event The menu event.
+ * @private
+ */
+os.ui.menu.layer.onSave_ = function(event) {
+  var context = event.getContext();
+  if (context) {
+    const sources = os.ui.menu.common.getSourcesFromContext(context);
+    if (sources && sources.length == 1) {
+      const source = sources[0];
+      const exporter = os.ui.file.ExportManager.getInstance().getExportMethods()[1];
+      const options = /** @type {os.ex.ExportOptions} */ ({
+        items: source.getFeatures(),
+        fields: os.source.getExportFields(source, false, exporter.supportsTime()),
+        title: source.getTitle(),
+        exporter: exporter
+      });
+
+      os.ui.file.ExportManager.getInstance().exportItems(options);
+      source.setHasModifications(false);
+    }
+  }
 };
 
 

--- a/src/os/ui/menu/layermenu.js
+++ b/src/os/ui/menu/layermenu.js
@@ -4,6 +4,8 @@ goog.require('goog.Timer');
 goog.require('ol.array');
 goog.require('ol.extent');
 goog.require('os.action.EventType');
+goog.require('os.alert.AlertEventSeverity');
+goog.require('os.alert.AlertManager');
 goog.require('os.command.FlyToExtent');
 goog.require('os.fn');
 goog.require('os.layer.ILayer');
@@ -358,6 +360,9 @@ os.ui.menu.layer.onSave_ = function(event) {
 
       os.ui.file.ExportManager.getInstance().exportItems(options);
       source.setHasModifications(false);
+
+      const msg = `${source.getTitle()} changes saved successfully.`;
+      os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.SUCCESS);
     }
   }
 };

--- a/src/os/ui/menu/layermenu.js
+++ b/src/os/ui/menu/layermenu.js
@@ -359,18 +359,25 @@ os.ui.menu.layer.onSave_ = function(event) {
   var context = event.getContext();
   if (context) {
     const sources = os.ui.menu.common.getSourcesFromContext(context);
+
     if (sources && sources.length == 1) {
+      let exporter = os.ui.file.ExportManager.getInstance().getExportMethods()[1];
       const source = sources[0];
-      const exporter = os.ui.file.ExportManager.getInstance().getExportMethods()[1];
-      const descriptor = os.data.DataManager.getInstance().getDescriptor(source.getId());
       const layerName = source.getTitle(true);
+      const descriptor = os.data.DataManager.getInstance().getDescriptor(source.getId());
+
+      if (descriptor instanceof os.data.FileDescriptor) {
+        exporter = descriptor.getExporter();
+      }
+
       const options = /** @type {os.ex.ExportOptions} */ ({
         items: source.getFeatures(),
+        sources: [source],
         fields: os.source.getExportFields(source, false, exporter.supportsTime()),
         title: layerName,
-        exporter: exporter,
         keepTitle: true,
-        createDescriptor: !(descriptor instanceof os.data.FileDescriptor)
+        createDescriptor: !(descriptor instanceof os.data.FileDescriptor),
+        exporter
       });
 
       os.ui.file.ExportManager.getInstance().exportItems(options);
@@ -403,7 +410,7 @@ os.ui.menu.layer.onSaveAs_ = function(event) {
         sources: [source],
         fields: os.source.getExportFields(source, false, exporter.supportsTime()),
         title: layerName,
-        exporter: exporter
+        exporter
       });
 
       const confirmOptions = /** @type {!osx.window.ConfirmTextOptions} */ ({

--- a/src/os/ui/menu/layermenu.js
+++ b/src/os/ui/menu/layermenu.js
@@ -7,6 +7,8 @@ goog.require('os.action.EventType');
 goog.require('os.alert.AlertEventSeverity');
 goog.require('os.alert.AlertManager');
 goog.require('os.command.FlyToExtent');
+goog.require('os.data.DataManager');
+goog.require('os.data.FileDescriptor');
 goog.require('os.fn');
 goog.require('os.layer.ILayer');
 goog.require('os.metrics.keys');
@@ -76,7 +78,16 @@ os.ui.menu.layer.setup = function() {
         beforeRender: os.ui.menu.layer.visibleIfSupported,
         handler: os.ui.menu.layer.onSave_,
         metricKey: os.metrics.Layer.SAVE,
-        sort: -10000 // we want this to appear at the top when its available
+        sort: -10010 // we want this to appear at the top when its available
+      }, {
+        label: 'Save As...',
+        eventType: os.action.EventType.SAVE_LAYER_AS,
+        tooltip: 'Saves the changes to the layer to a new layer',
+        icons: ['<i class="fa fa-fw fa-save"></i>'],
+        beforeRender: os.ui.menu.layer.visibleIfSupported,
+        handler: os.ui.menu.layer.onSaveAs_,
+        metricKey: os.metrics.Layer.SAVE_AS,
+        sort: -10000 // we want this to appear right below save
       }, {
         label: 'Go To',
         eventType: os.action.EventType.GOTO,
@@ -300,7 +311,7 @@ os.ui.menu.layer.onDescription_ = function(event) {
   var layers = os.ui.menu.layer.getLayersFromContext(event.getContext());
   var msg = '';
   for (var i = 0; i < layers.length; i++) {
-    var descrip = os.dataManager.getDescriptor(layers[i].getId());
+    var descrip = os.data.DataManager.getInstance().getDescriptor(layers[i].getId());
     if (descrip) {
       msg += descrip.getHtmlDescription();
       if (i < layers.length - 1) {
@@ -351,20 +362,83 @@ os.ui.menu.layer.onSave_ = function(event) {
     if (sources && sources.length == 1) {
       const source = sources[0];
       const exporter = os.ui.file.ExportManager.getInstance().getExportMethods()[1];
+      const descriptor = os.data.DataManager.getInstance().getDescriptor(source.getId());
+      const layerName = source.getTitle(true);
       const options = /** @type {os.ex.ExportOptions} */ ({
         items: source.getFeatures(),
         fields: os.source.getExportFields(source, false, exporter.supportsTime()),
-        title: source.getTitle(),
-        exporter: exporter
+        title: layerName,
+        exporter: exporter,
+        keepTitle: true,
+        createDescriptor: !(descriptor instanceof os.data.FileDescriptor)
       });
 
       os.ui.file.ExportManager.getInstance().exportItems(options);
       source.setHasModifications(false);
 
-      const msg = `${source.getTitle()} changes saved successfully.`;
+      const msg = `${layerName} changes saved successfully.`;
       os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.SUCCESS);
     }
   }
+};
+
+
+/**
+ * Handle the "Save As" menu event.
+ *
+ * @param {!os.ui.menu.MenuEvent<os.ui.menu.layer.Context>} event The menu event.
+ * @private
+ */
+os.ui.menu.layer.onSaveAs_ = function(event) {
+  var context = event.getContext();
+  if (context) {
+    const sources = os.ui.menu.common.getSourcesFromContext(context);
+    if (sources && sources.length == 1) {
+      const source = sources[0];
+      const layerName = source.getTitle(true);
+      const exporter = os.ui.file.ExportManager.getInstance().getExportMethods()[1];
+
+      const options = /** @type {os.ex.ExportOptions} */ ({
+        items: source.getFeatures(),
+        sources: [source],
+        fields: os.source.getExportFields(source, false, exporter.supportsTime()),
+        title: layerName,
+        exporter: exporter
+      });
+
+      const confirmOptions = /** @type {!osx.window.ConfirmTextOptions} */ ({
+        confirm: os.ui.menu.layer.confirmSaveAs_.bind(undefined, options),
+        defaultValue: layerName,
+        prompt: 'Please choose a name for the new layer:',
+        windowOptions: /** @type {!osx.window.WindowOptions} */ ({
+          icon: 'fa fa-save-o',
+          label: `Save ${layerName} As`
+        })
+      });
+
+      os.ui.window.launchConfirmText(confirmOptions);
+    }
+  }
+};
+
+
+/**
+ * Handles confirming the save as dialog.
+ * @param {os.ex.ExportOptions} options The folder options.
+ * @param {string} title The chosen folder title.
+ */
+os.ui.menu.layer.confirmSaveAs_ = function(options, title) {
+  options.title = title;
+  options.keepTitle = true;
+  options.createDescriptor = true;
+
+  os.ui.file.ExportManager.getInstance().exportItems(options);
+
+  const source = options.sources[0];
+  source.setHasModifications(false);
+
+  const msg = `${title} changes saved successfully.`;
+  os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.SUCCESS);
 };
 
 

--- a/src/os/ui/window/confirmtext.js
+++ b/src/os/ui/window/confirmtext.js
@@ -35,10 +35,11 @@ os.ui.Module.directive('confirmtext', [os.ui.window.confirmTextDirective]);
  *
  * @param {!angular.Scope} $scope
  * @param {!angular.JQLite} $element
+ * @param {!angular.$timeout} $timeout
  * @constructor
  * @ngInject
  */
-os.ui.window.ConfirmTextCtrl = function($scope, $element) {
+os.ui.window.ConfirmTextCtrl = function($scope, $element, $timeout) {
   if ($scope.$parent['select']) {
     setTimeout(function() {
       $element.find('[name="title"]').select();
@@ -49,6 +50,10 @@ os.ui.window.ConfirmTextCtrl = function($scope, $element) {
     if (newVal != oldVal) {
       $scope.$parent['confirmValue'] = newVal;
     }
+  });
+
+  $timeout(function() {
+    $element.find('.js-confirm-input').focus();
   });
 
   $scope.$emit(os.ui.WindowEventType.READY);

--- a/src/os/ui/window/confirmtext.js
+++ b/src/os/ui/window/confirmtext.js
@@ -35,16 +35,21 @@ os.ui.Module.directive('confirmtext', [os.ui.window.confirmTextDirective]);
  *
  * @param {!angular.Scope} $scope
  * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout
  * @constructor
  * @ngInject
  */
-os.ui.window.ConfirmTextCtrl = function($scope, $element, $timeout) {
-  if ($scope.$parent['select']) {
-    setTimeout(function() {
-      $element.find('[name="title"]').select();
-    }, 10);
-  }
+os.ui.window.ConfirmTextCtrl = function($scope, $element) {
+  /**
+   * @type {?angular.Scope}
+   * @private
+   */
+  this.scope_ = $scope;
+
+  /**
+   * @type {?angular.JQLite}
+   * @private
+   */
+  this.element_ = $element;
 
   $scope.$watch('confirmValue', function(newVal, oldVal) {
     if (newVal != oldVal) {
@@ -52,11 +57,19 @@ os.ui.window.ConfirmTextCtrl = function($scope, $element, $timeout) {
     }
   });
 
-  $timeout(function() {
-    $element.find('.js-confirm-input').focus();
-  });
-
   $scope.$emit(os.ui.WindowEventType.READY);
+};
+
+
+/**
+ * Angular initialization lifecycle function.
+ */
+os.ui.window.ConfirmTextCtrl.prototype.$onInit = function() {
+  if (this.scope_.$parent['select']) {
+    this.element_.find('.js-confirm-input').select();
+  }
+
+  this.element_.find('.js-confirm-input').focus();
 };
 
 

--- a/src/plugin/file/csv/csvdescriptor.js
+++ b/src/plugin/file/csv/csvdescriptor.js
@@ -1,6 +1,8 @@
 goog.provide('plugin.file.csv.CSVDescriptor');
+
 goog.require('os.data.FileDescriptor');
 goog.require('os.layer.LayerType');
+goog.require('plugin.file.csv.CSVExporter');
 goog.require('plugin.file.csv.CSVParserConfig');
 goog.require('plugin.file.csv.CSVProvider');
 
@@ -121,6 +123,14 @@ plugin.file.csv.CSVDescriptor.prototype.getUseHeader = function() {
  */
 plugin.file.csv.CSVDescriptor.prototype.setUseHeader = function(useHeader) {
   this.parserConfig['useHeader'] = useHeader;
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.file.csv.CSVDescriptor.prototype.getExporter = function() {
+  return new plugin.file.csv.CSVExporter();
 };
 
 

--- a/src/plugin/file/csv/csvdescriptor.js
+++ b/src/plugin/file/csv/csvdescriptor.js
@@ -138,8 +138,8 @@ plugin.file.csv.CSVDescriptor.prototype.getExporter = function() {
 /**
  * @inheritDoc
  */
-plugin.file.csv.CSVDescriptor.prototype.onDataChange = function(options) {
-  plugin.file.csv.CSVDescriptor.base(this, 'onDataChange', options);
+plugin.file.csv.CSVDescriptor.prototype.onFileChange = function(options) {
+  plugin.file.csv.CSVDescriptor.base(this, 'onFileChange', options);
 
   // update the parser config to match the default parser config
   const conf = os.ui.file.csv.DEFAULT_CONFIG;

--- a/src/plugin/file/csv/csvdescriptor.js
+++ b/src/plugin/file/csv/csvdescriptor.js
@@ -2,6 +2,7 @@ goog.provide('plugin.file.csv.CSVDescriptor');
 
 goog.require('os.data.FileDescriptor');
 goog.require('os.layer.LayerType');
+goog.require('os.ui.file.csv');
 goog.require('plugin.file.csv.CSVExporter');
 goog.require('plugin.file.csv.CSVParserConfig');
 goog.require('plugin.file.csv.CSVProvider');
@@ -131,6 +132,23 @@ plugin.file.csv.CSVDescriptor.prototype.setUseHeader = function(useHeader) {
  */
 plugin.file.csv.CSVDescriptor.prototype.getExporter = function() {
   return new plugin.file.csv.CSVExporter();
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.file.csv.CSVDescriptor.prototype.onDataChange = function(options) {
+  plugin.file.csv.CSVDescriptor.base(this, 'onDataChange', options);
+
+  // update the parser config to match the default parser config
+  const conf = os.ui.file.csv.DEFAULT_CONFIG;
+  this.parserConfig['color'] = conf['color'];
+  this.parserConfig['commentChar'] = conf['commentChar'];
+  this.parserConfig['dataRow'] = conf['dataRow'];
+  this.parserConfig['delimiter'] = conf['delimiter'];
+  this.parserConfig['headerRow'] = conf['headerRow'];
+  this.parserConfig['useHeader'] = conf['useHeader'];
 };
 
 

--- a/src/plugin/file/csv/ui/csvimportui.js
+++ b/src/plugin/file/csv/ui/csvimportui.js
@@ -1,12 +1,15 @@
 goog.provide('plugin.file.csv.ui.CSVImportUI');
 
+goog.require('os.data.DataManager');
 goog.require('os.ui.file.ui.csv.ConfigStep');
 goog.require('os.ui.im.FileImportUI');
 goog.require('os.ui.window');
 goog.require('os.ui.wiz.GeometryStep');
 goog.require('os.ui.wiz.OptionsStep');
 goog.require('os.ui.wiz.step.TimeStep');
+goog.require('plugin.file.csv.CSVDescriptor');
 goog.require('plugin.file.csv.CSVParserConfig');
+goog.require('plugin.file.csv.CSVProvider');
 goog.require('plugin.file.csv.ui.csvImportDirective');
 
 
@@ -35,14 +38,7 @@ plugin.file.csv.ui.CSVImportUI.prototype.getTitle = function() {
 plugin.file.csv.ui.CSVImportUI.prototype.launchUI = function(file, opt_config) {
   plugin.file.csv.ui.CSVImportUI.base(this, 'launchUI', file, opt_config);
 
-  var steps = [
-    new os.ui.file.ui.csv.ConfigStep(),
-    new os.ui.wiz.GeometryStep(),
-    new os.ui.wiz.step.TimeStep(),
-    new os.ui.wiz.OptionsStep()
-  ];
-
-  var config = new plugin.file.csv.CSVParserConfig();
+  const config = new plugin.file.csv.CSVParserConfig();
 
   if (opt_config) {
     this.mergeConfig(opt_config, config);
@@ -52,11 +48,23 @@ plugin.file.csv.ui.CSVImportUI.prototype.launchUI = function(file, opt_config) {
   config['title'] = file.getFileName();
   config.updateLinePreview();
 
-  var scopeOptions = {
+  if (opt_config && opt_config['defaultImport']) {
+    this.handleDefaultImport(file, config);
+    return;
+  }
+
+  const steps = [
+    new os.ui.file.ui.csv.ConfigStep(),
+    new os.ui.wiz.GeometryStep(),
+    new os.ui.wiz.step.TimeStep(),
+    new os.ui.wiz.OptionsStep()
+  ];
+
+  const scopeOptions = {
     'config': config,
     'steps': steps
   };
-  var windowOptions = {
+  const windowOptions = {
     'label': 'CSV Import',
     'icon': 'fa fa-sign-in',
     'x': 'center',
@@ -70,7 +78,7 @@ plugin.file.csv.ui.CSVImportUI.prototype.launchUI = function(file, opt_config) {
     'modal': true,
     'show-close': true
   };
-  var template = '<csvimport resize-with="' + os.ui.windowSelector.WINDOW + '"></csvimport>';
+  const template = '<csvimport resize-with="' + os.ui.windowSelector.WINDOW + '"></csvimport>';
   os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
 };
 
@@ -86,4 +94,54 @@ plugin.file.csv.ui.CSVImportUI.prototype.mergeConfig = function(from, to) {
   to['delimiter'] = from['delimiter'];
   to['headerRow'] = from['headerRow'];
   to['useHeader'] = from['useHeader'];
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.file.csv.ui.CSVImportUI.prototype.getDefaultConfig = function(file, config) {
+  // use the default expected CSV config values before doing the preview and mapping autodetection
+  config['color'] = '#ffffff';
+  config['commentChar'] = '#';
+  config['dataRow'] = 2;
+  config['delimiter'] = ',';
+  config['headerRow'] = 1;
+  config['useHeader'] = true;
+
+  try {
+    config.updatePreview();
+
+    const features = config['preview'];
+    if ((!config['mappings'] || config['mappings'].length <= 0) && features && features.length > 0) {
+      // no mappings have been set yet, so try to auto detect them
+      const mm = os.im.mapping.MappingManager.getInstance();
+      const mappings = mm.autoDetect(features);
+      if (mappings && mappings.length > 0) {
+        config['mappings'] = mappings;
+      }
+    }
+  } catch (e) {
+  }
+
+  return config;
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.file.csv.ui.CSVImportUI.prototype.handleDefaultImport = function(file, config) {
+  config['file'] = file;
+  config['title'] = file.getFileName();
+
+  config = this.getDefaultConfig(file, config);
+
+  // create the descriptor and add it
+  if (config) {
+    const descriptor = plugin.file.csv.CSVDescriptor.createFromConfig(config);
+    plugin.file.csv.CSVProvider.getInstance().addDescriptor(descriptor);
+    os.data.DataManager.getInstance().addDescriptor(descriptor);
+    descriptor.setActive(true);
+  }
 };

--- a/src/plugin/file/csv/ui/csvimportui.js
+++ b/src/plugin/file/csv/ui/csvimportui.js
@@ -1,6 +1,7 @@
 goog.provide('plugin.file.csv.ui.CSVImportUI');
 
 goog.require('os.data.DataManager');
+goog.require('os.ui.file.csv');
 goog.require('os.ui.file.ui.csv.ConfigStep');
 goog.require('os.ui.im.FileImportUI');
 goog.require('os.ui.window');
@@ -102,12 +103,13 @@ plugin.file.csv.ui.CSVImportUI.prototype.mergeConfig = function(from, to) {
  */
 plugin.file.csv.ui.CSVImportUI.prototype.getDefaultConfig = function(file, config) {
   // use the default expected CSV config values before doing the preview and mapping autodetection
-  config['color'] = '#ffffff';
-  config['commentChar'] = '#';
-  config['dataRow'] = 2;
-  config['delimiter'] = ',';
-  config['headerRow'] = 1;
-  config['useHeader'] = true;
+  const conf = os.ui.file.csv.DEFAULT_CONFIG;
+  config['color'] = conf['color'];
+  config['commentChar'] = conf['commentChar'];
+  config['dataRow'] = conf['dataRow'];
+  config['delimiter'] = conf['delimiter'];
+  config['headerRow'] = conf['headerRow'];
+  config['useHeader'] = conf['useHeader'];
 
   try {
     config.updatePreview();

--- a/src/plugin/file/geojson/geojsondescriptor.js
+++ b/src/plugin/file/geojson/geojsondescriptor.js
@@ -1,6 +1,8 @@
 goog.provide('plugin.file.geojson.GeoJSONDescriptor');
+
 goog.require('os.data.FileDescriptor');
 goog.require('os.layer.LayerType');
+goog.require('plugin.file.geojson.GeoJSONExporter');
 goog.require('plugin.file.geojson.GeoJSONParserConfig');
 goog.require('plugin.file.geojson.GeoJSONProvider');
 
@@ -36,6 +38,14 @@ plugin.file.geojson.GeoJSONDescriptor.prototype.getLayerOptions = function() {
   var options = plugin.file.geojson.GeoJSONDescriptor.base(this, 'getLayerOptions');
   options['type'] = 'GeoJSON';
   return options;
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.file.geojson.GeoJSONDescriptor.prototype.getExporter = function() {
+  return new plugin.file.geojson.GeoJSONExporter();
 };
 
 

--- a/src/plugin/file/kml/kmldescriptor.js
+++ b/src/plugin/file/kml/kmldescriptor.js
@@ -5,6 +5,7 @@ goog.require('os.layer');
 goog.require('os.layer.LayerType');
 goog.require('os.style');
 goog.require('os.ui.ControlType');
+goog.require('plugin.file.kml.KMLExporter');
 goog.require('plugin.file.kml.KMLProvider');
 
 
@@ -44,6 +45,14 @@ plugin.file.kml.KMLDescriptor.prototype.getLayerOptions = function() {
   options[os.layer.LayerOption.SHOW_FORCE_COLOR] = true;
 
   return options;
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.file.kml.KMLDescriptor.prototype.getExporter = function() {
+  return new plugin.file.kml.KMLExporter();
 };
 
 

--- a/src/plugin/file/kml/ui/kmlimportui.js
+++ b/src/plugin/file/kml/ui/kmlimportui.js
@@ -1,7 +1,11 @@
 goog.provide('plugin.file.kml.ui.KMLImportUI');
+
+goog.require('os.data.DataManager');
 goog.require('os.parse.FileParserConfig');
 goog.require('os.ui.im.FileImportUI');
 goog.require('os.ui.window');
+goog.require('plugin.file.kml.KMLDescriptor');
+goog.require('plugin.file.kml.KMLProvider');
 goog.require('plugin.file.kml.ui.kmlImportDirective');
 
 
@@ -40,6 +44,11 @@ plugin.file.kml.ui.KMLImportUI.prototype.launchUI = function(file, opt_config) {
   config['file'] = file;
   config['title'] = file.getFileName();
 
+  if (opt_config && opt_config['defaultImport']) {
+    this.handleDefaultImport(file, config);
+    return;
+  }
+
   var scopeOptions = {
     'config': config
   };
@@ -55,6 +64,23 @@ plugin.file.kml.ui.KMLImportUI.prototype.launchUI = function(file, opt_config) {
     'modal': true,
     'show-close': true
   };
+
   var template = '<kmlimport></kmlimport>';
   os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.file.kml.ui.KMLImportUI.prototype.handleDefaultImport = function(file, config) {
+  config = this.getDefaultConfig(file, config);
+
+  // create the descriptor and add it
+  if (config) {
+    const descriptor = plugin.file.kml.KMLDescriptor.createFromConfig(config);
+    plugin.file.kml.KMLProvider.getInstance().addDescriptor(descriptor);
+    os.data.DataManager.getInstance().addDescriptor(descriptor);
+    descriptor.setActive(true);
+  }
 };

--- a/src/plugin/file/kml/ui/kmltreeexportui.js
+++ b/src/plugin/file/kml/ui/kmltreeexportui.js
@@ -183,7 +183,16 @@ plugin.file.kml.ui.KMLTreeExportCtrl.prototype.confirm = function() {
   if (root) {
     var items = root.getChildren() || [root];
     items = this['additionalOptions'] ? this.scope['exportData'] : items;
-    os.ui.exportManager.exportItems(items, null, this['title'], this['exporter'], this['persister']);
+
+    var options = /** @type {os.ex.ExportOptions} */ ({
+      items: items,
+      fields: null,
+      title: this['title'],
+      exporter: this['exporter'],
+      persister: this['persister']
+    });
+
+    os.ui.exportManager.exportItems(options);
     this.close_();
   }
 };

--- a/src/plugin/file/shp/shpdescriptor.js
+++ b/src/plugin/file/shp/shpdescriptor.js
@@ -1,7 +1,9 @@
 goog.provide('plugin.file.shp.SHPDescriptor');
+
 goog.require('os.data.FileDescriptor');
 goog.require('os.file.FileStorage');
 goog.require('os.layer.LayerType');
+goog.require('plugin.file.shp.SHPExporter');
 goog.require('plugin.file.shp.SHPParserConfig');
 goog.require('plugin.file.shp.SHPProvider');
 
@@ -113,6 +115,14 @@ plugin.file.shp.SHPDescriptor.prototype.clearData = function() {
     var fs = os.file.FileStorage.getInstance();
     fs.deleteFile(url2);
   }
+};
+
+
+/**
+ * @inheritDoc
+ */
+plugin.file.shp.SHPDescriptor.prototype.getExporter = function() {
+  return new plugin.file.shp.SHPExporter();
 };
 
 

--- a/src/plugin/file/shp/shpdescriptor.js
+++ b/src/plugin/file/shp/shpdescriptor.js
@@ -133,10 +133,6 @@ plugin.file.shp.SHPDescriptor.prototype.onDataChange = function(options) {
   plugin.file.shp.SHPDescriptor.base(this, 'onDataChange', options);
 
   // ensure that the URL is set correctly in case we are converting from a shp/dbf file to a zip shp file
-  const name = this.getTitle() || 'New File';
-  const url = os.file.getLocalUrl(name);
-
-  this.setUrl(url);
   this.setUrl2('');
 };
 

--- a/src/plugin/file/shp/shpdescriptor.js
+++ b/src/plugin/file/shp/shpdescriptor.js
@@ -129,6 +129,21 @@ plugin.file.shp.SHPDescriptor.prototype.getExporter = function() {
 /**
  * @inheritDoc
  */
+plugin.file.shp.SHPDescriptor.prototype.onDataChange = function(options) {
+  plugin.file.shp.SHPDescriptor.base(this, 'onDataChange', options);
+
+  // ensure that the URL is set correctly in case we are converting from a shp/dbf file to a zip shp file
+  const name = this.getTitle() || 'New File';
+  const url = os.file.getLocalUrl(name);
+
+  this.setUrl(url);
+  this.setUrl2('');
+};
+
+
+/**
+ * @inheritDoc
+ */
 plugin.file.shp.SHPDescriptor.prototype.persist = function(opt_obj) {
   if (!opt_obj) {
     opt_obj = {};

--- a/src/plugin/file/shp/shpdescriptor.js
+++ b/src/plugin/file/shp/shpdescriptor.js
@@ -129,8 +129,8 @@ plugin.file.shp.SHPDescriptor.prototype.getExporter = function() {
 /**
  * @inheritDoc
  */
-plugin.file.shp.SHPDescriptor.prototype.onDataChange = function(options) {
-  plugin.file.shp.SHPDescriptor.base(this, 'onDataChange', options);
+plugin.file.shp.SHPDescriptor.prototype.onFileChange = function(options) {
+  plugin.file.shp.SHPDescriptor.base(this, 'onFileChange', options);
 
   // ensure that the URL is set correctly in case we are converting from a shp/dbf file to a zip shp file
   this.setUrl2('');

--- a/src/plugin/file/shp/shpdescriptor.js
+++ b/src/plugin/file/shp/shpdescriptor.js
@@ -1,6 +1,7 @@
 goog.provide('plugin.file.shp.SHPDescriptor');
 
 goog.require('os.data.FileDescriptor');
+goog.require('os.file');
 goog.require('os.file.FileStorage');
 goog.require('os.layer.LayerType');
 goog.require('plugin.file.shp.SHPExporter');
@@ -133,7 +134,12 @@ plugin.file.shp.SHPDescriptor.prototype.onFileChange = function(options) {
   plugin.file.shp.SHPDescriptor.base(this, 'onFileChange', options);
 
   // ensure that the URL is set correctly in case we are converting from a shp/dbf file to a zip shp file
-  this.setUrl2('');
+  const url2 = this.getUrl2();
+  if (url2 && os.file.isLocal(url2)) {
+    const fs = os.file.FileStorage.getInstance();
+    fs.deleteFile(url2);
+    this.setUrl2('');
+  }
 };
 
 

--- a/src/plugin/file/shp/shpexporter.js
+++ b/src/plugin/file/shp/shpexporter.js
@@ -12,6 +12,7 @@ goog.require('os.file.File');
 goog.require('os.source.Vector');
 goog.require('os.time.ITime');
 goog.require('plugin.file.shp.data.SHPHeader');
+goog.require('plugin.file.shp.mime');
 goog.require('plugin.file.shp.ui.shpExportDirective');
 
 
@@ -171,7 +172,7 @@ plugin.file.shp.SHPExporter.prototype.getLabel = function() {
  * @inheritDoc
  */
 plugin.file.shp.SHPExporter.prototype.getMimeType = function() {
-  return 'application/zip';
+  return plugin.file.shp.mime.ZIP_TYPE;
 };
 
 

--- a/src/plugin/file/shp/ui/zipshpimportui.js
+++ b/src/plugin/file/shp/ui/zipshpimportui.js
@@ -72,14 +72,14 @@ plugin.file.shp.ui.ZipSHPImportUI.prototype.launchUI = function(file, opt_config
   if (content instanceof ArrayBuffer) {
     zip.createReader(new zip.ArrayBufferReader(content),
         this.handleZipReader.bind(this), this.handleZipReaderError.bind(this));
-  } else {
+  } else if (content instanceof ArrayBuffer) {
     // convert the blob to an ArrayBuffer and proceed down the normal path
     content.arrayBuffer().then((arrayBuffer) => {
       this.zipFile_.setContent(arrayBuffer);
       zip.createReader(new zip.ArrayBufferReader(arrayBuffer),
           this.handleZipReader.bind(this), this.handleZipReaderError.bind(this));
     }, (reason) => {
-      // womp womp
+      this.handleZipReaderError(reason);
     });
   }
 };
@@ -96,11 +96,20 @@ plugin.file.shp.ui.ZipSHPImportUI.prototype.handleZipReader = function(reader) {
 
 
 /**
+ * Handles ZIP reader errors.
+ * @param {*} opt_error Optional error message/exception.
  * @protected
  */
-plugin.file.shp.ui.ZipSHPImportUI.prototype.handleZipReaderError = function() {
+plugin.file.shp.ui.ZipSHPImportUI.prototype.handleZipReaderError = function(opt_error) {
   // failed reading the zip file
   var msg = 'Error reading zip file!"';
+
+  if (typeof opt_error == 'string') {
+    msg += ` Details: ${opt_error}`;
+  } else if (opt_error instanceof Error) {
+    msg += ` Details: ${opt_error.message}.`;
+  }
+
   os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.ERROR);
 };
 

--- a/src/plugin/file/shp/ui/zipshpimportui.js
+++ b/src/plugin/file/shp/ui/zipshpimportui.js
@@ -72,7 +72,7 @@ plugin.file.shp.ui.ZipSHPImportUI.prototype.launchUI = function(file, opt_config
   if (content instanceof ArrayBuffer) {
     zip.createReader(new zip.ArrayBufferReader(content),
         this.handleZipReader.bind(this), this.handleZipReaderError.bind(this));
-  } else if (content instanceof ArrayBuffer) {
+  } else if (content instanceof Blob) {
     // convert the blob to an ArrayBuffer and proceed down the normal path
     content.arrayBuffer().then((arrayBuffer) => {
       this.zipFile_.setContent(arrayBuffer);

--- a/src/plugin/heatmap/heatmap.js
+++ b/src/plugin/heatmap/heatmap.js
@@ -212,7 +212,14 @@ const onImageComplete = function(layer, event) {
     exporter.addFile(imageFile);
     exporter.setCompress(true);
 
-    exportManager.exportItems([kmlFile], [''], layerTitle + '.kmz', exporter);
+    var options = /** @type {os.ex.ExportOptions} */ ({
+      items: [kmlFile],
+      fields: [''],
+      title: layerTitle + '.kmz',
+      exporter: exporter
+    });
+
+    exportManager.exportItems(options);
   } else {
     AlertManager.getInstance().sendAlert('Failed saving canvas to PNG');
   }

--- a/src/plugin/params/paramsmenu.js
+++ b/src/plugin/params/paramsmenu.js
@@ -25,7 +25,8 @@ const layerSetup = function() {
       icons: ['<i class="fa fa-fw fa-gears"></i>'],
       beforeRender: visibleIfSupported_,
       handler: handleLayerAction_,
-      metricKey: pluginParams.Metrics.EDIT_PARAMS
+      metricKey: pluginParams.Metrics.EDIT_PARAMS,
+      sort: 10000
     });
   }
 };

--- a/src/plugin/places/placessource.js
+++ b/src/plugin/places/placessource.js
@@ -22,7 +22,6 @@ plugin.places.PlacesSource = function(opt_options) {
   this.refreshEnabled = false;
 };
 goog.inherits(plugin.places.PlacesSource, plugin.file.kml.KMLSource);
-os.implements(plugin.places.PlacesSource, os.source.IModifiableSource.ID);
 
 
 /**

--- a/test/os/ui/file/exportmanager.test.js
+++ b/test/os/ui/file/exportmanager.test.js
@@ -10,6 +10,13 @@ describe('os.ui.file.ExportManager', function() {
   var items = ['gonna', 'be', 'output'];
   var fields = ['1', '2', '3'];
   var title = 'ExportManagerTest';
+  var options = {
+    items: null,
+    fields: fields,
+    title: title,
+    exporter: null,
+    persister: null
+  };
 
   beforeEach(function() {
     eMethod.reset();
@@ -21,20 +28,24 @@ describe('os.ui.file.ExportManager', function() {
   it('should log an error when no items are provided', function() {
     expect(goog.log.error.calls.length).toBe(0);
 
-    em.exportItems(null, fields, title);
+    em.exportItems(options);
     expect(goog.log.error.calls.length).toBe(1);
 
-    em.exportItems([], fields, title);
+    options.items = [];
+    em.exportItems(options);
     expect(goog.log.error.calls.length).toBe(2);
   });
 
   it('should log an error when exporting before methods are available', function() {
     expect(goog.log.error.calls.length).toBe(0);
 
-    em.exportItems(items, fields, title);
+    options.items = items;
+    em.exportItems(options);
     expect(goog.log.error.calls.length).toBe(1);
 
-    em.exportItems(items, fields, title, eMethod, pMethod);
+    options.exporter = eMethod;
+    options.persister = pMethod;
+    em.exportItems(options);
     expect(goog.log.error.calls.length).toBe(1);
   });
 
@@ -99,7 +110,9 @@ describe('os.ui.file.ExportManager', function() {
     spyOn(pMethod, 'save').andCallThrough();
 
     expect(eMethod.output).toBeNull();
-    em.exportItems(items, fields, title, eMethod, pMethod);
+    options.exporter = eMethod;
+    options.persister = pMethod;
+    em.exportItems(options);
 
     expect(eMethod.process).toHaveBeenCalled();
 
@@ -111,14 +124,22 @@ describe('os.ui.file.ExportManager', function() {
 
   it('should launch an export dialog when methods are not provided', function() {
     spyOn(em, 'launchExportDialog_');
+    spyOn(em, 'doExport_');
 
-    em.exportItems(items, fields, title);
+    options.exporter = null;
+    options.persister = null;
+    em.exportItems(options);
     expect(em.launchExportDialog_.calls.length).toBe(1);
 
-    em.exportItems(items, fields, title, eMethod);
-    expect(em.launchExportDialog_.calls.length).toBe(2);
+    // when an exporter is provided but no persister, save the file directly to storage
+    options.exporter = eMethod;
+    options.persister = null;
+    em.exportItems(options);
+    expect(em.doExport_.calls.length).toBe(1);
 
-    em.exportItems(items, fields, title, undefined, pMethod);
-    expect(em.launchExportDialog_.calls.length).toBe(3);
+    options.exporter = null;
+    options.persister = pMethod;
+    em.exportItems(options);
+    expect(em.launchExportDialog_.calls.length).toBe(2);
   });
 });

--- a/views/file/exportdialog.html
+++ b/views/file/exportdialog.html
@@ -13,7 +13,9 @@
       <div class="d-flex flex-fill form-group flex-shrink-0" ng-show="exportdialog.getKeys(exportdialog.persisters).length">
         <label class="col-3 col-form-label text-right">Save To</label>
         <div class="col">
-          <select class="custom-select" ng-model="persister" ng-options="value as key for (key, value) in exportdialog.persisters"></select>
+          <select class="custom-select" ng-model="persister" ng-options="value as key for (key, value) in exportdialog.persisters">
+            <option ng-if="exportdialog.appName" value="">{{exportdialog.appName}}</option>
+          </select>
         </div>
       </div>
 

--- a/views/file/filesettings.html
+++ b/views/file/filesettings.html
@@ -1,0 +1,15 @@
+<div class="d-flex flex-column flex-fill container-fluid u-overflow-x-auto u-overflow-y-auto">
+  <div class="d-flex flex-row flex-shrink-0">
+    <h4 class="col p-0">Files</h4>
+  </div>
+  <div class="form-group">Use these settings to configure your file preferences.</div>
+
+  <div class="form-group">
+    <div class="form-check" title="Whether to automatically save changes when modifying features in file layers.">
+      <input class="form-check-input" id="autoSaveFiles" type="checkbox" name="autoSaveFiles"
+          ng-model="ctrl.autoSaveFiles"
+          ng-change="ctrl.toggle('autoSaveFiles')">
+      <label class="form-check-label" for="autoSaveFiles">Auto-Save File Layers On Data Change</label>
+    </div>
+  </div>
+</div>

--- a/views/window/confirmtext.html
+++ b/views/window/confirmtext.html
@@ -3,7 +3,7 @@
   <div>
     <label for="title" ng-if="formLabel" class="u-required">{{formLabel}}:</label>
     <div>
-      <input type="text" class="form-control" name="title" ng-model="confirmValue" required ng-maxlength="limit">
+      <input type="text" class="js-confirm-input form-control" name="title" ng-model="confirmValue" required ng-maxlength="limit">
       <validation-message target="textForm.title"></validation-message>
     </div>
   </div>


### PR DESCRIPTION
Adds support for exporting files with Opensphere as the target to save them to. This includes adding support to all current file types (as well as Geopackage) to support export and direct reimport back into the tool. This can be done automatically for file layers or by accessing the "Save" menu option on a layer with pending changes.

Also adds a basic File Settings plugin which currently only has one option, but that we want to add to in the future for better file management.