### PR TITLE
fix(puny): only watch resize on Element children

### DIFF
--- a/src/os/ui/nav/navbaroptions.js
+++ b/src/os/ui/nav/navbaroptions.js
@@ -70,13 +70,13 @@ os.ui.navbaroptions.init = function() {
 
   // Bottom navbar options
   os.ui.list.add(os.ui.nav.Location.BOTTOM_LEFT,
-      '<div id="zoom-level" class="nav-item mr-1 my-auto flex-shrink-0"></li>', 100);
+      '<div id="zoom-level" class="nav-item mr-1 my-auto flex-shrink-0"></div>', 100);
   os.ui.list.add(os.ui.nav.Location.BOTTOM_LEFT, '<scale-line></scale-line>', 200);
   os.ui.list.add(os.ui.nav.Location.BOTTOM_LEFT,
-      '<div id="mouse-position" class="nav-item mr-1 my-auto flex-shrink-0"></li>', 300);
+      '<div id="mouse-position" class="nav-item mr-1 my-auto flex-shrink-0"></div>', 300);
 
   os.ui.list.add(os.ui.nav.Location.BOTTOM_RIGHT,
-      '<div id="js-dock-bottom-micro__container"></li>', 0);
+      '<div id="js-dock-bottom-micro__container"></div>', 0);
   os.ui.list.add(os.ui.nav.Location.BOTTOM_RIGHT, 'settings-button', 100);
   os.ui.list.add(os.ui.nav.Location.BOTTOM_RIGHT, 'legend-button', 200);
   os.ui.list.add(os.ui.nav.Location.BOTTOM_RIGHT, 'servers-button', 300);

--- a/src/os/ui/util/punyparent.js
+++ b/src/os/ui/util/punyparent.js
@@ -60,7 +60,7 @@ os.ui.util.PunyParentCtrl = function($scope, $element) {
 
   /**
    * Children that are watched for size changes.
-   * @type {!Array<!Node>}
+   * @type {!Array<!Element>}
    * @private
    */
   this.watchedChildren_ = [];
@@ -159,10 +159,13 @@ os.ui.util.PunyParentCtrl.prototype.onMutation_ = function(mutationsList, observ
  * @private
  */
 os.ui.util.PunyParentCtrl.prototype.watchChild_ = function(child) {
-  const childEl = $(child);
-  if (!childEl.hasClass('resize-triggers') && !childEl.hasClass('resize-sensor')) {
-    os.ui.resize(childEl, this.onChildResizeFn_);
-    this.watchedChildren_.push(child);
+  // Ignore non-Element children (like comments), which cannot be watched for resize.
+  if (child instanceof Element) {
+    const childEl = $(child);
+    if (!childEl.hasClass('resize-triggers') && !childEl.hasClass('resize-sensor')) {
+      os.ui.resize(childEl, this.onChildResizeFn_);
+      this.watchedChildren_.push(child);
+    }
   }
 };
 
@@ -173,11 +176,14 @@ os.ui.util.PunyParentCtrl.prototype.watchChild_ = function(child) {
  * @private
  */
 os.ui.util.PunyParentCtrl.prototype.unwatchChild_ = function(child) {
-  const index = this.watchedChildren_.indexOf(child);
-  if (index > -1) {
-    const childEl = $(child);
-    os.ui.removeResize(childEl, this.onChildResizeFn_);
-    this.watchedChildren_.splice(index, 1);
+  // Ignore non-Element children (like comments), which cannot be watched for resize.
+  if (child instanceof Element) {
+    const index = this.watchedChildren_.indexOf(child);
+    if (index > -1) {
+      const childEl = $(child);
+      os.ui.removeResize(childEl, this.onChildResizeFn_);
+      this.watchedChildren_.splice(index, 1);
+    }
   }
 };
 


### PR DESCRIPTION
If an element using `punyparent` had a direct child that wasn't an `Element`, the resize listener would fail because `appendElement` is only supported by Elements. This may happen if the direct child has an `ng-if`, which will replace the element with a comment when the condition is false.

I also fixed incorrect HTML in some nav elements. I had a partial fix previously to change the `li` to a `div`, because the list we're adding to already wraps elements in an `li` and that nesting was invalid. Fixed the closing element to also use `div`.