### PR TITLE
Fix remaining Closure library deprecations

### DIFF
--- a/src/os/interaction/modifyinteraction.js
+++ b/src/os/interaction/modifyinteraction.js
@@ -3,6 +3,7 @@ goog.module.declareLegacyNamespace();
 
 const {getRandomString} = goog.require('goog.string');
 const KeyCodes = goog.require('goog.events.KeyCodes');
+const KeyEvent = goog.require('goog.events.KeyEvent');
 const KeyHandler = goog.require('goog.events.KeyHandler');
 const {getUid} = goog.require('ol');
 const Collection = goog.require('ol.Collection');
@@ -30,7 +31,6 @@ const osWindow = goog.require('os.ui.window');
 const windowSelector = goog.require('os.ui.windowSelector');
 const {MODAL_SELECTOR} = goog.require('os.ui');
 
-const KeyEvent = goog.requireType('goog.events.KeyEvent');
 const MapBrowserPointerEvent = goog.requireType('ol.MapBrowserPointerEvent');
 const Geometry = goog.requireType('ol.geom.Geometry');
 const OSMap = goog.requireType('os.Map');
@@ -182,7 +182,7 @@ class Modify extends OLModify {
      * @protected
      */
     this.keyHandler = new KeyHandler(document, true);
-    this.keyHandler.listen(KeyHandler.EventType.KEY, this.handleKeyEvent, true, this);
+    this.keyHandler.listen(KeyEvent.EventType.KEY, this.handleKeyEvent, true, this);
 
     // jank alert: the functions that are called when the interaction starts and ends are hard to override, so instead
     // listen to our own events and toggle the map movement on and off

--- a/src/os/mainctrl.js
+++ b/src/os/mainctrl.js
@@ -762,7 +762,7 @@ os.MainCtrl.prototype.handleKeyEvent_ = function(event) {
         if (ctrlOr) {
           os.metrics.Metrics.getInstance().updateMetric(os.metrics.keys.Map.SEARCH_KB, 1);
           event.preventDefault();
-          $('.search-box .search-query').focus();
+          $('.search-box .search-query').trigger('focus');
         }
         break;
       case goog.events.KeyCodes.L:

--- a/src/os/mainctrl.js
+++ b/src/os/mainctrl.js
@@ -4,6 +4,7 @@ goog.require('goog.Uri');
 goog.require('goog.async.Deferred');
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
+goog.require('goog.events.KeyEvent');
 goog.require('goog.events.KeyHandler');
 goog.require('ol.ViewHint');
 goog.require('os');
@@ -595,7 +596,7 @@ os.MainCtrl.prototype.onPluginsLoaded = function(opt_e) {
   os.ui.onboarding.OnboardingManager.getInstance().displayOnboarding(os.ROOT + 'onboarding/intro.json');
 
   // set up key handlers
-  this.keyHandler_.listen(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent_, false, this);
+  this.keyHandler_.listen(goog.events.KeyEvent.EventType.KEY, this.handleKeyEvent_, false, this);
 };
 
 

--- a/src/os/ui/animationsettings.js
+++ b/src/os/ui/animationsettings.js
@@ -1,6 +1,7 @@
 goog.provide('os.ui.AnimationSettingsCtrl');
 goog.provide('os.ui.animationSettingsDirective');
 
+goog.require('goog.events.KeyEvent');
 goog.require('goog.events.KeyHandler');
 goog.require('goog.math.Range');
 goog.require('os');
@@ -99,7 +100,7 @@ os.ui.AnimationSettingsCtrl = function($scope, $element) {
    * @private
    */
   this.keyHandler_ = new goog.events.KeyHandler(goog.dom.getDocument());
-  this.keyHandler_.listen(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent_, false, this);
+  this.keyHandler_.listen(goog.events.KeyEvent.EventType.KEY, this.handleKeyEvent_, false, this);
 
   this.scope.$emit(os.ui.WindowEventType.READY);
 };

--- a/src/os/ui/column/columnmanager.js
+++ b/src/os/ui/column/columnmanager.js
@@ -1,6 +1,7 @@
 goog.provide('os.ui.column.ColumnManagerCtrl');
 goog.provide('os.ui.column.columnManagerDirective');
 
+goog.require('goog.events.KeyEvent');
 goog.require('goog.events.KeyHandler');
 goog.require('goog.string');
 goog.require('ol.array');
@@ -189,9 +190,9 @@ os.ui.column.ColumnManagerCtrl.prototype.destroy_ = function() {
  */
 os.ui.column.ColumnManagerCtrl.prototype.listenForKeys = function(enableListen) {
   if (enableListen) {
-    this.keyHandler_.listen(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent_, false, this);
+    this.keyHandler_.listen(goog.events.KeyEvent.EventType.KEY, this.handleKeyEvent_, false, this);
   } else {
-    this.keyHandler_.unlisten(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent_, false, this);
+    this.keyHandler_.unlisten(goog.events.KeyEvent.EventType.KEY, this.handleKeyEvent_, false, this);
   }
 };
 

--- a/src/os/ui/datetime/wheeldate.js
+++ b/src/os/ui/datetime/wheeldate.js
@@ -52,7 +52,7 @@ os.ui.Module.directive('wheelDate', [os.ui.datetime.wheelDateDirective]);
 os.ui.datetime.newToday_ = function(id) {
   os.ui.datetime.oldToday_.call(this, id);
   this['_selectDate'](id);
-  $(id).blur();
+  $(id).trigger('blur');
 };
 
 

--- a/src/os/ui/descriptioninfo.js
+++ b/src/os/ui/descriptioninfo.js
@@ -178,7 +178,7 @@ os.ui.SlickDescriptionAsyncRenderer = function(elem, row, dataContext, colDef) {
       var $elem = $(elem);
       var doc = elem.ownerDocument;
       var myWin = doc.defaultView || doc.parentWindow;
-      $elem.click(function() {
+      $elem.on('click', function() {
         if (os.inIframe(myWin)) {
           os.ui.launchDescriptionInfo(id, desc);
         } else {

--- a/src/os/ui/draw/drawpicker.js
+++ b/src/os/ui/draw/drawpicker.js
@@ -2,6 +2,7 @@ goog.provide('os.ui.draw.DrawPickerCtrl');
 goog.provide('os.ui.draw.drawPickerDirective');
 
 goog.require('goog.Disposable');
+goog.require('goog.events.KeyEvent');
 goog.require('goog.events.KeyHandler');
 goog.require('ol.geom.Point');
 goog.require('os');
@@ -126,7 +127,7 @@ os.ui.draw.DrawPickerCtrl = function($scope, $element) {
    * @protected
    */
   this.keyHandler = new goog.events.KeyHandler(goog.dom.getDocument());
-  this.keyHandler.listen(goog.events.KeyHandler.EventType.KEY, this.onKey, false, this);
+  this.keyHandler.listen(goog.events.KeyEvent.EventType.KEY, this.onKey, false, this);
 
   if ($scope['menu']) {
     /**

--- a/src/os/ui/featureedit.js
+++ b/src/os/ui/featureedit.js
@@ -4,6 +4,7 @@ goog.provide('os.ui.featureEditDirective');
 goog.require('goog.Disposable');
 goog.require('goog.asserts');
 goog.require('goog.dom.classlist');
+goog.require('goog.events.KeyEvent');
 goog.require('goog.events.KeyHandler');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
@@ -887,7 +888,7 @@ os.ui.FeatureEditCtrl.prototype.onMapEnabled_ = function(event, isEnabled) {
       // listen for ESC to cancel waiting for a mouse click
       if (!this.keyHandler) {
         this.keyHandler = new goog.events.KeyHandler(goog.dom.getDocument());
-        this.keyHandler.listen(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent, false, this);
+        this.keyHandler.listen(goog.events.KeyEvent.EventType.KEY, this.handleKeyEvent, false, this);
       }
     } else {
       goog.dispose(this.keyHandler);

--- a/src/os/ui/im/filesupport.js
+++ b/src/os/ui/im/filesupport.js
@@ -5,6 +5,7 @@ goog.provide('os.ui.im.fileSupportDirective');
 goog.require('goog.Disposable');
 goog.require('goog.Promise');
 goog.require('goog.dom');
+goog.require('goog.events.KeyEvent');
 goog.require('goog.events.KeyHandler');
 goog.require('os.file.upload');
 goog.require('os.string');
@@ -96,7 +97,7 @@ os.ui.im.FileSupportCtrl = function($scope, $element) {
    * @private
    */
   this.keyHandler_ = new goog.events.KeyHandler(goog.dom.getDocument());
-  this.keyHandler_.listen(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent_, false, this);
+  this.keyHandler_.listen(goog.events.KeyEvent.EventType.KEY, this.handleKeyEvent_, false, this);
 
   /**
    * The application name.

--- a/src/os/ui/ol/interaction/abstractdrawinteraction.js
+++ b/src/os/ui/ol/interaction/abstractdrawinteraction.js
@@ -3,6 +3,7 @@ goog.provide('os.ui.ol.interaction.AbstractDraw');
 goog.require('goog.dom');
 goog.require('goog.events.BrowserEvent');
 goog.require('goog.events.KeyCodes');
+goog.require('goog.events.KeyEvent');
 goog.require('goog.events.KeyHandler');
 goog.require('goog.log');
 goog.require('goog.log.Logger');
@@ -216,7 +217,7 @@ os.ui.ol.interaction.AbstractDraw.prototype.setActive = function(active) {
  */
 os.ui.ol.interaction.AbstractDraw.prototype.handleEvent = function(mapBrowserEvent) {
   var stopEvent = false;
-  if (mapBrowserEvent.type == goog.events.KeyHandler.EventType.KEY) {
+  if (mapBrowserEvent.type == goog.events.KeyEvent.EventType.KEY) {
     var browserEvent = new goog.events.BrowserEvent(mapBrowserEvent.originalEvent);
     stopEvent = browserEvent.keyCode == goog.events.KeyCodes.ESC;
 
@@ -242,7 +243,7 @@ os.ui.ol.interaction.AbstractDraw.prototype.begin = function(mapBrowserEvent) {
   if (map && !this.drawing) {
     this.drawing = true;
     this.keyHandler_ = new goog.events.KeyHandler(goog.dom.getDocument(), true);
-    this.keyHandler_.listen(goog.events.KeyHandler.EventType.KEY, this.onKey, true, this);
+    this.keyHandler_.listen(goog.events.KeyEvent.EventType.KEY, this.onKey, true, this);
     map.getView().setHint(ol.ViewHint.INTERACTING, 1);
     this.dispatchEvent(new os.ui.draw.DrawEvent(os.ui.draw.DrawEventType.DRAWSTART,
         mapBrowserEvent.coordinate));
@@ -311,7 +312,7 @@ os.ui.ol.interaction.AbstractDraw.prototype.cleanup = function() {
   }
 
   if (this.keyHandler_) {
-    this.keyHandler_.unlisten(goog.events.KeyHandler.EventType.KEY, this.onKey, true, this);
+    this.keyHandler_.unlisten(goog.events.KeyEvent.EventType.KEY, this.onKey, true, this);
     this.keyHandler_.dispose();
     this.keyHandler_ = null;
   }

--- a/src/os/ui/ol/interaction/drawpolygoninteraction.js
+++ b/src/os/ui/ol/interaction/drawpolygoninteraction.js
@@ -1,6 +1,7 @@
 goog.provide('os.ui.ol.interaction.DrawPolygon');
 
 goog.require('goog.events.BrowserEvent');
+goog.require('goog.events.KeyEvent');
 goog.require('goog.events.KeyHandler');
 goog.require('ol');
 goog.require('ol.MapBrowserEventType');
@@ -249,7 +250,7 @@ os.ui.ol.interaction.DrawPolygon.prototype.begin = function(mapBrowserEvent) {
   this.coords.length = 0;
   this.backupcoords.length = 0;
   this.undoKeyHandler_ = new goog.events.KeyHandler(goog.dom.getDocument(), true);
-  this.undoKeyHandler_.listen(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent_, true, this);
+  this.undoKeyHandler_.listen(goog.events.KeyEvent.EventType.KEY, this.handleKeyEvent_, true, this);
 };
 
 

--- a/src/os/ui/propertyinfo.js
+++ b/src/os/ui/propertyinfo.js
@@ -205,7 +205,7 @@ os.ui.SlickPropertiesAsyncRenderer = function(elem, row, dataContext, colDef) {
       var doc = elem.ownerDocument;
       var myWin = doc.defaultView || doc.parentWindow;
       goog.object.forEach(properties, os.ui.processProperty);
-      $elem.click(function() {
+      $elem.on('click', function() {
         if (os.inIframe(myWin)) {
           os.ui.launchPropertyInfo(id, properties);
         } else {

--- a/src/os/ui/query/area/userarea.js
+++ b/src/os/ui/query/area/userarea.js
@@ -6,6 +6,7 @@ goog.require('goog.Disposable');
 goog.require('goog.Promise');
 goog.require('goog.async.Delay');
 goog.require('goog.dom');
+goog.require('goog.events.KeyEvent');
 goog.require('goog.events.KeyHandler');
 goog.require('ol.Feature');
 goog.require('ol.array');
@@ -122,7 +123,7 @@ os.ui.query.area.UserAreaCtrl = function($scope, $element, $timeout) {
    * @protected
    */
   this.keyHandler = new goog.events.KeyHandler(goog.dom.getDocument());
-  this.keyHandler.listen(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent, false, this);
+  this.keyHandler.listen(goog.events.KeyEvent.EventType.KEY, this.handleKeyEvent, false, this);
 
   /**
    * Delay to update the area from the form.
@@ -228,16 +229,16 @@ os.ui.query.area.UserAreaCtrl = function($scope, $element, $timeout) {
   /**
    * @type {string}
    */
-  this['reverseHelp'] = `Reverse the horizontal direction of your box, causing it to take the longer path between 
+  this['reverseHelp'] = `Reverse the horizontal direction of your box, causing it to take the longer path between
       your defined corners instead of the shorter one.`;
 
   /**
    * @type {string}
    */
-  this['customPopoverContent'] = `Enter coordinates with spaces between latitude/longitude and commas separating 
+  this['customPopoverContent'] = `Enter coordinates with spaces between latitude/longitude and commas separating
       coordinate pairs or MGRS values. The polygon will be validated/closed if necessary.<br><br>
-      Takes DD, DMS, DDM or MGRS. If Lat/Lon, the first coordinate is assumed to 
-      be latitude unless it is zero-padded (0683000.55 or 058.135), three-digits (105&deg;30'10.1&quot; or 
+      Takes DD, DMS, DDM or MGRS. If Lat/Lon, the first coordinate is assumed to
+      be latitude unless it is zero-padded (0683000.55 or 058.135), three-digits (105&deg;30'10.1&quot; or
       105.3), or contains the direction (68 30 12 W or 105 E).`;
 
   /**

--- a/src/os/ui/slick/asyncrenderer.js
+++ b/src/os/ui/slick/asyncrenderer.js
@@ -16,7 +16,7 @@ os.ui.slick.asyncrenderer.slickColActAsyncRenderer = function(node, elem, row, d
   var $formatted = $elem.find('.col-act-mult');
   if ($formatted.length > 0) {
     var value = $formatted.data()['colvalue'];
-    $formatted.click(goog.partial(os.ui.slick.asyncrenderer.openDialog, value, colDef,
+    $formatted.on('click', goog.partial(os.ui.slick.asyncrenderer.openDialog, value, colDef,
         {'sourceId': node['sourceId']}));
   }
 };

--- a/src/os/ui/textprompt.js
+++ b/src/os/ui/textprompt.js
@@ -4,6 +4,7 @@ goog.provide('os.ui.textPromptDirective');
 goog.require('goog.async.Delay');
 goog.require('goog.dom');
 goog.require('goog.events.KeyCodes');
+goog.require('goog.events.KeyEvent');
 goog.require('goog.events.KeyHandler');
 goog.require('os.ui.Module');
 goog.require('os.ui.window');
@@ -51,7 +52,7 @@ os.ui.TextPromptCtrl = function($scope, $element) {
    * @private
    */
   this.keyHandler_ = new goog.events.KeyHandler(goog.dom.getDocument());
-  this.keyHandler_.listen(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent_, false, this);
+  this.keyHandler_.listen(goog.events.KeyEvent.EventType.KEY, this.handleKeyEvent_, false, this);
   this.delay_ = new goog.async.Delay(this.select_, 50, this);
   $scope.$emit(os.ui.WindowEventType.READY);
   $scope.$watch('value', this.onValueChange_.bind(this));

--- a/src/os/ui/timeline/abstracttimelinectrl.js
+++ b/src/os/ui/timeline/abstracttimelinectrl.js
@@ -2,6 +2,7 @@ goog.provide('os.ui.timeline.AbstractTimelineCtrl');
 
 goog.require('goog.async.Delay');
 goog.require('goog.events.KeyCodes');
+goog.require('goog.events.KeyEvent');
 goog.require('goog.events.KeyHandler');
 goog.require('goog.math.Range');
 goog.require('os.config.Settings');
@@ -236,7 +237,7 @@ os.ui.timeline.AbstractTimelineCtrl = function($scope, $element, $timeout) {
    * @private
    */
   this.keyHandler_ = new goog.events.KeyHandler(this.element[0]);
-  this.keyHandler_.listen(goog.events.KeyHandler.EventType.KEY, this.onKey, false, this);
+  this.keyHandler_.listen(goog.events.KeyEvent.EventType.KEY, this.onKey, false, this);
 
   /**
    * @type {os.ui.menu.Menu|undefined}

--- a/src/os/ui/timelinesettings.js
+++ b/src/os/ui/timelinesettings.js
@@ -1,6 +1,7 @@
 goog.provide('os.ui.TimeSettingsCtrl');
 goog.provide('os.ui.timeSettingsDirective');
 
+goog.require('goog.events.KeyEvent');
 goog.require('goog.events.KeyHandler');
 goog.require('goog.math.Range');
 goog.require('goog.math.RangeSet');
@@ -75,7 +76,7 @@ os.ui.TimeSettingsCtrl = function($scope, $element) {
    * @private
    */
   this.keyHandler_ = new goog.events.KeyHandler(goog.dom.getDocument());
-  this.keyHandler_.listen(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent_, false, this);
+  this.keyHandler_.listen(goog.events.KeyEvent.EventType.KEY, this.handleKeyEvent_, false, this);
 
   this.scope.$emit(os.ui.WindowEventType.READY);
 };

--- a/src/os/ui/window/confirm.js
+++ b/src/os/ui/window/confirm.js
@@ -3,6 +3,7 @@ goog.module.declareLegacyNamespace();
 
 const {getDocument} = goog.require('goog.dom');
 const KeyCodes = goog.require('goog.events.KeyCodes');
+const KeyEvent = goog.require('goog.events.KeyEvent');
 const KeyHandler = goog.require('goog.events.KeyHandler');
 const {noop} = goog.require('os.fn');
 const Module = goog.require('os.ui.Module');
@@ -140,7 +141,7 @@ class Controller {
      * @private
      */
     this.keyHandler_ = new KeyHandler(getDocument());
-    this.keyHandler_.listen(KeyHandler.EventType.KEY, this.handleKeyEvent_, false, this);
+    this.keyHandler_.listen(KeyEvent.EventType.KEY, this.handleKeyEvent_, false, this);
 
     $timeout(function() {
       $scope.$emit(WindowEventType.READY);

--- a/src/os/ui/windowui.js
+++ b/src/os/ui/windowui.js
@@ -7,6 +7,7 @@ goog.require('goog.async.Delay');
 goog.require('goog.dom.ViewportSizeMonitor');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
+goog.require('goog.events.KeyEvent');
 goog.require('goog.events.KeyHandler');
 goog.require('goog.log');
 goog.require('ol.array');
@@ -236,7 +237,7 @@ os.ui.WindowCtrl = function($scope, $element, $timeout) {
   // If its a closeable window modal, let ESC close it
   if ($scope['showClose'] && $scope['modal']) {
     this.keyHandler_ = new goog.events.KeyHandler(goog.dom.getDocument());
-    this.keyHandler_.listen(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent_, false, this);
+    this.keyHandler_.listen(goog.events.KeyEvent.EventType.KEY, this.handleKeyEvent_, false, this);
   }
 
   // listen for mousedown so z-index can be updated
@@ -302,7 +303,7 @@ os.ui.WindowCtrl.prototype.disposeInternal = function() {
   }
 
   if (this.keyHandler_) {
-    this.keyHandler_.unlisten(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent_, false, this);
+    this.keyHandler_.unlisten(goog.events.KeyEvent.EventType.KEY, this.handleKeyEvent_, false, this);
     this.keyHandler_.dispose();
     this.keyHandler_ = null;
   }

--- a/src/plugin/position/copyposition.js
+++ b/src/plugin/position/copyposition.js
@@ -2,7 +2,10 @@ goog.provide('plugin.position.CopyPositionCtrl');
 goog.provide('plugin.position.copyPositionDirective');
 
 goog.require('goog.Disposable');
-goog.require('goog.events');
+goog.require('goog.dom');
+goog.require('goog.events.KeyCodes');
+goog.require('goog.events.KeyEvent');
+goog.require('goog.events.KeyHandler');
 goog.require('os');
 goog.require('os.action.EventType');
 goog.require('os.ui.Module');
@@ -57,7 +60,7 @@ plugin.position.CopyPositionCtrl = function($scope, $element) {
    * @private
    */
   this.keyHandler_ = new goog.events.KeyHandler(goog.dom.getDocument());
-  this.keyHandler_.listen(goog.events.KeyHandler.EventType.KEY, this.handleKeyEvent_, false, this);
+  this.keyHandler_.listen(goog.events.KeyEvent.EventType.KEY, this.handleKeyEvent_, false, this);
 
   $scope.$emit(os.ui.WindowEventType.READY);
 


### PR DESCRIPTION
This fixes remaining deprecation warnings with the exception of:

- `goog.inherits`: These will be resolved as we migrate to modules.
- `goog.iter.Iterator`: We're extending `goog.storage.mechanism.IterableMechanism` which has not been deprecated, and still requires defining a function that returns a `goog.iter.Iterator`. I don't think we can resolve this one without a more significant refactor, and presumably Closure will have a better solution before they remove the deprecated class.