### PR TITLE
fix(vector): notify feature changed in modify function

### DIFF
--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -3722,6 +3722,9 @@ os.source.Vector.prototype.getModifyFunction = function() {
     // Update the ellipse, if needed.
     os.feature.createEllipse(originalFeature, true);
 
+    // Notify that the feature/geometry changed, in case previous steps did not do this.
+    originalFeature.changed();
+
     this.notifyDataChange();
   };
 };


### PR DESCRIPTION
Point and MultiPoint are not interpolated, which was firing the feature change event for other geometries. This ensures a change event will always be fired on a modified feature.