### PR TITLE
Fix html lint warnings

### DIFF
--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -10,7 +10,9 @@
   "rules": {
     "element-name": "off",
     "element-required-attributes": "off",
-    "no-inline-style": "warn",
+    "no-inline-style": ["error", {
+      "exclude": ["ng-style"]
+    }],
     "no-raw-characters": "warn",
     "prefer-button": "warn",
     "wcag/h30": "warn",

--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -13,12 +13,8 @@
     "no-inline-style": ["error", {
       "exclude": ["ng-style"]
     }],
-    "no-raw-characters": "warn",
-    "prefer-button": "warn",
-    "wcag/h30": "warn",
     "wcag/h32": "off",
     "wcag/h37": "off",
-    "prefer-native-element": "warn",
     "text-content": "off"
   }
 }

--- a/scss/opensphere.scss
+++ b/scss/opensphere.scss
@@ -42,6 +42,7 @@
 @import 'os/overrides_slickgrid';
 @import 'os/overrides_tuieditor';
 @import 'os/propertiestab';
+@import 'os/ringoptions';
 @import 'os/searchresults';
 @import 'os/singlepage';
 @import 'os/slicktree';

--- a/scss/os/_ringoptions.scss
+++ b/scss/os/_ringoptions.scss
@@ -1,0 +1,3 @@
+.c-ring-scroll-section {
+  max-height: 10rem;
+}

--- a/views/color/colorpalette.html
+++ b/views/color/colorpalette.html
@@ -3,7 +3,8 @@
     <tbody>
       <tr ng-repeat="row in rows">
         <td class="c-colorpalette__cell m-0 p-0" ng-repeat="color in row" ng-click="palette.pick(color)" title="{{palette.getTitle(color)}}">
-          <div class="c-colorpalette__colorswatch" ng-class="{'c-colorpalette__selected': value === color}"  ng-style="{'background-color': color}"></div>
+          <div class="c-colorpalette__colorswatch" ng-class="{'c-colorpalette__selected': value === color}"
+              ng-style="{'background-color': color}"></div>
         </td>
       </tr>
     </tbody>

--- a/views/column/mapping/columnmappingexport.html
+++ b/views/column/mapping/columnmappingexport.html
@@ -30,7 +30,7 @@
           </label>Selected
         </div>
       </div>
-      <input type="submit" hidden>
+      <button type="submit" hidden></button>
     </form>
   </div>
 
@@ -44,7 +44,7 @@
         <i class="fa fa-check"></i>
         OK
       </button>
-      <button class="btn btn-secondary" ng-click="cmExportCtrl.close()">
+      <button class="btn btn-secondary" type="button" ng-click="cmExportCtrl.close()">
         <i class="fa fa-ban"></i>
         Cancel
       </button>

--- a/views/data/addcolumn.html
+++ b/views/data/addcolumn.html
@@ -2,17 +2,17 @@
   <div class="modal-body">
     <form name="addColumnForm" ng-submit="addcolumn.finish()" novalidate>
       <addcolumnform name="addcolumn.name" value="addcolumn.value" validators="addcolumn.validators"></addcolumnform>
-      <input type="submit" class="d-none">
+      <button type="submit" hidden></button>
     </form>
   </div>
   <div class="modal-footer">
-      <button class="btn btn-primary" ng-click="addcolumn.finish()" ng-disabled="addColumnForm.$invalid">
-        <i class="fa fa-check"></i>
-        OK
-      </button>
-      <button class="btn btn-secondary" ng-click="addcolumn.cancel()">
-        <i class="fa fa-ban"></i>
-        Cancel
-      </button>
+    <button class="btn btn-primary" ng-click="addcolumn.finish()" ng-disabled="addColumnForm.$invalid">
+      <i class="fa fa-check"></i>
+      OK
+    </button>
+    <button class="btn btn-secondary" type="button" ng-click="addcolumn.cancel()">
+      <i class="fa fa-ban"></i>
+      Cancel
+    </button>
   </div>
 </div>

--- a/views/feature/featureinfocell.html
+++ b/views/feature/featureinfocell.html
@@ -5,7 +5,7 @@
   <span ng-switch-when="ca">
     <span>{{property.value}} </span>
     <span ng-if="actions.length == 1" data-colvalue="property.value">
-      <a ng-href="{{action}}" target="_blank">
+      <a ng-href="{{action}}" target="_blank" aria-label="{{description}}">
         <i class="fa fa-external-link-square" title="{{description}}"></i>
       </a>
     </span>

--- a/views/file/importdialog.html
+++ b/views/file/importdialog.html
@@ -1,25 +1,31 @@
 <div class="d-flex flex-column flex-fill">
-  <div ng-form="importForm" class="modal-body">
+  <form class="modal-body" name="importForm" ng-submit="importdialog.accept()">
     <div class="input-group">
       <input type="text" class="form-control" placeholder="Choose a file or enter a URL" name="url" ng-model="importdialog.url" ng-required="true" ng-maxlength="1000" ng-readonly="importdialog.fileChosen || importdialog.loading">
       <div class="input-group-append">
-        <button class="btn form-control w-auto border border-left-0 u-border-color-input" ng-click="importdialog.clearFile()" ng-disabled="importdialog.loading"
+        <button class="btn form-control w-auto border border-left-0 u-border-color-input" type="button"
+            ng-click="importdialog.clearFile()"
+            ng-disabled="importdialog.loading"
             title="Clear the file/URL">
           <i class="fa fa-times"></i>
         </button>
-        <button class="btn btn-secondary" ng-click="importdialog.openFileBrowser()" ng-disabled="importdialog.loading" title="Choose a local file">
+        <button class="btn btn-secondary" type="button"
+            ng-click="importdialog.openFileBrowser()"
+            ng-disabled="importdialog.loading"
+            title="Choose a local file">
           Browse
         </button>
       </div>
     </div>
     <validation-message target="importForm.url"></validation-message>
-  </div>
+  </form>
   <div class="modal-footer">
     <button class="btn btn-primary" ng-click="importdialog.accept()" ng-disabled="importForm.$invalid || importdialog.loading" title="Load the file for import">
       <i class="fa" ng-class="importdialog.loading && 'fa-spin fa-spinner' || 'fa-chevron-circle-right'"></i>
       <span>{{importdialog.loading ? 'Loading' : confirmText}}</span>
     </button>
-    <button ng-if="!importdialog.hideCancel" class="btn btn-secondary" ng-click="importdialog.cancel()" title="Cancel file import">
+    <button ng-if="!importdialog.hideCancel" class="btn btn-secondary" type="button"
+        ng-click="importdialog.cancel()" title="Cancel file import">
       <i class="fa fa-ban"></i>
       Cancel
     </button>

--- a/views/forms/multiurl.html
+++ b/views/forms/multiurl.html
@@ -42,7 +42,7 @@
         </div>
       </div>
 
-      <input type="submit" hidden>
+      <button type="submit" hidden></button>
 
       <div class="alert alert-danger" ng-if="error">
         <h5>Error!</h5>

--- a/views/forms/singleurl.html
+++ b/views/forms/singleurl.html
@@ -1,13 +1,15 @@
 <div class="flex-fill w-100 d-flex flex-column">
   <div class="modal-body container flex-fill">
-    <singleurlform></singleurlform>
+    <form name="singleUrlForm" ng-submit="ctrl.accept()">
+      <singleurlform></singleurlform>
+    </form>
   </div>
   <div class="modal-footer d-flex">
     <button class="btn btn-primary" ng-click="ctrl.accept()" ng-disabled="form.$invalid || testing">
       <i class="fa fa-check"></i>
       {{edit ? 'Save' : 'OK'}}
     </button>
-    <button class="btn btn-secondary" ng-click="ctrl.close()">
+    <button class="btn btn-secondary" type="button" ng-click="ctrl.close()">
       <i class="fa fa-ban"></i>
       Cancel
     </button>

--- a/views/forms/singleurlform.html
+++ b/views/forms/singleurlform.html
@@ -30,7 +30,7 @@
         Please enter a URL <span ng-if="urlExample">(e.g. {{urlExample}})</span>
       </small>
     </div>
-    <input type="submit" hidden>
+    <button type="submit" hidden></button>
     <div class="alert alert-danger" ng-if="error">
       <h5>Error!</h5>
       <p ng-bind-html="error" class="m-0"></p>

--- a/views/geo/ringoptions.html
+++ b/views/geo/ringoptions.html
@@ -43,7 +43,7 @@
           </div>
         </div>
 
-        <div class="col-4 overflow-auto js-ring-scroll-section" style="max-height:10rem;">
+        <div class="col-4 overflow-auto c-ring-scroll-section js-ring-scroll-section">
           <div class="mb-1 row" ng-repeat="ring in ctrl.options.rings | limitTo: 50">
             <input class="form-control px-1" ng-class="ctrl.options.type == 'auto' ? 'col-12' : 'col-9'" type="number" required name="count" step="any" ng-change="ctrl.update()" ng-model="ring.radius" ng-disabled="!ctrl.options.enabled || ctrl.options.type == 'auto'">
             <button class="btn btn-outline-danger col-3 border-0" ng-click="ctrl.remove($index, true)" ng-if="ctrl.options.type == 'manual'" ng-disabled="!ctrl.options.enabled || ctrl.options.rings.length <= 1">

--- a/views/plugin/ogc/ui/ogcserverimport.html
+++ b/views/plugin/ogc/ui/ogcserverimport.html
@@ -1,6 +1,8 @@
 <div class="c-ogcserver-form flex-fill w-100 d-flex flex-column">
   <div class="modal-body container flex-fill">
-    <ogcserverform></ogcserverform>
+    <form name="ogcServerForm" ng-submit="ctrl.accept()">
+      <ogcserverform></ogcserverform>
+    </form>
   </div>
   <div class="modal-footer d-flex">
     <button class="btn btn-primary" ng-click="ctrl.accept()" ng-disabled="form.$invalid || testing">

--- a/views/plugin/ogc/ui/ogcserverimportform.html
+++ b/views/plugin/ogc/ui/ogcserverimportform.html
@@ -53,7 +53,7 @@
         Please enter the WFS URL (e.g. https://www.example.com/ogcserver/wfs)
       </small>
     </div>
-    <input type="submit" hidden>
+    <button type="submit" hidden></button>
     <div class="alert alert-danger" ng-if="error">
       <h5>Error!</h5>
       <p ng-bind-html="error" class="m-0"></p>

--- a/views/query/editarea.html
+++ b/views/query/editarea.html
@@ -2,7 +2,7 @@
   <div class="modal-body">
     <form name="areaForm" ng-submit="ctrl.accept()">
       <basicinfo config="config" columns="columns"></basicinfo>
-      <input type="submit" hidden>
+      <button type="submit" hidden></button>
     </form>
   </div>
   <div class="modal-footer">

--- a/views/query/mergeareas.html
+++ b/views/query/mergeareas.html
@@ -13,7 +13,7 @@
         </div>
       </div>
 
-      <input type="submit" hidden>
+      <button type="submit" hidden></button>
     </form>
   </div>
   <div class="modal-footer">

--- a/views/window/stateimportexport.html
+++ b/views/window/stateimportexport.html
@@ -37,7 +37,7 @@
         </div>
       </div>
 
-      <input type="submit" hidden>
+      <button type="submit" hidden></button>
 
       <div class="container-fluid">
         <div class="row" ng-if="stateForm.showClear && !stateForm.isSaving">
@@ -97,7 +97,7 @@
       <i class="fa fa-check"></i>
       OK
     </button>
-    <button class="btn btn-secondary" ng-click="stateForm.close()">
+    <button class="btn btn-secondary" type="button" ng-click="stateForm.close()">
       <i class="fa fa-ban"></i>
       Cancel
     </button>

--- a/views/window/stateimportexport.html
+++ b/views/window/stateimportexport.html
@@ -75,7 +75,7 @@
                              x-content="stateForm.getDescription(s)"></popover>
                       </label>
                     </div>
-                    <div ng-if="!s.supported" class="d-flex" style="justify-content: space-between">
+                    <div ng-if="!s.supported" class="d-flex justify-content-between">
                       <div><i class="fa fa-lg fa-times text-danger mr-1"></i> {{stateForm.getTitle(s)}}</div>
                       <popover ng-show="help" class="pt-1" icon="'fa fa-lg fa-question-circle-o'"
                           x-pos="'right'" x-title="stateForm.getTitle(s)"


### PR DESCRIPTION
- Replaced inline `style` with CSS classes.
- Allowed `ng-style`. This directive is useful for dynamically changing styles based on scope/controller values.
- Replaced `<input type="submit" hidden>` with `<button type="submit" hidden></button>` per `htmlvalidate` suggestion. I also fixed some cases where Enter was not submitting a form, such as the generic import dialog and server import UI's.
- Updated `htmlvalidate` config to error on checks that have been resolved.