### PR TITLE
Refactor more plugins to use goog.module

### DIFF
--- a/src/plugin/cesium/sync/heatmapsynchronizer.js
+++ b/src/plugin/cesium/sync/heatmapsynchronizer.js
@@ -13,6 +13,7 @@ const PropertyChange = goog.require('os.layer.PropertyChange');
 const events = goog.require('os.ol.events');
 const cesium = goog.require('plugin.cesium');
 const CesiumSynchronizer = goog.require('plugin.cesium.sync.CesiumSynchronizer');
+const {EXTENT_SCALE_FACTOR} = goog.require('plugin.heatmap');
 const HeatmapPropertyType = goog.require('plugin.heatmap.HeatmapPropertyType');
 const HeatmapField = goog.require('plugin.heatmap.HeatmapField');
 
@@ -126,7 +127,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
     if (img) {
       // scale back the extent so the image is positioned in the correct location
       var extent = this.layer.getExtent().slice();
-      scaleFromCenter(extent, 1 / plugin.heatmap.EXTENT_SCALE_FACTOR);
+      scaleFromCenter(extent, 1 / EXTENT_SCALE_FACTOR);
 
       this.activeLayer_ = this.cesiumLayers_.addImageryProvider(new Cesium.SingleTileImageryProvider({
         url: img,

--- a/src/plugin/heatmap/cmd/gradientcmd.js
+++ b/src/plugin/heatmap/cmd/gradientcmd.js
@@ -1,54 +1,54 @@
-goog.provide('plugin.heatmap.cmd.Gradient');
-goog.require('os.command.AbstractStyle');
+goog.module('plugin.heatmap.cmd.Gradient');
 
+const AbstractStyle = goog.require('os.command.AbstractStyle');
 
 
 /**
  * Changes the gradient of a heatmap.
- *
- * @extends {os.command.AbstractStyle}
- * @param {string} layerId
- * @param {number} value
- * @param {number=} opt_oldValue
- * @constructor
  */
-plugin.heatmap.cmd.Gradient = function(layerId, value, opt_oldValue) {
-  plugin.heatmap.cmd.Gradient.base(this, 'constructor', layerId, value, opt_oldValue);
-  this.title = 'Change heatmap gradient';
-};
-goog.inherits(plugin.heatmap.cmd.Gradient, os.command.AbstractStyle);
-
-
-/**
- * @inheritDoc
- */
-plugin.heatmap.cmd.Gradient.prototype.getOldValue = function() {
-  var layer = /** @type {plugin.heatmap.Heatmap} */ (this.getLayer());
-
-  if (layer) {
-    return layer.getGradient();
+class Gradient extends AbstractStyle {
+  /**
+   * Constructor.
+   * @param {string} layerId
+   * @param {number} value
+   * @param {number=} opt_oldValue
+   */
+  constructor(layerId, value, opt_oldValue) {
+    super(layerId, value, opt_oldValue);
+    this.title = 'Change heatmap gradient';
   }
 
-  return null;
-};
+  /**
+   * @inheritDoc
+   */
+  getOldValue() {
+    var layer = /** @type {plugin.heatmap.Heatmap} */ (this.getLayer());
 
+    if (layer) {
+      return layer.getGradient();
+    }
 
-/**
- * @inheritDoc
- */
-plugin.heatmap.cmd.Gradient.prototype.applyValue = function(config, value) {
-  var layer = /** @type {plugin.heatmap.Heatmap} */ (this.getLayer());
-  if (layer) {
-    layer.setGradient(value);
+    return null;
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  applyValue(config, value) {
+    var layer = /** @type {plugin.heatmap.Heatmap} */ (this.getLayer());
+    if (layer) {
+      layer.setGradient(value);
+    }
+  }
 
-/**
- * I'm just here so I don't throw an error.
- *
- * @inheritDoc
- */
-plugin.heatmap.cmd.Gradient.prototype.getLayerConfig = function() {
-  return {};
-};
+  /**
+   * I'm just here so I don't throw an error.
+   *
+   * @inheritDoc
+   */
+  getLayerConfig() {
+    return {};
+  }
+}
+
+exports = Gradient;

--- a/src/plugin/heatmap/cmd/intensitycmd.js
+++ b/src/plugin/heatmap/cmd/intensitycmd.js
@@ -1,54 +1,54 @@
-goog.provide('plugin.heatmap.cmd.Intensity');
-goog.require('os.command.AbstractStyle');
+goog.module('plugin.heatmap.cmd.Intensity');
 
+const AbstractStyle = goog.require('os.command.AbstractStyle');
 
 
 /**
  * Changes the intensity of a heatmap.
- *
- * @extends {os.command.AbstractStyle}
- * @param {string} layerId
- * @param {number} value
- * @param {number=} opt_oldValue
- * @constructor
  */
-plugin.heatmap.cmd.Intensity = function(layerId, value, opt_oldValue) {
-  plugin.heatmap.cmd.Intensity.base(this, 'constructor', layerId, value, opt_oldValue);
-  this.title = 'Change heatmap intensity';
-};
-goog.inherits(plugin.heatmap.cmd.Intensity, os.command.AbstractStyle);
-
-
-/**
- * @inheritDoc
- */
-plugin.heatmap.cmd.Intensity.prototype.getOldValue = function() {
-  var layer = /** @type {plugin.heatmap.Heatmap} */ (this.getLayer());
-
-  if (layer) {
-    return layer.getIntensity();
+class Intensity extends AbstractStyle {
+  /**
+   * Constructor.
+   * @param {string} layerId
+   * @param {number} value
+   * @param {number=} opt_oldValue
+   */
+  constructor(layerId, value, opt_oldValue) {
+    super(layerId, value, opt_oldValue);
+    this.title = 'Change heatmap intensity';
   }
 
-  return null;
-};
+  /**
+   * @inheritDoc
+   */
+  getOldValue() {
+    var layer = /** @type {plugin.heatmap.Heatmap} */ (this.getLayer());
 
+    if (layer) {
+      return layer.getIntensity();
+    }
 
-/**
- * @inheritDoc
- */
-plugin.heatmap.cmd.Intensity.prototype.applyValue = function(config, value) {
-  var layer = /** @type {plugin.heatmap.Heatmap} */ (this.getLayer());
-  if (layer) {
-    layer.setIntensity(value);
+    return null;
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  applyValue(config, value) {
+    var layer = /** @type {plugin.heatmap.Heatmap} */ (this.getLayer());
+    if (layer) {
+      layer.setIntensity(value);
+    }
+  }
 
-/**
- * I'm just here so I don't throw an error.
- *
- * @inheritDoc
- */
-plugin.heatmap.cmd.Intensity.prototype.getLayerConfig = function() {
-  return {};
-};
+  /**
+   * I'm just here so I don't throw an error.
+   *
+   * @inheritDoc
+   */
+  getLayerConfig() {
+    return {};
+  }
+}
+
+exports = Intensity;

--- a/src/plugin/heatmap/cmd/sizecmd.js
+++ b/src/plugin/heatmap/cmd/sizecmd.js
@@ -1,54 +1,54 @@
-goog.provide('plugin.heatmap.cmd.Size');
-goog.require('os.command.AbstractStyle');
+goog.module('plugin.heatmap.cmd.Size');
 
+const AbstractStyle = goog.require('os.command.AbstractStyle');
 
 
 /**
  * Changes the size of a heatmap.
- *
- * @extends {os.command.AbstractStyle}
- * @param {string} layerId
- * @param {number} value
- * @param {number=} opt_oldValue
- * @constructor
  */
-plugin.heatmap.cmd.Size = function(layerId, value, opt_oldValue) {
-  plugin.heatmap.cmd.Size.base(this, 'constructor', layerId, value, opt_oldValue);
-  this.title = 'Change heatmap intensity';
-};
-goog.inherits(plugin.heatmap.cmd.Size, os.command.AbstractStyle);
-
-
-/**
- * @inheritDoc
- */
-plugin.heatmap.cmd.Size.prototype.getOldValue = function() {
-  var layer = /** @type {plugin.heatmap.Heatmap} */ (this.getLayer());
-
-  if (layer) {
-    return layer.getSize();
+class Size extends AbstractStyle {
+  /**
+   * Constructor.
+   * @param {string} layerId
+   * @param {number} value
+   * @param {number=} opt_oldValue
+   */
+  constructor(layerId, value, opt_oldValue) {
+    super(layerId, value, opt_oldValue);
+    this.title = 'Change heatmap intensity';
   }
 
-  return null;
-};
+  /**
+   * @inheritDoc
+   */
+  getOldValue() {
+    var layer = /** @type {plugin.heatmap.Heatmap} */ (this.getLayer());
 
+    if (layer) {
+      return layer.getSize();
+    }
 
-/**
- * @inheritDoc
- */
-plugin.heatmap.cmd.Size.prototype.applyValue = function(config, value) {
-  var layer = /** @type {plugin.heatmap.Heatmap} */ (this.getLayer());
-  if (layer) {
-    layer.setSize(value);
+    return null;
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  applyValue(config, value) {
+    var layer = /** @type {plugin.heatmap.Heatmap} */ (this.getLayer());
+    if (layer) {
+      layer.setSize(value);
+    }
+  }
 
-/**
- * I'm just here so I don't throw an error.
- *
- * @inheritDoc
- */
-plugin.heatmap.cmd.Size.prototype.getLayerConfig = function() {
-  return {};
-};
+  /**
+   * I'm just here so I don't throw an error.
+   *
+   * @inheritDoc
+   */
+  getLayerConfig() {
+    return {};
+  }
+}
+
+exports = Size;

--- a/src/plugin/heatmap/heatmapfield.js
+++ b/src/plugin/heatmap/heatmapfield.js
@@ -1,0 +1,10 @@
+goog.module('plugin.heatmap.HeatmapField');
+
+/**
+ * @enum {string}
+ */
+exports = {
+  GEOMETRY_TYPE: '_geometryType',
+  HEATMAP_GEOMETRY: '_heatmapGeometry',
+  CANVAS: '_canvas'
+};

--- a/src/plugin/heatmap/heatmaplayer.js
+++ b/src/plugin/heatmap/heatmaplayer.js
@@ -1,30 +1,36 @@
-goog.provide('plugin.heatmap.Heatmap');
+goog.module('plugin.heatmap.Heatmap');
 
-goog.require('goog.string');
-goog.require('ol.events');
-goog.require('ol.geom.GeometryType');
-goog.require('ol.render.Event');
-goog.require('ol.style.Icon');
-goog.require('ol.style.Style');
-goog.require('os.events.LayerEvent');
-goog.require('os.events.PropertyChangeEvent');
-goog.require('os.implements');
-goog.require('os.layer');
-goog.require('os.layer.ILayer');
-goog.require('os.layer.Vector');
-goog.require('os.registerClass');
-goog.require('os.source');
-goog.require('os.source.Request');
-goog.require('os.source.Vector');
-goog.require('os.style');
-goog.require('os.ui.Icons');
-goog.require('os.ui.renamelayer');
-goog.require('plugin.heatmap');
-goog.require('plugin.heatmap.heatmapLayerUIDirective');
+const dom = goog.require('ol.dom');
+const olExtent = goog.require('ol.extent');
+const Point = goog.require('ol.geom.Point');
+const olRenderEventType = goog.require('ol.render.EventType');
+const MapContainer = goog.require('os.MapContainer');
+const EventType = goog.require('os.action.EventType');
+const color = goog.require('os.color');
+const LayerEventType = goog.require('os.events.LayerEventType');
 
-goog.requireType('ol.Feature');
-goog.requireType('ol.render.Feature');
+const dispatcher = goog.require('os.Dispatcher');
+const events = goog.require('ol.events');
+const GeometryType = goog.require('ol.geom.GeometryType');
+const Icon = goog.require('ol.style.Icon');
+const Style = goog.require('ol.style.Style');
+const LayerEvent = goog.require('os.events.LayerEvent');
+const osImplements = goog.require('os.implements');
+const osLayer = goog.require('os.layer');
+const ILayer = goog.require('os.layer.ILayer');
+const VectorLayer = goog.require('os.layer.Vector');
+const RequestSource = goog.require('os.source.Request');
+const osStyle = goog.require('os.style');
+const renamelayer = goog.require('os.ui.renamelayer');
+const heatmap = goog.require('plugin.heatmap');
+const HeatmapField = goog.require('plugin.heatmap.HeatmapField');
+const {directiveTag: layerUI} = goog.require('plugin.heatmap.HeatmapLayerUI');
+const HeatmapPropertyType = goog.require('plugin.heatmap.HeatmapPropertyType');
+const SynchronizerType = goog.require('plugin.heatmap.SynchronizerType');
 
+const Event = goog.requireType('ol.render.Event');
+const Feature = goog.requireType('ol.Feature');
+const RenderFeature = goog.requireType('ol.render.Feature');
 
 
 /**
@@ -32,613 +38,596 @@ goog.requireType('ol.render.Feature');
  * images to represent each feature in the original layer. These are drawn as alpha < 1 monochrome images that are
  * then composited together and colored with a gradient (in the heatmap source). The more features that overlap in
  * a given area, the higher the alpha in that area and the more intense the color in the final image.
- *
- * @extends {os.layer.Vector}
- * @param {olx.layer.VectorOptions} options
- * @constructor
  */
-plugin.heatmap.Heatmap = function(options) {
-  options = options || {};
-
-  // Openlayers 4.6.0 moved vector image rendering to ol.layer.Vector with renderMode: 'image'
-  if (!options['renderMode']) {
-    options['renderMode'] = 'image';
-  }
-
-  plugin.heatmap.Heatmap.base(this, 'constructor', options);
-
+class Heatmap extends VectorLayer {
   /**
-   * The array of hex colors. Used for external interface.
-   * @type {Array<string>}
-   * @private
+   * Constructor.
+   * @param {olx.layer.VectorOptions} options
    */
-  this.gradient_ = os.color.THERMAL_HEATMAP_GRADIENT_HEX;
+  constructor(options) {
+    options = options || {};
 
-  /**
-   * The array of rgba values used to actually apply the gradient
-   * @type {Uint8ClampedArray}
-   * @private
-   */
-  this.actualGradient_ = plugin.heatmap.createGradient(this.gradient_);
-
-  /**
-   * The last modified image.
-   * @type {?ol.ImageCanvas}
-   * @private
-   */
-  this.lastImage_ = null;
-
-  /**
-   * The number of features for max intensity.
-   * @type {number}
-   * @private
-   */
-  this.intensity_ = 25;
-
-  /**
-   * Draw radius for each feature.
-   * @type {number}
-   * @private
-   */
-  this.size_ = 5;
-
-  /**
-   * Point blur factor.
-   * @type {number}
-   * @private
-   */
-  this.pointBlur_ = 5;
-
-  /**
-   * Line blur factor.
-   * @type {number}
-   * @private
-   */
-  this.lineStringBlur_ = 5;
-
-  /**
-   * Polygon blur factor.
-   * @type {number}
-   * @private
-   */
-  this.polygonBlur_ = 10;
-
-  /**
-   * Caches point images. Significantly speeds up point rendering because they don't need to be redrawn.
-   * @type {Object<number, !Array<!ol.style.Style>>}
-   * @private
-   */
-  this.pointStyleCache_ = {};
-
-  // this is an image overlay, but it needs to appear in the layers window
-  this.setHidden(false);
-  this.setLayerUI('heatmaplayerui');
-  this.setSynchronizerType(plugin.heatmap.SynchronizerType.HEATMAP);
-  this.setOSType(os.layer.LayerType.IMAGE);
-  this.setExplicitType(os.layer.ExplicitLayerType.IMAGE);
-  this.setDoubleClickHandler(null);
-
-  if (options['title']) {
-    this.setTitle('Heatmap - ' + options['title']);
-  }
-
-  this.setStyle(this.styleFunc.bind(this));
-
-  // For performance reasons, don't sort the features before rendering.
-  // The render order is not relevant for a heatmap representation.
-  this.setRenderOrder(null);
-
-  ol.events.listen(this, ol.render.EventType.PRECOMPOSE, this.onPreCompose_, this);
-};
-goog.inherits(plugin.heatmap.Heatmap, os.layer.Vector);
-os.implements(plugin.heatmap.Heatmap, os.layer.ILayer.ID);
-
-
-/**
- * @inheritDoc
- */
-plugin.heatmap.Heatmap.prototype.disposeInternal = function() {
-  plugin.heatmap.Heatmap.base(this, 'disposeInternal');
-
-  this.pointStyleCache_ = null;
-};
-
-
-/**
- * @param {!ol.render.Event} event The render event.
- * @private
- * @suppress {accessControls}
- */
-plugin.heatmap.Heatmap.prototype.onPreCompose_ = function(event) {
-  if (event && event.context) {
-    var mapContainer = os.MapContainer.getInstance();
-    var map = mapContainer.getMap();
-    var layer = /** @type {ol.layer.Layer} */ (event.target);
-    var layerRenderer = /** @type {ol.renderer.canvas.ImageLayer} */ (map.getRenderer().getLayerRenderer(layer));
-    var image = layerRenderer ? /** @type {ol.ImageCanvas} */ (layerRenderer.image_) : undefined;
-
-    if (!image || image === this.lastImage_) {
-      // image isn't ready or has already been colored - nothing to do.
-      return;
+    // Openlayers 4.6.0 moved vector image rendering to ol.layer.Vector with renderMode: 'image'
+    if (!options['renderMode']) {
+      options['renderMode'] = 'image';
     }
 
-    // save the last image that was updated so we don't try to modify it further
-    this.lastImage_ = image;
+    super(options);
 
-    var canvas = image.getImage();
-    var context = canvas.getContext('2d');
-    var frameState = event.frameState;
-    var extent = frameState ? frameState.extent : undefined;
-    var pixelRatio = frameState ? frameState.pixelRatio : undefined;
-    var resolution = frameState ? frameState.viewState.resolution : undefined;
+    /**
+     * The array of hex colors. Used for external interface.
+     * @type {Array<string>}
+     * @private
+     */
+    this.gradient_ = color.THERMAL_HEATMAP_GRADIENT_HEX;
 
-    if (context && canvas && extent && pixelRatio != null && resolution != null) {
-      // Apply the gradient pixel by pixel. This is slow, so should be done as infrequently as possible.
-      var imageData = context.getImageData(0, 0, canvas.width, canvas.height);
-      var view8 = imageData.data;
-      var alpha;
-      for (var i = 0, ii = view8.length; i < ii; i += 4) {
-        alpha = view8[i + 3] * 4;
-        if (alpha) {
-          view8[i] = this.actualGradient_[alpha];
-          view8[i + 1] = this.actualGradient_[alpha + 1];
-          view8[i + 2] = this.actualGradient_[alpha + 2];
-          view8[i + 3] = alpha * 4;
-        }
+    /**
+     * The array of rgba values used to actually apply the gradient
+     * @type {Uint8ClampedArray}
+     * @private
+     */
+    this.actualGradient_ = heatmap.createGradient(this.gradient_);
+
+    /**
+     * The last modified image.
+     * @type {?ol.ImageCanvas}
+     * @private
+     */
+    this.lastImage_ = null;
+
+    /**
+     * The number of features for max intensity.
+     * @type {number}
+     * @private
+     */
+    this.intensity_ = 25;
+
+    /**
+     * Draw radius for each feature.
+     * @type {number}
+     * @private
+     */
+    this.size_ = 5;
+
+    /**
+     * Point blur factor.
+     * @type {number}
+     * @private
+     */
+    this.pointBlur_ = 5;
+
+    /**
+     * Line blur factor.
+     * @type {number}
+     * @private
+     */
+    this.lineStringBlur_ = 5;
+
+    /**
+     * Polygon blur factor.
+     * @type {number}
+     * @private
+     */
+    this.polygonBlur_ = 10;
+
+    /**
+     * Caches point images. Significantly speeds up point rendering because they don't need to be redrawn.
+     * @type {Object<number, !Array<!Style>>}
+     * @private
+     */
+    this.pointStyleCache_ = {};
+
+    // this is an image overlay, but it needs to appear in the layers window
+    this.setHidden(false);
+    this.setLayerUI(layerUI);
+    this.setSynchronizerType(SynchronizerType.HEATMAP);
+    this.setOSType(osLayer.LayerType.IMAGE);
+    this.setExplicitType(osLayer.ExplicitLayerType.IMAGE);
+    this.setDoubleClickHandler(null);
+
+    if (options['title']) {
+      this.setTitle('Heatmap - ' + options['title']);
+    }
+
+    this.setStyle(this.styleFunc.bind(this));
+
+    // For performance reasons, don't sort the features before rendering.
+    // The render order is not relevant for a heatmap representation.
+    this.setRenderOrder(null);
+
+    events.listen(this, olRenderEventType.PRECOMPOSE, this.onPreCompose_, this);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
+
+    this.pointStyleCache_ = null;
+  }
+
+  /**
+   * @param {!Event} event The render event.
+   * @private
+   * @suppress {accessControls}
+   */
+  onPreCompose_(event) {
+    if (event && event.context) {
+      var mapContainer = MapContainer.getInstance();
+      var map = mapContainer.getMap();
+      var layer = /** @type {ol.layer.Layer} */ (event.target);
+      var layerRenderer = /** @type {ol.renderer.canvas.ImageLayer} */ (map.getRenderer().getLayerRenderer(layer));
+      var image = layerRenderer ? /** @type {ol.ImageCanvas} */ (layerRenderer.image_) : undefined;
+
+      if (!image || image === this.lastImage_) {
+        // image isn't ready or has already been colored - nothing to do.
+        return;
       }
-      context.putImageData(imageData, 0, 0);
 
-      // scale the extent so the heatmap isn't clipped
-      extent = extent.slice();
-      ol.extent.scaleFromCenter(extent, plugin.heatmap.EXTENT_SCALE_FACTOR);
+      // save the last image that was updated so we don't try to modify it further
+      this.lastImage_ = image;
 
-      // copy the image
-      var c = /** @type {HTMLCanvasElement} */ (document.createElement('canvas'));
-      c.width = canvas.width;
-      c.height = canvas.height;
-      var ctx = c.getContext('2d');
-      ctx.drawImage(canvas, 0, 0);
+      var canvas = image.getImage();
+      var context = canvas.getContext('2d');
+      var frameState = event.frameState;
+      var extent = frameState ? frameState.extent : undefined;
+      var pixelRatio = frameState ? frameState.pixelRatio : undefined;
+      var resolution = frameState ? frameState.viewState.resolution : undefined;
 
-      // cache the image and its data URL for the synchronizer
-      this.set(plugin.heatmap.HeatmapField.CANVAS, c);
+      if (context && canvas && extent && pixelRatio != null && resolution != null) {
+        // Apply the gradient pixel by pixel. This is slow, so should be done as infrequently as possible.
+        var imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+        var view8 = imageData.data;
+        var alpha;
+        for (var i = 0, ii = view8.length; i < ii; i += 4) {
+          alpha = view8[i + 3] * 4;
+          if (alpha) {
+            view8[i] = this.actualGradient_[alpha];
+            view8[i + 1] = this.actualGradient_[alpha + 1];
+            view8[i + 2] = this.actualGradient_[alpha + 2];
+            view8[i + 3] = alpha * 4;
+          }
+        }
+        context.putImageData(imageData, 0, 0);
+
+        // scale the extent so the heatmap isn't clipped
+        extent = extent.slice();
+        olExtent.scaleFromCenter(extent, heatmap.EXTENT_SCALE_FACTOR);
+
+        // copy the image
+        var c = /** @type {HTMLCanvasElement} */ (document.createElement('canvas'));
+        c.width = canvas.width;
+        c.height = canvas.height;
+        var ctx = c.getContext('2d');
+        ctx.drawImage(canvas, 0, 0);
+
+        // cache the image and its data URL for the synchronizer
+        this.set(HeatmapField.CANVAS, c);
+      }
     }
   }
-};
 
-
-/**
- * Creates the heatmap styles for each feature to draw to the canvas.
- *
- * @param {ol.Feature|ol.render.Feature} feature
- * @param {number} resolution
- * @return {Array<ol.style.Style>}
- */
-plugin.heatmap.Heatmap.prototype.styleFunc = function(feature, resolution) {
-  var style;
-  var opacity = 1 / this.intensity_;
-  var useCache = feature.get(plugin.heatmap.HeatmapField.HEATMAP_GEOMETRY) instanceof ol.geom.Point;
-
-  if (useCache) {
-    // point styles are indexed by intensity
-    style = this.pointStyleCache_[this.intensity_];
-  }
-
-  if (!style) {
-    // only create the style if it wasn't in the cache
-    var img = this.createImage(/** @type {ol.Feature} */ (feature));
-    var icon = new ol.style.Icon({
-      opacity: opacity,
-      img: img,
-      imgSize: [img.width, img.height]
-    });
-
-    style = [
-      new ol.style.Style({
-        image: icon
-      })
-    ];
+  /**
+   * Creates the heatmap styles for each feature to draw to the canvas.
+   *
+   * @param {Feature|RenderFeature} feature
+   * @param {number} resolution
+   * @return {Array<Style>}
+   */
+  styleFunc(feature, resolution) {
+    var style;
+    var opacity = 1 / this.intensity_;
+    var useCache = feature.get(HeatmapField.HEATMAP_GEOMETRY) instanceof Point;
 
     if (useCache) {
-      this.pointStyleCache_[this.intensity_] = style;
+      // point styles are indexed by intensity
+      style = this.pointStyleCache_[this.intensity_];
     }
+
+    if (!style) {
+      // only create the style if it wasn't in the cache
+      var img = this.createImage(/** @type {Feature} */ (feature));
+      var icon = new Icon({
+        opacity: opacity,
+        img: img,
+        imgSize: [img.width, img.height]
+      });
+
+      style = [
+        new Style({
+          image: icon
+        })
+      ];
+
+      if (useCache) {
+        this.pointStyleCache_[this.intensity_] = style;
+      }
+    }
+
+    return style;
   }
 
-  return style;
-};
+  /**
+   * @param {Feature|RenderFeature} feature
+   * @return {HTMLCanvasElement} Data URL for a circle.
+   * @protected
+   */
+  createImage(feature) {
+    // start with a tiny blank canvas in case we fail to draw the image (for some reason)
+    var context = dom.createCanvasContext2D(1, 1);
+    var type = /** @type {string} */ (feature.get(HeatmapField.GEOMETRY_TYPE));
+    var geom = /** @type {ol.geom.Geometry} */ (feature.get(HeatmapField.HEATMAP_GEOMETRY));
 
+    switch (type) {
+      case GeometryType.POINT:
+        context = this.drawPoint(geom);
+        break;
+      case GeometryType.MULTI_POINT:
+        context = this.drawMultiPoint(geom);
+        break;
+      case GeometryType.LINE_STRING:
+        context = this.drawLineString(geom);
+        break;
+      case GeometryType.POLYGON:
+        context = this.drawPolygon(geom);
+        break;
+      case GeometryType.MULTI_POLYGON:
+        context = this.drawMultiPolygon(geom);
+        break;
+      default:
+        break;
+    }
 
-/**
- * @param {ol.Feature|ol.render.Feature} feature
- * @return {HTMLCanvasElement} Data URL for a circle.
- * @protected
- */
-plugin.heatmap.Heatmap.prototype.createImage = function(feature) {
-  // start with a tiny blank canvas in case we fail to draw the image (for some reason)
-  var context = ol.dom.createCanvasContext2D(1, 1);
-  var type = /** @type {string} */ (feature.get(plugin.heatmap.HeatmapField.GEOMETRY_TYPE));
-  var geom = /** @type {ol.geom.Geometry} */ (feature.get(plugin.heatmap.HeatmapField.HEATMAP_GEOMETRY));
-
-  switch (type) {
-    case ol.geom.GeometryType.POINT:
-      context = this.drawPoint(geom);
-      break;
-    case ol.geom.GeometryType.MULTI_POINT:
-      context = this.drawMultiPoint(geom);
-      break;
-    case ol.geom.GeometryType.LINE_STRING:
-      context = this.drawLineString(geom);
-      break;
-    case ol.geom.GeometryType.POLYGON:
-      context = this.drawPolygon(geom);
-      break;
-    case ol.geom.GeometryType.MULTI_POLYGON:
-      context = this.drawMultiPolygon(geom);
-      break;
-    default:
-      break;
+    return context.canvas;
   }
 
-  return context.canvas;
-};
-
-
-/**
- * Draws a circle for the passed in feature.
- *
- * @param {ol.geom.Geometry} geom
- * @return {CanvasRenderingContext2D} Data URL for a circle.
- */
-plugin.heatmap.Heatmap.prototype.drawPoint = function(geom) {
-  var radius = this.size_;
-  var blur = this.pointBlur_;
-  var halfSize = radius + blur + 1;
-  var size = 2 * halfSize;
-  var center = halfSize - 250;
-
-  var context = ol.dom.createCanvasContext2D(size, size);
-  context.shadowOffsetX = context.shadowOffsetY = 250;
-  context.shadowBlur = blur;
-  context.shadowColor = '#000';
-  context.beginPath();
-  context.arc(center, center, radius, 0, Math.PI * 2, true);
-  context.fill();
-
-  return context;
-};
-
-
-/**
- * Draws a circle for the passed in feature.
- *
- * @param {ol.geom.Geometry} geom
- * @return {CanvasRenderingContext2D} Data URL for a circle.
- */
-plugin.heatmap.Heatmap.prototype.drawMultiPoint = function(geom) {
-  var mp = /** @type {ol.geom.MultiPoint} */ (geom);
-  var context = null;
-
-  if (mp) {
-    var pixelExtent = plugin.heatmap.Heatmap.getPixelExtent(mp);
-    var points = mp.getCoordinates();
-
+  /**
+   * Draws a circle for the passed in feature.
+   *
+   * @param {ol.geom.Geometry} geom
+   * @return {CanvasRenderingContext2D} Data URL for a circle.
+   */
+  drawPoint(geom) {
     var radius = this.size_;
     var blur = this.pointBlur_;
-    var sizeX = Math.abs(pixelExtent[1][0] - pixelExtent[0][0]) + 2 * blur;
-    var sizeY = Math.abs(pixelExtent[1][1] - pixelExtent[0][1]) + 2 * blur;
-    context = ol.dom.createCanvasContext2D(sizeX, sizeY);
-    context.shadowOffsetY = 4 * sizeY;
+    var halfSize = radius + blur + 1;
+    var size = 2 * halfSize;
+    var center = halfSize - 250;
+
+    var context = dom.createCanvasContext2D(size, size);
+    context.shadowOffsetX = context.shadowOffsetY = 250;
     context.shadowBlur = blur;
     context.shadowColor = '#000';
+    context.beginPath();
+    context.arc(center, center, radius, 0, Math.PI * 2, true);
+    context.fill();
 
-    for (var i = 0, ii = points.length; i < ii; i++) {
-      var coordinate = points[i];
-      var pixel = os.MapContainer.getInstance().getMap().get2DPixelFromCoordinate(coordinate);
-      var xPos = Math.abs(pixelExtent[0][0] - pixel[0]) + blur;
-      var yPos = Math.abs(pixelExtent[0][1] - pixel[1]) + blur - 4 * sizeY;
-
-      context.beginPath();
-      context.arc(xPos, yPos, radius, 0, Math.PI * 2, true);
-      context.fill();
-    }
+    return context;
   }
 
-  return context;
-};
+  /**
+   * Draws a circle for the passed in feature.
+   *
+   * @param {ol.geom.Geometry} geom
+   * @return {CanvasRenderingContext2D} Data URL for a circle.
+   */
+  drawMultiPoint(geom) {
+    var mp = /** @type {ol.geom.MultiPoint} */ (geom);
+    var context = null;
 
+    if (mp) {
+      var pixelExtent = Heatmap.getPixelExtent(mp);
+      var points = mp.getCoordinates();
 
-/**
- * Draws a polygon for the passed in feature.
- *
- * @param {ol.geom.Geometry} geom
- * @return {CanvasRenderingContext2D}
- */
-plugin.heatmap.Heatmap.prototype.drawPolygon = function(geom) {
-  var polygon = /** @type {ol.geom.Polygon} */ (geom);
-  var context = null;
+      var radius = this.size_;
+      var blur = this.pointBlur_;
+      var sizeX = Math.abs(pixelExtent[1][0] - pixelExtent[0][0]) + 2 * blur;
+      var sizeY = Math.abs(pixelExtent[1][1] - pixelExtent[0][1]) + 2 * blur;
+      context = dom.createCanvasContext2D(sizeX, sizeY);
+      context.shadowOffsetY = 4 * sizeY;
+      context.shadowBlur = blur;
+      context.shadowColor = '#000';
 
-  if (polygon) {
-    var pixelExtent = plugin.heatmap.Heatmap.getPixelExtent(polygon);
-    var rings = polygon.getCoordinates();
-
-    var blur = this.polygonBlur_;
-    var sizeX = Math.abs(pixelExtent[1][0] - pixelExtent[0][0]) + 2 * blur;
-    var sizeY = Math.abs(pixelExtent[1][1] - pixelExtent[0][1]) + 2 * blur;
-    context = ol.dom.createCanvasContext2D(sizeX, sizeY);
-
-    for (var i = 0, ii = rings.length; i < ii; i++) {
-      var coordinates = rings[i];
-      for (var j = 0, jj = coordinates.length; j < jj; j++) {
-        var coordinate = coordinates[j];
-        var pixel = os.MapContainer.getInstance().getMap().get2DPixelFromCoordinate(coordinate);
+      for (var i = 0, ii = points.length; i < ii; i++) {
+        var coordinate = points[i];
+        var pixel = MapContainer.getInstance().getMap().get2DPixelFromCoordinate(coordinate);
         var xPos = Math.abs(pixelExtent[0][0] - pixel[0]) + blur;
         var yPos = Math.abs(pixelExtent[0][1] - pixel[1]) + blur - 4 * sizeY;
-        j === 0 ? context.moveTo(xPos, yPos) : context.lineTo(xPos, yPos);
+
+        context.beginPath();
+        context.arc(xPos, yPos, radius, 0, Math.PI * 2, true);
+        context.fill();
       }
     }
 
-    plugin.heatmap.Heatmap.drawShadow(context, sizeY, blur);
+    return context;
   }
 
-  return context;
-};
+  /**
+   * Draws a polygon for the passed in feature.
+   *
+   * @param {ol.geom.Geometry} geom
+   * @return {CanvasRenderingContext2D}
+   */
+  drawPolygon(geom) {
+    var polygon = /** @type {ol.geom.Polygon} */ (geom);
+    var context = null;
 
+    if (polygon) {
+      var pixelExtent = Heatmap.getPixelExtent(polygon);
+      var rings = polygon.getCoordinates();
 
-/**
- * Draws a polygon for the passed in feature.
- *
- * @param {ol.geom.Geometry} geom
- * @return {CanvasRenderingContext2D}
- */
-plugin.heatmap.Heatmap.prototype.drawMultiPolygon = function(geom) {
-  var mp = /** @type {ol.geom.MultiPolygon} */ (geom);
-  var context = null;
+      var blur = this.polygonBlur_;
+      var sizeX = Math.abs(pixelExtent[1][0] - pixelExtent[0][0]) + 2 * blur;
+      var sizeY = Math.abs(pixelExtent[1][1] - pixelExtent[0][1]) + 2 * blur;
+      context = dom.createCanvasContext2D(sizeX, sizeY);
 
-  if (mp) {
-    var pixelExtent = plugin.heatmap.Heatmap.getPixelExtent(mp);
-    var polygons = mp.getCoordinates();
-
-    var blur = this.polygonBlur_;
-    var sizeX = Math.abs(pixelExtent[1][0] - pixelExtent[0][0]) + 2 * blur;
-    var sizeY = Math.abs(pixelExtent[1][1] - pixelExtent[0][1]) + 2 * blur;
-    context = ol.dom.createCanvasContext2D(sizeX, sizeY);
-
-    for (var i = 0, ii = polygons.length; i < ii; i++) {
-      var rings = polygons[i];
-      for (var j = 0, jj = rings.length; j < jj; j++) {
-        var coordinates = rings[j];
-        for (var k = 0, kk = coordinates.length; k < kk; k++) {
-          var coordinate = coordinates[k];
-          var pixel = os.MapContainer.getInstance().getMap().get2DPixelFromCoordinate(coordinate);
+      for (var i = 0, ii = rings.length; i < ii; i++) {
+        var coordinates = rings[i];
+        for (var j = 0, jj = coordinates.length; j < jj; j++) {
+          var coordinate = coordinates[j];
+          var pixel = MapContainer.getInstance().getMap().get2DPixelFromCoordinate(coordinate);
           var xPos = Math.abs(pixelExtent[0][0] - pixel[0]) + blur;
           var yPos = Math.abs(pixelExtent[0][1] - pixel[1]) + blur - 4 * sizeY;
-          k === 0 ? context.moveTo(xPos, yPos) : context.lineTo(xPos, yPos);
+          j === 0 ? context.moveTo(xPos, yPos) : context.lineTo(xPos, yPos);
         }
       }
+
+      Heatmap.drawShadow(context, sizeY, blur);
     }
 
-    // add the shadow
-    plugin.heatmap.Heatmap.drawShadow(context, sizeY, blur);
+    return context;
   }
 
-  return context;
-};
+  /**
+   * Draws a polygon for the passed in feature.
+   *
+   * @param {ol.geom.Geometry} geom
+   * @return {CanvasRenderingContext2D}
+   */
+  drawMultiPolygon(geom) {
+    var mp = /** @type {ol.geom.MultiPolygon} */ (geom);
+    var context = null;
 
+    if (mp) {
+      var pixelExtent = Heatmap.getPixelExtent(mp);
+      var polygons = mp.getCoordinates();
 
-/**
- * Draws a linestring for the passed in feature.
- *
- * @param {ol.geom.Geometry} geom
- * @return {CanvasRenderingContext2D}
- */
-plugin.heatmap.Heatmap.prototype.drawLineString = function(geom) {
-  var lineString = /** @type {ol.geom.LineString} */ (geom);
-  var context = null;
+      var blur = this.polygonBlur_;
+      var sizeX = Math.abs(pixelExtent[1][0] - pixelExtent[0][0]) + 2 * blur;
+      var sizeY = Math.abs(pixelExtent[1][1] - pixelExtent[0][1]) + 2 * blur;
+      context = dom.createCanvasContext2D(sizeX, sizeY);
 
-  if (lineString) {
-    var pixelExtent = plugin.heatmap.Heatmap.getPixelExtent(lineString);
-    var coordinates = lineString.getCoordinates();
+      for (var i = 0, ii = polygons.length; i < ii; i++) {
+        var rings = polygons[i];
+        for (var j = 0, jj = rings.length; j < jj; j++) {
+          var coordinates = rings[j];
+          for (var k = 0, kk = coordinates.length; k < kk; k++) {
+            var coordinate = coordinates[k];
+            var pixel = MapContainer.getInstance().getMap().get2DPixelFromCoordinate(coordinate);
+            var xPos = Math.abs(pixelExtent[0][0] - pixel[0]) + blur;
+            var yPos = Math.abs(pixelExtent[0][1] - pixel[1]) + blur - 4 * sizeY;
+            k === 0 ? context.moveTo(xPos, yPos) : context.lineTo(xPos, yPos);
+          }
+        }
+      }
 
-    var blur = this.lineStringBlur_;
-    var sizeX = Math.abs(pixelExtent[1][0] - pixelExtent[0][0]) + 4 * blur;
-    var sizeY = Math.abs(pixelExtent[1][1] - pixelExtent[0][1]) + 4 * blur;
-    context = ol.dom.createCanvasContext2D(sizeX, sizeY);
-
-    for (var i = 0, ii = coordinates.length; i < ii; i++) {
-      var coordinate = coordinates[i];
-      var pixel = os.MapContainer.getInstance().getMap().get2DPixelFromCoordinate(coordinate);
-      var xPos = Math.abs(pixelExtent[0][0] - pixel[0]) + 2 * blur;
-      var yPos = Math.abs(pixelExtent[0][1] - pixel[1]) + 2 * blur - 4 * sizeY;
-      i === 0 ? context.moveTo(xPos, yPos) : context.lineTo(xPos, yPos);
+      // add the shadow
+      Heatmap.drawShadow(context, sizeY, blur);
     }
 
-    // add the shadow and do a stroke instead of a fill (lineStrings are special)
-    context.lineWidth = this.size_;
+    return context;
+  }
+
+  /**
+   * Draws a linestring for the passed in feature.
+   *
+   * @param {ol.geom.Geometry} geom
+   * @return {CanvasRenderingContext2D}
+   */
+  drawLineString(geom) {
+    var lineString = /** @type {ol.geom.LineString} */ (geom);
+    var context = null;
+
+    if (lineString) {
+      var pixelExtent = Heatmap.getPixelExtent(lineString);
+      var coordinates = lineString.getCoordinates();
+
+      var blur = this.lineStringBlur_;
+      var sizeX = Math.abs(pixelExtent[1][0] - pixelExtent[0][0]) + 4 * blur;
+      var sizeY = Math.abs(pixelExtent[1][1] - pixelExtent[0][1]) + 4 * blur;
+      context = dom.createCanvasContext2D(sizeX, sizeY);
+
+      for (var i = 0, ii = coordinates.length; i < ii; i++) {
+        var coordinate = coordinates[i];
+        var pixel = MapContainer.getInstance().getMap().get2DPixelFromCoordinate(coordinate);
+        var xPos = Math.abs(pixelExtent[0][0] - pixel[0]) + 2 * blur;
+        var yPos = Math.abs(pixelExtent[0][1] - pixel[1]) + 2 * blur - 4 * sizeY;
+        i === 0 ? context.moveTo(xPos, yPos) : context.lineTo(xPos, yPos);
+      }
+
+      // add the shadow and do a stroke instead of a fill (lineStrings are special)
+      context.lineWidth = this.size_;
+      context.shadowOffsetY = 4 * sizeY;
+      context.shadowBlur = blur;
+      context.shadowColor = '#000';
+      context.stroke();
+    }
+
+    return context;
+  }
+
+  /**
+   * Gets the last rendered image canvas.
+   *
+   * @return {?ol.ImageCanvas} The image canvas, or null.
+   */
+  getLastImage() {
+    return this.lastImage_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getExtent() {
+    var extent = null;
+
+    var canvas = this.getLastImage();
+    if (canvas) {
+      // get it from the canvas
+      extent = canvas.getExtent().slice();
+    } else {
+      // use the full map extent if the canvas isn't ready
+      extent = MapContainer.getInstance().getViewExtent().slice();
+    }
+
+    // scale the extent so the image is positioned properly
+    olExtent.scaleFromCenter(extent, heatmap.EXTENT_SCALE_FACTOR);
+
+    return extent;
+  }
+
+  /**
+   * Get the intensity
+   *
+   * @return {number}
+   */
+  getIntensity() {
+    return this.intensity_;
+  }
+
+  /**
+   * Set the intensity
+   *
+   * @param {number} value
+   */
+  setIntensity(value) {
+    this.intensity_ = value;
+    this.updateSource(HeatmapPropertyType.INTENSITY);
+  }
+
+  /**
+   * Get the size
+   *
+   * @return {number}
+   */
+  getSize() {
+    return this.size_;
+  }
+
+  /**
+   * Set the size
+   *
+   * @param {number} value
+   */
+  setSize(value) {
+    this.size_ = value;
+    this.updateSource(HeatmapPropertyType.SIZE);
+  }
+
+  /**
+   * Get the gradient. This value is kept on the source.
+   *
+   * @return {Array<string>}
+   */
+  getGradient() {
+    return this.gradient_;
+  }
+
+  /**
+   * Set the gradient. This value is kept on the source.
+   *
+   * @param {Array<string>} value
+   */
+  setGradient(value) {
+    this.gradient_ = value;
+    this.actualGradient_ = heatmap.createGradient(this.gradient_);
+    this.updateSource(HeatmapPropertyType.GRADIENT);
+  }
+
+  /**
+   * Trigger a render on the source. Necessary because the heatmap source deliberately avoids rerendering the heatmap as
+   * much as possible.
+   *
+   * @param {string=} opt_eventType Optional type for the style event.
+   */
+  updateSource(opt_eventType) {
+    this.pointStyleCache_ = {};
+    osStyle.notifyStyleChange(this, undefined, opt_eventType);
+  }
+
+  /**
+   * @inheritDoc
+   * @see {os.ui.action.IActionTarget}
+   */
+  supportsAction(type, opt_actionArgs) {
+    var source = this.getSource();
+
+    switch (type) {
+      case EventType.REMOVE_LAYER:
+      case EventType.IDENTIFY:
+        return true;
+      case EventType.RENAME:
+        return !!opt_actionArgs && goog.isArrayLike(opt_actionArgs) && opt_actionArgs.length === 1;
+      case EventType.REFRESH:
+        return source instanceof RequestSource;
+      default:
+        break;
+    }
+
+    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  callAction(type) {
+    switch (type) {
+      case EventType.EXPORT:
+        return heatmap.exportHeatmap(this);
+      case EventType.IDENTIFY:
+        this.identify();
+        break;
+      case EventType.REMOVE_LAYER:
+        var removeEvent = new LayerEvent(LayerEventType.REMOVE, this.getId());
+        dispatcher.getInstance().dispatchEvent(removeEvent);
+        break;
+      case EventType.RENAME:
+        renamelayer.launchRenameDialog(this);
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * @param {ol.geom.Geometry} geom
+   * @return {Array<number>}
+   */
+  static getPixelExtent(geom) {
+    var extent = geom.getExtent();
+    var e1 = MapContainer.getInstance().getMap().get2DPixelFromCoordinate([extent[0], extent[3]]);
+    var e2 = MapContainer.getInstance().getMap().get2DPixelFromCoordinate([extent[2], extent[1]]);
+    return [e1, e2];
+  }
+
+  /**
+   * Draws the blurred shadow in the appropriate position.
+   *
+   * @param {CanvasRenderingContext2D} context
+   * @param {number} sizeY
+   * @param {number} blur
+   */
+  static drawShadow(context, sizeY, blur) {
     context.shadowOffsetY = 4 * sizeY;
     context.shadowBlur = blur;
     context.shadowColor = '#000';
-    context.stroke();
+    context.fill();
   }
+}
 
-  return context;
-};
-
-
-/**
- * Gets the last rendered image canvas.
- *
- * @return {?ol.ImageCanvas} The image canvas, or null.
- */
-plugin.heatmap.Heatmap.prototype.getLastImage = function() {
-  return this.lastImage_;
-};
+osImplements(Heatmap, ILayer.ID);
 
 
-/**
- * @inheritDoc
- */
-plugin.heatmap.Heatmap.prototype.getExtent = function() {
-  var extent = null;
-
-  var canvas = this.getLastImage();
-  if (canvas) {
-    // get it from the canvas
-    extent = canvas.getExtent().slice();
-  } else {
-    // use the full map extent if the canvas isn't ready
-    extent = os.MapContainer.getInstance().getViewExtent().slice();
-  }
-
-  // scale the extent so the image is positioned properly
-  ol.extent.scaleFromCenter(extent, plugin.heatmap.EXTENT_SCALE_FACTOR);
-
-  return extent;
-};
-
-
-/**
- * Get the intensity
- *
- * @return {number}
- */
-plugin.heatmap.Heatmap.prototype.getIntensity = function() {
-  return this.intensity_;
-};
-
-
-/**
- * Set the intensity
- *
- * @param {number} value
- */
-plugin.heatmap.Heatmap.prototype.setIntensity = function(value) {
-  this.intensity_ = value;
-  this.updateSource(plugin.heatmap.HeatmapPropertyType.INTENSITY);
-};
-
-
-/**
- * Get the size
- *
- * @return {number}
- */
-plugin.heatmap.Heatmap.prototype.getSize = function() {
-  return this.size_;
-};
-
-
-/**
- * Set the size
- *
- * @param {number} value
- */
-plugin.heatmap.Heatmap.prototype.setSize = function(value) {
-  this.size_ = value;
-  this.updateSource(plugin.heatmap.HeatmapPropertyType.SIZE);
-};
-
-
-/**
- * Get the gradient. This value is kept on the source.
- *
- * @return {Array<string>}
- */
-plugin.heatmap.Heatmap.prototype.getGradient = function() {
-  return this.gradient_;
-};
-
-
-/**
- * Set the gradient. This value is kept on the source.
- *
- * @param {Array<string>} value
- */
-plugin.heatmap.Heatmap.prototype.setGradient = function(value) {
-  this.gradient_ = value;
-  this.actualGradient_ = plugin.heatmap.createGradient(this.gradient_);
-  this.updateSource(plugin.heatmap.HeatmapPropertyType.GRADIENT);
-};
-
-
-/**
- * Trigger a render on the source. Necessary because the heatmap source deliberately avoids rerendering the heatmap as
- * much as possible.
- *
- * @param {string=} opt_eventType Optional type for the style event.
- */
-plugin.heatmap.Heatmap.prototype.updateSource = function(opt_eventType) {
-  this.pointStyleCache_ = {};
-  os.style.notifyStyleChange(this, undefined, opt_eventType);
-};
-
-
-/**
- * @inheritDoc
- * @see {os.ui.action.IActionTarget}
- */
-plugin.heatmap.Heatmap.prototype.supportsAction = function(type, opt_actionArgs) {
-  var source = this.getSource();
-
-  switch (type) {
-    case os.action.EventType.REMOVE_LAYER:
-    case os.action.EventType.IDENTIFY:
-      return true;
-    case os.action.EventType.RENAME:
-      return !!opt_actionArgs && goog.isArrayLike(opt_actionArgs) && opt_actionArgs.length === 1;
-    case os.action.EventType.REFRESH:
-      return source instanceof os.source.Request;
-    default:
-      break;
-  }
-
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.heatmap.Heatmap.prototype.callAction = function(type) {
-  switch (type) {
-    case os.action.EventType.EXPORT:
-      return plugin.heatmap.exportHeatmap(this);
-    case os.action.EventType.IDENTIFY:
-      this.identify();
-      break;
-    case os.action.EventType.REMOVE_LAYER:
-      var removeEvent = new os.events.LayerEvent(os.events.LayerEventType.REMOVE, this.getId());
-      os.dispatcher.dispatchEvent(removeEvent);
-      break;
-    case os.action.EventType.RENAME:
-      os.ui.renamelayer.launchRenameDialog(this);
-      break;
-    default:
-      break;
-  }
-};
-
-
-/**
- * @param {ol.geom.Geometry} geom
- * @return {Array<number>}
- */
-plugin.heatmap.Heatmap.getPixelExtent = function(geom) {
-  var extent = geom.getExtent();
-  var e1 = os.MapContainer.getInstance().getMap().get2DPixelFromCoordinate([extent[0], extent[3]]);
-  var e2 = os.MapContainer.getInstance().getMap().get2DPixelFromCoordinate([extent[2], extent[1]]);
-  return [e1, e2];
-};
-
-
-/**
- * Draws the blurred shadow in the appropriate position.
- *
- * @param {CanvasRenderingContext2D} context
- * @param {number} sizeY
- * @param {number} blur
- */
-plugin.heatmap.Heatmap.drawShadow = function(context, sizeY, blur) {
-  context.shadowOffsetY = 4 * sizeY;
-  context.shadowBlur = blur;
-  context.shadowColor = '#000';
-  context.fill();
-};
+exports = Heatmap;

--- a/src/plugin/heatmap/heatmaplayerconfig.js
+++ b/src/plugin/heatmap/heatmaplayerconfig.js
@@ -1,94 +1,87 @@
-goog.provide('plugin.heatmap.HeatmapLayerConfig');
+goog.module('plugin.heatmap.HeatmapLayerConfig');
 
-goog.require('goog.log');
-goog.require('goog.log.Logger');
-goog.require('ol.source.Vector');
-goog.require('os.layer.config.AbstractLayerConfig');
-goog.require('plugin.heatmap.Heatmap');
+const log = goog.require('goog.log');
+const OLVectorSource = goog.require('ol.source.Vector');
+const AbstractLayerConfig = goog.require('os.layer.config.AbstractLayerConfig');
+const heatmap = goog.require('plugin.heatmap');
+const Heatmap = goog.require('plugin.heatmap.Heatmap');
 
+const Logger = goog.requireType('goog.log.Logger');
 
 
 /**
  * Config for a layer containing heatmap data.
  *
- * @extends {os.layer.config.AbstractLayerConfig}
- * @constructor
  * @template T
  */
-plugin.heatmap.HeatmapLayerConfig = function() {
-  plugin.heatmap.HeatmapLayerConfig.base(this, 'constructor');
-  this.log = plugin.heatmap.HeatmapLayerConfig.LOGGER_;
+class HeatmapLayerConfig extends AbstractLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.log = logger;
+
+    /**
+     * @type {boolean}
+     * @protected
+     */
+    this.animate = false;
+  }
 
   /**
-   * @type {boolean}
+   * @inheritDoc
+   */
+  createLayer(options) {
+    this.initializeConfig(options);
+
+    var source = this.getSource(options);
+    var layer = this.getLayer(source, options);
+    layer.setId(/** @type {string} */ (options['id']));
+
+    if (options['explicitType'] != null) {
+      layer.setExplicitType(/** @type {string} */ (options['explicitType']));
+    }
+
+    return layer;
+  }
+
+  /**
+   * @param {OLVectorSource} source The layer source.
+   * @param {Object<string, *>} options
+   * @return {Heatmap}
    * @protected
    */
-  this.animate = false;
-};
-goog.inherits(plugin.heatmap.HeatmapLayerConfig, os.layer.config.AbstractLayerConfig);
+  getLayer(source, options) {
+    return new Heatmap({
+      'source': source,
+      'title': options['title']
+    });
+  }
 
+  /**
+   * @param {Object} options Layer configuration options.
+   * @return {OLVectorSource}
+   * @protected
+   *
+   * @suppress {checkTypes}
+   */
+  getSource(options) {
+    options = options || {};
 
-/**
- * Id for this layer config
- * @type {string}
- * @const
- */
-plugin.heatmap.HeatmapLayerConfig.ID = 'heatmap';
+    var sourceId = /** @type {string|undefined} */ (options['sourceId']);
+    options.features = heatmap.getSourceFeatures(sourceId);
+
+    return new OLVectorSource(options);
+  }
+}
 
 
 /**
  * Logger
- * @type {goog.log.Logger}
- * @private
- * @const
+ * @type {Logger}
  */
-plugin.heatmap.HeatmapLayerConfig.LOGGER_ = goog.log.getLogger('plugin.heatmap.HeatmapLayerConfig');
+const logger = log.getLogger('plugin.heatmap.HeatmapLayerConfig');
 
 
-/**
- * @inheritDoc
- */
-plugin.heatmap.HeatmapLayerConfig.prototype.createLayer = function(options) {
-  this.initializeConfig(options);
-
-  var source = this.getSource(options);
-  var layer = this.getLayer(source, options);
-  layer.setId(/** @type {string} */ (options['id']));
-
-  if (options['explicitType'] != null) {
-    layer.setExplicitType(/** @type {string} */ (options['explicitType']));
-  }
-
-  return layer;
-};
-
-
-/**
- * @param {ol.source.Vector} source The layer source.
- * @param {Object<string, *>} options
- * @return {plugin.heatmap.Heatmap}
- * @protected
- */
-plugin.heatmap.HeatmapLayerConfig.prototype.getLayer = function(source, options) {
-  return new plugin.heatmap.Heatmap({
-    'source': source,
-    'title': options['title']
-  });
-};
-
-
-/**
- * @param {Object} options Layer configuration options.
- * @return {ol.source.Vector}
- * @protected
- *
- * @suppress {checkTypes}
- */
-plugin.heatmap.HeatmapLayerConfig.prototype.getSource = function(options) {
-  options = options || {};
-
-  var sourceId = /** @type {string|undefined} */ (options['sourceId']);
-  options.features = plugin.heatmap.getSourceFeatures(sourceId);
-
-  return new ol.source.Vector(options);
-};
+exports = HeatmapLayerConfig;

--- a/src/plugin/heatmap/heatmaplayerui.js
+++ b/src/plugin/heatmap/heatmaplayerui.js
@@ -1,15 +1,16 @@
-goog.provide('plugin.heatmap.HeatmapLayerUICtrl');
-goog.provide('plugin.heatmap.heatmapLayerUIDirective');
+goog.module('plugin.heatmap.HeatmapLayerUI');
 
-goog.require('goog.async.Delay');
-goog.require('os');
-goog.require('os.style');
-goog.require('os.ui.Module');
-goog.require('os.ui.layer');
-goog.require('os.ui.layer.DefaultLayerUICtrl');
-goog.require('plugin.heatmap.cmd.Gradient');
-goog.require('plugin.heatmap.cmd.Intensity');
-goog.require('plugin.heatmap.cmd.Size');
+
+const googObject = goog.require('goog.object');
+const Delay = goog.require('goog.async.Delay');
+const {ROOT} = goog.require('os');
+const osColor = goog.require('os.color');
+const Module = goog.require('os.ui.Module');
+const DefaultLayerUICtrl = goog.require('os.ui.layer.DefaultLayerUICtrl');
+const HeatmapPropertyType = goog.require('plugin.heatmap.HeatmapPropertyType');
+const Gradient = goog.require('plugin.heatmap.cmd.Gradient');
+const Intensity = goog.require('plugin.heatmap.cmd.Intensity');
+const Size = goog.require('plugin.heatmap.cmd.Size');
 
 
 /**
@@ -17,209 +18,213 @@ goog.require('plugin.heatmap.cmd.Size');
  *
  * @return {angular.Directive}
  */
-plugin.heatmap.heatmapLayerUIDirective = function() {
-  return {
-    restrict: 'AE',
-    replace: true,
-    templateUrl: os.ROOT + 'views/plugin/heatmap/heatmap.html',
-    controller: plugin.heatmap.HeatmapLayerUICtrl,
-    controllerAs: 'heatmap'
-  };
-};
+const directive = () => ({
+  restrict: 'AE',
+  replace: true,
+  templateUrl: ROOT + 'views/plugin/heatmap/heatmap.html',
+  controller: Controller,
+  controllerAs: 'heatmap'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'heatmaplayerui';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('heatmaplayerui', [plugin.heatmap.heatmapLayerUIDirective]);
+Module.directive('heatmaplayerui', [directive]);
 
 
 
 /**
  * Controller for the vector layer UI
- *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout
- * @constructor
- * @extends {os.ui.layer.DefaultLayerUICtrl}
- * @ngInject
+ * @unrestricted
  */
-plugin.heatmap.HeatmapLayerUICtrl = function($scope, $element, $timeout) {
-  plugin.heatmap.HeatmapLayerUICtrl.base(this, 'constructor', $scope, $element, $timeout);
+class Controller extends DefaultLayerUICtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @param {!angular.$timeout} $timeout
+   * @ngInject
+   */
+  constructor($scope, $element, $timeout) {
+    super($scope, $element, $timeout);
 
-  $scope.$on('size.slidestop', this.onSizeChange.bind(this));
-  $scope.$on('intensity.slidestop', this.onIntensityChange.bind(this));
-  $scope.$on('intensity.spinstop', this.onIntensityChange.bind(this));
-  this['maxIntensity'] = 50;
+    $scope.$on('size.slidestop', this.onSizeChange.bind(this));
+    $scope.$on('intensity.slidestop', this.onIntensityChange.bind(this));
+    $scope.$on('intensity.spinstop', this.onIntensityChange.bind(this));
+    this['maxIntensity'] = 50;
 
-  // add heatmap-specific events to the initEvents array
-  this.initEvents = this.initEvents.concat(goog.object.getValues(plugin.heatmap.HeatmapPropertyType));
-  this.intensityDelay = new goog.async.Delay(this.changeIntensity_, 1000, this);
-};
-goog.inherits(plugin.heatmap.HeatmapLayerUICtrl, os.ui.layer.DefaultLayerUICtrl);
-
-
-/**
- * @inheritDoc
- */
-plugin.heatmap.HeatmapLayerUICtrl.prototype.initUI = function() {
-  plugin.heatmap.HeatmapLayerUICtrl.base(this, 'initUI');
-
-  if (this.scope) {
-    this.scope['size'] = this.getSize_();
-    this.scope['intensity'] = this.getIntensity_();
-
-    this.scope['gradients'] = [
-      {'title': 'Rainbow', 'gradient': os.color.RAINBOW_HEATMAP_GRADIENT_HEX},
-      {'title': 'Thermal', 'gradient': os.color.THERMAL_HEATMAP_GRADIENT_HEX}
-    ];
-    var gradient = this.getGradient_();
-    this.scope['gradient'] = this.scope['gradients'][gradient == os.color.THERMAL_HEATMAP_GRADIENT_HEX ? 1 : 0];
+    // add heatmap-specific events to the initEvents array
+    this.initEvents = this.initEvents.concat(googObject.getValues(HeatmapPropertyType));
+    this.intensityDelay = new Delay(this.changeIntensity_, 1000, this);
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  initUI() {
+    super.initUI();
 
-/**
- * Handles changes to the gradient
- *
- * @export
- */
-plugin.heatmap.HeatmapLayerUICtrl.prototype.onGradientChange = function() {
-  var value = this.scope['gradient']['gradient'];
-  var fn =
-      /**
-       * @param {os.layer.ILayer} layer
-       * @return {os.command.ICommand}
-       */
-      function(layer) {
-        return new plugin.heatmap.cmd.Gradient(layer.getId(), value);
-      };
+    if (this.scope) {
+      this.scope['size'] = this.getSize_();
+      this.scope['intensity'] = this.getIntensity_();
 
-  this.createCommand(fn);
-};
-
-
-/**
- * Handles changes to the gradient
- *
- * @return {Array}
- * @private
- */
-plugin.heatmap.HeatmapLayerUICtrl.prototype.getGradient_ = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      try {
-        var layer = /** @type {plugin.heatmap.Heatmap} */ (items[i].getLayer());
-        if (layer) {
-          return layer.getGradient();
-        }
-      } catch (e) {
-      }
-    }
-  }
-  return [];
-};
-
-
-/**
- * Handles changes to size
- *
- * @param {angular.Scope.Event} event
- * @param {number} value
- * @protected
- */
-plugin.heatmap.HeatmapLayerUICtrl.prototype.onSizeChange = function(event, value) {
-  var fn =
-      /**
-       * @param {os.layer.ILayer} layer
-       * @return {os.command.ICommand}
-       */
-      function(layer) {
-        return new plugin.heatmap.cmd.Size(layer.getId(), value);
-      };
-
-  this.createCommand(fn);
-};
-
-
-/**
- * Gets the size from the layer
- *
- * @return {number}
- * @private
- */
-plugin.heatmap.HeatmapLayerUICtrl.prototype.getSize_ = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      try {
-        var layer = /** @type {plugin.heatmap.Heatmap} */ (items[i].getLayer());
-        if (layer) {
-          return layer.getSize();
-        }
-      } catch (e) {
-      }
+      this.scope['gradients'] = [
+        {'title': 'Rainbow', 'gradient': osColor.RAINBOW_HEATMAP_GRADIENT_HEX},
+        {'title': 'Thermal', 'gradient': osColor.THERMAL_HEATMAP_GRADIENT_HEX}
+      ];
+      var gradient = this.getGradient_();
+      this.scope['gradient'] = this.scope['gradients'][gradient == osColor.THERMAL_HEATMAP_GRADIENT_HEX ? 1 : 0];
     }
   }
 
-  return 1.0;
-};
+  /**
+   * Handles changes to the gradient
+   *
+   * @export
+   */
+  onGradientChange() {
+    var value = this.scope['gradient']['gradient'];
+    var fn =
+        /**
+         * @param {os.layer.ILayer} layer
+         * @return {os.command.ICommand}
+         */
+        function(layer) {
+          return new Gradient(layer.getId(), value);
+        };
 
-
-/**
- * Handles changes to intensity
- *
- * @param {angular.Scope.Event} event
- * @param {number} value
- * @protected
- */
-plugin.heatmap.HeatmapLayerUICtrl.prototype.onIntensityChange = function(event, value) {
-  this.scope['intensity'] = value;
-  this.intensityDelay.start();
-};
-
-
-/**
- * Implements changes to intensity
- *
- * @private
- */
-plugin.heatmap.HeatmapLayerUICtrl.prototype.changeIntensity_ = function() {
-  var value = this.scope['intensity'];
-  var fn =
-      /**
-       * @param {os.layer.ILayer} layer
-       * @return {os.command.ICommand}
-       */
-      function(layer) {
-        return new plugin.heatmap.cmd.Intensity(layer.getId(), value);
-      };
-
-  this.createCommand(fn);
-};
-
-
-/**
- * Gets the intensity from the layer
- *
- * @return {number}
- * @private
- */
-plugin.heatmap.HeatmapLayerUICtrl.prototype.getIntensity_ = function() {
-  var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      try {
-        var layer = /** @type {plugin.heatmap.Heatmap} */ (items[i].getLayer());
-        if (layer) {
-          return layer.getIntensity();
-        }
-      } catch (e) {
-      }
-    }
+    this.createCommand(fn);
   }
 
-  return this['maxIntensity'] / 2; // default to the middle of the slider - THIN-8618
+  /**
+   * Handles changes to the gradient
+   *
+   * @return {Array}
+   * @private
+   */
+  getGradient_() {
+    var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        try {
+          var layer = /** @type {plugin.heatmap.Heatmap} */ (items[i].getLayer());
+          if (layer) {
+            return layer.getGradient();
+          }
+        } catch (e) {
+        }
+      }
+    }
+    return [];
+  }
+
+  /**
+   * Handles changes to size
+   *
+   * @param {angular.Scope.Event} event
+   * @param {number} value
+   * @protected
+   */
+  onSizeChange(event, value) {
+    var fn =
+        /**
+         * @param {os.layer.ILayer} layer
+         * @return {os.command.ICommand}
+         */
+        function(layer) {
+          return new Size(layer.getId(), value);
+        };
+
+    this.createCommand(fn);
+  }
+
+  /**
+   * Gets the size from the layer
+   *
+   * @return {number}
+   * @private
+   */
+  getSize_() {
+    var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        try {
+          var layer = /** @type {plugin.heatmap.Heatmap} */ (items[i].getLayer());
+          if (layer) {
+            return layer.getSize();
+          }
+        } catch (e) {
+        }
+      }
+    }
+
+    return 1.0;
+  }
+
+  /**
+   * Handles changes to intensity
+   *
+   * @param {angular.Scope.Event} event
+   * @param {number} value
+   * @protected
+   */
+  onIntensityChange(event, value) {
+    this.scope['intensity'] = value;
+    this.intensityDelay.start();
+  }
+
+  /**
+   * Implements changes to intensity
+   *
+   * @private
+   */
+  changeIntensity_() {
+    var value = this.scope['intensity'];
+    var fn =
+        /**
+         * @param {os.layer.ILayer} layer
+         * @return {os.command.ICommand}
+         */
+        function(layer) {
+          return new Intensity(layer.getId(), value);
+        };
+
+    this.createCommand(fn);
+  }
+
+  /**
+   * Gets the intensity from the layer
+   *
+   * @return {number}
+   * @private
+   */
+  getIntensity_() {
+    var items = /** @type {Array<!os.data.LayerNode>} */ (this.scope['items']);
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        try {
+          var layer = /** @type {plugin.heatmap.Heatmap} */ (items[i].getLayer());
+          if (layer) {
+            return layer.getIntensity();
+          }
+        } catch (e) {
+        }
+      }
+    }
+
+    return this['maxIntensity'] / 2; // default to the middle of the slider - THIN-8618
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/heatmap/heatmapmenu.js
+++ b/src/plugin/heatmap/heatmapmenu.js
@@ -1,129 +1,133 @@
-goog.provide('plugin.heatmap.menu');
+goog.module('plugin.heatmap.menu');
 
-goog.require('os.ui.menu.MenuItemType');
-goog.require('os.ui.menu.layer');
-goog.require('plugin.heatmap');
+const asserts = goog.require('goog.asserts');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const LayerNode = goog.require('os.data.LayerNode');
+const metrics = goog.require('os.metrics');
+
+const AlertManager = goog.require('os.alert.AlertManager');
+const MenuItemType = goog.require('os.ui.menu.MenuItemType');
+const layerMenu = goog.require('os.ui.menu.layer');
+const heatmap = goog.require('plugin.heatmap');
+const Heatmap = goog.require('plugin.heatmap.Heatmap');
 
 
 /**
  * Heatmap event group label.
  * @type {string}
- * @const
  */
-plugin.heatmap.menu.GROUP_LABEL = 'Heatmap';
-
+const GROUP_LABEL = 'Heatmap';
 
 /**
  * Heatmap menu events.
  * @enum {string}
  */
-plugin.heatmap.menu.EventType = {
+const EventType = {
   EXPORT: 'heatmap:export',
   GENERATE_HEATMAP: 'heatmap:generate'
 };
 
-
 /**
  * Add heatmap menu items to the layer menu.
  */
-plugin.heatmap.menu.setup = function() {
-  var menu = os.ui.menu.layer.MENU;
-  if (menu && !menu.getRoot().find(plugin.heatmap.menu.EventType.EXPORT)) {
+const setup = function() {
+  var menu = layerMenu.MENU;
+  if (menu && !menu.getRoot().find(EventType.EXPORT)) {
     var menuRoot = menu.getRoot();
-    var toolsGroup = menuRoot.find(os.ui.menu.layer.GroupLabel.TOOLS);
-    goog.asserts.assert(toolsGroup, 'Group should exist! Check spelling?');
+    var toolsGroup = menuRoot.find(layerMenu.GroupLabel.TOOLS);
+    asserts.assert(toolsGroup, 'Group should exist! Check spelling?');
 
     //
     // TODO: Enable heatmap export after switching to an image layer.
     //
 
     menuRoot.addChild({
-      label: plugin.heatmap.menu.GROUP_LABEL,
-      type: os.ui.menu.MenuItemType.GROUP,
+      label: GROUP_LABEL,
+      type: MenuItemType.GROUP,
       children: [{
         label: 'Export Heatmap...',
-        eventType: plugin.heatmap.menu.EventType.EXPORT,
+        eventType: EventType.EXPORT,
         tooltip: 'Exports the heatmap as a KML Ground Overlay',
         icons: ['<i class="fa fa-fw fa-download"></i>'],
-        beforeRender: plugin.heatmap.menu.visibleIfSupported_,
-        handler: plugin.heatmap.menu.exportLayer_,
-        metricKey: os.metrics.Layer.HEATMAP
+        beforeRender: visibleIfSupported_,
+        handler: exportLayer_,
+        metricKey: metrics.Layer.HEATMAP
       }]
     });
 
     // this item is added for vector layers to be able to generate heatmaps
     toolsGroup.addChild({
       label: 'Generate Heatmap',
-      eventType: plugin.heatmap.menu.EventType.GENERATE_HEATMAP,
+      eventType: EventType.GENERATE_HEATMAP,
       tooltip: 'Generate a heatmap of current features',
       icons: ['<i class="fa fa-fw fa-fire"></i>'],
-      beforeRender: os.ui.menu.layer.visibleIfSupported,
-      handler: plugin.heatmap.menu.generateHeatmap_,
-      metricKey: os.metrics.Layer.HEATMAP
+      beforeRender: layerMenu.visibleIfSupported,
+      handler: generateHeatmap_,
+      metricKey: metrics.Layer.HEATMAP
     });
   }
 };
 
-
 /**
  * Show the heatmap menu item if layers in the context support it.
  *
- * @param {os.ui.menu.layer.Context} context The menu context.
- * @private
+ * @param {layerMenu.Context} context The menu context.
  * @this {os.ui.menu.MenuItem}
  */
-plugin.heatmap.menu.visibleIfSupported_ = function(context) {
+const visibleIfSupported_ = function(context) {
   this.visible = false;
 
   if (context && context.length == 1) {
     var node = context[0];
-    if (node instanceof os.data.LayerNode) {
+    if (node instanceof LayerNode) {
       var layer = node.getLayer();
-      this.visible = layer instanceof plugin.heatmap.Heatmap;
+      this.visible = layer instanceof Heatmap;
     }
   }
 };
-
 
 /**
  * Handle heatmap layer export event.
  *
- * @param {!os.ui.menu.MenuEvent<os.ui.menu.layer.Context>} event The menu event.
- * @private
+ * @param {!os.ui.menu.MenuEvent<layerMenu.Context>} event The menu event.
  */
-plugin.heatmap.menu.exportLayer_ = function(event) {
+const exportLayer_ = function(event) {
   var context = event.getContext();
   if (context && context.length == 1) {
     var node = context[0];
     var layer = node.getLayer();
-    if (layer instanceof plugin.heatmap.Heatmap) {
-      plugin.heatmap.exportHeatmap(layer);
+    if (layer instanceof Heatmap) {
+      heatmap.exportHeatmap(layer);
     }
   }
 };
 
-
 /**
  * Handle generate heatmap event. Adds a heatmap layer to the map.
  *
- * @param {!os.ui.menu.MenuEvent<os.ui.menu.layer.Context>} event The menu event.
- * @private
+ * @param {!os.ui.menu.MenuEvent<layerMenu.Context>} event The menu event.
  */
-plugin.heatmap.menu.generateHeatmap_ = function(event) {
+const generateHeatmap_ = function(event) {
   var context = event.getContext();
   if (context) {
-    var layers = os.ui.menu.layer.getLayersFromContext(context);
+    var layers = layerMenu.getLayersFromContext(context);
     if (layers.length) {
       for (var i = 0; i < layers.length; i++) {
         var layer = layers[i];
         var source = /** @type {os.source.Vector} */ (layer.getSource());
         if (!source || source.getFeatureCount() <= 0) {
-          os.alertManager.sendAlert('No features in selected layer. Unable to generate heatmap.',
-              os.alert.AlertEventSeverity.WARNING);
+          AlertManager.getInstance().sendAlert('No features in selected layer. Unable to generate heatmap.',
+              AlertEventSeverity.WARNING);
         } else {
-          plugin.heatmap.createHeatmap(layer);
+          heatmap.createHeatmap(layer);
         }
       }
     }
   }
+};
+
+exports = {
+  GROUP_LABEL,
+  EventType,
+  setup
 };

--- a/src/plugin/heatmap/heatmappropertytype.js
+++ b/src/plugin/heatmap/heatmappropertytype.js
@@ -1,0 +1,10 @@
+goog.module('plugin.heatmap.HeatmapPropertyType');
+
+/**
+ * @enum {string}
+ */
+exports = {
+  INTENSITY: 'intensity',
+  SIZE: 'size',
+  GRADIENT: 'gradient'
+};

--- a/src/plugin/heatmap/heatmapsynchronizertype.js
+++ b/src/plugin/heatmap/heatmapsynchronizertype.js
@@ -1,0 +1,8 @@
+goog.module('plugin.heatmap.SynchronizerType');
+
+/**
+ * @enum {string}
+ */
+exports = {
+  HEATMAP: 'heatmap'
+};

--- a/src/plugin/osm/nom/nominatim.js
+++ b/src/plugin/osm/nom/nominatim.js
@@ -1,28 +1,26 @@
-goog.provide('plugin.osm.nom');
-goog.provide('plugin.osm.nom.SettingKey');
+goog.module('plugin.osm.nom');
+
+const style = goog.require('os.style');
+const kml = goog.require('os.ui.file.kml');
 
 
 /**
  * Plugin identifier.
  * @type {string}
- * @const
  */
-plugin.osm.nom.ID = 'nominatim';
-
+const ID = 'nominatim';
 
 /**
  * User-facing name for the search provider.
  * @type {string}
- * @const
  */
-plugin.osm.nom.SEARCH_NAME = 'Places (OpenStreetMap)';
-
+const SEARCH_NAME = 'Places (OpenStreetMap)';
 
 /**
  * Fields on OSM Nominatim response data.
  * @enum {string}
  */
-plugin.osm.nom.ResultField = {
+const ResultField = {
   BBOX: 'boundingbox',
   CATEGORY: 'category',
   DISPLAY_NAME: 'display_name',
@@ -35,69 +33,59 @@ plugin.osm.nom.ResultField = {
   TYPE: 'type'
 };
 
-
 /**
  * Fields on OSM Nominatim `extradata` objects.
  * @enum {string}
  */
-plugin.osm.nom.ExtraDataField = {
+const ExtraDataField = {
   PLACE: 'place',
   POPULATION: 'population'
 };
 
-
 /**
  * Field used to label search results.
  * @type {string}
- * @const
  */
-plugin.osm.nom.LABEL_FIELD = plugin.osm.nom.ResultField.DISPLAY_NAME;
-
+const LABEL_FIELD = ResultField.DISPLAY_NAME;
 
 /**
  * Base search result score.
  * @type {number}
- * @const
  */
-plugin.osm.nom.BASE_SCORE = 100;
-
+const BASE_SCORE = 100;
 
 /**
  * Multiplier to apply to search result importance based on OSM type.
  * @enum {number}
  */
-plugin.osm.nom.OSMTypeMultiplier = {
+const OSMTypeMultiplier = {
   'relation': 1.2,
   'way': 1.1
 };
 
-
 /**
  * The base settings key for the plugin.
  * @type {string}
- * @const
  */
-plugin.osm.nom.BASE_SETTING_KEY = 'plugin.osm.nom';
+const BASE_SETTING_KEY = 'plugin.osm.nom';
 
 /**
  * Settings keys for the plugin.
  * @enum {string}
  */
-plugin.osm.nom.SettingKey = {
-  URL: plugin.osm.nom.BASE_SETTING_KEY + '.url'
+const SettingKey = {
+  URL: BASE_SETTING_KEY + '.url'
 };
-
 
 /**
  * Style config for search results.
  * @type {!Object}
- * @const
  */
-plugin.osm.nom.VECTOR_CONFIG = {
+const VECTOR_CONFIG = {
   // show a white label with the place name
   'labelColor': 'rgba(255,255,255,1)',
   'labels': [{
-    'column': plugin.osm.nom.LABEL_FIELD,
+    'column': LABEL_FIELD,
     'showColumn': false
   }],
 
@@ -105,13 +93,13 @@ plugin.osm.nom.VECTOR_CONFIG = {
   'image': {
     'type': 'icon',
     'scale': 0.75,
-    'src': os.ui.file.kml.GOOGLE_EARTH_URL + os.ui.file.kml.GoogleEarthIcons.WHT_BLANK,
+    'src': kml.GOOGLE_EARTH_URL + kml.GoogleEarthIcons.WHT_BLANK,
     'color': 'rgba(0,255,255,1)'
   },
 
   // this will only be applied to line and polygon types
   'stroke': {
-    'width': os.style.DEFAULT_STROKE_WIDTH,
+    'width': style.DEFAULT_STROKE_WIDTH,
     'color': 'rgba(0,0,255,1)'
   },
   'fill': {
@@ -119,22 +107,21 @@ plugin.osm.nom.VECTOR_CONFIG = {
   }
 };
 
-
 /**
  * Get the search score for an OSM Nominatim result.
  *
  * @param {ol.Feature} feature The feature result.
  * @return {number} The search score.
  */
-plugin.osm.nom.getSearchScore = function(feature) {
-  var score = plugin.osm.nom.BASE_SCORE;
+const getSearchScore = function(feature) {
+  var score = BASE_SCORE;
 
   if (feature) {
-    var importance = /** @type {number|undefined} */ (feature.get(plugin.osm.nom.ResultField.IMPORTANCE));
+    var importance = /** @type {number|undefined} */ (feature.get(ResultField.IMPORTANCE));
     if (importance) {
-      var osmType = /** @type {string|undefined} */ (feature.get(plugin.osm.nom.ResultField.OSM_TYPE));
-      if (osmType && osmType in plugin.osm.nom.OSMTypeMultiplier) {
-        importance = importance * plugin.osm.nom.OSMTypeMultiplier[osmType];
+      var osmType = /** @type {string|undefined} */ (feature.get(ResultField.OSM_TYPE));
+      if (osmType && osmType in OSMTypeMultiplier) {
+        importance = importance * OSMTypeMultiplier[osmType];
       }
 
       score = score + importance;
@@ -144,4 +131,18 @@ plugin.osm.nom.getSearchScore = function(feature) {
   }
 
   return score;
+};
+
+exports = {
+  BASE_SCORE,
+  BASE_SETTING_KEY,
+  ID,
+  LABEL_FIELD,
+  SEARCH_NAME,
+  VECTOR_CONFIG,
+  ExtraDataField,
+  OSMTypeMultiplier,
+  ResultField,
+  SettingKey,
+  getSearchScore
 };

--- a/src/plugin/osm/nom/nominatimplugin.js
+++ b/src/plugin/osm/nom/nominatimplugin.js
@@ -1,32 +1,36 @@
-goog.provide('plugin.osm.nom.NominatimPlugin');
+goog.module('plugin.osm.nom.NominatimPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.search.SearchManager');
-goog.require('plugin.osm.nom');
-goog.require('plugin.osm.nom.NominatimSearch');
+const Settings = goog.require('os.config.Settings');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const SearchManager = goog.require('os.search.SearchManager');
+const {ID, SEARCH_NAME, SettingKey} = goog.require('plugin.osm.nom');
+const NominatimSearch = goog.require('plugin.osm.nom.NominatimSearch');
 
 
 /**
  * Provides an interface to the OSM Nominatim API.
- *
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.osm.nom.NominatimPlugin = function() {
-  plugin.osm.nom.NominatimPlugin.base(this, 'constructor');
-  this.id = plugin.osm.nom.ID;
-};
-goog.inherits(plugin.osm.nom.NominatimPlugin, os.plugin.AbstractPlugin);
-
-
-/**
- * @inheritDoc
- */
-plugin.osm.nom.NominatimPlugin.prototype.init = function() {
-  // register the search provider if configured
-  var url = /** @type {string|undefined} */ (os.settings.get(plugin.osm.nom.SettingKey.URL));
-  if (url) {
-    var search = new plugin.osm.nom.NominatimSearch(plugin.osm.nom.SEARCH_NAME);
-    os.search.SearchManager.getInstance().registerSearch(search);
+class NominatimPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = ID;
   }
-};
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    // register the search provider if configured
+    const url = /** @type {string|undefined} */ (Settings.getInstance().get(SettingKey.URL));
+    if (url) {
+      const search = new NominatimSearch(SEARCH_NAME);
+      SearchManager.getInstance().registerSearch(search);
+    }
+  }
+}
+
+exports = NominatimPlugin;

--- a/src/plugin/osm/nom/nominatimsearch.js
+++ b/src/plugin/osm/nom/nominatimsearch.js
@@ -1,165 +1,161 @@
-goog.provide('plugin.osm.nom.NominatimSearch');
+goog.module('plugin.osm.nom.NominatimSearch');
 
-goog.require('goog.Promise');
-goog.require('os.fn');
-goog.require('os.net.Request');
-goog.require('os.search.AbstractUrlSearch');
-goog.require('os.search.IGeoSearch');
-goog.require('plugin.osm.nom');
-goog.require('plugin.osm.nom.NominatimParser');
-goog.require('plugin.osm.nom.SearchResult');
+const Promise = goog.require('goog.Promise');
+const Settings = goog.require('os.config.Settings');
+const fn = goog.require('os.fn');
+const osImplements = goog.require('os.implements');
+const Request = goog.require('os.net.Request');
+const AbstractUrlSearch = goog.require('os.search.AbstractUrlSearch');
+const IGeoSearch = goog.require('os.search.IGeoSearch');
+const nom = goog.require('plugin.osm.nom');
+const NominatimParser = goog.require('plugin.osm.nom.NominatimParser');
+const SearchResult = goog.require('plugin.osm.nom.SearchResult');
 
 
 /**
  * Search provider for the OSM Nominatim API.
  *
- * @param {string} name The search provider name.
- * @extends {os.search.AbstractUrlSearch}
- * @implements {os.search.IGeoSearch}
- * @constructor
+ * @implements {IGeoSearch}
  */
-plugin.osm.nom.NominatimSearch = function(name) {
-  plugin.osm.nom.NominatimSearch.base(this, 'constructor', plugin.osm.nom.ID, name);
-  this.type = plugin.osm.nom.ID;
-
+class NominatimSearch extends AbstractUrlSearch {
   /**
-   * The geo search extent.
-   * @type {Array<number>|undefined}
-   * @protected
+   * Constructor.
+   * @param {string} name The search provider name.
    */
-  this.geoExtent = undefined;
-};
-goog.inherits(plugin.osm.nom.NominatimSearch, os.search.AbstractUrlSearch);
-os.implements(plugin.osm.nom.NominatimSearch, os.search.IGeoSearch.ID);
+  constructor(name) {
+    super(nom.ID, name);
+    this.type = nom.ID;
 
-
-/**
- * @inheritDoc
- */
-plugin.osm.nom.NominatimSearch.prototype.shouldNormalize = function() {
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.osm.nom.NominatimSearch.prototype.getSearchUrl = function(term, opt_start, opt_pageSize) {
-  var url = /** @type {string} */ (os.settings.get(plugin.osm.nom.SettingKey.URL, ''));
-  if (url) {
-    if (opt_pageSize) {
-      // limit the number of results
-      url += '&limit=' + opt_pageSize;
-    }
-
-    if (this.geoExtent) {
-      // restrict the query to the current extent
-      url += '&bounded=1';
-      url += '&viewbox=' + this.geoExtent.join(',');
-    }
+    /**
+     * The geo search extent.
+     * @type {Array<number>|undefined}
+     * @protected
+     */
+    this.geoExtent = undefined;
   }
 
-  return url;
-};
+  /**
+   * @inheritDoc
+   */
+  shouldNormalize() {
+    return false;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  getSearchUrl(term, opt_start, opt_pageSize) {
+    var url = /** @type {string} */ (Settings.getInstance().get(nom.SettingKey.URL, ''));
+    if (url) {
+      if (opt_pageSize) {
+        // limit the number of results
+        url += '&limit=' + opt_pageSize;
+      }
 
-/**
- * @inheritDoc
- */
-plugin.osm.nom.NominatimSearch.prototype.onSearchSuccess = function(evt) {
-  var request = /** @type {os.net.Request} */ (evt.target);
-  var response = /** @type {string} */ (request.getResponse());
-  if (response) {
-    var parser = new plugin.osm.nom.NominatimParser();
-    parser.setSource(response);
+      if (this.geoExtent) {
+        // restrict the query to the current extent
+        url += '&bounded=1';
+        url += '&viewbox=' + this.geoExtent.join(',');
+      }
+    }
 
-    while (parser.hasNext()) {
-      var next = parser.parseNext();
-      if (next) {
-        if (Array.isArray(next)) {
-          this.results.concat(next.map(function(f) {
-            return f ? new plugin.osm.nom.SearchResult(f) : undefined;
-          }).filter(os.fn.filterFalsey));
-        } else {
-          this.results.push(new plugin.osm.nom.SearchResult(next));
+    return url;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  onSearchSuccess(evt) {
+    var request = /** @type {Request} */ (evt.target);
+    var response = /** @type {string} */ (request.getResponse());
+    if (response) {
+      var parser = new NominatimParser();
+      parser.setSource(response);
+
+      while (parser.hasNext()) {
+        var next = parser.parseNext();
+        if (next) {
+          if (Array.isArray(next)) {
+            this.results.concat(next.map(function(f) {
+              return f ? new SearchResult(f) : undefined;
+            }).filter(fn.filterFalsey));
+          } else {
+            this.results.push(new SearchResult(next));
+          }
         }
       }
     }
+
+    // superclass takes care of cleaning up request and sending events
+    super.onSearchSuccess(evt);
   }
 
-  // superclass takes care of cleaning up request and sending events
-  plugin.osm.nom.NominatimSearch.base(this, 'onSearchSuccess', evt);
-};
+  /**
+   * @inheritDoc
+   */
+  supportsGeoDistance() {
+    return false;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  supportsGeoExtent() {
+    return true;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.osm.nom.NominatimSearch.prototype.supportsGeoDistance = function() {
-  return false;
-};
+  /**
+   * @inheritDoc
+   */
+  supportsGeoShape() {
+    return false;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  setGeoDistance(center, distance) {
+    // not supported
+  }
 
-/**
- * @inheritDoc
- */
-plugin.osm.nom.NominatimSearch.prototype.supportsGeoExtent = function() {
-  return true;
-};
+  /**
+   * @inheritDoc
+   */
+  setGeoExtent(extent, opt_center, opt_distance) {
+    this.geoExtent = extent;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  setGeoShape(shape, opt_center, opt_distance) {
+    // not supported
+  }
+}
 
-/**
- * @inheritDoc
- */
-plugin.osm.nom.NominatimSearch.prototype.supportsGeoShape = function() {
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.osm.nom.NominatimSearch.prototype.setGeoDistance = function(center, distance) {
-  // not supported
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.osm.nom.NominatimSearch.prototype.setGeoExtent = function(extent, opt_center, opt_distance) {
-  this.geoExtent = extent;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.osm.nom.NominatimSearch.prototype.setGeoShape = function(shape, opt_center, opt_distance) {
-  // not supported
-};
+osImplements(NominatimSearch, IGeoSearch.ID);
 
 
 /**
  * Get the top result from Nominatim.
  *
  * @param {string} term The search term.
- * @return {!goog.Promise<(ol.Feature|undefined)>} A promise that resolves to the resulting feature, or is rejected with
+ * @return {!Promise<(ol.Feature|undefined)>} A promise that resolves to the resulting feature, or is rejected with
  *                                                 any errors.
  */
-plugin.osm.nom.feelingLucky = function(term) {
-  var url = /** @type {string} */ (os.settings.get(plugin.osm.nom.SettingKey.URL, ''));
+nom.feelingLucky = function(term) {
+  var url = /** @type {string} */ (Settings.getInstance().get(nom.SettingKey.URL, ''));
   if (url) {
     url = url.replace(/{s}/g, term);
     url += '&limit=1';
 
-    var request = new os.net.Request(url);
+    var request = new Request(url);
     request.setHeader('Accept', 'application/json, text/plain, */*');
 
-    return request.getPromise().then(plugin.osm.nom.parseFirst);
+    return request.getPromise().then(nom.parseFirst);
   }
 
-  return goog.Promise.reject('Nominatim service is not configured.');
+  return Promise.reject('Nominatim service is not configured.');
 };
 
 
@@ -169,9 +165,9 @@ plugin.osm.nom.feelingLucky = function(term) {
  * @param {*} response The server response.
  * @return {ol.Feature|undefined} The parsed feature, or undefined if none could be parsed.
  */
-plugin.osm.nom.parseFirst = function(response) {
+nom.parseFirst = function(response) {
   if (typeof response === 'string' || Array.isArray(response)) {
-    var parser = new plugin.osm.nom.NominatimParser();
+    var parser = new NominatimParser();
     parser.setSource(response);
 
     var next;
@@ -186,3 +182,4 @@ plugin.osm.nom.parseFirst = function(response) {
 
   return undefined;
 };
+exports = NominatimSearch;

--- a/src/plugin/osm/nom/nominatimsearchresult.js
+++ b/src/plugin/osm/nom/nominatimsearchresult.js
@@ -1,31 +1,34 @@
-goog.provide('plugin.osm.nom.SearchResult');
+goog.module('plugin.osm.nom.SearchResult');
 
-goog.require('os.ui.search.place.CoordinateResult');
-goog.require('plugin.osm.nom');
-goog.require('plugin.osm.nom.resultCardDirective');
-
+const style = goog.require('os.style');
+const StyleType = goog.require('os.style.StyleType');
+const CoordinateResult = goog.require('os.ui.search.place.CoordinateResult');
+const {LABEL_FIELD, VECTOR_CONFIG, getSearchScore} = goog.require('plugin.osm.nom');
+const {directiveTag: resultCardEl} = goog.require('plugin.osm.nom.ResultCardUI');
 
 
 /**
  * Search result card for Nominatim results.
- *
- * @param {ol.Feature} result The result feature.
- * @extends {os.ui.search.place.CoordinateResult}
- * @constructor
  */
-plugin.osm.nom.SearchResult = function(result) {
-  var score = plugin.osm.nom.getSearchScore(result);
-  plugin.osm.nom.SearchResult.base(this, 'constructor', result, plugin.osm.nom.LABEL_FIELD, score);
+class SearchResult extends CoordinateResult {
+  /**
+   * Constructor.
+   * @param {ol.Feature} result The result feature.
+   */
+  constructor(result) {
+    var score = getSearchScore(result);
+    super(result, LABEL_FIELD, score);
 
-  result.set(os.style.StyleType.FEATURE, plugin.osm.nom.VECTOR_CONFIG, true);
-  os.style.setFeatureStyle(result);
-};
-goog.inherits(plugin.osm.nom.SearchResult, os.ui.search.place.CoordinateResult);
+    result.set(StyleType.FEATURE, VECTOR_CONFIG, true);
+    style.setFeatureStyle(result);
+  }
 
+  /**
+   * @inheritDoc
+   */
+  getSearchUI() {
+    return `<${resultCardEl} result="result"></${resultCardEl}>`;
+  }
+}
 
-/**
- * @inheritDoc
- */
-plugin.osm.nom.SearchResult.prototype.getSearchUI = function() {
-  return '<nominatimresultcard result="result"></nominatimresultcard>';
-};
+exports = SearchResult;

--- a/src/plugin/osm/nom/nominatimsearchresultcard.js
+++ b/src/plugin/osm/nom/nominatimsearchresultcard.js
@@ -1,8 +1,10 @@
-goog.provide('plugin.osm.nom.ResultCardCtrl');
-goog.provide('plugin.osm.nom.resultCardDirective');
+goog.module('plugin.osm.nom.ResultCardUI');
 
-goog.require('os.ui.Module');
-goog.require('os.ui.search.FeatureResultCardCtrl');
+const googString = goog.require('goog.string');
+const {ROOT} = goog.require('os');
+const Module = goog.require('os.ui.Module');
+const FeatureResultCardCtrl = goog.require('os.ui.search.FeatureResultCardCtrl');
+const nom = goog.require('plugin.osm.nom');
 
 
 /**
@@ -10,81 +12,92 @@ goog.require('os.ui.search.FeatureResultCardCtrl');
  *
  * @return {angular.Directive}
  */
-plugin.osm.nom.resultCardDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    templateUrl: os.ROOT + 'views/plugin/osm/nom/nominatimresultcard.html',
-    controller: plugin.osm.nom.ResultCardCtrl,
-    controllerAs: 'ctrl'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  templateUrl: ROOT + 'views/plugin/osm/nom/nominatimresultcard.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'nominatimresultcard';
 
 
 /**
  * Register the nominatimresultcard directive.
  */
-os.ui.Module.directive('nominatimresultcard', [plugin.osm.nom.resultCardDirective]);
+Module.directive('nominatimresultcard', [directive]);
 
 
 /**
  * Controller for the nominatimresultcard directive.
- *
- * @param {!angular.Scope} $scope The Angular scope.
- * @param {!angular.JQLite} $element The root DOM element.
- * @constructor
- * @extends {os.ui.search.FeatureResultCardCtrl}
- * @ngInject
+ * @unrestricted
  */
-plugin.osm.nom.ResultCardCtrl = function($scope, $element) {
-  plugin.osm.nom.ResultCardCtrl.base(this, 'constructor', $scope, $element);
-
+class Controller extends FeatureResultCardCtrl {
   /**
-   * Details to display in the result card.
-   * @type {string}
+   * Constructor.
+   * @param {!angular.Scope} $scope The Angular scope.
+   * @param {!angular.JQLite} $element The root DOM element.
+   * @ngInject
    */
-  this['details'] = '';
+  constructor($scope, $element) {
+    super($scope, $element);
 
-  var details = [];
+    /**
+     * Details to display in the result card.
+     * @type {string}
+     */
+    this['details'] = '';
 
-  var category = this.getField(plugin.osm.nom.ResultField.CATEGORY);
-  var type = this.getField(plugin.osm.nom.ResultField.TYPE);
-  if (category && type) {
-    category = goog.string.toTitleCase(category);
-    type = goog.string.toTitleCase(type);
+    var details = [];
 
-    details.push(category + ' (' + type + ')');
-  }
+    var category = this.getField(nom.ResultField.CATEGORY);
+    var type = this.getField(nom.ResultField.TYPE);
+    if (category && type) {
+      category = googString.toTitleCase(category);
+      type = googString.toTitleCase(type);
 
-  var extraTags = /** @type {Object|undefined} */ (this.feature.get(plugin.osm.nom.ResultField.EXTRA_TAGS));
-  if (extraTags) {
-    var place = /** @type {string|undefined} */ (extraTags[plugin.osm.nom.ExtraDataField.PLACE]);
-    if (place) {
-      details.push(goog.string.toTitleCase(place));
+      details.push(category + ' (' + type + ')');
     }
 
-    var population = /** @type {string|undefined} */ (extraTags[plugin.osm.nom.ExtraDataField.POPULATION]);
-    if (population) {
-      var popNum = Number(population);
-      if (!isNaN(popNum)) {
-        details.push('Population: ' + popNum.toLocaleString());
-      } else {
-        details.push('Population: ' + population);
+    var extraTags = /** @type {Object|undefined} */ (this.feature.get(nom.ResultField.EXTRA_TAGS));
+    if (extraTags) {
+      var place = /** @type {string|undefined} */ (extraTags[nom.ExtraDataField.PLACE]);
+      if (place) {
+        details.push(googString.toTitleCase(place));
+      }
+
+      var population = /** @type {string|undefined} */ (extraTags[nom.ExtraDataField.POPULATION]);
+      if (population) {
+        var popNum = Number(population);
+        if (!isNaN(popNum)) {
+          details.push('Population: ' + popNum.toLocaleString());
+        } else {
+          details.push('Population: ' + population);
+        }
       }
     }
+
+    this['details'] = details.join(' - ');
   }
 
-  this['details'] = details.join(' - ');
-};
-goog.inherits(plugin.osm.nom.ResultCardCtrl, os.ui.search.FeatureResultCardCtrl);
+  /**
+   * Get the title to display on the card.
+   *
+   * @return {string} The title.
+   * @export
+   */
+  getTitle() {
+    return /** @type {string} */ (this.feature.get(nom.ResultField.DISPLAY_NAME)) || 'Unknown Result';
+  }
+}
 
-
-/**
- * Get the title to display on the card.
- *
- * @return {string} The title.
- * @export
- */
-plugin.osm.nom.ResultCardCtrl.prototype.getTitle = function() {
-  return /** @type {string} */ (this.feature.get(plugin.osm.nom.ResultField.DISPLAY_NAME) || 'Unknown Result');
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/overview/overviewplugin.js
+++ b/src/plugin/overview/overviewplugin.js
@@ -1,45 +1,48 @@
-goog.provide('plugin.overview.OverviewPlugin');
+goog.module('plugin.overview.OverviewPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.plugin.AbstractPlugin');
-goog.require('plugin.basemap');
-goog.require('plugin.overview.OverviewMap');
-
+const MapContainer = goog.require('os.MapContainer');
+const Settings = goog.require('os.config.Settings');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const OverviewMap = goog.require('plugin.overview.OverviewMap');
 
 
 /**
  * Adds an overview map to the map controls that syncs with the current base maps
- *
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.overview.OverviewPlugin = function() {
-  plugin.overview.OverviewPlugin.base(this, 'constructor');
-  this.id = 'overview';
+class OverviewPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = 'overview';
+
+    /**
+     * @type {?OverviewMap}
+     * @protected
+     */
+    this.control = null;
+  }
 
   /**
-   * @type {?plugin.overview.OverviewMap}
-   * @protected
+   * @inheritDoc
    */
-  this.control = null;
-};
-goog.inherits(plugin.overview.OverviewPlugin, os.plugin.AbstractPlugin);
+  init() {
+    // add the overview map control
+    var collapsed = /** @type {boolean} */ (Settings.getInstance().get(OverviewMap.SHOW_KEY, false));
 
+    this.control = new OverviewMap({
+      collapsed: collapsed,
+      label: '\u00AB',
+      collapseLabel: '\u00BB',
+      layers: [
+        // just grab the base map group
+        MapContainer.getInstance().getMap().getLayers().getArray()[0]
+      ]});
 
-/**
- * @inheritDoc
- */
-plugin.overview.OverviewPlugin.prototype.init = function() {
-  // add the overview map control
-  var collapsed = /** @type {boolean} */ (os.settings.get(plugin.overview.OverviewMap.SHOW_KEY, false));
+    MapContainer.getInstance().getMap().getControls().push(this.control);
+  }
+}
 
-  this.control = new plugin.overview.OverviewMap({
-    collapsed: collapsed,
-    label: '\u00AB',
-    collapseLabel: '\u00BB',
-    layers: [
-      // just grab the base map group
-      os.MapContainer.getInstance().getMap().getLayers().getArray()[0]
-    ]});
-
-  os.MapContainer.getInstance().getMap().getControls().push(this.control);
-};
+exports = OverviewPlugin;

--- a/src/plugin/params/editrequestparams.js
+++ b/src/plugin/params/editrequestparams.js
@@ -1,12 +1,17 @@
-goog.provide('plugin.params.EditRequestParamsCtrl');
-goog.provide('plugin.params.editRequestParamsDirective');
+goog.module('plugin.params.EditRequestParamsUI');
 
-goog.require('goog.Disposable');
-goog.require('ol.array');
-goog.require('os');
-goog.require('os.data.ColumnDefinition');
-goog.require('os.ui.Module');
 goog.require('os.ui.slick.slickGridDirective');
+
+const Disposable = goog.require('goog.Disposable');
+const googString = goog.require('goog.string');
+const olArray = goog.require('ol.array');
+const os = goog.require('os');
+const ColumnDefinition = goog.require('os.data.ColumnDefinition');
+const Module = goog.require('os.ui.Module');
+const WindowEventType = goog.require('os.ui.WindowEventType');
+const SlickGridEvent = goog.require('os.ui.slick.SlickGridEvent');
+const osWindow = goog.require('os.ui.window');
+const pluginParams = goog.require('plugin.params');
 
 
 /**
@@ -14,319 +19,317 @@ goog.require('os.ui.slick.slickGridDirective');
  *
  * @return {angular.Directive}
  */
-plugin.params.editRequestParamsDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    scope: {
-      'layer': '=',
-      'params': '='
-    },
-    templateUrl: os.ROOT + 'views/plugin/params/editrequestparams.html',
-    controller: plugin.params.EditRequestParamsCtrl,
-    controllerAs: 'ctrl'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+
+  scope: {
+    'layer': '=',
+    'params': '='
+  },
+
+  templateUrl: os.ROOT + 'views/plugin/params/editrequestparams.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'editrequestparams';
 
 
 /**
  * Add the directive to the module.
  */
-os.ui.Module.directive('editrequestparams', [plugin.params.editRequestParamsDirective]);
+Module.directive('editrequestparams', [directive]);
 
 
 
 /**
  * Controller function for the editrequestparams directive
- *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @extends {goog.Disposable}
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.params.EditRequestParamsCtrl = function($scope, $element) {
-  plugin.params.EditRequestParamsCtrl.base(this, 'constructor');
-
+class Controller extends Disposable {
   /**
-   * @type {?angular.Scope}
-   * @protected
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @ngInject
    */
-  this.scope = $scope;
+  constructor($scope, $element) {
+    super();
 
-  /**
-   * @type {?angular.JQLite}
-   * @protected
-   */
-  this.element = $element;
+    /**
+     * @type {?angular.Scope}
+     * @protected
+     */
+    this.scope = $scope;
 
-  /**
-   * Counter for unique row id's.
-   * @type {number}
-   * @private
-   */
-  this.nextId_ = 0;
+    /**
+     * @type {?angular.JQLite}
+     * @protected
+     */
+    this.element = $element;
 
-  /**
-   * Initial parameter keys provided to the UI.
-   * @type {!Array<string>}
-   */
-  this['initialKeys'] = [];
+    /**
+     * Counter for unique row id's.
+     * @type {number}
+     * @private
+     */
+    this.nextId_ = 0;
 
-  /**
-   * If the layer supports multiple URLs.
-   * @type {boolean}
-   */
-  this['multiUrl'] = false;
+    /**
+     * Initial parameter keys provided to the UI.
+     * @type {!Array<string>}
+     */
+    this['initialKeys'] = [];
 
-  /**
-   * The parameter model for slickgrid.
-   * @type {Array<!Object>}
-   */
-  this['params'] = null;
-
-  /**
-   * The selected parameter in the grid.
-   * @type {Object}
-   */
-  this['selected'] = null;
-
-  /**
-   * The URL(s) for the layer.
-   * @type {Array<string>}
-   */
-  this['urls'] = null;
-
-  // initialize request URL(s)
-  var layer = /** @type {ol.layer.Layer|undefined} */ ($scope['layer']);
-  var urls = plugin.params.getUrlsForLayer(layer || null);
-  if (typeof urls == 'string') {
-    this['urls'] = [urls];
+    /**
+     * If the layer supports multiple URLs.
+     * @type {boolean}
+     */
     this['multiUrl'] = false;
-  } else if (urls) {
-    this['urls'] = urls;
-    this['multiUrl'] = true;
-  }
 
-  // initialize request parameters
-  var initialParams = /** @type {Object|undefined} */ ($scope['params']);
-  if (initialParams) {
-    this['params'] = [];
+    /**
+     * The parameter model for slickgrid.
+     * @type {Array<!Object>}
+     */
+    this['params'] = null;
 
-    for (var key in initialParams) {
-      this['initialKeys'].push(key);
-      this['params'].push({
-        'id': this.nextId_++,
-        'field': key,
-        'value': initialParams[key]
-      });
+    /**
+     * The selected parameter in the grid.
+     * @type {Object}
+     */
+    this['selected'] = null;
+
+    /**
+     * The URL(s) for the layer.
+     * @type {Array<string>}
+     */
+    this['urls'] = null;
+
+    // initialize request URL(s)
+    var layer = /** @type {ol.layer.Layer|undefined} */ ($scope['layer']);
+    var urls = pluginParams.getUrlsForLayer(layer || null);
+    if (typeof urls == 'string') {
+      this['urls'] = [urls];
+      this['multiUrl'] = false;
+    } else if (urls) {
+      this['urls'] = urls;
+      this['multiUrl'] = true;
     }
+
+    // initialize request parameters
+    var initialParams = /** @type {Object|undefined} */ ($scope['params']);
+    if (initialParams) {
+      this['params'] = [];
+
+      for (var key in initialParams) {
+        this['initialKeys'].push(key);
+        this['params'].push({
+          'id': this.nextId_++,
+          'field': key,
+          'value': initialParams[key]
+        });
+      }
+    }
+
+    this['gridOptions'] = {
+      'asyncEditorLoading': false,
+      'autoEdit': true,
+      'editable': true,
+      'enableCellNavigation': true,
+      'forceFitColumns': true,
+      'fullWidthRows': true,
+      'multiColumnSort': false,
+      'multiSelect': false
+    };
+
+    var fieldCol = new ColumnDefinition('Field', 'field');
+    fieldCol['editor'] = Slick.Editors.Text;
+
+    var valueCol = new ColumnDefinition('Value', 'value');
+    valueCol['editor'] = Slick.Editors.Text;
+
+    this['gridColumns'] = [fieldCol, valueCol];
+
+    $scope.$on('$destroy', this.dispose.bind(this));
+    $scope.$emit(WindowEventType.READY);
   }
 
-  this['gridOptions'] = {
-    'asyncEditorLoading': false,
-    'autoEdit': true,
-    'editable': true,
-    'enableCellNavigation': true,
-    'forceFitColumns': true,
-    'fullWidthRows': true,
-    'multiColumnSort': false,
-    'multiSelect': false
-  };
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
 
-  var fieldCol = new os.data.ColumnDefinition('Field', 'field');
-  fieldCol['editor'] = Slick.Editors.Text;
-
-  var valueCol = new os.data.ColumnDefinition('Value', 'value');
-  valueCol['editor'] = Slick.Editors.Text;
-
-  this['gridColumns'] = [fieldCol, valueCol];
-
-  $scope.$on('$destroy', this.dispose.bind(this));
-  $scope.$emit(os.ui.WindowEventType.READY);
-};
-goog.inherits(plugin.params.EditRequestParamsCtrl, goog.Disposable);
-
-
-/**
- * @inheritDoc
- */
-plugin.params.EditRequestParamsCtrl.prototype.disposeInternal = function() {
-  plugin.params.EditRequestParamsCtrl.base(this, 'disposeInternal');
-
-  this.scope = null;
-  this.element = null;
-};
-
-
-/**
- * Discard changes and close the window.
- *
- * @export
- */
-plugin.params.EditRequestParamsCtrl.prototype.cancel = function() {
-  this.close();
-};
-
-
-/**
- * Save the parameter changes and close the window.
- *
- * @export
- */
-plugin.params.EditRequestParamsCtrl.prototype.confirm = function() {
-  if (this.scope) {
-    this.scope.$broadcast(os.ui.slick.SlickGridEvent.COMMIT_EDIT);
+    this.scope = null;
+    this.element = null;
   }
 
-  var layer = /** @type {ol.layer.Layer|undefined} */ (this.scope['layer']);
-  if (layer) {
+  /**
+   * Discard changes and close the window.
+   *
+   * @export
+   */
+  cancel() {
+    this.close();
+  }
+
+  /**
+   * Save the parameter changes and close the window.
+   *
+   * @export
+   */
+  confirm() {
+    if (this.scope) {
+      this.scope.$broadcast(SlickGridEvent.COMMIT_EDIT);
+    }
+
+    var layer = /** @type {ol.layer.Layer|undefined} */ (this.scope['layer']);
+    if (layer) {
+      if (this['params']) {
+        var params = {};
+        var toDelete = [];
+
+        // map parameter data to an object
+        this['params'].forEach(function(p) {
+          var field = googString.makeSafe(p['field']);
+          if (!googString.isEmptyOrWhitespace(field)) {
+            params[field] = googString.makeSafe(p['value']);
+          }
+        });
+
+        // check if any keys have been deleted from the initial values
+        this['initialKeys'].forEach(function(key) {
+          if (!(key in params)) {
+            toDelete.push(key);
+          }
+        });
+
+        pluginParams.setParamsForLayer(layer, params, toDelete);
+      }
+
+      if (this['urls']) {
+        // skip empty URL's
+        var urls = this['urls'].filter(function(url) {
+          return !googString.isEmptyOrWhitespace(url);
+        });
+
+        if (urls.length > 0) {
+          pluginParams.setUrlsForLayer(layer, urls);
+        }
+      }
+    }
+
+    this.close();
+  }
+
+  /**
+   * Close the window.
+   *
+   * @protected
+   */
+  close() {
+    osWindow.close(this.element);
+  }
+
+  /**
+   * Add a new parameter row.
+   *
+   * @export
+   */
+  addRow() {
     if (this['params']) {
-      var params = {};
-      var toDelete = [];
+      this['params'] = this['params'].concat([{
+        'id': this.nextId_++,
+        'field': '',
+        'value': ''
+      }]);
+    }
+  }
 
-      // map parameter data to an object
-      this['params'].forEach(function(p) {
-        var field = goog.string.makeSafe(p['field']);
-        if (!goog.string.isEmptyOrWhitespace(field)) {
-          params[field] = goog.string.makeSafe(p['value']);
-        }
-      });
+  /**
+   * Remove the selected parameter row.
+   *
+   * @export
+   */
+  removeRow() {
+    if (this['selected'] && this['params']) {
+      olArray.remove(this['params'], this['selected']);
+      this['params'] = this['params'].slice();
+    }
+  }
 
-      // check if any keys have been deleted from the initial values
-      this['initialKeys'].forEach(function(key) {
-        if (!(key in params)) {
-          toDelete.push(key);
-        }
-      });
+  /**
+   * Add a URL.
+   *
+   * @export
+   */
+  addUrl() {
+    if (this['multiUrl'] && this['urls']) {
+      this['urls'].push('');
+    }
+  }
 
-      plugin.params.setParamsForLayer(layer, params, toDelete);
+  /**
+   * Remove a URL.
+   *
+   * @param {number} index The URL index.
+   * @export
+   */
+  removeUrl(index) {
+    if (index != null && this['urls'] && this['urls'].length > index) {
+      this['urls'].splice(index, 1);
+    }
+  }
+
+  /**
+   * Get the label to display for a URL control.
+   *
+   * @param {number} index The URL index.
+   * @return {string} The URL control label.
+   * @export
+   */
+  getUrlLabel(index) {
+    if (this['multiUrl']) {
+      return 'URL ' + (index + 1);
     }
 
-    if (this['urls']) {
-      // skip empty URL's
-      var urls = this['urls'].filter(function(url) {
-        return !goog.string.isEmptyOrWhitespace(url);
-      });
+    return 'URL';
+  }
 
-      if (urls.length > 0) {
-        plugin.params.setUrlsForLayer(layer, urls);
+  /**
+   * Test if the parameters are valid.
+   *
+   * @return {boolean} If all parameters are valid.
+   * @export
+   */
+  testValid() {
+    if (!this['urls'] || this['urls'].length == 0 || this['urls'].every(googString.isEmptyOrWhitespace)) {
+      this['errorMsg'] = (this['multiUrl'] ? 'At least one ' : '') + 'URL must be defined.';
+      return false;
+    }
+
+    if (this['params']) {
+      for (var i = 0; i < this['params'].length; i++) {
+        var p = this['params'][i];
+
+        // if a value is defined but no field, mark as invalid
+        if (!googString.isEmptyOrWhitespace(googString.makeSafe(p['value'])) &&
+            googString.isEmptyOrWhitespace(googString.makeSafe(p['field']))) {
+          this['errorMsg'] = 'Value defined without a Field.';
+          return false;
+        }
       }
     }
+
+    this['errorMsg'] = '';
+    return true;
   }
-
-  this.close();
-};
-
-
-/**
- * Close the window.
- *
- * @protected
- */
-plugin.params.EditRequestParamsCtrl.prototype.close = function() {
-  os.ui.window.close(this.element);
-};
-
-
-/**
- * Add a new parameter row.
- *
- * @export
- */
-plugin.params.EditRequestParamsCtrl.prototype.addRow = function() {
-  if (this['params']) {
-    this['params'] = this['params'].concat([{
-      'id': this.nextId_++,
-      'field': '',
-      'value': ''
-    }]);
-  }
-};
-
-
-/**
- * Remove the selected parameter row.
- *
- * @export
- */
-plugin.params.EditRequestParamsCtrl.prototype.removeRow = function() {
-  if (this['selected'] && this['params']) {
-    ol.array.remove(this['params'], this['selected']);
-    this['params'] = this['params'].slice();
-  }
-};
-
-
-/**
- * Add a URL.
- *
- * @export
- */
-plugin.params.EditRequestParamsCtrl.prototype.addUrl = function() {
-  if (this['multiUrl'] && this['urls']) {
-    this['urls'].push('');
-  }
-};
-
-
-/**
- * Remove a URL.
- *
- * @param {number} index The URL index.
- * @export
- */
-plugin.params.EditRequestParamsCtrl.prototype.removeUrl = function(index) {
-  if (index != null && this['urls'] && this['urls'].length > index) {
-    this['urls'].splice(index, 1);
-  }
-};
-
-
-/**
- * Get the label to display for a URL control.
- *
- * @param {number} index The URL index.
- * @return {string} The URL control label.
- * @export
- */
-plugin.params.EditRequestParamsCtrl.prototype.getUrlLabel = function(index) {
-  if (this['multiUrl']) {
-    return 'URL ' + (index + 1);
-  }
-
-  return 'URL';
-};
-
-
-/**
- * Test if the parameters are valid.
- *
- * @return {boolean} If all parameters are valid.
- * @export
- */
-plugin.params.EditRequestParamsCtrl.prototype.testValid = function() {
-  if (!this['urls'] || this['urls'].length == 0 || this['urls'].every(goog.string.isEmptyOrWhitespace)) {
-    this['errorMsg'] = (this['multiUrl'] ? 'At least one ' : '') + 'URL must be defined.';
-    return false;
-  }
-
-  if (this['params']) {
-    for (var i = 0; i < this['params'].length; i++) {
-      var p = this['params'][i];
-
-      // if a value is defined but no field, mark as invalid
-      if (!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(p['value'])) &&
-          goog.string.isEmptyOrWhitespace(goog.string.makeSafe(p['field']))) {
-        this['errorMsg'] = 'Value defined without a Field.';
-        return false;
-      }
-    }
-  }
-
-  this['errorMsg'] = '';
-  return true;
-};
+}
 
 
 /**
@@ -335,7 +338,7 @@ plugin.params.EditRequestParamsCtrl.prototype.testValid = function() {
  * @param {!ol.layer.Layer} layer The layer.
  * @param {Object} params The current layer params.
  */
-plugin.params.launchParamsEdit = function(layer, params) {
+const launchParamsEdit = function(layer, params) {
   var winLabel = 'Edit Parameters';
   var windowId = 'editParams';
 
@@ -363,5 +366,12 @@ plugin.params.launchParamsEdit = function(layer, params) {
   };
 
   var template = '<editrequestparams layer="layer" params="params"></editrequestparams>';
-  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+  osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+};
+
+exports = {
+  Controller,
+  directive,
+  directiveTag,
+  launchParamsEdit
 };

--- a/src/plugin/params/paramsmenu.js
+++ b/src/plugin/params/paramsmenu.js
@@ -1,81 +1,85 @@
-goog.provide('plugin.params.menu');
+goog.module('plugin.params.menu');
 
-goog.require('os.implements');
-goog.require('os.ol.source.IUrlSource');
-goog.require('os.ui.menu.layer');
-goog.require('plugin.params');
-goog.require('plugin.params.editRequestParamsDirective');
+const asserts = goog.require('goog.asserts');
+const Layer = goog.require('ol.layer.Layer');
+const AlertManager = goog.require('os.alert.AlertManager');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const layerMenu = goog.require('os.ui.menu.layer');
+const pluginParams = goog.require('plugin.params');
+const {launchParamsEdit} = goog.require('plugin.params.EditRequestParamsUI');
 
 
 /**
  * Set up params menu items in the layer menu.
  */
-plugin.params.menu.layerSetup = function() {
-  var menu = os.ui.menu.layer.MENU;
-  if (menu && !menu.getRoot().find(plugin.params.EventType.EDIT_PARAMS)) {
-    var group = menu.getRoot().find(os.ui.menu.layer.GroupLabel.LAYER);
-    goog.asserts.assert(group, 'Group should exist! Check spelling?');
+const layerSetup = function() {
+  var menu = layerMenu.MENU;
+  if (menu && !menu.getRoot().find(pluginParams.EventType.EDIT_PARAMS)) {
+    var group = menu.getRoot().find(layerMenu.GroupLabel.LAYER);
+    asserts.assert(group, 'Group should exist! Check spelling?');
 
     group.addChild({
       label: 'Edit Parameters...',
-      eventType: plugin.params.EventType.EDIT_PARAMS,
+      eventType: pluginParams.EventType.EDIT_PARAMS,
       tooltip: 'Edit request parameters for the layer',
       icons: ['<i class="fa fa-fw fa-gears"></i>'],
-      beforeRender: plugin.params.menu.visibleIfSupported_,
-      handler: plugin.params.menu.handleLayerAction_,
-      metricKey: plugin.params.Metrics.EDIT_PARAMS
+      beforeRender: visibleIfSupported_,
+      handler: handleLayerAction_,
+      metricKey: pluginParams.Metrics.EDIT_PARAMS
     });
   }
 };
 
-
 /**
  * Clean up params menu items in the layer menu.
  */
-plugin.params.menu.layerDispose = function() {
-  var menu = os.ui.menu.layer.MENU;
-  if (menu && !menu.getRoot().find(plugin.params.EventType.EDIT_PARAMS)) {
-    var group = menu.getRoot().find(os.ui.menu.layer.GroupLabel.LAYER);
+const layerDispose = function() {
+  var menu = layerMenu.MENU;
+  if (menu && !menu.getRoot().find(pluginParams.EventType.EDIT_PARAMS)) {
+    var group = menu.getRoot().find(layerMenu.GroupLabel.LAYER);
     if (group) {
-      group.removeChild(plugin.params.EventType.EDIT_PARAMS);
+      group.removeChild(pluginParams.EventType.EDIT_PARAMS);
     }
   }
 };
-
 
 /**
  * Test if an event context supports editing layer request parameters.
  *
- * @param {os.ui.menu.layer.Context} context The menu context.
+ * @param {layerMenu.Context} context The menu context.
  * @this {os.ui.menu.MenuItem}
  */
-plugin.params.menu.visibleIfSupported_ = function(context) {
+const visibleIfSupported_ = function(context) {
   this.visible = false;
 
   // only allow editing parameters for one layer at a time
   if (context && context.length === 1) {
-    var layers = os.ui.menu.layer.getLayersFromContext(context);
-    if (layers && layers.length === 1 && layers[0] instanceof ol.layer.Layer) {
-      this.visible = plugin.params.supportsParamOverrides(/** @type {!ol.layer.Layer} */ (layers[0]));
+    var layers = layerMenu.getLayersFromContext(context);
+    if (layers && layers.length === 1 && layers[0] instanceof Layer) {
+      this.visible = pluginParams.supportsParamOverrides(/** @type {!ol.layer.Layer} */ (layers[0]));
     }
   }
 };
 
-
 /**
  * Handle params event from the layer menu.
  *
- * @param {!os.ui.menu.MenuEvent<os.ui.menu.layer.Context>} event The menu event.
- * @private
+ * @param {!os.ui.menu.MenuEvent<layerMenu.Context>} event The menu event.
  */
-plugin.params.menu.handleLayerAction_ = function(event) {
-  var layers = os.ui.menu.layer.getLayersFromContext(event.getContext());
-  if (layers && layers.length === 1 && layers[0] instanceof ol.layer.Layer) {
+const handleLayerAction_ = function(event) {
+  var layers = layerMenu.getLayersFromContext(event.getContext());
+  if (layers && layers.length === 1 && layers[0] instanceof Layer) {
     var layer = /** @type {!ol.layer.Layer} */ (layers[0]);
-    var params = plugin.params.getParamsFromLayer(layer);
-    plugin.params.launchParamsEdit(layer, params);
+    var params = pluginParams.getParamsFromLayer(layer);
+    launchParamsEdit(layer, params);
   } else {
-    os.alertManager.sendAlert('Unexpected layer selection. Please select a single layer and try again.',
-        os.alert.AlertEventSeverity.WARNING);
+    AlertManager.getInstance().sendAlert('Unexpected layer selection. Please select a single layer and try again.',
+        AlertEventSeverity.WARNING);
   }
+};
+
+exports = {
+  layerSetup,
+  layerDispose,
+  visibleIfSupported_
 };

--- a/src/plugin/params/paramsplugin.js
+++ b/src/plugin/params/paramsplugin.js
@@ -1,39 +1,65 @@
-goog.provide('plugin.params.ParamsPlugin');
+goog.module('plugin.params.ParamsPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.plugin.AbstractPlugin');
-goog.require('plugin.params');
-goog.require('plugin.params.menu');
-
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const params = goog.require('plugin.params');
+const menu = goog.require('plugin.params.menu');
 
 
 /**
  * Allow changing request parameters for layers in opensphere
- *
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.params.ParamsPlugin = function() {
-  plugin.params.ParamsPlugin.base(this, 'constructor');
+class ParamsPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
 
-  this.id = plugin.params.ID;
-  this.errorMessage = null;
-};
-goog.inherits(plugin.params.ParamsPlugin, os.plugin.AbstractPlugin);
-goog.addSingletonGetter(plugin.params.ParamsPlugin);
+    this.id = params.ID;
+    this.errorMessage = null;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
+    menu.layerDispose();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    menu.layerSetup();
+  }
+
+  /**
+   * Get the global instance.
+   * @return {!ParamsPlugin}
+   */
+  static getInstance() {
+    if (!instance) {
+      instance = new ParamsPlugin();
+    }
+
+    return instance;
+  }
+
+  /**
+   * Set the global instance.
+   * @param {ParamsPlugin} value
+   */
+  static setInstance(value) {
+    instance = value;
+  }
+}
 
 /**
- * @inheritDoc
+ * Global instance.
+ * @type {ParamsPlugin|undefined}
  */
-plugin.params.ParamsPlugin.prototype.disposeInternal = function() {
-  plugin.params.ParamsPlugin.base(this, 'disposeInternal');
-  plugin.params.menu.layerDispose();
-};
+let instance;
 
-
-/**
- * @inheritDoc
- */
-plugin.params.ParamsPlugin.prototype.init = function() {
-  plugin.params.menu.layerSetup();
-};
+exports = ParamsPlugin;

--- a/src/plugin/storage/persistplugin.js
+++ b/src/plugin/storage/persistplugin.js
@@ -4,9 +4,13 @@ goog.module.declareLegacyNamespace();
 const browser = goog.require('goog.labs.userAgent.browser');
 const log = goog.require('goog.log');
 const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const alertManager = goog.require('os.alert.AlertManager');
+const settings = goog.require('os.config.Settings');
 const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
 const Metrics = goog.require('os.metrics.Metrics');
 const {launchConfirm} = goog.require('os.ui.window.ConfirmUI');
+
+
 const LOGGER_ = log.getLogger('PersistPlugin');
 
 const PERSISTENCE_SUCCEEDED = 'storage.persistence.succeeded';
@@ -33,7 +37,7 @@ class PersistPlugin extends AbstractPlugin {
   init() {
     const msgs = [];
     const metrics = Metrics.getInstance();
-    const helpUrl = os.settings.get('plugin.storage.persistenceHelp', 'https://web.dev/persistent-storage/');
+    const helpUrl = settings.getInstance().get('plugin.storage.persistenceHelp', 'https://web.dev/persistent-storage/');
 
     if (navigator.storage && navigator.storage.persist) {
       navigator.storage.persisted().then((result) => {
@@ -49,7 +53,7 @@ class PersistPlugin extends AbstractPlugin {
 
               if (userDecision) {
                 msgs.push(`By declining persistent storage, your application settings may be automatically
-                  reset when under storage pressure (the conditions for that event vary by browser). Get more info 
+                  reset when under storage pressure (the conditions for that event vary by browser). Get more info
                   <a href="${helpUrl}" rel="noopener" target="_blank">here</a>`);
                 this.log(msgs);
                 metrics.updateMetric(PERSISTENCE_DECLINED, 1);
@@ -83,7 +87,7 @@ class PersistPlugin extends AbstractPlugin {
                   }
                 }
               } else {
-                msgs.push(`Browser automatically declined persistence. Get more info 
+                msgs.push(`Browser automatically declined persistence. Get more info
                   <a href="${helpUrl}" rel="noopener" target="_blank">here</a>`);
                 this.log(msgs);
                 metrics.updateMetric(PERSISTENCE_DECLINED, 1);
@@ -106,7 +110,7 @@ class PersistPlugin extends AbstractPlugin {
             will be automatically declined. `;
       }
 
-      msg += `Your application settings may be automatically reset when under storage pressure. Get more info 
+      msg += `Your application settings may be automatically reset when under storage pressure. Get more info
         <a href="${helpUrl}" rel="noopener" target="_blank">here</a>`;
       msgs.push(msg);
 
@@ -122,7 +126,7 @@ class PersistPlugin extends AbstractPlugin {
    */
   logOne(msg) {
     log.warning(LOGGER_, msg);
-    os.alertManager.sendAlert(msg, AlertEventSeverity.WARNING);
+    alertManager.getInstance().sendAlert(msg, AlertEventSeverity.WARNING);
   }
 
   /**

--- a/src/plugin/vectortile/doubleclickinteraction.js
+++ b/src/plugin/vectortile/doubleclickinteraction.js
@@ -14,6 +14,7 @@ const I3DSupport = goog.require('os.I3DSupport');
 const MapContainer = goog.require('os.MapContainer');
 const osImplements = goog.require('os.implements');
 const VectorTile = goog.require('os.layer.VectorTile');
+const launchMultiFeatureInfo = goog.require('os.ui.feature.launchMultiFeatureInfo');
 
 const Feature = goog.requireType('ol.Feature');
 const MapBrowserEvent = goog.requireType('ol.MapBrowserEvent');
@@ -122,7 +123,7 @@ const handleEvent = (mapBrowserEvent) => {
     }
 
     if (features.length > 0) {
-      os.ui.feature.launchMultiFeatureInfo(features.slice());
+      launchMultiFeatureInfo(features.slice());
     }
   }
 

--- a/src/plugin/vectortools/copylayercmd.js
+++ b/src/plugin/vectortools/copylayercmd.js
@@ -1,69 +1,75 @@
-goog.provide('plugin.vectortools.CopyLayer');
+goog.module('plugin.vectortools.CopyLayer');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.command.AbstractSource');
-goog.require('os.command.ICommand');
-goog.require('os.command.State');
+const MapContainer = goog.require('os.MapContainer');
+const VectorSource = goog.require('os.source.Vector');
+const vectortools = goog.require('plugin.vectortools');
 
+const AbstractSource = goog.require('os.command.AbstractSource');
+const State = goog.require('os.command.State');
+const ICommand = goog.requireType('os.command.ICommand');
 
 
 /**
  * Command for copying a vector layer
  *
- * @constructor
- * @implements {os.command.ICommand}
- * @extends {os.command.AbstractSource}
- * @param {!string} sourceId The data source ID to copy
- * @param {plugin.vectortools.Options=} opt_options The feature options
+ * @implements {ICommand}
  */
-plugin.vectortools.CopyLayer = function(sourceId, opt_options) {
-  plugin.vectortools.CopyLayer.base(this, 'constructor', sourceId);
-  this.title = 'Copy Layer';
-  this.newLayerId_ = '';
-  this.options_ = opt_options;
-};
-goog.inherits(plugin.vectortools.CopyLayer, os.command.AbstractSource);
-
-
-/**
- * @inheritDoc
- */
-plugin.vectortools.CopyLayer.prototype.execute = function() {
-  if (this.canExecute()) {
-    this.state = os.command.State.EXECUTING;
-
-    var s = this.getSource();
-    if (s instanceof os.source.Vector) {
-      var source = /** @type {os.source.Vector} */ (s);
-
-      // add the new layer
-      var newLayer = plugin.vectortools.addNewLayer(source.getId());
-
-      // keep track of its ID, use it for revert
-      var newSource = /** @type {os.source.Vector} */ (newLayer.getSource());
-      this.newLayerId_ = newSource.getId();
-
-      // get a cloning function and use it to do the feature copy
-      var cloneFunc = plugin.vectortools.getFeatureCloneFunction(this.newLayerId_);
-      var features = plugin.vectortools.getFeatures(source, this.options_);
-      newSource.addFeatures(features.map(cloneFunc));
-
-      this.state = os.command.State.SUCCESS;
-      return true;
-    }
+class CopyLayer extends AbstractSource {
+  /**
+   * Constructor.
+   * @param {!string} sourceId The data source ID to copy
+   * @param {plugin.vectortools.Options=} opt_options The feature options
+   */
+  constructor(sourceId, opt_options) {
+    super(sourceId);
+    this.title = 'Copy Layer';
+    this.newLayerId_ = '';
+    this.options_ = opt_options;
   }
 
-  return false;
-};
+  /**
+   * @inheritDoc
+   */
+  execute() {
+    if (this.canExecute()) {
+      this.state = State.EXECUTING;
 
+      var s = this.getSource();
+      if (s instanceof VectorSource) {
+        var source = /** @type {os.source.Vector} */ (s);
 
-/**
- * @inheritDoc
- */
-plugin.vectortools.CopyLayer.prototype.revert = function() {
-  this.state = os.command.State.REVERTING;
+        // add the new layer
+        var newLayer = vectortools.addNewLayer(source.getId());
 
-  // remove the layer by the layerId
-  os.MapContainer.getInstance().removeLayer(this.newLayerId_);
-  this.state = os.command.State.READY;
-  return true;
-};
+        // keep track of its ID, use it for revert
+        var newSource = /** @type {os.source.Vector} */ (newLayer.getSource());
+        this.newLayerId_ = newSource.getId();
+
+        // get a cloning function and use it to do the feature copy
+        var cloneFunc = vectortools.getFeatureCloneFunction(this.newLayerId_);
+        var features = vectortools.getFeatures(source, this.options_);
+        newSource.addFeatures(features.map(cloneFunc));
+
+        this.state = State.SUCCESS;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  revert() {
+    this.state = State.REVERTING;
+
+    // remove the layer by the layerId
+    MapContainer.getInstance().removeLayer(this.newLayerId_);
+    this.state = State.READY;
+    return true;
+  }
+}
+
+exports = CopyLayer;

--- a/src/plugin/vectortools/icons.js
+++ b/src/plugin/vectortools/icons.js
@@ -1,0 +1,13 @@
+goog.module('plugin.vectortools.Icons');
+goog.module.declareLegacyNamespace();
+
+
+/**
+ * Icons for the vectortools actions.
+ * @enum {string}
+ */
+exports = {
+  COPY_ICON: 'fa-copy',
+  MERGE_ICON: 'fa-compress',
+  JOIN_ICON: 'fa-object-group'
+};

--- a/src/plugin/vectortools/joinlayercmd.js
+++ b/src/plugin/vectortools/joinlayercmd.js
@@ -1,300 +1,299 @@
-goog.provide('plugin.vectortools.JoinLayer');
+goog.module('plugin.vectortools.JoinLayer');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.array');
-goog.require('os.command.AbstractSource');
-goog.require('os.command.ICommand');
-goog.require('os.command.State');
-
+const asserts = goog.require('goog.asserts');
+const MapContainer = goog.require('os.MapContainer');
+const osArray = goog.require('os.array');
+const AbstractSource = goog.require('os.command.AbstractSource');
+const State = goog.require('os.command.State');
+const ICommand = goog.requireType('os.command.ICommand');
+const RecordField = goog.require('os.data.RecordField');
+const layer = goog.require('os.layer');
+const vectortools = goog.require('plugin.vectortools');
 
 
 /**
  * Command for copying a vector layer
  *
- * @constructor
- * @implements {os.command.ICommand}
- * @extends {os.command.AbstractSource}
- * @param {!Array<string>} sourceIds The data source ID to join
- * @param {!Array<string>} indexFields The field to use as the join index on each source
- * @param {string} indexerType The type of indexer this command uses
- * @param {string=} opt_name Optional name to give the merged layer
- * @param {plugin.vectortools.Options=} opt_options The feature options
+ * @implements {ICommand}
  */
-plugin.vectortools.JoinLayer = function(sourceIds, indexFields, indexerType, opt_name, opt_options) {
-  goog.asserts.assert(sourceIds && indexFields && sourceIds.length === indexFields.length,
-      'Argument error! sourceIds and indexFields must be present and have equal lengths');
-
+class JoinLayer extends AbstractSource {
   /**
-   * @type {Array<string>}
-   * @private
+   * Constructor.
+   * @param {!Array<string>} sourceIds The data source ID to join
+   * @param {!Array<string>} indexFields The field to use as the join index on each source
+   * @param {string} indexerType The type of indexer this command uses
+   * @param {string=} opt_name Optional name to give the merged layer
+   * @param {plugin.vectortools.Options=} opt_options The feature options
    */
-  this.sourceIds_ = sourceIds;
+  constructor(sourceIds, indexFields, indexerType, opt_name, opt_options) {
+    asserts.assert(sourceIds && indexFields && sourceIds.length === indexFields.length,
+        'Argument error! sourceIds and indexFields must be present and have equal lengths');
 
-  /**
-   * @type {Array<string>}
-   * @private
-   */
-  this.indexFields_ = indexFields;
+    super(sourceIds[0]);
+    this.title = 'Join Layer';
 
-  /**
-   * @type {string}
-   * @private
-   */
-  this.indexerType_ = indexerType;
+    /**
+     * @type {Array<string>}
+     * @private
+     */
+    this.sourceIds_ = sourceIds;
 
-  var exact = plugin.vectortools.JoinLayer.exactAccessor_;
-  var caseInsensitive = plugin.vectortools.JoinLayer.caseInsensitiveAccessor_;
+    /**
+     * @type {Array<string>}
+     * @private
+     */
+    this.indexFields_ = indexFields;
 
-  /**
-   * @type {Object<string, function(string):function(Object):(number|string)>}
-   * @private
-   */
-  this.indexers_ = {
-    'unique': this.getUniqueIndexer(exact),
-    'contains': this.getContainsIndexer(exact),
-    'uniqueCaseInsensitive': this.getUniqueIndexer(caseInsensitive),
-    'containsCaseInsensitive': this.getContainsIndexer(caseInsensitive)
-  };
+    /**
+     * @type {string}
+     * @private
+     */
+    this.indexerType_ = indexerType;
 
-  this.options_ = opt_options;
+    var exact = JoinLayer.exactAccessor_;
+    var caseInsensitive = JoinLayer.caseInsensitiveAccessor_;
 
-  plugin.vectortools.JoinLayer.base(this, 'constructor', sourceIds[0]);
-  this.title = 'Join Layer';
+    /**
+     * @type {Object<string, function(string):function(Object):(number|string)>}
+     * @private
+     */
+    this.indexers_ = {
+      'unique': this.getUniqueIndexer(exact),
+      'contains': this.getContainsIndexer(exact),
+      'uniqueCaseInsensitive': this.getUniqueIndexer(caseInsensitive),
+      'containsCaseInsensitive': this.getContainsIndexer(caseInsensitive)
+    };
 
-  /**
-   * @type {?string}
-   * @private
-   */
-  this.newLayerId_ = null;
+    this.options_ = opt_options;
 
-  /**
-   * @type {string}
-   * @private
-   */
-  this.newLayerName_ = os.layer.getUniqueTitle(opt_name || 'Joined Layer');
-};
-goog.inherits(plugin.vectortools.JoinLayer, os.command.AbstractSource);
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.newLayerId_ = null;
 
-
-/**
- * @inheritDoc
- */
-plugin.vectortools.JoinLayer.prototype.execute = function() {
-  if (this.canExecute()) {
-    this.state = os.command.State.EXECUTING;
-
-    var sources = this.sourceIds_.map(this.mapSources_, this);
-    if (sources) {
-      var newLayer = plugin.vectortools.addNewLayer(sources[0].getId());
-      var newSource = /** @type {os.source.Vector} */ (newLayer.getSource());
-
-      this.newLayerId_ = newSource.getId();
-      newLayer.setTitle(this.newLayerName_);
-      newSource.setTitle(this.newLayerName_);
-
-      var columnAssocs = plugin.vectortools.getColumnMappings(this.sourceIds_);
-      newSource.setColumns(plugin.vectortools.getCombinedColumns(sources, columnAssocs));
-      var indexers = this.indexFields_.map(this.getIndexer_());
-      var cloneFunc = plugin.vectortools.getFeatureCloneFunction(this.newLayerId_);
-      var options = this.options_;
-
-      var sets = sources.map(
-          /**
-           * @param {os.source.Vector} source The source
-           * @param {number} i The source index
-           * @return {os.array.JoinSet}
-           */
-          function(source, i) {
-            var features = plugin.vectortools.getFeatures(source, options);
-            var data = i === 0 ? features.map(cloneFunc) : features;
-            return {
-              data: data,
-              crossProduct: i === 0,
-              indexer: indexers[i]
-            };
-          });
-
-      var features = os.array.join(sets, this.getCopier_(columnAssocs));
-      newSource.addFeatures(features);
-      this.state = os.command.State.SUCCESS;
-      return true;
-    }
+    /**
+     * @type {string}
+     * @private
+     */
+    this.newLayerName_ = layer.getUniqueTitle(opt_name || 'Joined Layer');
   }
 
-  return false;
-};
+  /**
+   * @inheritDoc
+   */
+  execute() {
+    if (this.canExecute()) {
+      this.state = State.EXECUTING;
 
+      var sources = this.sourceIds_.map(this.mapSources_, this);
+      if (sources) {
+        var newLayer = vectortools.addNewLayer(sources[0].getId());
+        var newSource = /** @type {os.source.Vector} */ (newLayer.getSource());
 
-/**
- * @return {function(string):function(Object):(number|string)}
- * @private
- */
-plugin.vectortools.JoinLayer.prototype.getIndexer_ = function() {
-  return this.indexers_[this.indexerType_] || this.uniqueIndexer_;
-};
+        this.newLayerId_ = newSource.getId();
+        newLayer.setTitle(this.newLayerName_);
+        newSource.setTitle(this.newLayerName_);
 
+        var columnAssocs = vectortools.getColumnMappings(this.sourceIds_);
+        newSource.setColumns(vectortools.getCombinedColumns(sources, columnAssocs));
+        var indexers = this.indexFields_.map(this.getIndexer_());
+        var cloneFunc = vectortools.getFeatureCloneFunction(this.newLayerId_);
+        var options = this.options_;
 
-/**
- * @param {Object} obj
- * @param {string} field
- * @return {string|number}
- * @private
- */
-plugin.vectortools.JoinLayer.exactAccessor_ = function(obj, field) {
-  return /** @type {string|number} */ (/** @type {ol.Feature} */ (obj).get(field));
-};
+        var sets = sources.map(
+            /**
+             * @param {os.source.Vector} source The source
+             * @param {number} i The source index
+             * @return {osArray.JoinSet}
+             */
+            function(source, i) {
+              var features = vectortools.getFeatures(source, options);
+              var data = i === 0 ? features.map(cloneFunc) : features;
+              return {
+                data: data,
+                crossProduct: i === 0,
+                indexer: indexers[i]
+              };
+            });
 
+        var features = osArray.join(sets, this.getCopier_(columnAssocs));
+        newSource.addFeatures(features);
+        this.state = State.SUCCESS;
+        return true;
+      }
+    }
 
-/**
- * @param {Object} obj
- * @param {string} field
- * @return {string|number}
- * @private
- */
-plugin.vectortools.JoinLayer.caseInsensitiveAccessor_ = function(obj, field) {
-  var val = /** @type {string|number} */ (/** @type {ol.Feature} */ (obj).get(field));
-  return val ? val.toString().toLowerCase() : val;
-};
+    return false;
+  }
 
+  /**
+   * @return {function(string):function(Object):(number|string)}
+   * @private
+   */
+  getIndexer_() {
+    return this.indexers_[this.indexerType_];
+  }
 
-/**
- * @param {function(Object, string):(number|string)} accessorFunction
- * @return {function(string):function(Object):(number|string)}
- * @protected
- */
-plugin.vectortools.JoinLayer.prototype.getUniqueIndexer = function(accessorFunction) {
-  return (
-    /**
-     * @param {string} field
-     * @return {function(Object):(number|string)} index function
-     * @private
-     */
-    function(field) {
+  /**
+   * @param {function(Object, string):(number|string)} accessorFunction
+   * @return {function(string):function(Object):(number|string)}
+   * @protected
+   */
+  getUniqueIndexer(accessorFunction) {
+    return (
       /**
-       * @param {Object} obj
-       * @return {number|string} the index value
+       * @param {string} field
+       * @return {function(Object):(number|string)} index function
+       * @private
        */
-      var indexer = function(obj) {
-        return accessorFunction(obj, field);
-      };
+      function(field) {
+        /**
+         * @param {Object} obj
+         * @return {number|string} the index value
+         */
+        var indexer = function(obj) {
+          return accessorFunction(obj, field);
+        };
 
-      return indexer;
-    });
-};
+        return indexer;
+      });
+  }
 
+  /**
+   * @param {function(Object, string):(number|string)} accessorFunction
+   * @return {function(string):function(Object, boolean):(number|string)}
+   * @protected
+   */
+  getContainsIndexer(accessorFunction) {
+    var memoryIndex = [];
 
-/**
- * @param {function(Object, string):(number|string)} accessorFunction
- * @return {function(string):function(Object, boolean):(number|string)}
- * @protected
- */
-plugin.vectortools.JoinLayer.prototype.getContainsIndexer = function(accessorFunction) {
-  var memoryIndex = [];
-
-  return (
-    /**
-     * @param {string} field
-     * @return {function(Object, boolean):(number|string)} index function
-     * @private
-     */
-    function(field) {
+    return (
       /**
-       * @param {Object} obj
-       * @param {boolean} crossProduct
-       * @return {number|string} the index value
+       * @param {string} field
+       * @return {function(Object, boolean):(number|string)} index function
+       * @private
        */
-      var indexer = function(obj, crossProduct) {
-        var val = accessorFunction(obj, field);
-        if (crossProduct && memoryIndex.indexOf(val) == -1) {
-          memoryIndex.push(val);
-        } else if (val) {
-          for (var i = 0, ii = memoryIndex.length; i < ii; i++) {
-            var mem = memoryIndex[i];
-            if (mem && mem.indexOf(val) != -1 || val.indexOf(mem) != -1) {
-              return mem;
+      function(field) {
+        /**
+         * @param {Object} obj
+         * @param {boolean} crossProduct
+         * @return {number|string} the index value
+         */
+        var indexer = function(obj, crossProduct) {
+          var val = accessorFunction(obj, field);
+          if (crossProduct && memoryIndex.indexOf(val) == -1) {
+            memoryIndex.push(val);
+          } else if (val) {
+            for (var i = 0, ii = memoryIndex.length; i < ii; i++) {
+              var mem = memoryIndex[i];
+              if (mem && mem.indexOf(val) != -1 || val.indexOf(mem) != -1) {
+                return mem;
+              }
             }
           }
-        }
 
-        return val;
-      };
+          return val;
+        };
 
-      return indexer;
-    });
-};
-
-
-
-/**
- * @param {?Object<string, Object<string, string>>} columnAssocs Columns to transform by sourceId
- * @return {function(Object, Object):Object} the copy function for the join operation
- * @private
- * @suppress {accessControls}
- */
-plugin.vectortools.JoinLayer.prototype.getCopier_ = function(columnAssocs) {
-  /**
-   * @param {Object} from Object to copy from
-   * @param {Object} to Object to copy to
-   * @return {Object} resulting object
-   */
-  var copy = function(from, to) {
-    var featureFrom = /** @type {ol.Feature} */ (from);
-    var featureTo = /** @type {ol.Feature} */ (to);
-
-    // non-destructive copy
-    var fromValues = featureFrom.values_;
-    var toValues = featureTo.values_;
-    for (var key in fromValues) {
-      if (toValues[key] === undefined) {
-        toValues[key] = fromValues[key];
-      }
-    }
-
-    if (columnAssocs) {
-      var sourceFrom = /** @type {string} */ (featureFrom.get(os.data.RecordField.SOURCE_ID));
-      var sourceTo = /** @type {string} */ (featureTo.get(os.data.RecordField.SOURCE_ID));
-
-      var assocs = [];
-      if (sourceFrom && columnAssocs[sourceFrom]) {
-        assocs.push(columnAssocs[sourceFrom]);
-      }
-
-      if (sourceTo && columnAssocs[sourceTo]) {
-        assocs.push(columnAssocs[sourceTo]);
-      }
-
-      for (var i = 0, n = assocs.length; i < n; i++) {
-        plugin.vectortools.runColumnMapping(assocs[i], featureTo);
-      }
-    }
-
-    return featureTo;
-  };
-
-  return copy;
-};
-
-
-/**
- * @param {string} id The source id
- * @return {os.source.Vector}
- * @private
- */
-plugin.vectortools.JoinLayer.prototype.mapSources_ = function(id) {
-  this.sourceId = id;
-  return /** @type {os.source.Vector} */ (this.getSource());
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.vectortools.JoinLayer.prototype.revert = function() {
-  this.state = os.command.State.REVERTING;
-
-  if (this.newLayerId_) {
-    os.MapContainer.getInstance().removeLayer(this.newLayerId_);
+        return indexer;
+      });
   }
 
-  this.state = os.command.State.READY;
-  return true;
-};
+  /**
+   * @param {?Object<string, Object<string, string>>} columnAssocs Columns to transform by sourceId
+   * @return {function(Object, Object):Object} the copy function for the join operation
+   * @private
+   * @suppress {accessControls}
+   */
+  getCopier_(columnAssocs) {
+    /**
+     * @param {Object} from Object to copy from
+     * @param {Object} to Object to copy to
+     * @return {Object} resulting object
+     */
+    var copy = function(from, to) {
+      var featureFrom = /** @type {ol.Feature} */ (from);
+      var featureTo = /** @type {ol.Feature} */ (to);
+
+      // non-destructive copy
+      var fromValues = featureFrom.values_;
+      var toValues = featureTo.values_;
+      for (var key in fromValues) {
+        if (toValues[key] === undefined) {
+          toValues[key] = fromValues[key];
+        }
+      }
+
+      if (columnAssocs) {
+        var sourceFrom = /** @type {string} */ (featureFrom.get(RecordField.SOURCE_ID));
+        var sourceTo = /** @type {string} */ (featureTo.get(RecordField.SOURCE_ID));
+
+        var assocs = [];
+        if (sourceFrom && columnAssocs[sourceFrom]) {
+          assocs.push(columnAssocs[sourceFrom]);
+        }
+
+        if (sourceTo && columnAssocs[sourceTo]) {
+          assocs.push(columnAssocs[sourceTo]);
+        }
+
+        for (var i = 0, n = assocs.length; i < n; i++) {
+          vectortools.runColumnMapping(assocs[i], featureTo);
+        }
+      }
+
+      return featureTo;
+    };
+
+    return copy;
+  }
+
+  /**
+   * @param {string} id The source id
+   * @return {os.source.Vector}
+   * @private
+   */
+  mapSources_(id) {
+    this.sourceId = id;
+    return /** @type {os.source.Vector} */ (this.getSource());
+  }
+
+  /**
+   * @inheritDoc
+   */
+  revert() {
+    this.state = State.REVERTING;
+
+    if (this.newLayerId_) {
+      MapContainer.getInstance().removeLayer(this.newLayerId_);
+    }
+
+    this.state = State.READY;
+    return true;
+  }
+
+  /**
+   * @param {Object} obj
+   * @param {string} field
+   * @return {string|number}
+   * @private
+   */
+  static exactAccessor_(obj, field) {
+    return /** @type {string|number} */ (/** @type {ol.Feature} */ (obj).get(field));
+  }
+
+  /**
+   * @param {Object} obj
+   * @param {string} field
+   * @return {string|number}
+   * @private
+   */
+  static caseInsensitiveAccessor_(obj, field) {
+    var val = /** @type {string|number} */ (/** @type {ol.Feature} */ (obj).get(field));
+    return val ? val.toString().toLowerCase() : val;
+  }
+}
+
+exports = JoinLayer;

--- a/src/plugin/vectortools/joinwindow.js
+++ b/src/plugin/vectortools/joinwindow.js
@@ -1,5 +1,4 @@
 goog.module('plugin.vectortools.JoinUI');
-goog.module.declareLegacyNamespace();
 
 goog.require('os.ui.util.validationMessageDirective');
 goog.require('plugin.vectortools.MappingCounterUI');

--- a/src/plugin/vectortools/joinwindow.js
+++ b/src/plugin/vectortools/joinwindow.js
@@ -1,270 +1,280 @@
-goog.provide('plugin.vectortools.JoinCtrl');
-goog.provide('plugin.vectortools.joinDirective');
+goog.module('plugin.vectortools.JoinUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.array');
-goog.require('os');
-goog.require('os.data.OSDataManager');
-goog.require('os.data.SourceManager');
-goog.require('os.ui.Module');
 goog.require('os.ui.util.validationMessageDirective');
-goog.require('os.ui.window');
-goog.require('plugin.vectortools.JoinLayer');
-goog.require('plugin.vectortools.mappingCounterDirective');
+goog.require('plugin.vectortools.MappingCounterUI');
+
+const googString = goog.require('goog.string');
+const CommandProcessor = goog.require('os.command.CommandProcessor');
+const ogc = goog.require('os.ogc');
+const PropertyChange = goog.require('os.source.PropertyChange');
+const ui = goog.require('os.ui');
+const WindowEventType = goog.require('os.ui.WindowEventType');
+
+const olArray = goog.require('ol.array');
+const os = goog.require('os');
+const SourceManager = goog.require('os.data.SourceManager');
+const Module = goog.require('os.ui.Module');
+const osWindow = goog.require('os.ui.window');
+const JoinLayer = goog.require('plugin.vectortools.JoinLayer');
 
 
 /**
  * @return {angular.Directive}
  */
-plugin.vectortools.joinDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    scope: true,
-    templateUrl: os.ROOT + 'views/plugin/vectortools/join.html',
-    controller: plugin.vectortools.JoinCtrl,
-    controllerAs: 'ctrl'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  scope: true,
+  templateUrl: os.ROOT + 'views/plugin/vectortools/join.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'join';
 
 
 // add the directive to the module
-os.ui.Module.directive('join', [plugin.vectortools.joinDirective]);
+Module.directive(directiveTag, [directive]);
 
 
 
 /**
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @extends {os.data.SourceManager}
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.vectortools.JoinCtrl = function($scope, $element) {
-  plugin.vectortools.JoinCtrl.base(this, 'constructor');
-
+class Controller extends SourceManager {
   /**
-   * @type {?angular.Scope}
-   * @private
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @ngInject
    */
-  this.scope_ = $scope;
+  constructor($scope, $element) {
+    super();
 
-  /**
-   * @type {?angular.JQLite}
-   * @private
-   */
-  this.element_ = $element;
+    /**
+     * @type {?angular.Scope}
+     * @private
+     */
+    this.scope_ = $scope;
 
-  /**
-   * @type {!Array<string>}
-   * @private
-   */
-  this.sourceIds_ = $scope['sourceIds'];
+    /**
+     * @type {?angular.JQLite}
+     * @private
+     */
+    this.element_ = $element;
 
-  /**
-   * @type {string}
-   */
-  this['name'] = 'Joined Layer';
+    /**
+     * @type {!Array<string>}
+     * @private
+     */
+    this.sourceIds_ = $scope['sourceIds'];
 
-  /**
-   * @type {string}
-   */
-  this['joinMethod'] = 'unique';
+    /**
+     * @type {string}
+     */
+    this['name'] = 'Joined Layer';
 
-  /**
-   * @type {string}
-   */
-  this['chooseLayerHelp'] = 'Joining layers compares values in the chosen columns for each layer against the ' +
-      'Primary Layer and combines features whose values match. If the values match, the feature from the other ' +
-      'layer will be merged into the matching features in the Primary Layer.';
+    /**
+     * @type {string}
+     */
+    this['joinMethod'] = 'unique';
 
-  /**
-   * @type {string}
-   */
-  this['joinMethodHelp'] = 'The Join Method determines how we compare values between columns.' +
-      '<ul><li> Exact Match: Joins two features when the value is exactly the same on both.</li>' +
-      '<li> Contains: Joins two features when one value contains the other.</li>' +
-      '<li> Match (Case-Insensitive): Same as "Exact Match" but case-insensitive</li>' +
-      '<li> Contains (Case-Insensitive): Same as "Contains" but case-insensitive</li>';
+    /**
+     * @type {string}
+     */
+    this['chooseLayerHelp'] = 'Joining layers compares values in the chosen columns for each layer against the ' +
+        'Primary Layer and combines features whose values match. If the values match, the feature from the other ' +
+        'layer will be merged into the matching features in the Primary Layer.';
 
-  /**
-   * @type {Array<Object>}
-   */
-  this['joinSources'] = this.sourceIds_
-      .map(plugin.vectortools.JoinCtrl.mapSources)
-      .sort(plugin.vectortools.JoinCtrl.sortSources_);
+    /**
+     * @type {string}
+     */
+    this['joinMethodHelp'] = 'The Join Method determines how we compare values between columns.' +
+        '<ul><li> Exact Match: Joins two features when the value is exactly the same on both.</li>' +
+        '<li> Contains: Joins two features when one value contains the other.</li>' +
+        '<li> Match (Case-Insensitive): Same as "Exact Match" but case-insensitive</li>' +
+        '<li> Contains (Case-Insensitive): Same as "Contains" but case-insensitive</li>';
 
-  /**
-   * @type {?string}
-   */
-  this['primarySource'] = this['joinSources'][0]['id'];
+    /**
+     * @type {Array<Object>}
+     */
+    this['joinSources'] = this.sourceIds_
+        .map(Controller.mapSources)
+        .sort(Controller.sortSources_);
 
-  this.init();
-  $scope.$on('$destroy', this.disposeInternal.bind(this));
-  $scope.$emit(os.ui.WindowEventType.READY);
-};
-goog.inherits(plugin.vectortools.JoinCtrl, os.data.SourceManager);
+    /**
+     * @type {?string}
+     */
+    this['primarySource'] = this['joinSources'][0]['id'];
 
-
-/**
- * @inheritDoc
- */
-plugin.vectortools.JoinCtrl.prototype.disposeInternal = function() {
-  plugin.vectortools.JoinCtrl.base(this, 'disposeInternal');
-
-  this.scope_ = null;
-  this.element_ = null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.vectortools.JoinCtrl.prototype.init = function() {
-  plugin.vectortools.JoinCtrl.base(this, 'init');
-  /** @type {angular.$timeout} */ (os.ui.injector.get('$timeout'))(this.onUpdateDelay.bind(this));
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.vectortools.JoinCtrl.prototype.removeSource = function(source) {
-  plugin.vectortools.JoinCtrl.base(this, 'removeSource', source);
-  ol.array.remove(this.sourceIds_, source.getId());
-  this.onUpdateDelay();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.vectortools.JoinCtrl.prototype.onSourcePropertyChange = function(event) {
-  var p;
-  try {
-    p = event.getProperty();
-  } catch (e) {
-    return;
+    this.init();
+    $scope.$on('$destroy', this.disposeInternal.bind(this));
+    $scope.$emit(WindowEventType.READY);
   }
 
-  if (p === os.source.PropertyChange.FEATURES) {
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
+
+    this.scope_ = null;
+    this.element_ = null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    super.init();
+    /** @type {angular.$timeout} */ (ui.injector.get('$timeout'))(this.onUpdateDelay.bind(this));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  removeSource(source) {
+    super.removeSource(source);
+    olArray.remove(this.sourceIds_, source.getId());
     this.onUpdateDelay();
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  onSourcePropertyChange(event) {
+    var p;
+    try {
+      p = event.getProperty();
+    } catch (e) {
+      return;
+    }
 
-/**
- * @inheritDoc
- */
-plugin.vectortools.JoinCtrl.prototype.onUpdateDelay = function() {
-  if (!this.scope_) {
-    return;
-  }
-
-  this.scope_['joinForm'].$setValidity('featureCount', true);
-  this['count'] = 0;
-
-  for (var i = 0, ii = this.sourceIds_.length; i < ii; i++) {
-    var source = os.osDataManager.getSource(this.sourceIds_[i]);
-    if (source) {
-      this['count'] += source.getFeatures().length;
+    if (p === PropertyChange.FEATURES) {
+      this.onUpdateDelay();
     }
   }
 
-  if (this['count'] === 0) {
-    this.scope_['joinForm'].$setValidity('featureCount', false);
-    this['popoverText'] = 'Nothing to join.';
-    this['popoverTitle'] = 'No Features';
-    this['featureCountText'] = 'Nothing to join.';
-  } else if (2 * this['count'] > os.ogc.getMaxFeatures()) {
-    this.scope_['joinForm'].$setValidity('featureCount', false);
-    this['popoverText'] = 'Too many features!';
-    this['popoverTitle'] = 'Too Many Features';
-    this['featureCountText'] = 'This join would result in too many features for {APP} to handle. Reduce the number ' +
-        'of features you are joining and try again.';
+  /**
+   * @inheritDoc
+   */
+  onUpdateDelay() {
+    if (!this.scope_) {
+      return;
+    }
+
+    this.scope_['joinForm'].$setValidity('featureCount', true);
+    this['count'] = 0;
+
+    for (var i = 0, ii = this.sourceIds_.length; i < ii; i++) {
+      var source = os.osDataManager.getSource(this.sourceIds_[i]);
+      if (source) {
+        this['count'] += source.getFeatures().length;
+      }
+    }
+
+    if (this['count'] === 0) {
+      this.scope_['joinForm'].$setValidity('featureCount', false);
+      this['popoverText'] = 'Nothing to join.';
+      this['popoverTitle'] = 'No Features';
+      this['featureCountText'] = 'Nothing to join.';
+    } else if (2 * this['count'] > ogc.getMaxFeatures()) {
+      this.scope_['joinForm'].$setValidity('featureCount', false);
+      this['popoverText'] = 'Too many features!';
+      this['popoverTitle'] = 'Too Many Features';
+      this['featureCountText'] = 'This join would result in too many features for {APP} to handle. Reduce the number ' +
+          'of features you are joining and try again.';
+    }
+
+    ui.apply(this.scope_);
   }
 
-  os.ui.apply(this.scope_);
-};
+  /**
+   * Close the window.
+   *
+   * @export
+   */
+  close() {
+    osWindow.close(this.element_);
+  }
 
+  /**
+   * Builds and executes the command to perform the join then closes the window.
+   *
+   * @export
+   */
+  accept() {
+    var sources = this['joinSources'].map(function(item) {
+      return item['id'];
+    });
 
-/**
- * Close the window.
- *
- * @export
- */
-plugin.vectortools.JoinCtrl.prototype.close = function() {
-  os.ui.window.close(this.element_);
-};
+    var columns = this['joinSources'].map(function(item) {
+      return item['joinColumn']['field'];
+    });
 
+    // put the primary source at index 0
+    var primary = /** @type {string} */ (this['primarySource']);
+    var i = sources.indexOf(primary);
 
-/**
- * Builds and executes the command to perform the join then closes the window.
- *
- * @export
- */
-plugin.vectortools.JoinCtrl.prototype.accept = function() {
-  var sources = this['joinSources'].map(function(item) {
-    return item['id'];
-  });
+    var tmp = sources.splice(i, 1);
+    sources = tmp.concat(sources);
 
-  var columns = this['joinSources'].map(function(item) {
-    return item['joinColumn']['field'];
-  });
+    tmp = columns.splice(i, 1);
+    columns = tmp.concat(columns);
 
-  // put the primary source at index 0
-  var primary = /** @type {string} */ (this['primarySource']);
-  var i = sources.indexOf(primary);
+    var cmd = new JoinLayer(
+        /** @type {!Array<string>} */ (sources),
+        /** @type {!Array<string>} */ (columns),
+        this['joinMethod'],
+        this['name']);
 
-  var tmp = sources.splice(i, 1);
-  sources = tmp.concat(sources);
+    CommandProcessor.getInstance().addCommand(cmd);
+    this.close();
+  }
 
-  tmp = columns.splice(i, 1);
-  columns = tmp.concat(columns);
+  /**
+   * @param {string} id
+   * @return {Object}
+   * @protected
+   */
+  static mapSources(id) {
+    var source = os.osDataManager.getSource(id);
 
-  var cmd = new plugin.vectortools.JoinLayer(
-      /** @type {!Array<string>} */ (sources),
-      /** @type {!Array<string>} */ (columns),
-      this['joinMethod'],
-      this['name']);
+    return {
+      'id': source.getId(),
+      'title': source.getTitle(),
+      'cols': source.getColumns().sort(Controller.sortByName_)
+    };
+  }
 
-  os.command.CommandProcessor.getInstance().addCommand(cmd);
-  this.close();
-};
+  /**
+   * @param {os.data.ColumnDefinition} a
+   * @param {os.data.ColumnDefinition} b
+   * @return {number}
+   * @private
+   */
+  static sortByName_(a, b) {
+    return googString.numerateCompare(a['name'], b['name']);
+  }
 
+  /**
+   * @param {Object} a
+   * @param {Object} b
+   * @return {number}
+   * @private
+   */
+  static sortSources_(a, b) {
+    return googString.numerateCompare(a['title'], b['title']);
+  }
+}
 
-/**
- * @param {string} id
- * @return {Object}
- * @protected
- */
-plugin.vectortools.JoinCtrl.mapSources = function(id) {
-  var source = os.osDataManager.getSource(id);
-
-  return {
-    'id': source.getId(),
-    'title': source.getTitle(),
-    'cols': source.getColumns().sort(plugin.vectortools.JoinCtrl.sortByName_)
-  };
-};
-
-
-/**
- * @param {os.data.ColumnDefinition} a
- * @param {os.data.ColumnDefinition} b
- * @return {number}
- * @private
- */
-plugin.vectortools.JoinCtrl.sortByName_ = function(a, b) {
-  return goog.string.numerateCompare(a['name'], b['name']);
-};
-
-
-/**
- * @param {Object} a
- * @param {Object} b
- * @return {number}
- * @private
- */
-plugin.vectortools.JoinCtrl.sortSources_ = function(a, b) {
-  return goog.string.numerateCompare(a['title'], b['title']);
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/vectortools/mappingcounter.js
+++ b/src/plugin/vectortools/mappingcounter.js
@@ -1,10 +1,16 @@
-goog.provide('plugin.vectortools.MappingCounterCtrl');
-goog.provide('plugin.vectortools.mappingCounterDirective');
+goog.module('plugin.vectortools.MappingCounterUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os');
-goog.require('os.column.ColumnMappingManager');
-goog.require('os.ui.Module');
-goog.require('os.ui.menu.windows');
+const EventType = goog.require('goog.events.EventType');
+const googObject = goog.require('goog.object');
+const ui = goog.require('os.ui');
+const ColumnMappingSettings = goog.require('os.ui.column.mapping.ColumnMappingSettings');
+const vectortools = goog.require('plugin.vectortools');
+
+const os = goog.require('os');
+const ColumnMappingManager = goog.require('os.column.ColumnMappingManager');
+const Module = goog.require('os.ui.Module');
+const windows = goog.require('os.ui.menu.windows');
 
 
 /**
@@ -12,98 +18,111 @@ goog.require('os.ui.menu.windows');
  *
  * @return {angular.Directive}
  */
-plugin.vectortools.mappingCounterDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    scope: {
-      'sourceIds': '='
-    },
-    templateUrl: os.ROOT + 'views/plugin/vectortools/mappingcounter.html',
-    controller: plugin.vectortools.MappingCounterCtrl,
-    controllerAs: 'ctrl'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+
+  scope: {
+    'sourceIds': '='
+  },
+
+  templateUrl: os.ROOT + 'views/plugin/vectortools/mappingcounter.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'mappingcounter';
 
 
 /**
  * Add the directive to the module.
  */
-os.ui.Module.directive('mappingcounter', [plugin.vectortools.mappingCounterDirective]);
+Module.directive(directiveTag, [directive]);
 
 
 
 /**
  * Controller function for the mappingcounter directive
- *
- * @param {!angular.Scope} $scope
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.vectortools.MappingCounterCtrl = function($scope) {
+class Controller {
   /**
-   * @type {?angular.Scope}
-   * @private
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @ngInject
    */
-  this.scope_ = $scope;
+  constructor($scope) {
+    /**
+     * @type {?angular.Scope}
+     * @private
+     */
+    this.scope_ = $scope;
 
-  /**
-   * @type {string}
-   */
-  this['columnMappingHelp'] = 'Column Associations will put data from associated columns on the chosen layers into ' +
-      'a single column on the resulting layer. This is useful when the layers you are joining have sparse data ' +
-      'of the same type that you wish to analyze together in the resulting layer.';
+    /**
+     * @type {string}
+     */
+    this['columnMappingHelp'] = 'Column Associations will put data from associated columns on the chosen layers into ' +
+        'a single column on the resulting layer. This is useful when the layers you are joining have sparse data ' +
+        'of the same type that you wish to analyze together in the resulting layer.';
 
-  /**
-   * @type {number}
-   */
-  this['mappingCount'] = 0;
+    /**
+     * @type {number}
+     */
+    this['mappingCount'] = 0;
 
-  this.onColumnMappingsChange_();
-  os.column.ColumnMappingManager.getInstance()
-      .listen(goog.events.EventType.PROPERTYCHANGE, this.onColumnMappingsChange_, false, this);
-  $scope.$on('$destroy', this.destroy_.bind(this));
-};
-
-
-/**
- * Clean up.
- *
- * @private
- */
-plugin.vectortools.MappingCounterCtrl.prototype.destroy_ = function() {
-  os.column.ColumnMappingManager.getInstance()
-      .unlisten(goog.events.EventType.PROPERTYCHANGE, this.onColumnMappingsChange_, false, this);
-
-  this.scope_ = null;
-  this.element_ = null;
-};
-
-
-/**
- * Listener for changes to ColumnMappingManager. Recalculates the number of applicable column mappings to the current
- * layers.
- *
- * @private
- */
-plugin.vectortools.MappingCounterCtrl.prototype.onColumnMappingsChange_ = function() {
-  this['mappingCount'] = 0;
-
-  var mappings = plugin.vectortools.getColumnMappings(this.scope_['sourceIds']);
-  for (var key in mappings) {
-    var columnsMap = mappings[key];
-    this['mappingCount'] += goog.object.getCount(columnsMap);
+    this.onColumnMappingsChange_();
+    ColumnMappingManager.getInstance()
+        .listen(EventType.PROPERTYCHANGE, this.onColumnMappingsChange_, false, this);
+    $scope.$on('$destroy', this.destroy_.bind(this));
   }
 
-  os.ui.apply(this.scope_);
-};
+  /**
+   * Clean up.
+   *
+   * @private
+   */
+  destroy_() {
+    ColumnMappingManager.getInstance()
+        .unlisten(EventType.PROPERTYCHANGE, this.onColumnMappingsChange_, false, this);
 
+    this.scope_ = null;
+    this.element_ = null;
+  }
 
-/**
- * Launches the settings window for managing column mappings.
- *
- * @export
- */
-plugin.vectortools.MappingCounterCtrl.prototype.launchColumnMappings = function() {
-  os.ui.menu.windows.openSettingsTo(os.ui.column.mapping.ColumnMappingSettings.ID);
+  /**
+   * Listener for changes to ColumnMappingManager. Recalculates the number of applicable column mappings to the current
+   * layers.
+   *
+   * @private
+   */
+  onColumnMappingsChange_() {
+    this['mappingCount'] = 0;
+
+    var mappings = vectortools.getColumnMappings(this.scope_['sourceIds']);
+    for (var key in mappings) {
+      var columnsMap = mappings[key];
+      this['mappingCount'] += googObject.getCount(columnsMap);
+    }
+
+    ui.apply(this.scope_);
+  }
+
+  /**
+   * Launches the settings window for managing column mappings.
+   *
+   * @export
+   */
+  launchColumnMappings() {
+    windows.openSettingsTo(ColumnMappingSettings.ID);
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/vectortools/mergelayercmd.js
+++ b/src/plugin/vectortools/mergelayercmd.js
@@ -1,194 +1,194 @@
-goog.provide('plugin.vectortools.MergeLayer');
+goog.module('plugin.vectortools.MergeLayer');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.array');
-goog.require('os.column.ColumnMappingManager');
-goog.require('os.command.AbstractSource');
-goog.require('os.command.ICommand');
-goog.require('os.command.State');
-goog.require('os.data.CollectionManager');
-goog.require('os.data.OSDataManager');
-goog.require('os.events.LayerConfigEvent');
-goog.require('os.layer.Vector');
-goog.require('os.source.Vector');
-goog.require('os.style');
-goog.require('os.style.StyleManager');
+const os = goog.require('os');
+const MapContainer = goog.require('os.MapContainer');
+const osFeature = goog.require('os.feature');
+const layer = goog.require('os.layer');
+const vectortools = goog.require('plugin.vectortools');
 
+const State = goog.require('os.command.State');
+const style = goog.require('os.style');
+const ICommand = goog.requireType('os.command.ICommand');
+const VectorSource = goog.requireType('os.source.Vector');
 
 
 /**
  * Command for merging vector layers
  *
- * @constructor
- * @implements {os.command.ICommand}
- * @param {!Array<string>} sourceIds The data source IDs to merge
- * @param {string=} opt_name Optional name to give the merged layer
- * @param {plugin.vectortools.Options=} opt_options The options
+ * @implements {ICommand}
  */
-plugin.vectortools.MergeLayer = function(sourceIds, opt_name, opt_options) {
+class MergeLayer {
   /**
-   * @type {!Array<string>}
-   * @protected
+   * Constructor.
+   * @param {!Array<string>} sourceIds The data source IDs to merge
+   * @param {string=} opt_name Optional name to give the merged layer
+   * @param {plugin.vectortools.Options=} opt_options The options
    */
-  this.sourceIds = sourceIds;
+  constructor(sourceIds, opt_name, opt_options) {
+    /**
+     * @type {!Array<string>}
+     * @protected
+     */
+    this.sourceIds = sourceIds;
+
+    /**
+     * @type {!State}
+     */
+    this.state = State.READY;
+
+    this.title = 'Merge Layers';
+    this.options_ = opt_options;
+
+    /**
+     * @type {string}
+     * @private
+     */
+    this.newLayerId_ = '';
+
+    /**
+     * @type {string}
+     * @private
+     */
+    this.newLayerName_ = layer.getUniqueTitle(opt_name || 'Merged Layer');
+  }
 
   /**
-   * @type {!os.command.State}
+   * @return {Array.<os.source.ISource>} The sources
    */
-  this.state = os.command.State.READY;
-
-  this.title = 'Merge Layers';
-  this.options_ = opt_options;
+  getSources() {
+    // iterate thru all the sourceIds and get each of the sources
+    var sources = Array(this.sourceIds.length);
+    for (var i = 0; i < this.sourceIds.length; i++) {
+      sources[i] = os.osDataManager.getSource(this.sourceIds[i]);
+    }
+    return sources;
+  }
 
   /**
-   * @type {string}
-   * @private
+   * Checks if the command is ready to execute.
+   *
+   * @return {boolean}
    */
-  this.newLayerId_ = '';
+  canExecute() {
+    if (this.state !== State.READY) {
+      this.details = 'Command not in ready state.';
+      return false;
+    }
+
+    var sources = this.getSources();
+    if (!sources) {
+      this.state = State.ERROR;
+      return false;
+    }
+
+    return true;
+  }
 
   /**
-   * @type {string}
-   * @private
+   * @inheritDoc
    */
-  this.newLayerName_ = os.layer.getUniqueTitle(opt_name || 'Merged Layer');
-};
+  execute() {
+    if (this.canExecute()) {
+      this.state = State.EXECUTING;
 
+      var sources = this.getSources();
+      if (sources && sources.length > 0) {
+        // create a new source
+        var mergedLayer = vectortools.addNewLayer({'timeEnabled': true});
+        var mergedSource = /** @type {VectorSource} */ (mergedLayer.getSource());
+
+        this.newLayerId_ = mergedSource.getId();
+
+        mergedLayer.setTitle(this.newLayerName_);
+        mergedSource.setTitle(this.newLayerName_);
+
+        // for merged layers we want to allow layer level styling
+        var options = mergedLayer.getLayerOptions();
+        if (!options) {
+          options = {};
+        }
+        options[layer.LayerOption.SHOW_FORCE_COLOR] = true;
+        mergedLayer.setLayerOptions(options);
+
+        var columnMappings = vectortools.getColumnMappings(this.sourceIds);
+        mergedSource.setColumns(vectortools.getCombinedColumns(sources, columnMappings));
+
+        var mergedLayerFeatures = [];
+        var contribSrcColName = 'CONTRIBUTING_SOURCE';
+
+        for (var i = 0; i < sources.length; i++) {
+          var source = /** @type {VectorSource} */ (sources[i]);
+          if (source) {
+            var features = vectortools.getFeatures(source, this.options_);
+            var layerConfig = null;
+            var mapping = columnMappings[source.getId()];
+
+            for (var j = 0; j < features.length; j++) {
+              var feature = features[j];
+              if (feature) {
+                if (!layerConfig) {
+                  layerConfig = style.getLayerConfig(feature, source);
+                }
+                var copiedFeature = osFeature.copyFeature(feature, layerConfig);
+                if (mapping) {
+                  vectortools.runColumnMapping(mapping, copiedFeature);
+                }
+                if (!copiedFeature.get(contribSrcColName)) {
+                  copiedFeature.set(contribSrcColName, source.getTitle(true), true); // THIN-8644 contributing source
+                }
+
+                mergedLayerFeatures.push(copiedFeature);
+              }
+            }
+          }
+        }
+
+        mergedSource.addColumn(contribSrcColName);
+        mergedSource.addFeatures(mergedLayerFeatures);
+        this.state = State.SUCCESS;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  revert() {
+    this.state = State.REVERTING;
+    MapContainer.getInstance().removeLayer(this.newLayerId_);
+    this.state = State.READY;
+    return true;
+  }
+}
 
 /**
  * The current state of the command
  * @override
- * @type {!os.command.State}
+ * @type {!State}
  */
-plugin.vectortools.MergeLayer.prototype.state = os.command.State.READY;
+MergeLayer.prototype.state = State.READY;
 
 
 /**
  * @inheritDoc
  */
-plugin.vectortools.MergeLayer.prototype.isAsync = false;
+MergeLayer.prototype.isAsync = false;
 
 
 /**
  * @inheritDoc
  */
-plugin.vectortools.MergeLayer.prototype.title = 'Merge layers';
+MergeLayer.prototype.title = 'Merge layers';
 
 
 /**
  * @inheritDoc
  */
-plugin.vectortools.MergeLayer.prototype.details = null;
+MergeLayer.prototype.details = null;
 
 
-/**
- * @return {Array.<os.source.ISource>} The sources
- */
-plugin.vectortools.MergeLayer.prototype.getSources = function() {
-  // iterate thru all the sourceIds and get each of the sources
-  var sources = Array(this.sourceIds.length);
-  for (var i = 0; i < this.sourceIds.length; i++) {
-    sources[i] = os.osDataManager.getSource(this.sourceIds[i]);
-  }
-  return sources;
-};
-
-
-/**
- * Checks if the command is ready to execute.
- *
- * @return {boolean}
- */
-plugin.vectortools.MergeLayer.prototype.canExecute = function() {
-  if (this.state !== os.command.State.READY) {
-    this.details = 'Command not in ready state.';
-    return false;
-  }
-
-  var sources = this.getSources();
-  if (!sources) {
-    this.state = os.command.State.ERROR;
-    return false;
-  }
-
-  return true;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.vectortools.MergeLayer.prototype.execute = function() {
-  if (this.canExecute()) {
-    this.state = os.command.State.EXECUTING;
-
-    var sources = this.getSources();
-    if (sources && sources.length > 0) {
-      // create a new source
-      var mergedLayer = plugin.vectortools.addNewLayer({'timeEnabled': true});
-      var mergedSource = /** @type {os.source.Vector} */ (mergedLayer.getSource());
-
-      this.newLayerId_ = mergedSource.getId();
-
-      mergedLayer.setTitle(this.newLayerName_);
-      mergedSource.setTitle(this.newLayerName_);
-
-      // for merged layers we want to allow layer level styling
-      var options = mergedLayer.getLayerOptions();
-      if (!options) {
-        options = {};
-      }
-      options[os.layer.LayerOption.SHOW_FORCE_COLOR] = true;
-      mergedLayer.setLayerOptions(options);
-
-      var columnMappings = plugin.vectortools.getColumnMappings(this.sourceIds);
-      mergedSource.setColumns(plugin.vectortools.getCombinedColumns(sources, columnMappings));
-
-      var mergedLayerFeatures = [];
-      var contribSrcColName = 'CONTRIBUTING_SOURCE';
-
-      for (var i = 0; i < sources.length; i++) {
-        var source = /** @type {os.source.Vector} */ (sources[i]);
-        if (source) {
-          var features = plugin.vectortools.getFeatures(source, this.options_);
-          var layerConfig = null;
-          var mapping = columnMappings[source.getId()];
-
-          for (var j = 0; j < features.length; j++) {
-            var feature = features[j];
-            if (feature) {
-              if (!layerConfig) {
-                layerConfig = os.style.getLayerConfig(feature, source);
-              }
-              var copiedFeature = os.feature.copyFeature(feature, layerConfig);
-              if (mapping) {
-                plugin.vectortools.runColumnMapping(mapping, copiedFeature);
-              }
-              if (!copiedFeature.get(contribSrcColName)) {
-                copiedFeature.set(contribSrcColName, source.getTitle(true), true); // THIN-8644 contributing source
-              }
-
-              mergedLayerFeatures.push(copiedFeature);
-            }
-          }
-        }
-      }
-
-      mergedSource.addColumn(contribSrcColName);
-      mergedSource.addFeatures(mergedLayerFeatures);
-      this.state = os.command.State.SUCCESS;
-      return true;
-    }
-  }
-
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.vectortools.MergeLayer.prototype.revert = function() {
-  this.state = os.command.State.REVERTING;
-  os.MapContainer.getInstance().removeLayer(this.newLayerId_);
-  this.state = os.command.State.READY;
-  return true;
-};
+exports = MergeLayer;

--- a/src/plugin/vectortools/mergewindow.js
+++ b/src/plugin/vectortools/mergewindow.js
@@ -1,180 +1,191 @@
-goog.provide('plugin.vectortools.MergeCtrl');
-goog.provide('plugin.vectortools.mergeDirective');
+goog.module('plugin.vectortools.MergeUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.array');
-goog.require('os');
-goog.require('os.data.OSDataManager');
-goog.require('os.data.SourceManager');
-goog.require('os.source.PropertyChange');
-goog.require('os.ui.Module');
 goog.require('os.ui.util.validationMessageDirective');
-goog.require('os.ui.window');
-goog.require('plugin.vectortools.MergeLayer');
-goog.require('plugin.vectortools.mappingCounterDirective');
+goog.require('plugin.vectortools.MappingCounterUI');
+
+const CommandProcessor = goog.require('os.command.CommandProcessor');
+const ogc = goog.require('os.ogc');
+const ui = goog.require('os.ui');
+const WindowEventType = goog.require('os.ui.WindowEventType');
+
+const olArray = goog.require('ol.array');
+const os = goog.require('os');
+const SourceManager = goog.require('os.data.SourceManager');
+const PropertyChange = goog.require('os.source.PropertyChange');
+const Module = goog.require('os.ui.Module');
+const osWindow = goog.require('os.ui.window');
+const MergeLayer = goog.require('plugin.vectortools.MergeLayer');
 
 
 /**
  * @return {angular.Directive}
  */
-plugin.vectortools.mergeDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    scope: true,
-    templateUrl: os.ROOT + 'views/plugin/vectortools/merge.html',
-    controller: plugin.vectortools.MergeCtrl,
-    controllerAs: 'ctrl'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  scope: true,
+  templateUrl: os.ROOT + 'views/plugin/vectortools/merge.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'merge';
 
 
 // add the directive to the module
-os.ui.Module.directive('merge', [plugin.vectortools.mergeDirective]);
+Module.directive(directiveTag, [directive]);
 
 
 
 /**
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @extends {os.data.SourceManager}
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.vectortools.MergeCtrl = function($scope, $element) {
-  plugin.vectortools.MergeCtrl.base(this, 'constructor');
-
+class Controller extends SourceManager {
   /**
-   * @type {?angular.Scope}
-   * @private
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @ngInject
    */
-  this.scope_ = $scope;
+  constructor($scope, $element) {
+    super();
 
-  /**
-   * @type {?angular.JQLite}
-   * @private
-   */
-  this.element_ = $element;
+    /**
+     * @type {?angular.Scope}
+     * @private
+     */
+    this.scope_ = $scope;
 
-  /**
-   * @type {!Array<string>}
-   * @private
-   */
-  this.sourceIds_ = $scope['sourceIds'];
+    /**
+     * @type {?angular.JQLite}
+     * @private
+     */
+    this.element_ = $element;
 
-  /**
-   * @type {string}
-   */
-  this['name'] = 'New Layer';
+    /**
+     * @type {!Array<string>}
+     * @private
+     */
+    this.sourceIds_ = $scope['sourceIds'];
 
-  /**
-   * @type {string}
-   */
-  this['featureCountText'] = '';
+    /**
+     * @type {string}
+     */
+    this['name'] = 'New Layer';
 
-  this.init();
+    /**
+     * @type {string}
+     */
+    this['featureCountText'] = '';
 
-  $scope.$on('$destroy', this.disposeInternal.bind(this));
-  $scope.$emit(os.ui.WindowEventType.READY);
-};
-goog.inherits(plugin.vectortools.MergeCtrl, os.data.SourceManager);
+    this.init();
 
-
-/**
- * @inheritDoc
- */
-plugin.vectortools.MergeCtrl.prototype.disposeInternal = function() {
-  plugin.vectortools.MergeCtrl.base(this, 'disposeInternal');
-
-  this.scope_ = null;
-  this.element_ = null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.vectortools.MergeCtrl.prototype.init = function() {
-  plugin.vectortools.MergeCtrl.base(this, 'init');
-  /** @type {angular.$timeout} */ (os.ui.injector.get('$timeout'))(this.onUpdateDelay.bind(this));
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.vectortools.MergeCtrl.prototype.removeSource = function(source) {
-  plugin.vectortools.MergeCtrl.base(this, 'removeSource', source);
-
-  ol.array.remove(this.sourceIds_, source.getId());
-  this.onUpdateDelay();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.vectortools.MergeCtrl.prototype.onSourcePropertyChange = function(event) {
-  var p;
-  try {
-    p = event.getProperty();
-  } catch (e) {
-    return;
+    $scope.$on('$destroy', this.disposeInternal.bind(this));
+    $scope.$emit(WindowEventType.READY);
   }
 
-  if (p === os.source.PropertyChange.FEATURES) {
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
+
+    this.scope_ = null;
+    this.element_ = null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    super.init();
+    /** @type {angular.$timeout} */ (ui.injector.get('$timeout'))(this.onUpdateDelay.bind(this));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  removeSource(source) {
+    super.removeSource(source);
+
+    olArray.remove(this.sourceIds_, source.getId());
     this.onUpdateDelay();
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  onSourcePropertyChange(event) {
+    var p;
+    try {
+      p = event.getProperty();
+    } catch (e) {
+      return;
+    }
 
-/**
- * @inheritDoc
- */
-plugin.vectortools.MergeCtrl.prototype.onUpdateDelay = function() {
-  this.scope_['mergeForm'].$setValidity('featureCount', true);
-  this['count'] = 0;
-
-  for (var i = 0, ii = this.sourceIds_.length; i < ii; i++) {
-    var source = os.osDataManager.getSource(this.sourceIds_[i]);
-    if (source) {
-      this['count'] += source.getFeatures().length;
+    if (p === PropertyChange.FEATURES) {
+      this.onUpdateDelay();
     }
   }
 
-  if (this['count'] === 0) {
-    this.scope_['mergeForm'].$setValidity('featureCount', false);
-    this['popoverText'] = 'Nothing to merge.';
-    this['popoverTitle'] = 'No Features';
-    this['featureCountText'] = 'Nothing to merge.';
-  } else if (2 * this['count'] > os.ogc.getMaxFeatures()) {
-    this.scope_['mergeForm'].$setValidity('featureCount', false);
-    this['popoverText'] = 'Too many features!';
-    this['popoverTitle'] = 'Too Many Features';
-    this['featureCountText'] = 'This merge would result in too many features for {APP} to handle. Reduce the number ' +
-        'of features you are merging and try again.';
+  /**
+   * @inheritDoc
+   */
+  onUpdateDelay() {
+    this.scope_['mergeForm'].$setValidity('featureCount', true);
+    this['count'] = 0;
+
+    for (var i = 0, ii = this.sourceIds_.length; i < ii; i++) {
+      var source = os.osDataManager.getSource(this.sourceIds_[i]);
+      if (source) {
+        this['count'] += source.getFeatures().length;
+      }
+    }
+
+    if (this['count'] === 0) {
+      this.scope_['mergeForm'].$setValidity('featureCount', false);
+      this['popoverText'] = 'Nothing to merge.';
+      this['popoverTitle'] = 'No Features';
+      this['featureCountText'] = 'Nothing to merge.';
+    } else if (2 * this['count'] > ogc.getMaxFeatures()) {
+      this.scope_['mergeForm'].$setValidity('featureCount', false);
+      this['popoverText'] = 'Too many features!';
+      this['popoverTitle'] = 'Too Many Features';
+      this['featureCountText'] = 'This merge would result in too many features for {APP} to handle. Reduce the ' +
+          'number of features you are merging and try again.';
+    }
+
+    ui.apply(this.scope_);
   }
 
-  os.ui.apply(this.scope_);
-};
+  /**
+   * Close dialog
+   *
+   * @export
+   */
+  close() {
+    osWindow.close(this.element_);
+  }
 
+  /**
+   * Adds the command to perform the merge.
+   *
+   * @export
+   */
+  accept() {
+    var merge = new MergeLayer(this.sourceIds_, this['name']);
+    CommandProcessor.getInstance().addCommand(merge);
+    this.close();
+  }
+}
 
-/**
- * Close dialog
- *
- * @export
- */
-plugin.vectortools.MergeCtrl.prototype.close = function() {
-  os.ui.window.close(this.element_);
-};
-
-
-/**
- * Adds the command to perform the merge.
- *
- * @export
- */
-plugin.vectortools.MergeCtrl.prototype.accept = function() {
-  var merge = new plugin.vectortools.MergeLayer(this.sourceIds_, this['name']);
-  os.command.CommandProcessor.getInstance().addCommand(merge);
-  this.close();
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/vectortools/mergewindow.js
+++ b/src/plugin/vectortools/mergewindow.js
@@ -1,5 +1,4 @@
 goog.module('plugin.vectortools.MergeUI');
-goog.module.declareLegacyNamespace();
 
 goog.require('os.ui.util.validationMessageDirective');
 goog.require('plugin.vectortools.MappingCounterUI');

--- a/src/plugin/vectortools/options.js
+++ b/src/plugin/vectortools/options.js
@@ -1,0 +1,14 @@
+goog.module('plugin.vectortools.Options');
+goog.module.declareLegacyNamespace();
+
+
+/**
+ * @enum {number}
+ */
+exports = {
+  ALL: 0,
+  SHOWN: 1,
+  SELECTED: 2,
+  UNSELECTED: 3,
+  HIDDEN: 4
+};

--- a/src/plugin/vectortools/vectortools.js
+++ b/src/plugin/vectortools/vectortools.js
@@ -1,75 +1,75 @@
-goog.provide('plugin.vectortools');
-goog.provide('plugin.vectortools.Icons');
-goog.provide('plugin.vectortools.Options');
-goog.require('goog.string');
-goog.require('os.MapContainer');
-goog.require('os.column.ColumnMappingManager');
-goog.require('os.data.DataManager');
-goog.require('os.layer.Vector');
-goog.require('os.source.Vector');
-goog.require('plugin.vectortools.joinDirective');
-goog.require('plugin.vectortools.mergeDirective');
+goog.module('plugin.vectortools');
+goog.module.declareLegacyNamespace();
+
+const googArray = goog.require('goog.array');
+const googString = goog.require('goog.string');
+const MapContainer = goog.require('os.MapContainer');
+const ColumnMappingManager = goog.require('os.column.ColumnMappingManager');
+const DataManager = goog.require('os.data.DataManager');
+const RecordField = goog.require('os.data.RecordField');
+const IFilterable = goog.require('os.filter.IFilterable');
+const osImplements = goog.require('os.implements');
+const layer = goog.require('os.layer');
+const StyleType = goog.require('os.style.StyleType');
+const VectorLayer = goog.require('os.layer.Vector');
+const VectorSource = goog.require('os.source.Vector');
+
+const Options = goog.require('plugin.vectortools.Options');
+
 
 
 /**
- * Icons for the vectortools actions.
- * @enum {string}
+ * The currently selected option.
+ * @type {Options}
  */
-plugin.vectortools.Icons = {
-  COPY_ICON: 'fa-copy',
-  MERGE_ICON: 'fa-compress',
-  JOIN_ICON: 'fa-object-group'
+let option = Options.SHOWN;
+
+
+/**
+ * Get the currently selected option.
+ * @return {Options}
+ */
+const getOption = () => option;
+
+
+/**
+ * Set the currently selected option.
+ * @param {Options} value The option.
+ */
+const setOption = (value) => {
+  option = value;
 };
 
 
 /**
- * @enum {number}
- */
-plugin.vectortools.Options = {
-  ALL: 0,
-  SHOWN: 1,
-  SELECTED: 2,
-  UNSELECTED: 3,
-  HIDDEN: 4
-};
-
-
-/**
- * @type {plugin.vectortools.Options}
- */
-plugin.vectortools.option = plugin.vectortools.Options.SHOWN;
-
-
-/**
- * @param {os.source.Vector} source The vector source
- * @param {plugin.vectortools.Options=} opt_which Which features to retrieve
+ * @param {VectorSource} source The vector source
+ * @param {Options=} opt_which Which features to retrieve
  * @return {Array<!ol.Feature>} the features
  */
-plugin.vectortools.getFeatures = function(source, opt_which) {
-  opt_which = opt_which || plugin.vectortools.option;
+const getFeatures = function(source, opt_which) {
+  opt_which = opt_which || option;
 
   switch (opt_which) {
-    case plugin.vectortools.Options.ALL:
+    case Options.ALL:
       return source.getFeatures();
-    case plugin.vectortools.Options.SHOWN:
+    case Options.SHOWN:
       return source.getFilteredFeatures();
-    case plugin.vectortools.Options.SELECTED:
+    case Options.SELECTED:
       return source.getSelectedItems();
-    case plugin.vectortools.Options.UNSELECTED:
+    case Options.UNSELECTED:
       return source.getUnselectedItems();
-    case plugin.vectortools.Options.HIDDEN:
+    case Options.HIDDEN:
       return source.getHiddenItems();
     default:
       return [];
   }
 };
 
-
 /**
  * @param {string} sourceId
  * @return {function(ol.Feature):ol.Feature} map function used for cloning lists of features
  */
-plugin.vectortools.getFeatureCloneFunction = function(sourceId) {
+const getFeatureCloneFunction = function(sourceId) {
   /**
    * @param {ol.Feature} feature Original feature
    * @return {ol.Feature} copied feature
@@ -77,9 +77,9 @@ plugin.vectortools.getFeatureCloneFunction = function(sourceId) {
   var cloneFunc = function(feature) {
     var newFeature = feature.clone();
     newFeature.suppressEvents();
-    newFeature.set(os.data.RecordField.SOURCE_ID, sourceId, false);
-    newFeature.unset(os.style.StyleType.SELECT, false);
-    newFeature.unset(os.style.StyleType.HIGHLIGHT, false);
+    newFeature.set(RecordField.SOURCE_ID, sourceId, false);
+    newFeature.unset(StyleType.SELECT, false);
+    newFeature.unset(StyleType.HIGHLIGHT, false);
     newFeature.enableEvents();
     return newFeature;
   };
@@ -87,20 +87,19 @@ plugin.vectortools.getFeatureCloneFunction = function(sourceId) {
   return cloneFunc;
 };
 
-
 /**
  * Creates a new layer and returns it.
  *
  * @param {(string|Object)=} opt_restoreFromIdOrConfig An optional layerId or config to restore from
- * @return {os.layer.Vector}
+ * @return {VectorLayer}
  */
-plugin.vectortools.addNewLayer = function(opt_restoreFromIdOrConfig) {
-  var mm = os.MapContainer.getInstance();
-  var id = goog.string.getRandomString();
-  var newSource = new os.source.Vector();
+const addNewLayer = function(opt_restoreFromIdOrConfig) {
+  var mm = MapContainer.getInstance();
+  var id = googString.getRandomString();
+  var newSource = new VectorSource();
   newSource.setId(id);
 
-  var newLayer = new os.layer.Vector({
+  var newLayer = new VectorLayer({
     source: newSource
   });
   newLayer.setId(id);
@@ -114,7 +113,7 @@ plugin.vectortools.addNewLayer = function(opt_restoreFromIdOrConfig) {
       if (otherLayer) {
         newLayer.restore(otherLayer.persist());
 
-        var title = os.layer.getUniqueTitle(otherLayer.getTitle());
+        var title = layer.getUniqueTitle(otherLayer.getTitle());
         newLayer.setTitle(title);
         newSource.setTitle(title);
       }
@@ -126,16 +125,15 @@ plugin.vectortools.addNewLayer = function(opt_restoreFromIdOrConfig) {
   return newLayer;
 };
 
-
 /**
  * Gets a map of applicable column mappings to a set of sourceIds.
  *
  * @param {!Array<string>} sourceIds The list of source ids
  * @return {!Object<string, !Object<string, string>>} map of sourceIds to columns that should change
  */
-plugin.vectortools.getColumnMappings = function(sourceIds) {
-  var filterKeys = sourceIds.map(plugin.vectortools.mapIdToFilterKey_);
-  var mappings = os.column.ColumnMappingManager.getInstance().getAll();
+const getColumnMappings = function(sourceIds) {
+  var filterKeys = sourceIds.map(mapIdToFilterKey_);
+  var mappings = ColumnMappingManager.getInstance().getAll();
 
   /**
    * Filter mappings to only those which apply to at least two of the sources
@@ -168,7 +166,7 @@ plugin.vectortools.getColumnMappings = function(sourceIds) {
   var sortColumns = function(a, b) {
     var ai = filterKeys.indexOf(a['layer']);
     var bi = filterKeys.indexOf(b['layer']);
-    return goog.array.defaultCompare(ai, bi);
+    return googArray.defaultCompare(ai, bi);
   };
 
   /**
@@ -221,22 +219,19 @@ plugin.vectortools.getColumnMappings = function(sourceIds) {
   }, {});
 };
 
-
 /**
  * @param {string} id The source id
  * @return {?string} The filter key
- * @private
  */
-plugin.vectortools.mapIdToFilterKey_ = function(id) {
-  var d = os.dataManager.getDescriptor(id);
+const mapIdToFilterKey_ = function(id) {
+  var d = DataManager.getInstance().getDescriptor(id);
 
-  if (d && os.implements(d, os.filter.IFilterable.ID)) {
+  if (d && osImplements(d, IFilterable.ID)) {
     return /** @type {os.filter.IFilterable} */ (d).getFilterKey();
   }
 
   return id;
 };
-
 
 /**
  * Runs a column mapping on a feature.
@@ -244,7 +239,7 @@ plugin.vectortools.mapIdToFilterKey_ = function(id) {
  * @param {Object<string, string>} mapping
  * @param {ol.Feature} feature
  */
-plugin.vectortools.runColumnMapping = function(mapping, feature) {
+const runColumnMapping = function(mapping, feature) {
   if (mapping) {
     for (var key in mapping) {
       var newKey = mapping[key];
@@ -258,16 +253,15 @@ plugin.vectortools.runColumnMapping = function(mapping, feature) {
   }
 };
 
-
 /**
  * Returns the combined columns between several sources. Accounts for column mappings and columns that just
  * happen to be identical.
  *
- * @param {!Array<!os.source.Vector>} sources
+ * @param {!Array<!VectorSource>} sources
  * @param {!Object<string, !Object<string, string>>} mappings
  * @return {!Array<!os.data.ColumnDefinition|string>}
  */
-plugin.vectortools.getCombinedColumns = function(sources, mappings) {
+const getCombinedColumns = function(sources, mappings) {
   return sources.reduce(function(columns, source) {
     var filter = function(column) {
       if (typeof column === 'string') {
@@ -302,44 +296,13 @@ plugin.vectortools.getCombinedColumns = function(sources, mappings) {
   });
 };
 
-
-/**
- * Launches the Merge Layer window.
- *
- * @param {Array<string>} sourceIds The source/layer IDs to merge
- */
-plugin.vectortools.launchMergeWindow = function(sourceIds) {
-  var title = 'Merge ' + sourceIds.length + ' Layers';
-  os.ui.window.create({
-    'label': title,
-    'icon': 'fa ' + plugin.vectortools.Icons.MERGE_ICON,
-    'x': 'center',
-    'y': 'center',
-    'width': '400',
-    'height': 'auto',
-    'show-close': true
-  }, '<merge></merge>', undefined, undefined, undefined, {
-    'sourceIds': sourceIds
-  });
-};
-
-
-/**
- * Launches the Join Layer window.
- *
- * @param {Array<string>} sourceIds The source/layer IDs to join
- */
-plugin.vectortools.launchJoinWindow = function(sourceIds) {
-  var title = 'Join ' + sourceIds.length + ' Layers';
-  os.ui.window.create({
-    'label': title,
-    'icon': 'fa ' + plugin.vectortools.Icons.JOIN_ICON,
-    'x': 'center',
-    'y': 'center',
-    'width': '500',
-    'height': 'auto',
-    'show-close': true
-  }, '<join></join>', undefined, undefined, undefined, {
-    'sourceIds': sourceIds
-  });
+exports = {
+  getOption,
+  setOption,
+  getFeatures,
+  getFeatureCloneFunction,
+  addNewLayer,
+  getColumnMappings,
+  runColumnMapping,
+  getCombinedColumns
 };

--- a/src/plugin/vectortools/vectortoolsplugin.js
+++ b/src/plugin/vectortools/vectortoolsplugin.js
@@ -1,9 +1,6 @@
 goog.module('plugin.vectortools.VectorToolsPlugin');
 goog.module.declareLegacyNamespace();
 
-goog.require('plugin.vectortools.JoinUI');
-goog.require('plugin.vectortools.MergeUI');
-
 const asserts = goog.require('goog.asserts');
 const os = goog.require('os');
 const MapContainer = goog.require('os.MapContainer');
@@ -19,11 +16,10 @@ const VectorLayer = goog.require('os.layer.Vector');
 const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
 const MenuItemType = goog.require('os.ui.menu.MenuItemType');
 const osUiMenuLayer = goog.require('os.ui.menu.layer');
-const osWindow = goog.require('os.ui.window');
 
 const vectortools = goog.require('plugin.vectortools');
-const Icons = goog.require('plugin.vectortools.Icons');
 const CopyLayer = goog.require('plugin.vectortools.CopyLayer');
+const {launchJoinWindow, launchMergeWindow} = goog.require('plugin.vectortools.ui');
 
 
 /**
@@ -258,46 +254,6 @@ const nodeToSource = function(node) {
 const nodeToCopyCommand = function(node) {
   var layer = fn.mapNodeToLayer(node);
   return layer ? new CopyLayer(layer.getId()) : undefined;
-};
-
-/**
- * Launches the Merge Layer window.
- *
- * @param {Array<string>} sourceIds The source/layer IDs to merge
- */
-const launchMergeWindow = function(sourceIds) {
-  var title = 'Merge ' + sourceIds.length + ' Layers';
-  osWindow.create({
-    'label': title,
-    'icon': 'fa ' + Icons.MERGE_ICON,
-    'x': 'center',
-    'y': 'center',
-    'width': '400',
-    'height': 'auto',
-    'show-close': true
-  }, `<merge></merge>`, undefined, undefined, undefined, {
-    'sourceIds': sourceIds
-  });
-};
-
-/**
- * Launches the Join Layer window.
- *
- * @param {Array<string>} sourceIds The source/layer IDs to join
- */
-const launchJoinWindow = function(sourceIds) {
-  var title = 'Join ' + sourceIds.length + ' Layers';
-  osWindow.create({
-    'label': title,
-    'icon': 'fa ' + Icons.JOIN_ICON,
-    'x': 'center',
-    'y': 'center',
-    'width': '500',
-    'height': 'auto',
-    'show-close': true
-  }, `<join></join>`, undefined, undefined, undefined, {
-    'sourceIds': sourceIds
-  });
 };
 
 exports = VectorToolsPlugin;

--- a/src/plugin/vectortools/vectortoolsui.js
+++ b/src/plugin/vectortools/vectortoolsui.js
@@ -1,0 +1,46 @@
+goog.declareModuleId('plugin.vectortools.ui');
+
+const osWindow = goog.require('os.ui.window');
+const {directiveTag: joinEl} = goog.require('plugin.vectortools.JoinUI');
+const {directiveTag: mergeEl} = goog.require('plugin.vectortools.MergeUI');
+const Icons = goog.require('plugin.vectortools.Icons');
+
+/**
+ * Launches the Join Layer window.
+ *
+ * @param {Array<string>} sourceIds The source/layer IDs to join
+ */
+export const launchJoinWindow = function(sourceIds) {
+  const title = 'Join ' + sourceIds.length + ' Layers';
+  osWindow.create({
+    'label': title,
+    'icon': 'fa ' + Icons.JOIN_ICON,
+    'x': 'center',
+    'y': 'center',
+    'width': '500',
+    'height': 'auto',
+    'show-close': true
+  }, `<${joinEl}></${joinEl}>`, undefined, undefined, undefined, {
+    'sourceIds': sourceIds
+  });
+};
+
+/**
+ * Launches the Merge Layer window.
+ *
+ * @param {Array<string>} sourceIds The source/layer IDs to merge
+ */
+export const launchMergeWindow = function(sourceIds) {
+  const title = 'Merge ' + sourceIds.length + ' Layers';
+  osWindow.create({
+    'label': title,
+    'icon': 'fa ' + Icons.MERGE_ICON,
+    'x': 'center',
+    'y': 'center',
+    'width': '400',
+    'height': 'auto',
+    'show-close': true
+  }, `<${mergeEl}></${mergeEl}>`, undefined, undefined, undefined, {
+    'sourceIds': sourceIds
+  });
+};

--- a/test/plugin/heatmap/cmd/gradientcmd.test.js
+++ b/test/plugin/heatmap/cmd/gradientcmd.test.js
@@ -1,36 +1,47 @@
+goog.require('os.color');
+goog.require('os.layer.LayerType');
+goog.require('os.source.Vector');
+goog.require('plugin.heatmap');
 goog.require('plugin.heatmap.HeatmapLayerConfig');
 goog.require('plugin.heatmap.cmd.Gradient');
 
 
 describe('plugin.heatmap.cmd.Gradient', function() {
+  const osColor = goog.module.get('os.color');
+  const LayerType = goog.module.get('os.layer.LayerType');
+  const VectorSource = goog.module.get('os.source.Vector');
+  const heatmap = goog.module.get('plugin.heatmap');
+  const HeatmapLayerConfig = goog.module.get('plugin.heatmap.HeatmapLayerConfig');
+  const Gradient = goog.module.get('plugin.heatmap.cmd.Gradient');
+
   var createLayer = function() {
     var options = {
       'id': 'heatmapLayer',
-      'source': new os.source.Vector(),
+      'source': new VectorSource(),
       'title': 'My Heatmap',
       'animate': false,
-      'layerType': os.layer.LayerType.FEATURES,
+      'layerType': LayerType.FEATURES,
       'explicitType': '',
-      'type': plugin.heatmap.HeatmapLayerConfig.ID,
+      'type': heatmap.ID,
       'loadOnce': true
     };
 
-    var layerConfig = new plugin.heatmap.HeatmapLayerConfig();
+    var layerConfig = new HeatmapLayerConfig();
     return layerConfig.createLayer(options);
   };
 
   it('should execute by setting the new gradient value and revert by setting the old', function() {
     var layer = createLayer();
 
-    spyOn(plugin.heatmap.cmd.Gradient.prototype, 'getLayer').andCallFake(function() {
+    spyOn(Gradient.prototype, 'getLayer').andCallFake(function() {
       return layer;
     });
-    var cmd = new plugin.heatmap.cmd.Gradient('heatmapLayer', os.color.RAINBOW_HEATMAP_GRADIENT_HEX);
+    var cmd = new Gradient('heatmapLayer', osColor.RAINBOW_HEATMAP_GRADIENT_HEX);
 
     cmd.execute();
-    expect(layer.getGradient()).toEqual(os.color.RAINBOW_HEATMAP_GRADIENT_HEX);
+    expect(layer.getGradient()).toEqual(osColor.RAINBOW_HEATMAP_GRADIENT_HEX);
 
     cmd.revert();
-    expect(layer.getGradient()).toBe(os.color.THERMAL_HEATMAP_GRADIENT_HEX);
+    expect(layer.getGradient()).toBe(osColor.THERMAL_HEATMAP_GRADIENT_HEX);
   });
 });

--- a/test/plugin/heatmap/cmd/intensitycmd.test.js
+++ b/test/plugin/heatmap/cmd/intensitycmd.test.js
@@ -1,31 +1,40 @@
+goog.require('os.layer.LayerType');
+goog.require('os.source.Vector');
+goog.require('plugin.heatmap');
 goog.require('plugin.heatmap.HeatmapLayerConfig');
 goog.require('plugin.heatmap.cmd.Intensity');
 
 
 describe('plugin.heatmap.cmd.Intensity', function() {
+  const LayerType = goog.module.get('os.layer.LayerType');
+  const VectorSource = goog.module.get('os.source.Vector');
+  const heatmap = goog.module.get('plugin.heatmap');
+  const HeatmapLayerConfig = goog.module.get('plugin.heatmap.HeatmapLayerConfig');
+  const Intensity = goog.module.get('plugin.heatmap.cmd.Intensity');
+
   var createLayer = function() {
     var options = {
       'id': 'heatmapLayer',
-      'source': new os.source.Vector(),
+      'source': new VectorSource(),
       'title': 'My Heatmap',
       'animate': false,
-      'layerType': os.layer.LayerType.FEATURES,
+      'layerType': LayerType.FEATURES,
       'explicitType': '',
-      'type': plugin.heatmap.HeatmapLayerConfig.ID,
+      'type': heatmap.ID,
       'loadOnce': true
     };
 
-    var layerConfig = new plugin.heatmap.HeatmapLayerConfig();
+    var layerConfig = new HeatmapLayerConfig();
     return layerConfig.createLayer(options);
   };
 
   it('should execute by setting the new intensity value and revert by setting the old', function() {
     var layer = createLayer();
 
-    spyOn(plugin.heatmap.cmd.Intensity.prototype, 'getLayer').andCallFake(function() {
+    spyOn(Intensity.prototype, 'getLayer').andCallFake(function() {
       return layer;
     });
-    var cmd = new plugin.heatmap.cmd.Intensity('heatmapLayer', 3);
+    var cmd = new Intensity('heatmapLayer', 3);
 
     cmd.execute();
     expect(layer.getIntensity()).toBe(3);

--- a/test/plugin/heatmap/cmd/sizecmd.test.js
+++ b/test/plugin/heatmap/cmd/sizecmd.test.js
@@ -1,31 +1,40 @@
+goog.require('os.layer.LayerType');
+goog.require('os.source.Vector');
+goog.require('plugin.heatmap');
 goog.require('plugin.heatmap.HeatmapLayerConfig');
 goog.require('plugin.heatmap.cmd.Size');
 
 
 describe('plugin.heatmap.cmd.Size', function() {
+  const LayerType = goog.module.get('os.layer.LayerType');
+  const VectorSource = goog.module.get('os.source.Vector');
+  const heatmap = goog.module.get('plugin.heatmap');
+  const HeatmapLayerConfig = goog.module.get('plugin.heatmap.HeatmapLayerConfig');
+  const Size = goog.module.get('plugin.heatmap.cmd.Size');
+
   var createLayer = function() {
     var options = {
       'id': 'heatmapLayer',
-      'source': new os.source.Vector(),
+      'source': new VectorSource(),
       'title': 'My Heatmap',
       'animate': false,
-      'layerType': os.layer.LayerType.FEATURES,
+      'layerType': LayerType.FEATURES,
       'explicitType': '',
-      'type': plugin.heatmap.HeatmapLayerConfig.ID,
+      'type': heatmap.ID,
       'loadOnce': true
     };
 
-    var layerConfig = new plugin.heatmap.HeatmapLayerConfig();
+    var layerConfig = new HeatmapLayerConfig();
     return layerConfig.createLayer(options);
   };
 
   it('should execute by setting the new size value and revert by setting the old', function() {
     var layer = createLayer();
 
-    spyOn(plugin.heatmap.cmd.Size.prototype, 'getLayer').andCallFake(function() {
+    spyOn(Size.prototype, 'getLayer').andCallFake(function() {
       return layer;
     });
-    var cmd = new plugin.heatmap.cmd.Size('heatmapLayer', 20);
+    var cmd = new Size('heatmapLayer', 20);
 
     cmd.execute();
     expect(layer.getSize()).toBe(20);

--- a/test/plugin/heatmap/heatmap.test.js
+++ b/test/plugin/heatmap/heatmap.test.js
@@ -1,41 +1,70 @@
+goog.require('goog.string');
+goog.require('ol.Feature');
+goog.require('ol.geom.MultiPoint');
+goog.require('ol.geom.Point');
+goog.require('ol.style.Fill');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
+goog.require('os.Dispatcher');
+goog.require('os.data.RecordField');
 goog.require('os.events.LayerConfigEventType');
+goog.require('os.layer.LayerType');
 goog.require('os.source.Vector');
+goog.require('os.style');
 goog.require('plugin.heatmap');
+goog.require('plugin.heatmap.HeatmapField');
 goog.require('plugin.heatmap.HeatmapLayerConfig');
 
 
 describe('plugin.heatmap', function() {
+  const googString = goog.module.get('goog.string');
+  const Feature = goog.module.get('ol.Feature');
+  const MultiPoint = goog.module.get('ol.geom.MultiPoint');
+  const Point = goog.module.get('ol.geom.Point');
+  const Fill = goog.module.get('ol.style.Fill');
+  const Stroke = goog.module.get('ol.style.Stroke');
+  const Style = goog.module.get('ol.style.Style');
+  const Dispatcher = goog.module.get('os.Dispatcher');
+  const RecordField = goog.module.get('os.data.RecordField');
+  const LayerConfigEventType = goog.module.get('os.events.LayerConfigEventType');
+  const LayerType = goog.module.get('os.layer.LayerType');
+  const VectorSource = goog.module.get('os.source.Vector');
+  const style = goog.module.get('os.style');
+  const heatmap = goog.module.get('plugin.heatmap');
+  const HeatmapField = goog.module.get('plugin.heatmap.HeatmapField');
+  const HeatmapLayerConfig = goog.module.get('plugin.heatmap.HeatmapLayerConfig');
+
   var createLayer = function() {
     var options = {
-      'id': goog.string.getRandomString(),
-      'source': new os.source.Vector(),
+      'id': googString.getRandomString(),
+      'source': new VectorSource(),
       'title': 'My Heatmap',
       'animate': false,
-      'layerType': os.layer.LayerType.FEATURES,
+      'layerType': LayerType.FEATURES,
       'explicitType': '',
-      'type': plugin.heatmap.HeatmapLayerConfig.ID,
+      'type': heatmap.ID,
       'loadOnce': true
     };
 
-    var layerConfig = new plugin.heatmap.HeatmapLayerConfig();
+    var layerConfig = new HeatmapLayerConfig();
     return layerConfig.createLayer(options);
   };
 
   it('clones features', function() {
-    var feature = new ol.Feature(new ol.geom.MultiPoint([[5, 10], [30, 50], [25, 12]]));
-    var clone = plugin.heatmap.cloneFeature(feature);
+    var feature = new Feature(new MultiPoint([[5, 10], [30, 50], [25, 12]]));
+    var clone = heatmap.cloneFeature(feature);
 
     var pointGeom = clone.getGeometry();
-    var type = /** @type {string} */ (clone.get(plugin.heatmap.HeatmapField.GEOMETRY_TYPE));
-    var geom = /** @type {ol.geom.Geometry} */ (clone.get(plugin.heatmap.HeatmapField.HEATMAP_GEOMETRY));
-    var ellipse = /** @type {ol.geom.Geometry} */ (clone.get(os.data.RecordField.ELLIPSE));
+    var type = /** @type {string} */ (clone.get(HeatmapField.GEOMETRY_TYPE));
+    var geom = /** @type {ol.geom.Geometry} */ (clone.get(HeatmapField.HEATMAP_GEOMETRY));
+    var ellipse = /** @type {ol.geom.Geometry} */ (clone.get(RecordField.ELLIPSE));
 
     // check that it has a centered point geometry
-    expect(pointGeom instanceof ol.geom.Point).toBe(true);
+    expect(pointGeom instanceof Point).toBe(true);
     expect(pointGeom.getCoordinates()).toEqual([17.5, 30]);
 
     expect(type).toBe('MultiPoint');
-    expect(geom instanceof ol.geom.MultiPoint).toBe(true);
+    expect(geom instanceof MultiPoint).toBe(true);
     expect(ellipse).toBe(undefined);
   });
 
@@ -48,19 +77,19 @@ describe('plugin.heatmap', function() {
   });
 
   it('should clone features without styles'), function() {
-    var feature = new ol.Feature(new ol.geom.Point([5, 10]));
-    feature.setStyle(new ol.style.Style(
+    var feature = new Feature(new Point([5, 10]));
+    feature.setStyle(new Style(
         {
-          fill: new ol.style.Fill({
-            color: os.style.toRgbaString('#fff')
+          fill: new Fill({
+            color: style.toRgbaString('#fff')
           }),
-          stroke: new ol.style.Stroke({
+          stroke: new Stroke({
             color: '#000',
             width: 1
           })
         }
     ));
-    var clone = plugin.heatmap.cloneFeature(feature);
+    var clone = heatmap.cloneFeature(feature);
 
     expect(clone).toBeDefined();
     expect(clone.getStyle()).not().toBe(feature.getStyle());
@@ -71,11 +100,11 @@ describe('plugin.heatmap', function() {
     var onEvent = function(e) {
       count++;
     };
-    os.dispatcher.listen(src, os.events.LayerConfigEventType.CONFIGURE_AND_ADD, onEvent);
+    Dispatcher.getInstance().listen(src, LayerConfigEventType.CONFIGURE_AND_ADD, onEvent);
 
     var layer = createLayer();
     runs(function() {
-      plugin.heatmap.createHeatmap(layer);
+      heatmap.createHeatmap(layer);
     });
 
     waitsFor(function() {

--- a/test/plugin/heatmap/heatmaplayer.test.js
+++ b/test/plugin/heatmap/heatmaplayer.test.js
@@ -1,26 +1,55 @@
+goog.require('goog.events.EventType');
+goog.require('goog.string');
+goog.require('ol.Feature');
+goog.require('ol.events');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.MultiPoint');
 goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.Point');
+goog.require('ol.geom.Polygon');
+goog.require('os.MapContainer');
+goog.require('os.color');
+goog.require('os.layer.LayerType');
 goog.require('os.source.Vector');
+goog.require('plugin.heatmap');
 goog.require('plugin.heatmap.Heatmap');
 goog.require('plugin.heatmap.HeatmapLayerConfig');
+goog.require('plugin.heatmap.HeatmapPropertyType');
+goog.require('plugin.heatmap.SynchronizerType');
 
 
 describe('plugin.heatmap.Heatmap', function() {
+  const GoogEventType = goog.module.get('goog.events.EventType');
+  const googString = goog.module.get('goog.string');
+  const Feature = goog.module.get('ol.Feature');
+  const events = goog.module.get('ol.events');
+  const LineString = goog.module.get('ol.geom.LineString');
+  const MultiPoint = goog.module.get('ol.geom.MultiPoint');
+  const MultiPolygon = goog.module.get('ol.geom.MultiPolygon');
+  const Point = goog.module.get('ol.geom.Point');
+  const Polygon = goog.module.get('ol.geom.Polygon');
+  const MapContainer = goog.module.get('os.MapContainer');
+  const color = goog.module.get('os.color');
+  const LayerType = goog.module.get('os.layer.LayerType');
+  const VectorSource = goog.module.get('os.source.Vector');
+  const heatmap = goog.module.get('plugin.heatmap');
+  const HeatmapLayerConfig = goog.module.get('plugin.heatmap.HeatmapLayerConfig');
+  const HeatmapPropertyType = goog.module.get('plugin.heatmap.HeatmapPropertyType');
+  const SynchronizerType = goog.module.get('plugin.heatmap.SynchronizerType');
+
   var createLayer = function() {
     var options = {
-      'id': goog.string.getRandomString(),
-      'source': new os.source.Vector(),
+      'id': googString.getRandomString(),
+      'source': new VectorSource(),
       'title': 'My Heatmap',
       'animate': false,
-      'layerType': os.layer.LayerType.FEATURES,
+      'layerType': LayerType.FEATURES,
       'explicitType': '',
-      'type': plugin.heatmap.HeatmapLayerConfig.ID,
+      'type': heatmap.ID,
       'loadOnce': true
     };
 
-    var layerConfig = new plugin.heatmap.HeatmapLayerConfig();
+    var layerConfig = new HeatmapLayerConfig();
     return layerConfig.createLayer(options);
   };
 
@@ -33,64 +62,69 @@ describe('plugin.heatmap.Heatmap', function() {
 
     expect(layer.getSize()).toBe(5);
     expect(layer.getIntensity()).toBe(25);
-    expect(layer.getGradient()).toBe(os.color.THERMAL_HEATMAP_GRADIENT_HEX);
+    expect(layer.getGradient()).toBe(color.THERMAL_HEATMAP_GRADIENT_HEX);
     expect(layer.getOSType()).toBe('Image');
     expect(layer.getTitle()).toBe('Heatmap - My Heatmap');
-    expect(layer.getSynchronizerType()).toBe(plugin.heatmap.SynchronizerType.HEATMAP);
+    expect(layer.getSynchronizerType()).toBe(SynchronizerType.HEATMAP);
   });
 
   xit('should draw points correctly', function() {
     var layer = createLayer();
-    var feature = new ol.Feature(new ol.geom.Point([5, 10]));
-    var clone = plugin.heatmap.cloneFeature(feature);
+    var feature = new Feature(new Point([5, 10]));
+    var clone = heatmap.cloneFeature(feature);
 
     var context = layer.createImage(clone);
 
+    /* eslint-disable-next-line max-len */
     expect(context.toDataURL()).toBe('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABYAAAAWCAYAAADEtGw7AAABIUlEQVQ4T8XV10oEQRCF4W8VTBgRFCMoCMb3fxAjCApGFMSICQyU1Mo6jBcLtltQ9PQw/Z/q02EaCkWjEFdHwCHahe5s4zniPfMt24+6Wf9WccB60I+BzOhHvOIx8yn7IfIj6sABDeAwRjGOsYTH4IBe4wo3uEMI/IBXwdHvS+AEpjCNSQxmSQ+4wBnOcZkCz/i2pQqOakcSOIcFLGKmAj7FAQ5xnAK3rVVXweFjVBrAJaxgFSEylBXfJ2wHu9hPgag8/P+KKjhsmMcy1rCODcxWPD7BJrawjT0cIeyoBccOiKk3gQGNDK97c8xLTj3AzQyBsCYW9n/BxawotnjFtluxAxIrWuRIN3dLkUuodSv++bVZd8W29a4jf5C2Kqx+/AkT13QXFOheRwAAAABJRU5ErkJggg==');
   });
 
   xit('should draw multipoints correctly', function() {
-    spyOn(os.MapContainer.getInstance().getMap(), 'get2DPixelFromCoordinate').andCallFake(getPixel);
+    spyOn(MapContainer.getInstance().getMap(), 'get2DPixelFromCoordinate').andCallFake(getPixel);
     var layer = createLayer();
-    var feature = new ol.Feature(new ol.geom.MultiPoint([[5, 10], [30, 50], [20, 12]]));
-    var clone = plugin.heatmap.cloneFeature(feature);
+    var feature = new Feature(new MultiPoint([[5, 10], [30, 50], [20, 12]]));
+    var clone = heatmap.cloneFeature(feature);
 
     var context = layer.createImage(clone);
+    /* eslint-disable-next-line max-len */
     expect(context.toDataURL()).toBe('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACMAAAAyCAYAAADWU2JnAAAB/0lEQVRYR+3ZiWoUQRSF4S8G1ARXJAZXUBDUKL6Gz+Fb+AB5wriBoOCKirjiBi4cqIEmOG2V2mEgVVA0AzPT55669zb37yXTrSXsxxEcxwmcxDoOlNt+xAs8w/P8YKq1jMNFxBmcw3mc2ibmKR7g4ZRi9hZHIuICLuEyIuxgceADHuMO7k4pJkd0FhexgSu4itNYLWI+4Qm2cGtKMblhjmUmIkKykzv7ipivyZUiZmvXiFmoY1qoBF6o0l6oppeCiTsrOFQ68TEc3Vbab/Aab6espllnj6DkT0Sl3LPzOesb0muyP++EmNw099lTnMo1O+tH2d9z3SkxVc+/LmaeTd2Z7kxVCQ2+1HOm50zPmVYHes60Otb7TM+ZnjOtDuyKnKkaQfCzxr1/6TPVw1kZ1jIbja6I+ZvomsZWvM/EiFFBEZKx84+j5yC65oEeLzNL48vYkeWPg0ODR0eH8kF0sbqJYhaIGFz2bsydiLlWw2gH0cXqcN1qion7QavlPzLs/3ZFzPUaRjuILlaHWFZTTNzGPTwqRzVXzI0aRjuILuw2LLeaYs7QaoHPwR9zxdysYbSD6F4Vyj2JmM3CZ0cZ7SC64PW1qY6pVUzwenD7JAncekzB62G8Id1VLyhaSrs1gdPA0oGrX920NL3W0k7jyqqmmC2Pg9amN2vp//1B+Qv0Zf8FPX9LlQAAAABJRU5ErkJggg==');
   });
 
   xit('should draw polygons correctly', function() {
-    spyOn(os.MapContainer.getInstance().getMap(), 'get2DPixelFromCoordinate').andCallFake(getPixel);
+    spyOn(MapContainer.getInstance().getMap(), 'get2DPixelFromCoordinate').andCallFake(getPixel);
     var layer = createLayer();
-    var feature = new ol.Feature(new ol.geom.Polygon([[[5, 3], [30, 5], [32, 21], [12, 22], [5, 3]]]));
-    var clone = plugin.heatmap.cloneFeature(feature);
+    var feature = new Feature(new Polygon([[[5, 3], [30, 5], [32, 21], [12, 22], [5, 3]]]));
+    var clone = heatmap.cloneFeature(feature);
 
     var context = layer.createImage(clone);
+    /* eslint-disable-next-line max-len */
     expect(context.toDataURL()).toBe('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC8AAAAnCAYAAACfdBHBAAAFLElEQVRYR9WZ144bRxBFS5Zly7ac4///nKOcc8Yh+hCXxZoZcvVgeIHG5OGp27drqnsf1f/479ELsL/Is9PP/nMvy0MA8hn3p3OdZQuunz86Pr/3XviEZT8bL/V4S8QEc3/a9nO87yr4W+En6JcWbN9uBdDBE5B92t9r63FurwK4B14oYG2Pq4rGsVuD2fJ1BxOY7VbzmYsAboFPawj9clVNzWBSffb7j3fgv6rK9mfse673yEmYW+FVEzign1TVK61xjsZ17/f9aZGurrB/VNXUNgM4gk+rJPirVUV7WlWvrS37BEQAWijh09cEIJTAv1fVb1X169qyzzmuG2D2wKHy/HhaBTCgX4/2RuwbAOoTQIrjgFR5gGgJ/XNV0X5ZzUC4h3t99uT9PeW76oKjNMBvtvYsekH1fcekOjCoCiDtp9V+qKof45hA7AF666z+LfDaRZsA/lZVvb3aO2tLMASQ6tNr/ql82gUo4AAH+Puq+m419g2C4LjXZ09iHMHz4w5QoLALkAC/W1XvrcY+wQDPPXg/B64pLr2uXbAJagP9bVV9vbbfrGC4RoCMAb2/C293qzow2AU4IIF+v6o+XFv2CYjAgKeX9H1XngD0OoqqOLCAf1VVz1cjGHqAALn3YuBuKe9ABV6vaxcgP1jgH60tx5zHTsLzXH6w0jbCo6iqAwz4F1X15donGHoEWwHPGDn7fg8+U2OqruIfVxWNADiHdRK+Z5wOjw1QFGVRHXjAP1+NADiH+sAT6CF8t4ypETAAURngTwKec1zTNpPnsY+eB0J4lEVhYAH/bDUCER5r3QxvrQIE8Ol1fA64TeWxjenyaMAKj6IoCyTwgH+6tgSCjQgOa5lxzPVjtsmPkgPVDJOqC++gNduQlax7ssYx12d+R1Hg9LrgbBOe+zJdEsDVFzYtk19TLEOGAT5Vx/Oc49qW3y3MtE3PNCif8IDT0jbTgB3h0zKoSJbBEgDuWYbeYWDTW1Nt0+HxMIoyWLvy2Ed4sw1jBLudS4SebTiecrvpEX+jtoOVYFSdIAm2p8jM86S5niZTeQcrlmEMMJDN85YIm/CqjmcZqCiJHRIecIKgmd9T9fyyTqUw6lkWMBCFN9uYLhnE9IpfWIszBDi9N5Wf/G4BlilScFS3LFD1KbdnUabyWEDbmG2wDgHYLBMyx1tZbsJby6C8X1Ug+RCZbdhaEkzp0VpmqiZNk1kaAGppQBDsW9uMpUEqbw9oG3xrIaZtrGfMLn6UCJBAu9enuSnKaxvLYK1jbcOW3mCgmiKvirIjeL+s+JkcDqzNMhhwxoXTv5w5nT8m8WVNeL+w2CJLYT9KBIXqzqisaU45/gg+K0kDsIa3dgd8qiC3VgGEz0Gr91HZiQj72iUHqr05wpsqnUwDZ1GGt4V26qddcsrXB2ifhGQAzlmd/vUpYM5hL+avk/KZ502Xej/nrSqedskljgTOuWsub5jv+8TbMiCnfqbHXEIZU2Xmepc4CMDmykFf5sgMc7SQlEFoodxa/6TPL8CnPM+5XA3LNRoD0VJ9gckPUoL3Zbw+FnpP9AWnfNfhcl+uGNgDlgtWikLr8768kct5OcDSs9OKmYFpkb5KpjjnGf1U26h+rtlsrUf25/uy3tbx3nplv3aleE+VsUJxsUw9rQD3pbx8NmuZ3E+A6XwPcro/f+ciVfYLKqqN+vE0F+gKdcisLrcCns5fQe8pP13rBdzmC6d/AqybrzwbL9m79iD4WwJ8SBB7z9x1bW/F7K4X/Rc3/wuzaKhGOLndqwAAAABJRU5ErkJggg==');
   });
 
   xit('should draw multipolygons correctly', function() {
-    spyOn(os.MapContainer.getInstance().getMap(), 'get2DPixelFromCoordinate').andCallFake(getPixel);
+    spyOn(MapContainer.getInstance().getMap(), 'get2DPixelFromCoordinate').andCallFake(getPixel);
     var layer = createLayer();
-    var multiPolygon = new ol.geom.MultiPolygon([
+    var multiPolygon = new MultiPolygon([
       [[[5, 3], [30, 5], [32, 21], [12, 22], [5, 3]]],
       [[[50, 8], [170, 20], [190, 15], [60, 22], [50, 8]]],
       [[[5, 200], [220, 200], [205, 170], [300, 30], [5, 200]]]
     ]);
-    var feature = new ol.Feature(multiPolygon);
-    var clone = plugin.heatmap.cloneFeature(feature);
+    var feature = new Feature(multiPolygon);
+    var clone = heatmap.cloneFeature(feature);
 
     var context = layer.createImage(clone);
+    /* eslint-disable-next-line max-len */
     expect(context.toDataURL()).toBe('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAATsAAADZCAYAAABfJ5f6AAAgAElEQVR4Xu2dh7LjXG6Euc45p/d/uU3OOdvV6/uN+8fgBEqMIqZKJY2uxAAettAIjR8t9a8sUBYoCzzAAj+aOMfeZ2a+P7GL+khZ4FEW+J/G2bbef5Rx9jrZEVjxd/9c7729jrO2Wxb4BAs4mPF69N4nnPclzqEFdhHc9H8HOf4f37/ESdVBlAUuagEBm4Mc/4/POvzy8ja+iCOwA8x+6Qvs9H+95lGgt/EFqc19rAUioP33F6DpmYc+o9eAXQHehsshA7vowTm46fUv26MFfBziiCZveCq1qbLAJS3gnhwA919foKZnf7RA75IndreDaoGde2wObnr9K+HB3zNvr0DvbiuijndLC0TK6sD2n8uy6PEf4Tl6euXdbXRFIti5Vwd4AWa/uiyLP37N/i8AHIFeeXkbXbTazG0s4NRVIOYA9+/Lsujxb1/Peg3wAYpZEuM2J3+1A22BHTG6CHS/viyLQO43lmXRa/4P8PVAT+degHe1FVDHs6cFADtoq8AMgPvXZVn+5euh13oI+BzwHCz3PM5HbDsDO09KQFvl0TnI/eayLDwi8OmzLdDLAK8A8BFL7VEniUfmMTp5dQIzQO6fl2X5p2VZ/nFZFr3WwwEPgPQM7qOMuPXJzoKdgE5enIBNIPdby7L89tcz/9ffAD7oroMemdysTm/r86rtlQXOtgCZVeirPDqBGSD3D8uy/P3XQ4AH6EFrBY6AZcXtNriaa8HOgU5gFx94e05vSWjIS6wkxgYXrTZxaQt4nI3Ym6ipQExAJ1D7u6/H3y7Loof+L/CTpydAFDAK7PT98uw2utxrwU6eG17d7yzLEh+An0APL88TGa0kRmVtN7qgtZnTLeAUVmAFfVV8TkAnb+5vvh5/vSyLHvq/3tffobIFdhtfypkEhTwz0VKnsQI1gO53l2XRQ//XM4AnUMxAL8bzvMylQG/jC1ybO9wCeGLQV3l1AjB5bQCdAO4vvx5/9QV48u4EdgLF8ux2uGy9OjsvPRFAkaCI3h1A93sN0IuJjBjPa1HbSlzscMFrk7taoOXVib6KpoqyCuh+bg+Bnt4D7Nyzq5jdhper10Hh5Sd4dyQqiN3Je8Ojw8NzTw/vT5/TwzO3gN6oPi/L4G5ogtpUWWATC2SxOpIS8uoEZnh0P1uWRQ9AT+87jdX3yMbSPrbJQT55I73e2FYJikCKzKtAD9rqVDYDPs/eRtAb1ecV4D15ld7j3KNXR00dXp3icqKsAriffj0EePLsiNlRfqLveunJPSxw8aOcEQLw/lcyq3h4iuN5hjbG8Rz0+FsGelmpiosPuLrKxU1ah/dQC7RidWRfoa8COAc7AaDorWiu4nXK2lZyYodF1IuLZa1jCAEQw4teXszUAnajeJ53Y3ipiihu1eftcOFrk5tbgLo6z8BGrw6g+4nRWOJ1XnZSBcWbX55x+1ZLASVrIyNbS3xOHlyktg568vRiqYro7UypSiuLvIOJapNlga4FerE69+pEV/HoADt5daKw8uoEjO7VkZwo829kgZmMZwQ8PC338qChAJ5nbClTiXE8T2Rk1Nb7beXtZXJSmGHmPDYyWW2mLPCdBdZ6dQI9xe4yr646J3ZaYLMg4Z/zujjXt4sZ29hahqeXgR5enp5jqYpAL1LbGM8r0NtpgdRmhxaIsbosA+tJCQGdJybKqxuaeJsPzIJdBiaerc1AjzgcXl4rnhfBDy+PUhWobQS9qs/bZg3UVt6zQHl179nvsG+vBbsIeu7lQW8pI3FqG+N53mYmsCOWR4wvxvPk7dFvm9XnxSSGjvPVczvM+LWj21ugvLobXcJ3AWE2nievjA4MaGrWcjZTqoKnB212gQGnt0Vtb7QQb3qo5dXd6MK9C3bRg4rUFnqLxl1LKgpPL5aoAH5Zvy0Aqm3HuRjVb3ujRXjTQy2v7mYXbguwWxPPg4J621ksSo69tjFrK+BzKSnR29nWsy3P92aXug53YwuUV7exQffe3B43/4jayguL8TyntrFUJXp7xPNiv+1MfV5R271X1DO2X17dDa/zHmDXorYkEaCc3nomoHKpd++3dc8uK0rOpKQqnnfDxXijQy6v7kYX6ygPJ6vPy3ptBU5eqjLbb+v6eV6f5/E8ssNVqnLDBXrBQy6v7oIXZeaQ9vLs4r4j6JE19fq8VjwPLw8pKZ69XAXqO5KSohMjlsxEb3TGdvWZZ1qgvLqbXvejwC56krELw1vPEBmIpSpo54308zJpeJIYJSV104V6kcOe9erUIaH+1+qWuMiFO8ubmW09A/SyqWaZyIDX6JU0/IUW2QcdCmDHsGuG6KBCrGZ/l3CiB1YN/xLvjAN1Son4wMVxtGfnpzYbz2NmbQQ9srIjgQHaz3qjHiued+Ciu/GuoLACu5keWIEd4pzVA3vyhT8T7HrU1jO3MWubtZ5FkQHF8zzGp9eete3121Y87+RFedHdO4WNKsQS35T3Bn2FwkoAAK+OyWEM0ymv7uALfQWweyWeR+bWZ2E4tfXkRdaF4fMwSkrq4EV30915YoI5sD4xDGUTAR1gxzAdzZdAr64k109aAFcCuxhDjEkMr89zajsjDY+n15OGLympkxbhTXbrFFaAJQl1gR0Tw9yrQ5wTCsuIRMQ5y6s74aJfDeyilwcAQmtb+nk+ACiTkoqqKqP6PNfPq3jeCQvzYrv0YToMvdbIw5iYEMj9+MuzE/hBYfU5fV4gqe8DnBc7zc8+nKuC3avxvGzqWatUhR7cNdLwJSX12fdD6+yykhOfBesUVmBHyUnMwhaFPXH9XB3s1sTzetLwUT/PNfR61FYUGS+vpOFPXKgn7zqCneioaKw8Ns2QYL4EXh00NsquF9ideCHvAnavxvPWSsNTzuJ9urSelTT8iQv15F1nnl0GdiQnItiRiS0ae+KFvBPYrY3nAVIkMHr9ttmoR1rPXCWZzC3Jkornnbh4D9w1YKdnauwEdgIxyk58cphPD1MxsScoNCZRD7Z54Gk8e1d3BLtRPM+FPFtSUqPWM4/nUZ83koYvleTPvpdiNlYJB2VjBWYMwBbgxTYxgaGXntB94QD62Za7yNndGexG8Tzk2n3qmffbkrVttZ55uQqCobE+r6SkLrKQDziMlgCAgEyAlrWKUXqCdyeA9KLimg17wIXLKOGBu918V7OtZ95vS1wugl5v1GOcbxulpCiNyUY9fsIPy+YX7kYbjB0U1Nq1BmGr9IQOCoGht4sJ8ERlq97uwAXwaTdgD/Sgtz1p+Kzfttd6BrXNpOG1v2o9O3Ax77yrWGtHFwUlKMrKOp0V2FFrR1Y2Fhd77I7t73waz938p4HdiNpG/Tyfehbn2/ZmYfSk4enEaCUxPs2rftLdg3cnkMrEAChDkUcH2Ll3J8qbKZ8UnT1gFX0q2K0pVcmkpOSxjUY9ehdGJg3PRDUHPff0CvQOWOAb78KprAAK744yFJIVitU54NEjW3R24wuyZnOfDHYZmAA270jD91rPSGDIS3RqW9Lwa1bltT+b1dypyFgeG+1j6pwgYeGxO9FZeXf6nABSsTsKjSs7u/N1fwLYtUBvJA1P6xn1dnHqWUxkQG3J3PL9rCg5JjC4Dk+6Hjsv7d0276CEdyfQEngpfifvTnRWgId3p2forP5WdHa3y9Pe8BNvLgeW6OmJckb9PLowoLZZqcpo6hn6eRm1rfq8Exb+m7uMRcaK36mshELjjM4CePLuIp2ls6Kys29emN7Xnwh278bzoqqKPLqon5f12yI6SjY4zsOoeN6OC32HTbforAsEZHQ21t4JIEWDi87ucJF8k08Fu7XxPNfPG9XnZa1nUFsvVYn6edV6tvNi32HzFBpDZ13nTlQ10tlYe6fPZArGlZ3d4WI9Hex6pSrIObWorYsM4MmN5mH4qEd9HxCN+nlOrytru8PC32iTGZ1FESUWG4+ys653V3R2owtUnt04hhlVkn3UY09KajaJ0StVKSmpHRb6jpuMdFbenYDL6azidDE7SzlKFAqo3tmdLlZ5dt8bNuvCcC8PT6819Qwx0JGXJ28QSkypSknD77TQd96s01kvNpZ3R++sZ2edzmbZWQGmvLuisxteuAK7sZdHQgPAy6ThGQAUuzBG9JZeW6/Pa5WqVL/thgt/4005nVV3hRcbQ2ez7gp5dwLBrNhYoFl0dsMLVWA3NmZWqgLwkVGNUlIOelElORYlx/q8kZQU+44e6PhM6hN7WiCjs3GINr2zXn+X0VnR4KKzG1+tArt5g87U50FtXUpqpvWsJQ1PfV5JSc1fpzM/2aKzPnIROuuAp/ecznp3hXt3JRbwxtUtsFtnvCye561niudROCzAo7YuU0mOJSrZfFt9zwd6a9suTppRW2j3ujOrT29hgYzO0l2hFjHF7+TdxfhdpLMCR3mFaN8BogV2b1ylArvXjNcDvRkpKc/atoqSfepZT0qq6vNeu4Z7fcvprOJ3AqyMzrbEArx31ouNK3735hUrsHvPgCNqi6cnj4wkBhlYwMxHPUZvryclRZywpKTeu4Z7fHtEZ5lbQQsZ2VkBoP6mchR5d9BZxe9K++7NK1Vg96YBvwQ62UqszwOIYr+tTy/LSlXc2+uNeqRUBXrrlJpj8WN7/2xrCzMWiHSWwdreO0t3heveCfxEc/U3lI1jsXGVo8xcgeQzBXYvGm5gyygwIBDy+bNeqtKbehZr9SK1jfG8kpLa7nq+u6UenWUq2UyxsYqTi86+ezWCV7LB5moTiac3kpLyUY+R2kJxvVyFeJ+3ngGeTm3pxHBv02l3Xaz9LdCjs659F1vJEAvw3lkBXtHZN65ZeXZvGG/w1VE8ryclNRr16NTW9fMc9KKqSklJ7XetW1vu0VnGMMZiY9e+8zGMRWffvH4Fdm8acBLw9LGZeF5WqtIa9dgrVdF2GOhdUlL7XuPR1iOdpXc2k3InfqdnvDsBnmhv0dmRpVfcjG9uqr7escCoPg8vr9Vvm00983ied2GUNPz1lmKkswAexcZkZ3tS7khBFZ198fqWZ/ei4V78Wq/1LJOSwtMjPrd21GNJw794oTb+WovOipoiFjAqNnYpd1c2ruzs5MUqsJs01MYfWxPP8/o8n4fRGvUYp57h6UVqW1JSG1/UweYyOkuxMdlZ4neRzjJ3lkE9xO9q0PaKa1hgt8JYG380o7Y0+Xt9nlNbMrdRGt4pLUO9Z+rzKp638UWdADykm5RZde27KAUVxQIEhF5sXHR25bUrsFtpsB0+PtN6hhAAAgOukhzn2/ZGPbp+XklJ7XAxJ8AuDtoWaDmdxbvL4ndIQdWg7ReuXYHdC0bb6Str43nE43zqmbeerRn1mLWe4WVGMN7p9B+z2RGdnRm07dlZ9d4WnZ1YPgV2E0Y6+CMz8byeNHzUzxPojUY9Ehf0Lo9qPdvvwreys0i5y7uL2neK4yEFlUm5V+/s4HoV2O23oN/Z8ivxvEhtqc/L5OE9nud9uhm1VfywpKTeuZrffzfLziIFRbGxKKsro2TFxkVnV1yXArsVxjrho7PxPEDKW89aSYxs1CNZXldJpii5papSrWfvLYgWnaXYGO271qCeTMq96GznmhTYvbdgj/p2K57nQp5RGt7n245mYbiUFN/zUhUXDY36edig1tL61eCinAzqUcJCHpv3zvaKjSlHkWdYg7YL7Navwot+oxXPg2p61tal4fHyWq1nXq5Cr22szytp+O0XhdNZBm1DZxW/U2wuDtp2OptNJmNQTxUbh+tVv8bbL+C9tzjbeiZwQhrevbzZUY9MPsuk4SlIbsXzal3Nr4Js0LZKUVz7Dikor71D+y7SWe+uYNvzR/PBn6xFed+LOxPPg9pmoLe29awnDS/Qc6GDiuetW1dxMlkm5a5MbBa/o9hY5SgCSNe+cyBdd0Qf+OkCu/tf1FGpCtLwJDGoz5tpPYtdGJHaopRc0vDvryMvR5F3pofAK5tM5urGzJ117TsG9dSgbbsuBXbvL9IrbGG2VMWpLaUqM6MeY78t1LakpLa7+hmdlZfWo7NIQYnmOp2N2ndFZ0upeLuVepEtrYnnzUjD91rPSkpq+4ueDdoWcFFsLECbkXKHztag7fLstl+lF9tiBL2RNHxGbV9tPYPa+jyMiufNL5CWlDtSUD6ZLNLZLDsrOlx0tjy7+RV400+O4nk9aXjP2rbGPcb6PNfPY1h4xfPWLZ5s0Haks1HKHTpL/I7JZD5o+/FzZytmt24h3vHT78TzYhdGa6B3BD1ER8kGl5TUupWT0dls0HY2dxbtO7KzosFFZ8uzW7cCb/7p2Xie6+eN6vOy1jOKkr1UJaO2Wb9t/fj+/yIbDdr2YmOvv0MsAGVjBm1DZx9bjlKL6+YI9sLht1rPBD6ZNLxLSY2mnqGeTEGyJzEAUahzLEjW/vlX63JZMjpLd4VoKr2zArc4itHprEpXnM56i9oLy+e+X6lFdd9r9+6Rz8TzelJSiIZmqioR9FqlKiUN37+KvUHb9M7G7govRxEg0jv7+EHbBXbvQsa9vz8bz2tNPZttPVNMz1WSqc9zL6+kpPK1NKKznp2NUu76m0u5U2z8SO27Art7g9VWRz/TeoYQgNfneRfGSFklo7YlDT++gr1B20pCuFiAl6LQO6vYHtnZRw/aLrAbL7YnfaIXzyOjGqWkFNPzUY8OerEo2efbzkhJ6XhIZDw5ntejs0wmmyk2fvSg7QK7J0HZ/LnOxvO83xbwigOAslkYvfq8kpJaT2dd+y4mKyQeQLHxowdtF9jNA8DTPjkqVUFgIOu3jfV5sUQFACTmp89nUlIuTvp0afgenUXKPRYbZ1Lu8u4eSWcL7J4GYevPdyae15OS8qxtqygZ0HNqq9hgNvXsyfV5mZQ72nfy7nwyWRy0LSBUwsInk6Fs/IjuigK79Tf/U78xorZ4egIokhhObWOpSvT2nNpGKakR6D0pnteaTIYUFNnZnpT7I+lsgd1Toeu1854tVYHaKqbn08uyUhX39qJ+XqzPq3je98XGagWLg7aVrOgVG9Nd8Sg6W2D32k3/9G+N4nk+f3ZGSiorTI7UVllfEiIuMhAHALkH+qnXaTRoW94d8btIZ+mdpdgYwPv4yWQFdp96OxxzXhH0RlJSPuoRMENRhWcvV4H6UtoiwAM8ndrSiaHj8Yes8KlrvDdoW55br9gYKXdRX9e+++hi409dCMfc6rWXGCtzoMHjavXbzo56dGqLyEAEvaiq4kmMT43ntbKz8tTQvsO7y+J3KBs/ZtB2gV0B1lYWWBvPQwZKoDca9dgrVXmyNPyIznp2NtbfIeXu2Vm1k30snS2w2+pWr+1kHhSeHl6enonntfpts6lnHtPzLoyShv+/hAVKxEpWqJzEpdzl3QnYXPtOcTykoASIPplM2/hIOltgVyC1lwV6rWcZtcXT89YzhnoDdgzzRlVFwOcFyZ7EaElJAcCfEs/L6CxSUBQbi7KKysa5sz6Z7OPpbIHdXrd6bfeVeJ7X582MeoxTz7L6PEDPvUsHvE8AvRadVfLBte+yubNxMhnadx9HZwvsCpSOsMBsPM+pLZnb2HrmlBZPb6Y+79Ol4V2UU1SUQdvy2Lx3tldsTDmKvkt3xccoGxfYHXGr1z5m4nn0wVI4rJq6qJIcRQZ6ox5dP+8JUlIOSorhCaygs+qHdSmojM5mk8kEmh8zmazAroDoDAusjec56MX6vKwgOUpJxaln8iB96pmO5xOkpLJB2/TOon0XlY1JXGR0VoAJ4N1+0HaB3Rm3eu1zTTyvJw0PfV0z6pG4oHd5fFI8L04mg876oG0lJrL4HcXGnp39GDpbYFfAc7YFXonnyVPL6vNaXh6envfpZtT2U6ThvRxFYKWHkhWIBfhksjhoW5lbdWAgFoCU++3pbIHd2bd67X9tPA+Q8tazVhIjG/VIlpdRj95v2xrofbd+24zOxkHbvUE9dFdk2ne3pbMFdgU2V7NAK57nQp5RGn629Sybeuag90lSUtmgbS82FqDNSLl776zid7fNzhbYXe1Wr+MZxfOgmp61JXM703rm5Sr02sb6vE+RkmpNJqN31sUCIp3NsrMM2kbs81artcDuVpfrcQebxfOy1jOXhncvb3bUI5PPMml4FFVa8bwr30PZoO1IZ6OUO3NnfdA2g3o8fnc7OnvlC/W4O7tOuGmBHuhBb3vS8Fm/ba/1DGqbScNrf67ucvV4XkZnBXienY29sypHUbYW7Tuys6LBorK3pLMFdoUwd7JAFs9zKSmk4X3qmY96pNe2NQujJw2vbd5VSmo0aNuzs15wjFgAysaK39Fd4XMrtP3L/yuwu/wlqgMMFpgtVcmmnsljG416jP22URreVZLvUqqS0Vm6K7x3tiflrs+pdIXeWby728TvCuwKS+5qgTXxvBlp+F7r2SdISfUGbdM72ytHkXdH76wA73aTyQrs7nqr13G36vNG0vC0jrmqindgZEO9fR6Gt55BbaG3cczj1eJ5Izrbk3LX39Rfi5Q7yYrbaN8V2BVofIoFRvE82sM8nhdHPVKH5/p5rp0Xs7bo52XU9orS8L1B2/TOEr/zUhTF8eT16W/y7m45aLvA7lNu9ToPWeCdeF7swphJYpC1FeiRDb66lFSPzgrwZouNKUe5DZ0tsCuQ+EQLzMbzXD9vVJ+XtZ5RlOylKhm1jfQ2AvPR16BHZ137Ls6tUDkKxca3G7RdYHf0Mqv9HWmBd6Sk5OmhqpIJDMTWM09iAKItaXiBXxZzPMo2PTqLlHssNkYKyqXcb0VnC+yOWl61nzMtMBPP60lJUa4yA3qtUhU6MeJQ77NAL5NyR/tO3p1PJouDtgWEors+mezydLbA7sxbsPZ9pAVm43mtqWezrWfyBl0lmVGP7uVdpT6vNZkMKSiysz0p99vQ2QK7I2+32tcVLDDTeoYQgNfnxVKVXrkKWVuntleUhp8ZtK0sbK/YmO4KeYWubHy5YuMCuyvcfnUMZ1igF88joxqlpLz1LKokx6LkKA0/kpLS8ZwhDT8atC3vjvhdpLP0zlJsDOBdcjJZgd0Zt1nt80oWmI3nterzekmM1tQz6vOuIiXVG7Qtz61XbIyUO8XG6q645KDtArsr3XZ1LGdZYFSqgsBA1m8b6/NiiQpJDWJ+PtQ7U0k+I543Q2fx7rL4HcrGlx60XWB31u1V+72iBWbieT0pKc/atoqSvfWsJyUVs7Z7t56N6KxnZ2P9HZPJPDurdrJL0dkCuyvecnVMZ1tgRG3x9AR8JDFi61lr4lmrPo+s7ZnS8D06q7icvLuofac4HlJQAkSfTHYpOltgd/ZtVfu/qgVmS1WgtqKkPr0sK1Vxb68Vz/NSFebbHjXqMaOzSEFRbCzKKiqbDdpmMtkl6WyB3VVvtTquq1hgFM/z+bMzUlJZYXKktiQwBKAuMnAEtW3RWQl3uvZdNnc2G7R9GTpbYHeVW6qO4+oWiKA3kpLyUY+AGdSWZy9XId5HPZ8AD/B0aksnho7HH7LfVvczdFbPoqIM2pbH5r2zvWJjylFQNj5dCmor41x9odbxlQW2ssAonteTkhr12zq1RWQggt4R0vBOZ1UcrGJh6Kz6YRWbi4O2vXc2m0wm0Dx10HaB3Va3QG3nSRZYG8+ThybQmhn12CtV8STG3lJS2aBtemfRvovKxgBeRme9u+KUyWQFdk+6Retct7bAbDyv1W+bTT3zmJ53YZwhDR8nk0FnfTKZMrFZ/I5iY8/OIhZwyqDtArutl39t74kW6LWeqUwlUls8PeJza0c9HikN7+UoAis9lKxALCDSWZWiyMNzKSjEAnzu7OG9swV2T7w165z3ssCaeJ7X57nIAHV4nrzIqC2eXqS2W0tJZXQ2DtruDeqhuyLTvjuUzhbY7bXsa7tPtcBsPM+pLZnb2HrmlJah3jP1eVvH87JB24rfxUHbrXKUrNj48EHbBXZPvSXrvPe2wEzrGUIAqqeDmnoSw0UGeqMeXT9vLymplpS7KGoUC/BhPXHQtkDSB20fRmcL7PZe8rX9p1tgbTzPQS/W52UFyVFKyuN5WeuZjucVKals0Haks1HKXaAnb4/4HZPJfNA2YKft7/qvwG5X89bGywLfLDATz+tJw0f9PAGfK6wAeq6qQlzQuzzeaT3L6KyAK9JZSlBIVgjw0L4jOysPT1T2MDpbYFd3Y1ngOAu8Es9r1ee1vDxAz/t0M2r7qpTUaNC2Z2e9fzbSWWV0nc7uXo5SYHfcQq89lQWwwGw8D5Dy1rNWEiMb9UiW11WS6bcV2AF4a0Y9ZnSW7grvne1JuetzKl1xOustaruslAK7XcxaGy0LTFmgFc8DiHpSUqPWsyglhae3hZRUb9A2vbO9chQlNOidFeAdMpmswG5qTdaHygK7WqAVz8Pz8qwtmduZ1jMvV6HXNtbnvSoNP6KzPSl3/U3lKEi5U2y8q1hAgd2ua7g2XhaYtsBs65lLw+OtQW0FaKPZtkw+Y76tS8NTkNyK5/kx9gZt0ztL/M5LURTHk9env5GdPWQyWYHd9FqsD5YFDrHATDyvJw2/tvWsJw0v0NPx+ENG0P8pFcHDk1fmvbMCPHlw0FkHvJidVTZ3dzpbYHfI+q2dlAVWW2BUqkI8z6ee+ahHvLzWLAwvVYnUVtuckZLipJBuQvtOnlrUvotzKwR4SEEdMmi7wG71GqwvlAUOs8BsqUo29UweG4Kgo4HekdqulZKC0sq7E+BRbIyUeyw2du07pNyz3tlNuysK7A5bt7WjssDLFlgTz5uRhu+1nr0iJQWlFTgJ8JRdRftOcTmfTBYHbQsIBXg+mWyX7GyB3cvrr75YFjjcAhH0RtLwtI65qkrPy+u1nkFtobdZbR7xuyjl7r2zPSn3Xelsgd3h67V2WBZ42wKjeF5PGt6nnrXGPWatZwwB8gFAMWurEwPwkHKXh4dYgJIVvWJjgSKTyVzZeBM6W2D39rqrDZQFTrHAO/G82IUxk8QgayvQI0F1jK8AABLnSURBVBvsXp6LCwjwoLPK0CoeR3aW+F2ks/TOUmxMOcpmg7YL7E5Zp7XTssBmFpiN57l+3qg+L2s9oyjZS1Va1FYn5/E7JSyy7Kz3zpKd9WJjfW+zQdsFdputudpQWeBUC7Raz+RxZdLwUT/PtfN6UlI+6hEvz0EvengCKxIW0Fm8uyx+h7Lx5oO2C+xOXZ+187LA5haYief1pKQoVxl1YkQpqTjQm+Pw2bNSOmlNJkP7jslknp3dZNB2gd3ma602WBY43QKz8bzW1DNPYvS8PHmDrpKsshcXDJWXB6X1+jsXC3DtOwEeUlCZlPtbvbMFdqevyzqAssBuFphpPUMIwOvzYqnKqCg5Ulv38gA8eXiis8TvMin3rNh4MzpbYLfbOqsNlwUuY4FePI+MqlPbbNRjbx5GVp9HFwbbx8MD8GL8LiYrskHbb9HZArvLrMc6kLLA7haYjed5vy00ddR61pp65mKhDnjU33l3RVQ2FuC59h3Kxi/R2QK73ddX7aAscCkLjEpVEBjI+m1jfV4sUYnzbV0wVJ4jKioqS0HdmISFYnXKzgJ4DOpBLOBtOltgd6l1WAdTFjjMAjPxvJ6UlGdtW0XJUWCA7gvtm6JjLzgG8OKgHh+0jRSUEh6rJpMV2B22tmpHZYFLWmBEbXvS8Nmox+jt+QAgWs7kNUbAU4YWsU88PHl5AkDoLOUoL9HZArtLrr86qLLAoRaYLVWB2ioO59PLslIV9/Ziry1FyNovlJYOCwGewI3MrM+d9d5ZpNzR0hvOnS2wO3RN1c7KApe2wCie5/NnZ6SkYo0eoEjLmXt4Ai8HPCitwM6VjWPv7DSdLbC79NqrgysLnGKBCHojKSkf9RipLTV62fAfipChtAzclgfnlFbAp4cP6lGsbxWdLbA7ZS3VTssCt7DAKJ7Xk5LqjXokuYGHp8SF/jHHQh6eFx0Ddq6Msjo7W2B3izVXB1kWOM0Ca+N5FCSPRj3GxAWUFuFPBzx08Cg0jq1kU8XGBXanraHacVngVhaYjee1+m196hkFyDxnMTwVHYuq4uGRuNCzwE6xO7y7KSmoArtbrbc62LLA6RbotZ5lUlKx9cw7MbzrwgEPSht18JhXwZAelaJIScWFPr274gfGKrA7fe3UAZQFbmmBNfE8Mrfeeuag58XHlKXIKCilkKWVR6cHYOdDtofeXYHdLddZHXRZ4BIWmI3nObUlc4tSiosIMNmM1rIM8ERrobFQWXl3w86KArtLrJk6iLLArS0w03qGlJQ8N1dJZr4tfbf8TYCnkhfEP4nhiboK5HjI61NsT2BHosLnVnwzbIHdrddYHXxZ4FIWeCWe550YUf1YACnAU5eEz6IV4AnkeCZu1627K7C71FqpgykLfIQFZuJ5mX5eVD2WF6ikh/4BeBQey5vzB55dc8B2gd1HrK06ibLA5SywNp7n9JaEBskK1I5RShGwQWv1TMyOfllvIZNhftE3W2B3uTVSB1QW+CgLrI3noXAc51loOz6PVoAH6PGawdoFdh+1hOpkygL3skArnieaygO9O7K3PrzH6awP4JY3xwOwiwmKtz27rb3CoUTLxtd26+P/5i5vfJy1ubLAJ1lgJp5Hzy3gBxhiB8Xv5L3xEMhFrw5hz7dobHRLIx1ugUgLzOL7o/+/c+GzY585/tljz47tFRB/5Tvv2KW+WxY40gKj1jP39sjIIukOeAnM5MHpIdDjmfd1D3EfveTZtVzR+H7LcH4T/+BAwoHFv23hNfkxAnB6zx+9OOYIhEd/xyYFnOPb6h2vu34oxva9yidGoKfEhEBOz8hM8R1dZ4DNgc+l2l8Cu5brqfdd6yoChxs1Ap0fCCgcD5T3M/Bbc8Hi8fsxuxHJ+sSbLQNpALj3txbA9YDxCNB85cdjKxBpAVn2fu+zW9hwzRqqz+5ngZ4TBdBxn0ZMATNQLI5zKb6tk9lfUAcx3znuZobALUrnAAY68+wHPDz4SdtH743j7x17Zpfv3OIvb7TnoTqo9LzV1jYiKI2AcO3fX/U23wG+UShhNkzSYgnxRzQD9neOf3LZ1cdWWiDz8rQJd0YcFON1zkDuB9d5BuwyoHN5Zn8NgPAdaGEEiojGcG/n3/5e5prO2DICXZb54fgd/KJRMy9U+9dxuYfXutF6N2DLe50F0QwQ13qbaz6/xqPqAVdcI6yV1q88f8/YgtuwxQ6yH54R2M+ssfrMthZorZkYhorXruWMfDu6WbADXZFwITXMMF0G4ZI9yfg1iy16bwQXyajEZ0DvFcBzmu3yM96Y7GlugqHuMme/IH4ubmTPAGVAmAFb9HR74DkCTf9u9rrlaY62O/v3CLwRuBzQ4g8R14rPxF/07Ac0XgcfvuKvsXG8JtkPxba3bm3tVQtEbGoxgpkf6l8cwwjsWGDQVJp547ANmnd9+ncEDF9wHlAE3FQrE4sE6XUDENfMiZw5do6b80FtgZoebSOCkZ9H/Fsv5qjPjv7e2lfv/ZaHOQLRbJtsiwW05ngjcLDIszCCX5sYM83iqRmVcTD3H1BqrDx4HUGwZZvWObx6w9b33rfACKPiHiLzmPbs+LXVYnOgQ54FpQL+73MhPVWceXXUyDjI0eum9g+ae+l5oyraf51bpvQbDI9OQJwJCXrzMWBNXM9d5QhWTsWj5+AgMfM6A8IMaFrbygD4nc/Gcxv9PwMP9+JiEou1EWO9MR7s/4+AF388/QfUSxL8/cgqCvTeB6MzttCKqXePpYea0TOS14MWlcT24pg06VKpkVeAh4fENjKvTuCFkoH626RigEgfagb6v0DP1QxG3l2MMTLr0o+diUcuD+3DP9DDzzy7DEQiMEUK1QJGB7kRoPT+7n+bfZ1RvggGLY8p+1yk6JGOOrBRThCTRPF9/7uXH/iPEMdCvJcfUarssziwe33ZD015eGdA2M77nAE7PCO8IgGdxqL9/tfjD76eBX4CD/fuKOVwz45fXQGdQExghlwLwnwS59NrQE9g6FpVHieLJnJvlGnmOna8UB2njl/HrWcmmCMc6AN8sU/P82qBXwvgMtDqAdQIlHRs3h7jNC4DpRbN432Pkfp70XOKHpPbyClslv3Wj4kni1hjsZjU/+9eXgZ2Hvvlh9Sr6r3iPia/4o+Txyh3vgVr80dZYAR2Tl8FYgIEgYWA4g+XZfmjr4deC/wEdvqMqxVEwGChQV9FXSXEh9wyE4SkNy/AYyhuJrucAR1gB9AxvRxvTseuh44doBbgCcQjUOPZeSxrls6OAIztjMBsxrvKAKwFXvH9eOMDGv5+rFSP3pIfo8dM4g+PgxqA59nw+DqCoIcXuDZ+PhHkPOYbW4pixX0GeM34z1E3aO1nOwu0wA4q6PEu0TwBhkBNQPHHy7L86dezXgs4BIQCO3lSLObWr7AWojw2eW8MxRXQafq3D8XV3wSI+mxMVLglWnE6lFAjSOuYATwG+Pa80lmQcxBrve7RxRa4ZV5W9K7cKyPGGUErAzNvt4ntN/5/tMKcMvo+Afjo2WVeXCxZiv+PfZFOcaHIbt+Y1WckX8zuA4hOd2PGP55Hgd52mHPalnpgR4yFWB30VaD2J19A92dfz/o/tBCwQ1Y58+xYiKKweHUCOAHdz5Zl+fnXa4biMjItCvNFsOOXn2SKe6MO0gI6HbODnXt23Fi9BMUo3rbGY/MYUva65Y1FajnywBzo/GYfvY4UsQV2ej/z7AA79+a8jMnLgjKPj7973A7PzmN2HFcL4NA7cy/Pwbzo7GlQtP+Oe2Dni9G9Ojy6P1+WRQ8Bnt4TlZWHFD27FtihOIpXJ7AT0P306yHA03uaJESiogV2vWSKvFEdF5Rb3qiAzj0790g9uRK90l7Wcy24+U3qANeLk2XUMlLK+H/32qIHhz0zsOu9F7cZA/6tmF0Gdj1wi7G9CHYeXohAT7yu59m5JFD07jwuXJ7d/li0+x4ysIsUluC+AEOAJqAQwP2FgZ3e098AjSxmx8LUotIiA+wUq5MHJ3AT0P3k6yHgA+yYD9kDO/fqUD0la0x8EY8Uzw6AzhIrDtIjLy7G315NDOh7kX7yXgvoeuA2Ar7M0+uBYwzy+/cd7HsJilZiIktatBIUrFESX25/Bz0/Xgc/3o9gB2jHzHKB3e5QtP8OWmAHhaU2zWN18owEdDzw7ERjKT8ZJSgAO3ls8twEagI7Ad2Pv54FfKK1jE0jIxtvqsyr0/7lYXLcAjUAjjijPD1R2+jVeTG0Z5EzQOuBXPTQWt5b/JzHJWfibf6ZCF6jv7U+H+N60SPMgNcTMhnYxaxsVmYSy1P4DO+T8Ihg59cpo7VOux0A/byid1qe3f74c+geMrCLHpIoLMF99+oAO8CDbKziZASbs19gAsQkJwRmxOoAOj072Mmz8/ITLUy/obgJqKkjVkeJDAmVjL4SqyMgHj26kddGnKoFbi1aGpMLrYRC5tlFD5DvRpDqeYOjv8V4YNxnjC22PDsHqLVFxE5bI4WNa9e9sSzJkwF/5plmoF2e3aGwtM/O4oJxCktiQh4SMS+BhXt1itkR6G/F62L5BskJwE6enYOdgE4Pp7FZgiLzHuhzFdh5qQnxupiBjeUmnH+krQBW6ybqxd/4roNZBDqPF7VobJaMaG3HAbb1OvtuPI9IxzM7ODjE+jTPkLsH3msJi90WsXPCt+lrwPcdr192HtmPkwO2A1yB3T74c+hWM7BzCivQECBQl9ajsPL+5AUy/szpIIsF74BiYnlsqqeLnp3oLGAnz09gx8RvFiTlB3r2zDF1dZ49Fo3lIQ+UujqOFwEAgFnH2/LYMk8tUtS1AJOBXW+b0atqeZWcRwZi/reW95qBRha/jDGumCXnWjlQ9UAsA0lnCf463jARcAHjeI6tsISfS4HcoXC0784ysMtq6yg3UXxO3hzJCYGfvCYvyo0lJ57RJHYC2KnsxD07khOisIrhKXFBnR0FohHsojcawY5uCTo+BMoCQtrDMqAbgYmD0wjYogcVQay1r/i5CFzRW/H/927sFlhFUIg3faSJnhxoxbd8fbXAKnpqfKflwcVt9u6Q6O1xnDPnyvntewfW1g+zQAQ7PCQBAL2kgIXH6wR6elBf515dBI8YPPY2MQc7srGUnyhpIa+PDgpqpPC4orcQOyZIUNAeRjtbBDqa0v1GGHlVkVK2aGwGbBkVHgEX5+w0K752EMtu6vieX5cMuCJQxM84GLQoX/Zj6tTTvfPW65ltxBvGQyfZcWZA7udXQHcYBB23o+yX1/tJvXQDsAPo5NXRJkbsi/KBVpAfz06UVAXForFkY0VlBXg8aBvzGjviWdxc/uvvHqnotzw3+mEVv9Mx0v/qHR707/JrP5NF3RvE1nhfWi3uqURKmdGyzBNrveee+ej17MqNABYBMKPBGaC19pclL/yzkerG/xfYzV7JG30uAzuXciLu5aUbeHS0iGXlJtELcM+HshNvFROw0Som0NNremN7rWIR7Byo8UwBvUxzz88/C2LPvBc/A910KpmBV4tK8X4GYpkH1vK41t7QLe8sA7gMOF5d9i3gmwWy7HOtbbZicKNzf/Xc6nsXsoDHR3RYHuj38g0SFN5mRRGxAJHp3Z6U4KaNtA0ai6wTVFbgBsjJ21NigpKTlggAx+81XIA1NYIIc3KMeJ8ca4xFtSjl00DsTt7NWsBs3YItMLzQLVuH8qoFemBH54RiXQrue0YTtRDiX1mNWowpEdQH7OigEE11aSeKiAWC8uoQ7/Syh0hzdB4Z4DFRnOeW7HqM132yJ3YnEHt1Xdf3ygLfWaAHdlEaiWwmXQfQ10zhpOUdCbBchh1FYnlwegjgeA199cSEU7wY53G9s54umlPfGITPqOVd6GSBWN3gZYGOBSLY6f/EveQNKd6FCICr+xLshxqS0fT4EUF8vCSvYAfwmDmBHLueXZLd9cgciOIpOYA56GWv9V1PoPgxXzEmViBWt3BZYAMLtMCOdq84s4FZEzMS5hHsvFyD/kSBWRy0Q1uYS7FTeuEZw0hlAbEIfP5/XvPdLIh/VGC/QGyDBVybKAvMWiDLxnqtnbdfZZO4vKYuenWejcyympShEMPzZ/pnPU7XArpIZx3AHdxmMnStrFwWuO4FsyvQPbsC63NlgYMsEMFOu21lNn2+qo8cBFC4wT0L64H/DPygtlE6yDsU+N6MJxQBLTs/N22B2EELrXZTFjjbAhk4xMxmpiJLAiCjhbGUI4JgzHR6gW6kvr6ttd7SmnKEtds++7rV/ssCZYGVFmh5QlGVwrXHMrVYj4HFDGf2/whimTfotLXAaOWFrY+XBcoCP7RA5v24txbldvD6okeXBfxHgf4eKDplLaCrVVsWKAu8bYEW1esF+WMGtxUDi2AXATEDyFE87e0Trg2UBcoCz7RAL67VCu6PYmEtT6yyl89cY3XWZYFLWGAEXDrImc9kJ1P08xKXuA6iLFAWeAfIynplgbJAWeBWFvhfLgp0YA9k28EAAAAASUVORK5CYII=');
   });
 
   xit('should draw linestrings correctly', function() {
-    spyOn(os.MapContainer.getInstance().getMap(), 'get2DPixelFromCoordinate').andCallFake(getPixel);
+    spyOn(MapContainer.getInstance().getMap(), 'get2DPixelFromCoordinate').andCallFake(getPixel);
     var layer = createLayer();
-    var feature = new ol.Feature(new ol.geom.LineString([[5, 10], [30, 50], [80, 50]]));
-    var clone = plugin.heatmap.cloneFeature(feature);
+    var feature = new Feature(new LineString([[5, 10], [30, 50], [80, 50]]));
+    var clone = heatmap.cloneFeature(feature);
 
     var context = layer.createImage(clone);
+    /* eslint-disable-next-line max-len */
     expect(context.toDataURL()).toBe('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAF8AAAA8CAYAAAAALGYBAAAECklEQVR4Xu2ch46jQBBEay/nnKMu6uL/f8jlnPdyzvn0Tt0Sspwwg4cxjTSCZb0GHu3qGrbbS4olG4GlbEeOAyvgZwyCgN9j+Nz8FdL/T6Bvg6PEoPgrifHH1r498vbmvEigr5a01sYaW6/MGIxNDg30H5K+2/Bt9g9dcsHnuMDeLGmLpK225mf2l7j8kvRe0gdb+/bPrsEnugG9W9JeSXtsbC8YPhH/XNKLyprtb12Cj9ysM/CHJR2xcUjSjoLhf5H0UNIDW/s2+zshO8gNOo/MAP6UpNO25mcin9978mJdyvJR0q0h41NX4CM3GyXtk3RS0nkbbCM/fCI8cZGwfpdCXhLwb0u6OXADOgGfqAfuTklHJZ2TdFHSWUkHzemQnLgIkhYnTRIrZfncZdlBTnA2gEZqAH9B0jH7NJCYXlvCemmOoST4nH812XryzZ5wSbIbTFqOm9QAn5uA4yHiOdlHFj3Lkt4VFvlcQ+espnt6nAzOBpkh4tF7HM4qSa8k3ano5ZMC4ZOffGJVnWxlnWSRZJGb/eZqXG5O2H60/Z6kKzZwDEQ++0tKuJ17vFD19Gi7J9kzJkFEBaCvSbok6ar5ZLSfSUtJVrO2MWjz8cKgpwc4UY/c4HZ4pvPGbBngiXysGtqPcygp6muDb/vp4aCnR+cZTKyYTOECmA1etnFd0mPT+pHPQ2a6yo7+UVuRP87TH7BHxs8kAdzlBt0n8X5ddLnxWGgL/jhPj+VkEoXEeNSTZJ/aBGvh5aZN+JM8PTYMeUHjiXqin4dQb82qLXSSrSpg6sif1tPfMPDcgLuWZJGbkZ64o7Ld6LRSw5/W0yM3RD0PoZhQIUMlPUpoBL0N2QlPX/OWpIr88PQ1waf0+eHpM8EPTz8D+FSRH54+E/zw9DOCbxr54ekbgG8KPzx9Jvjh6RuCnzXyw9MnAD8r/PD0meCHp08EfpbID0+fCX54+oTg60R+ePrE4OvAD0+fCX54+hbATxP54elbAj8N/PD0meCHp28R/KTID0+fCb57eroEqSamvrJaTx+1NwluzKh/oFMzT9NatZ6eOksKXOmTpawvam8a3oBx8ClmpYuEsm7As6ZpjSJWKsy84qzXtTdN+E+CT6TTukM3CfKzzZoWqC6mzI+6erZ7UU/fBPSwv50kO1QUIz00NtDCQzchfUdUmd23jpLe1NPPCz7+fpPV0SM1tPTssm8IoVWTSKfEm8piGtd6UU8/L/g+s6Wcm8SL/nMz2E+7Dp0jVBUDvjf19POC73MAPgG076yvfCcCJdwUtQKd0Zt6+nnC92Ph+X34Pv8iH/9in9Tn1Yv3S1Uo2wtYqS8y4KcmWuP9An4NWKlfGvBTE63xfgG/BqzULw34qYnWeL9/XdqmTE4qWL4AAAAASUVORK5CYII=');
   });
 
@@ -100,32 +134,32 @@ describe('plugin.heatmap.Heatmap', function() {
     var gradientCount = 0;
     var onPropertyChange = function(event) {
       var property = event.getProperty();
-      if (property == plugin.heatmap.HeatmapPropertyType.GRADIENT) {
+      if (property == HeatmapPropertyType.GRADIENT) {
         gradientCount++;
-      } else if (property == plugin.heatmap.HeatmapPropertyType.SIZE) {
+      } else if (property == HeatmapPropertyType.SIZE) {
         sizeCount++;
-      } else if (property == plugin.heatmap.HeatmapPropertyType.INTENSITY) {
+      } else if (property == HeatmapPropertyType.INTENSITY) {
         intensityCount++;
       }
     };
 
     var layer = createLayer();
-    ol.events.listen(layer, goog.events.EventType.PROPERTYCHANGE, onPropertyChange);
+    events.listen(layer, GoogEventType.PROPERTYCHANGE, onPropertyChange);
 
     layer.setSize(20);
-    layer.setGradient(os.color.RAINBOW_HEATMAP_GRADIENT_HEX);
+    layer.setGradient(color.RAINBOW_HEATMAP_GRADIENT_HEX);
     layer.setIntensity(10);
 
     expect(gradientCount).toBe(1);
     expect(sizeCount).toBe(1);
     expect(intensityCount).toBe(1);
-    ol.events.unlisten(layer, goog.events.EventType.PROPERTYCHANGE, onPropertyChange);
+    events.unlisten(layer, GoogEventType.PROPERTYCHANGE, onPropertyChange);
   });
 
   it('should create styles and cache them for points', function() {
     var layer = createLayer();
-    var feature = new ol.Feature(new ol.geom.Point([5, 10]));
-    var clone = plugin.heatmap.cloneFeature(feature);
+    var feature = new Feature(new Point([5, 10]));
+    var clone = heatmap.cloneFeature(feature);
     clone.setId('myId');
 
     var style = layer.styleFunc(clone, .5);

--- a/test/plugin/heatmap/heatmapplugin.test.js
+++ b/test/plugin/heatmap/heatmapplugin.test.js
@@ -1,8 +1,14 @@
+goog.require('goog.string');
+goog.require('os.data.DataManager');
 goog.require('os.data.event.DataEvent');
+goog.require('os.data.event.DataEventType');
+goog.require('os.layer.LayerType');
+goog.require('os.layer.config.LayerConfigManager');
 goog.require('os.source.Vector');
 goog.require('os.ui.menu.layer');
 goog.require('os.webgl.SynchronizerManager');
 goog.require('plugin.cesium.sync.HeatmapSynchronizer');
+goog.require('plugin.heatmap');
 goog.require('plugin.heatmap.HeatmapLayerConfig');
 goog.require('plugin.heatmap.HeatmapPlugin');
 goog.require('plugin.heatmap.SynchronizerType');
@@ -10,56 +16,70 @@ goog.require('plugin.heatmap.menu');
 
 
 describe('plugin.heatmap.HeatmapPlugin', function() {
+  const googString = goog.module.get('goog.string');
+  const DataManager = goog.module.get('os.data.DataManager');
+  const DataEvent = goog.module.get('os.data.event.DataEvent');
+  const DataEventType = goog.module.get('os.data.event.DataEventType');
+  const LayerType = goog.module.get('os.layer.LayerType');
+  const LayerConfigManager = goog.module.get('os.layer.config.LayerConfigManager');
+  const VectorSource = goog.module.get('os.source.Vector');
+  const layerMenu = goog.module.get('os.ui.menu.layer');
+  const SynchronizerManager = goog.module.get('os.webgl.SynchronizerManager');
+  const heatmap = goog.module.get('plugin.heatmap');
+  const HeatmapLayerConfig = goog.module.get('plugin.heatmap.HeatmapLayerConfig');
+  const HeatmapPlugin = goog.module.get('plugin.heatmap.HeatmapPlugin');
+  const SynchronizerType = goog.module.get('plugin.heatmap.SynchronizerType');
+  const heatmapMenu = goog.module.get('plugin.heatmap.menu');
   const HeatmapSynchronizer = goog.module.get('plugin.cesium.sync.HeatmapSynchronizer');
 
   var createLayer = function() {
     var options = {
-      'id': goog.string.getRandomString(),
-      'source': new os.source.Vector(),
+      'id': googString.getRandomString(),
+      'source': new VectorSource(),
       'title': 'My Heatmap',
       'animate': false,
-      'layerType': os.layer.LayerType.FEATURES,
+      'layerType': LayerType.FEATURES,
       'explicitType': '',
-      'type': plugin.heatmap.HeatmapLayerConfig.ID,
+      'type': heatmap.ID,
       'loadOnce': true
     };
 
-    var layerConfig = new plugin.heatmap.HeatmapLayerConfig();
+    var layerConfig = new HeatmapLayerConfig();
     return layerConfig.createLayer(options);
   };
 
   it('should register the appropriate stuffs', function() {
-    os.ui.menu.layer.setup();
+    layerMenu.setup();
 
-    var p = new plugin.heatmap.HeatmapPlugin();
+    var p = new HeatmapPlugin();
     p.init();
 
-    var lcm = os.layer.config.LayerConfigManager.getInstance();
-    var lc = lcm.getLayerConfig(plugin.heatmap.HeatmapLayerConfig.ID);
-    expect(lc instanceof plugin.heatmap.HeatmapLayerConfig).toBe(true);
+    var lcm = LayerConfigManager.getInstance();
+    var lc = lcm.getLayerConfig(heatmap.ID);
+    expect(lc instanceof HeatmapLayerConfig).toBe(true);
     lcm.layerConfigs_ = {};
 
     var layer = createLayer();
-    var sm = os.webgl.SynchronizerManager.getInstance();
+    var sm = SynchronizerManager.getInstance();
 
     // now is registered by the WebGLRenderer (e.g. Cesium) plugin; spoof it
-    sm.registerSynchronizer(plugin.heatmap.SynchronizerType.HEATMAP, HeatmapSynchronizer);
+    sm.registerSynchronizer(SynchronizerType.HEATMAP, HeatmapSynchronizer);
 
     var synchronizer = sm.getSynchronizer(layer);
     expect(synchronizer).toBe(HeatmapSynchronizer);
     sm.synchronizers_ = {};
 
-    var dm = os.dataManager;
-    var source = new os.source.Vector();
+    var dm = DataManager.getInstance();
+    var source = new VectorSource();
 
-    var event = new os.data.event.DataEvent(os.data.event.DataEventType.SOURCE_ADDED, source);
+    var event = new DataEvent(DataEventType.SOURCE_ADDED, source);
     dm.dispatchEvent(event);
-    expect(source.getSupportsAction(plugin.heatmap.menu.EventType.GENERATE_HEATMAP)).toBe(true);
+    expect(source.getSupportsAction(heatmapMenu.EventType.GENERATE_HEATMAP)).toBe(true);
 
-    var menu = os.ui.menu.layer.MENU;
+    var menu = layerMenu.MENU;
     // expect(menu.getRoot().find(plugin.heatmap.menu.EventType.EXPORT)).not.toBe(null);
-    expect(menu.getRoot().find(plugin.heatmap.menu.EventType.GENERATE_HEATMAP)).not.toBe(null);
+    expect(menu.getRoot().find(heatmapMenu.EventType.GENERATE_HEATMAP)).not.toBe(null);
 
-    os.ui.menu.layer.dispose();
+    layerMenu.dispose();
   });
 });

--- a/test/plugin/osm/nom/nominatimparser.test.js
+++ b/test/plugin/osm/nom/nominatimparser.test.js
@@ -1,15 +1,21 @@
 goog.require('goog.net.EventType');
 goog.require('goog.net.XhrIo');
+goog.require('ol.Feature');
 goog.require('plugin.osm.nom.NominatimParser');
 
 describe('plugin.osm.nom.NominatimParser', function() {
-  var parser = new plugin.osm.nom.NominatimParser();
+  const EventType = goog.module.get('goog.net.EventType');
+  const XhrIo = goog.module.get('goog.net.XhrIo');
+  const Feature = goog.module.get('ol.Feature');
+  const NominatimParser = goog.module.get('plugin.osm.nom.NominatimParser');
+
+  var parser = new NominatimParser();
   var response;
 
   var loadResponse = function() {
     if (!response) {
-      var xhr = new goog.net.XhrIo();
-      xhr.listen(goog.net.EventType.SUCCESS, function() {
+      var xhr = new XhrIo();
+      xhr.listen(EventType.SUCCESS, function() {
         response = xhr.getResponse();
       }, false);
 
@@ -40,7 +46,7 @@ describe('plugin.osm.nom.NominatimParser', function() {
     while (parser.hasNext()) {
       next = parser.parseNext();
       expect(next).toBeDefined();
-      expect(next instanceof ol.Feature).toBe(true);
+      expect(next instanceof Feature).toBe(true);
       expect(next.getGeometry()).toBeDefined();
 
       numResults++;

--- a/test/plugin/osm/nom/nominatimplugin.test.js
+++ b/test/plugin/osm/nom/nominatimplugin.test.js
@@ -1,41 +1,48 @@
+goog.require('os.config.Settings');
 goog.require('os.search.SearchManager');
 goog.require('plugin.osm.nom');
 goog.require('plugin.osm.nom.NominatimPlugin');
 goog.require('plugin.osm.nom.NominatimSearch');
 
 describe('plugin.osm.nom.NominatimPlugin', function() {
+  const Settings = goog.module.get('os.config.Settings');
+  const SearchManager = goog.module.get('os.search.SearchManager');
+  const nom = goog.module.get('plugin.osm.nom');
+  const NominatimPlugin = goog.module.get('plugin.osm.nom.NominatimPlugin');
+  const NominatimSearch = goog.module.get('plugin.osm.nom.NominatimSearch');
+
   it('should initialize properly', function() {
-    var nomPlugin = new plugin.osm.nom.NominatimPlugin();
-    expect(nomPlugin.getId()).toBe(plugin.osm.nom.ID);
+    var nomPlugin = new NominatimPlugin();
+    expect(nomPlugin.getId()).toBe(nom.ID);
 
     // replace the global search manager with our own
-    var sm = new os.search.SearchManager();
-    spyOn(os.search.SearchManager, 'getInstance').andReturn(sm);
+    var sm = new SearchManager();
+    spyOn(SearchManager, 'getInstance').andReturn(sm);
 
     // search does not exist prior to initialization
-    var search = sm.getSearch(plugin.osm.nom.ID);
+    var search = sm.getSearch(nom.ID);
     expect(search).toBeNull();
 
     // remove url from settings
-    os.settings.set(plugin.osm.nom.SettingKey.URL, undefined);
+    Settings.getInstance().set(nom.SettingKey.URL, undefined);
 
     // initialize the plugin
     nomPlugin.init();
 
     // search was not added without setting
-    search = sm.getSearch(plugin.osm.nom.ID);
+    search = sm.getSearch(nom.ID);
     expect(search).toBeNull();
 
     // add url to settings
-    os.settings.set(plugin.osm.nom.SettingKey.URL, 'http://fake.url/');
+    Settings.getInstance().set(nom.SettingKey.URL, 'http://fake.url/');
 
     // initialize the plugin
     nomPlugin.init();
 
     // search should be registered
-    search = sm.getSearch(plugin.osm.nom.ID);
+    search = sm.getSearch(nom.ID);
     expect(search).toBeDefined();
-    expect(search instanceof plugin.osm.nom.NominatimSearch).toBe(true);
-    expect(search.name).toBe(plugin.osm.nom.SEARCH_NAME);
+    expect(search instanceof NominatimSearch).toBe(true);
+    expect(search.name).toBe(nom.SEARCH_NAME);
   });
 });


### PR DESCRIPTION
Transforms heatmap, nominatim, overview, params, storage, and vectortools plugins to use `goog.module`.

The `vectortools` plugin also had a slight refactor to move the UI launch methods to a new file. This was cleaner from a dependency standpoint.