### PR TITLE
fix(net): electron domain handler to prevent uri modification

### DIFF
--- a/src/plugin/electron/electronplugin.js
+++ b/src/plugin/electron/electronplugin.js
@@ -5,9 +5,11 @@ goog.require('plugin.electron.ElectronMemoryConfigUI');
 
 const Settings = goog.require('os.config.Settings');
 const Request = goog.require('os.net.Request');
+const RequestHandlerFactory = goog.require('os.net.RequestHandlerFactory');
 const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
 const {ID, SettingKey, isElectron} = goog.require('plugin.electron');
 const ElectronConfirmCertUI = goog.require('plugin.electron.ElectronConfirmCertUI');
+const ElectronHandler = goog.require('plugin.electron.net.ElectronHandler');
 
 
 /**
@@ -62,6 +64,8 @@ class ElectronPlugin extends AbstractPlugin {
     if (isElectron()) {
       ElectronOS.registerCertificateHandler(onCertificateRequest);
       os.ui.list.add('pluginMemoryConfig', '<electronmemoryconfig></electronmemoryconfig>');
+
+      RequestHandlerFactory.addHandler(ElectronHandler);
 
       /**
        * Electron uses the file protocol, so those URL's need to be considered safe.

--- a/src/plugin/electron/net/electronhandler.js
+++ b/src/plugin/electron/net/electronhandler.js
@@ -1,0 +1,32 @@
+goog.module('plugin.electron.net.ElectronHandler');
+
+const HandlerType = goog.require('os.net.HandlerType');
+const SameDomainHandler = goog.require('os.net.SameDomainHandler');
+
+/**
+ * Electron request handler.
+ */
+class ElectronHandler extends SameDomainHandler {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handles(method, uri) {
+    return true;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getHandlerType() {
+    return HandlerType.EXT_DOMAIN;
+  }
+}
+
+exports = ElectronHandler;


### PR DESCRIPTION
Created a new electron request handler at the same priority level as ext/same-domain in order to prevent any proxying from occurring in opensphere-desktop.

(Fixes an issue where `os.net.ProxyHandler` always handles "proxyable" requests even without configuration).