### PR TITLE
fix(vectortools): hide the disable checkbox for merge/join layers

### DIFF
--- a/src/plugin/vectortools/vectortools.js
+++ b/src/plugin/vectortools/vectortools.js
@@ -122,6 +122,15 @@ const addNewLayer = function(opt_restoreFromIdOrConfig) {
     }
   }
 
+  // we don't want the node checkbox visible -- that just deletes the merged/copied/joined features permanently
+  let opts = newLayer.getLayerOptions();
+  if (opts) {
+    opts['hideDisable'] = true;
+  } else {
+    opts = {'hideDisable': true};
+  }
+  newLayer.setLayerOptions(opts);
+
   return newLayer;
 };
 


### PR DESCRIPTION
Adds actual configuration for the support created in !1034
