### PR TITLE
Replace additional global references in plugins

### DIFF
--- a/.jscodeshift.json
+++ b/.jscodeshift.json
@@ -28,6 +28,7 @@
   "moduleBlacklist": [
     "goog",
     "goog.declareModuleId",
+    "goog.define",
     "goog.module",
     "goog.partial",
     "goog.provide",

--- a/.jscodeshift.json
+++ b/.jscodeshift.json
@@ -51,6 +51,7 @@
     "ol.layer.Vector": "OLVectorLayer",
     "ol.obj": "olObj",
     "ol.proj": "olProj",
+    "ol.render.Feature": "RenderFeature",
     "ol.source.Vector": "OLVectorSource",
     "ol.string": "olString",
 

--- a/src/plugin/cesium/cesium.js
+++ b/src/plugin/cesium/cesium.js
@@ -28,9 +28,9 @@ const ImageryProvider = goog.require('plugin.cesium.ImageryProvider');
 const Deferred = goog.requireType('goog.async.Deferred');
 const Geometry = goog.requireType('ol.geom.Geometry');
 const GeometryCollection = goog.requireType('ol.geom.GeometryCollection');
+const SimpleGeometry = goog.requireType('ol.geom.SimpleGeometry');
 const LayerBase = goog.requireType('ol.layer.Base');
 const Layer = goog.requireType('ol.layer.Layer');
-const SimpleGeometry = goog.requireType('ol.geom.SimpleGeometry');
 const Projection = goog.requireType('ol.proj.Projection');
 
 

--- a/src/plugin/cesium/cesiumplugin.js
+++ b/src/plugin/cesium/cesiumplugin.js
@@ -1,7 +1,6 @@
 goog.module('plugin.cesium.Plugin');
 goog.module.declareLegacyNamespace();
 
-const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
 const MapContainer = goog.require('os.MapContainer');
 const settings = goog.require('os.config.Settings');
 const DataManager = goog.require('os.data.DataManager');
@@ -9,6 +8,7 @@ const ProviderEntry = goog.require('os.data.ProviderEntry');
 const osImplements = goog.require('os.implements');
 const Group = goog.require('os.layer.Group');
 const ILayer = goog.require('os.layer.ILayer');
+const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
 const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
 const ImportManager = goog.require('os.ui.im.ImportManager');
 const AbstractWebGLRenderer = goog.require('os.webgl.AbstractWebGLRenderer');

--- a/src/plugin/cesium/cesiumrenderer.js
+++ b/src/plugin/cesium/cesiumrenderer.js
@@ -1,6 +1,7 @@
 goog.module('plugin.cesium.CesiumRenderer');
 
 const Promise = goog.require('goog.Promise');
+const dispose = goog.require('goog.dispose');
 const classlist = goog.require('goog.dom.classlist');
 const log = goog.require('goog.log');
 const {clamp} = goog.require('goog.math');
@@ -8,20 +9,19 @@ const userAgent = goog.require('goog.userAgent');
 const ViewHint = goog.require('ol.ViewHint');
 const OLCesium = goog.require('olcs.OLCesium');
 
-const MapEvent = goog.require('os.MapEvent');
-const terrain = goog.require('os.map.terrain');
-const MapContainer = goog.require('os.MapContainer');
 const dispatcher = goog.require('os.Dispatcher');
+const MapContainer = goog.require('os.MapContainer');
+const MapEvent = goog.require('os.MapEvent');
 const CommandProcessor = goog.require('os.command.CommandProcessor');
 const DisplaySetting = goog.require('os.config.DisplaySetting');
 const settings = goog.require('os.config.Settings');
 const osFeature = goog.require('os.feature');
 const SynchronizerType = goog.require('os.layer.SynchronizerType');
 const {WEBGL_CANVAS_CLASS} = goog.require('os.map');
+const terrain = goog.require('os.map.terrain');
 const AbstractWebGLRenderer = goog.require('os.webgl.AbstractWebGLRenderer');
 const AltitudeMode = goog.require('os.webgl.AltitudeMode');
 const SynchronizerManager = goog.require('os.webgl.SynchronizerManager');
-const HeatmapSynchronizerType = goog.require('plugin.heatmap.SynchronizerType');
 
 const {
   DEFAULT_FOG_DENSITY,
@@ -50,6 +50,7 @@ const ImageSynchronizer = goog.require('plugin.cesium.sync.ImageSynchronizer');
 const RootSynchronizer = goog.require('plugin.cesium.sync.RootSynchronizer');
 const TileSynchronizer = goog.require('plugin.cesium.sync.TileSynchronizer');
 const VectorSynchronizer = goog.require('plugin.cesium.sync.VectorSynchronizer');
+const HeatmapSynchronizerType = goog.require('plugin.heatmap.SynchronizerType');
 
 const OLMap = goog.requireType('ol.Map');
 const AbstractSynchronizer = goog.requireType('olcs.AbstractSynchronizer');
@@ -642,7 +643,7 @@ class CesiumRenderer extends AbstractWebGLRenderer {
     if (this.terrainLayer_) {
       MapContainer.getInstance().removeLayer(this.terrainLayer_);
 
-      goog.dispose(this.terrainLayer_);
+      dispose(this.terrainLayer_);
       this.terrainLayer_ = undefined;
     }
 

--- a/src/plugin/cesium/command/flytospherecmd.js
+++ b/src/plugin/cesium/command/flytospherecmd.js
@@ -6,6 +6,7 @@ const FlyToExtent = goog.require('os.command.FlyToExtent');
 const State = goog.require('os.command.State');
 const osMap = goog.require('os.map');
 
+const Camera = goog.requireType('plugin.cesium.Camera');
 
 /**
  * @suppress {accessControls}
@@ -32,14 +33,14 @@ class FlyToSphere extends AbstractSyncCommand {
      */
     this.oldPosition_ = MapContainer.getInstance().persistCameraState();
 
-    var cam = /** @type {plugin.cesium.Camera} */ (MapContainer.getInstance().getWebGLCamera());
+    var cam = /** @type {Camera} */ (MapContainer.getInstance().getWebGLCamera());
     var minRange = cam.calcDistanceForResolution(
         osMap.zoomToResolution(osMap.MAX_AUTO_ZOOM, osMap.PROJECTION), 0);
 
     sphere.radius = sphere.radius || 10;
 
     // gets the default offset
-    var camera = /** @type {plugin.cesium.Camera} */ (MapContainer.getInstance().getWebGLCamera());
+    var camera = /** @type {Camera} */ (MapContainer.getInstance().getWebGLCamera());
     var offset = new Cesium.HeadingPitchRange(camera.cam_.heading, camera.cam_.pitch,
         FlyToExtent.DEFAULT_BUFFER * 2 * sphere.radius);
 
@@ -68,7 +69,7 @@ class FlyToSphere extends AbstractSyncCommand {
 
     this.sphere_.radius *= FlyToExtent.DEFAULT_BUFFER;
 
-    var cam = /** @type {plugin.cesium.Camera} */ (MapContainer.getInstance().getWebGLCamera());
+    var cam = /** @type {Camera} */ (MapContainer.getInstance().getWebGLCamera());
     cam.cam_.flyToBoundingSphere(this.sphere_, this.options_);
 
     this.sphere_.radius /= FlyToExtent.DEFAULT_BUFFER;

--- a/src/plugin/cesium/imageryprovider.js
+++ b/src/plugin/cesium/imageryprovider.js
@@ -3,8 +3,8 @@ goog.module('plugin.cesium.ImageryProvider');
 goog.require('os.mixin.VectorImageTile');
 
 const ol = goog.require('ol');
-const TileState = goog.require('ol.TileState');
 const ImageTile = goog.require('ol.ImageTile');
+const TileState = goog.require('ol.TileState');
 const VectorImageTile = goog.require('ol.VectorImageTile');
 const events = goog.require('ol.events');
 const VectorTile = goog.require('ol.source.VectorTile');

--- a/src/plugin/cesium/interaction/cesiumdrawpolygoninteraction.js
+++ b/src/plugin/cesium/interaction/cesiumdrawpolygoninteraction.js
@@ -1,11 +1,11 @@
 goog.module('plugin.cesium.interaction.drawpolygon');
 
+const core = goog.require('olcs.core');
 const dispatcher = goog.require('os.Dispatcher');
 const MapContainer = goog.require('os.MapContainer');
 const MapEvent = goog.require('os.MapEvent');
-const osInterpolate = goog.require('os.interpolate');
-const core = goog.require('olcs.core');
 const DrawPolygon = goog.require('os.interaction.DrawPolygon');
+const osInterpolate = goog.require('os.interpolate');
 
 const LineString = goog.requireType('ol.geom.LineString');
 const CesiumRenderer = goog.requireType('plugin.cesium.CesiumRenderer');

--- a/src/plugin/cesium/layer.js
+++ b/src/plugin/cesium/layer.js
@@ -1,8 +1,7 @@
 goog.module('plugin.cesium.Layer');
 
-const GoogEventType = goog.require('goog.events.EventType');
-
 const Delay = goog.require('goog.async.Delay');
+const GoogEventType = goog.require('goog.events.EventType');
 const log = goog.require('goog.log');
 const googString = goog.require('goog.string');
 const OLLayer = goog.require('ol.layer.Layer');
@@ -25,6 +24,7 @@ const {adjustIconSet, createIconSet} = goog.require('os.ui.icons');
 
 const LayerType = goog.requireType('ol.LayerType');
 const IActionTarget = goog.requireType('os.ui.action.IActionTarget');
+const CesiumRenderer = goog.requireType('plugin.cesium.CesiumRenderer');
 
 
 /**
@@ -713,7 +713,7 @@ class Layer extends OLLayer {
     if (MapContainer.getInstance()) {
       var renderer = MapContainer.getInstance().getWebGLRenderer();
       if (renderer) {
-        return /** @type {plugin.cesium.CesiumRenderer} */ (renderer).getCesiumScene();
+        return /** @type {CesiumRenderer} */ (renderer).getCesiumScene();
       }
     }
 

--- a/src/plugin/cesium/mixin/cesiummixin.js
+++ b/src/plugin/cesium/mixin/cesiummixin.js
@@ -9,10 +9,10 @@ import {load as loadRenderLoopMixin} from './renderloopmixin';
 
 const dispatcher = goog.require('os.Dispatcher');
 const MapEvent = goog.require('os.MapEvent');
-const {prune} = goog.require('os.object');
 const {getCrossOrigin} = goog.require('os.net');
 const CrossOrigin = goog.require('os.net.CrossOrigin');
 const Request = goog.require('os.net.Request');
+const {prune} = goog.require('os.object');
 
 
 /**

--- a/src/plugin/cesium/mixin/olcesiummixin.js
+++ b/src/plugin/cesium/mixin/olcesiummixin.js
@@ -6,6 +6,7 @@ const I3DSupport = goog.require('os.I3DSupport');
 const osImplements = goog.require('os.implements');
 
 const Interaction = goog.requireType('ol.interaction.Interaction');
+const Camera = goog.requireType('plugin.cesium.Camera');
 
 
 /**
@@ -116,13 +117,13 @@ export const load = () => {
       }
 
       // enable the cesium camera and update it from OpenLayers view
-      /** @type {plugin.cesium.Camera} */ (this.camera_).setEnabled(true);
+      /** @type {Camera} */ (this.camera_).setEnabled(true);
       this.camera_.readFromView();
       this.render_();
     } else {
       // update the OpenLayers view from the cesium camera, then disable the camera
       this.camera_.updateView();
-      /** @type {plugin.cesium.Camera} */ (this.camera_).setEnabled(false);
+      /** @type {Camera} */ (this.camera_).setEnabled(false);
 
       if (this.isOverMap_) {
         interactions = this.map_.getInteractions();

--- a/src/plugin/cesium/mixin/renderloopmixin.js
+++ b/src/plugin/cesium/mixin/renderloopmixin.js
@@ -1,7 +1,7 @@
 goog.declareModuleId('plugin.cesium.mixin.renderloop');
 
-const Dispatcher = goog.require('os.Dispatcher');
 const AutoRenderLoop = goog.require('olcs.AutoRenderLoop');
+const Dispatcher = goog.require('os.Dispatcher');
 const MapEvent = goog.require('os.MapEvent');
 const TimelineController = goog.require('os.time.TimelineController');
 const TimelineEventType = goog.require('os.time.TimelineEventType');

--- a/src/plugin/cesium/primitive.js
+++ b/src/plugin/cesium/primitive.js
@@ -2,8 +2,8 @@ goog.declareModuleId('plugin.cesium.primitive');
 
 const Delay = goog.require('goog.async.Delay');
 const {clamp} = goog.require('goog.math');
-const {GeometryInstanceId} = goog.require('plugin.cesium');
 const {unsafeClone} = goog.require('os.object');
+const {GeometryInstanceId} = goog.require('plugin.cesium');
 const {getHeightReference, isPrimitiveClassTypeChanging} = goog.require('plugin.cesium.sync.HeightReference');
 const styleUtils = goog.require('plugin.cesium.sync.style');
 

--- a/src/plugin/cesium/sync/converter.js
+++ b/src/plugin/cesium/sync/converter.js
@@ -1,13 +1,13 @@
 goog.module('plugin.cesium.sync.converter');
 
+const GeometryType = goog.require('ol.geom.GeometryType');
 const DynamicFeature = goog.require('os.feature.DynamicFeature');
+const Ellipse = goog.require('os.geom.Ellipse');
 const DynamicLineStringConverter = goog.require('plugin.cesium.sync.DynamicLineStringConverter');
 const DynamicMultiPolygonConverter = goog.require('plugin.cesium.sync.DynamicMultiPolygonConverter');
 const DynamicPolygonConverter = goog.require('plugin.cesium.sync.DynamicPolygonConverter');
-const Ellipse = goog.require('os.geom.Ellipse');
 const EllipseConverter = goog.require('plugin.cesium.sync.EllipseConverter');
 const GeometryCollectionConverter = goog.require('plugin.cesium.sync.GeometryCollectionConverter');
-const GeometryType = goog.require('ol.geom.GeometryType');
 const LabelConverter = goog.require('plugin.cesium.sync.LabelConverter');
 const LineStringConverter = goog.require('plugin.cesium.sync.LineStringConverter');
 const MultiDynamicLineStringConverter = goog.require('plugin.cesium.sync.MultiDynamicLineStringConverter');
@@ -18,11 +18,11 @@ const PointConverter = goog.require('plugin.cesium.sync.PointConverter');
 const PolygonConverter = goog.require('plugin.cesium.sync.PolygonConverter');
 const {runConverter} = goog.require('plugin.cesium.sync.runConverter');
 
-const IConverter = goog.requireType('plugin.cesium.sync.IConverter');
 const Feature = goog.requireType('ol.Feature');
 const Geometry = goog.requireType('ol.geom.Geometry');
 const Style = goog.requireType('ol.style.Style');
 const VectorContext = goog.requireType('plugin.cesium.VectorContext');
+const IConverter = goog.requireType('plugin.cesium.sync.IConverter');
 
 /**
  * @param {!Feature} feature

--- a/src/plugin/cesium/sync/dynamiclinestring.js
+++ b/src/plugin/cesium/sync/dynamiclinestring.js
@@ -1,8 +1,8 @@
 goog.module('plugin.cesium.sync.DynamicLineString');
 
 const {GeometryInstanceId} = goog.require('plugin.cesium');
-const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
 const {getDashPattern, getLineStringPositions} = goog.require('plugin.cesium.sync.linestring');
+const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
 
 const Feature = goog.requireType('ol.Feature');
 const LineString = goog.requireType('ol.geom.LineString');

--- a/src/plugin/cesium/sync/dynamicpolygonconverter.js
+++ b/src/plugin/cesium/sync/dynamicpolygonconverter.js
@@ -3,9 +3,9 @@ goog.module('plugin.cesium.sync.DynamicPolygonConverter');
 const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
 const {createOrUpdateSegment} = goog.require('plugin.cesium.sync.DynamicLineString');
 
-const Polygon = goog.requireType('ol.geom.Polygon');
 const Feature = goog.requireType('ol.Feature');
 const Geometry = goog.requireType('ol.geom.Geometry');
+const Polygon = goog.requireType('ol.geom.Polygon');
 const Style = goog.requireType('ol.style.Style');
 const VectorContext = goog.requireType('plugin.cesium.VectorContext');
 

--- a/src/plugin/cesium/sync/ellipseconverter.js
+++ b/src/plugin/cesium/sync/ellipseconverter.js
@@ -1,15 +1,15 @@
 goog.module('plugin.cesium.sync.EllipseConverter');
 
-const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
-const DynamicLineStringConverter = goog.require('plugin.cesium.sync.DynamicLineStringConverter');
-const ILayer = goog.require('os.layer.ILayer');
 const LineString = goog.require('ol.geom.LineString');
+const implementz = goog.require('os.implements');
+const ILayer = goog.require('os.layer.ILayer');
 const StyleField = goog.require('os.style.StyleField');
 const StyleManager = goog.require('os.style.StyleManager');
-const {runConverter} = goog.require('plugin.cesium.sync.runConverter');
-const implementz = goog.require('os.implements');
+const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
+const DynamicLineStringConverter = goog.require('plugin.cesium.sync.DynamicLineStringConverter');
 const EllipsoidConverter = goog.require('plugin.cesium.sync.EllipsoidConverter');
 const PolygonConverter = goog.require('plugin.cesium.sync.PolygonConverter');
+const {runConverter} = goog.require('plugin.cesium.sync.runConverter');
 
 const Feature = goog.requireType('ol.Feature');
 const Style = goog.requireType('ol.style.Style');

--- a/src/plugin/cesium/sync/ellipsoid.js
+++ b/src/plugin/cesium/sync/ellipsoid.js
@@ -5,9 +5,9 @@ const {GeometryInstanceId} = goog.require('plugin.cesium');
 const {createColoredPrimitive} = goog.require('plugin.cesium.primitive');
 const {getColor} = goog.require('plugin.cesium.sync.style');
 
-const Ellipse = goog.requireType('os.geom.Ellipse');
 const Feature = goog.requireType('ol.Feature');
 const Style = goog.requireType('ol.style.Style');
+const Ellipse = goog.requireType('os.geom.Ellipse');
 const VectorContext = goog.requireType('plugin.cesium.VectorContext');
 
 

--- a/src/plugin/cesium/sync/ellipsoidconverter.js
+++ b/src/plugin/cesium/sync/ellipsoidconverter.js
@@ -19,4 +19,3 @@ class EllipsoidConverter extends PolygonConverter {
 
 
 exports = EllipsoidConverter;
-

--- a/src/plugin/cesium/sync/gettransformfunction.js
+++ b/src/plugin/cesium/sync/gettransformfunction.js
@@ -1,9 +1,9 @@
 goog.module('plugin.cesium.sync.getTransformFunction');
 
 const olProj = goog.require('ol.proj');
-const Projection = goog.requireType('ol.proj.Projection');
 const osMap = goog.require('os.map');
 const osProj = goog.require('os.proj');
+const Projection = goog.requireType('ol.proj.Projection');
 
 
 /**
@@ -60,4 +60,3 @@ exports = () => {
 
   return olTransform ? transformFunction : null;
 };
-

--- a/src/plugin/cesium/sync/heatmapsynchronizer.js
+++ b/src/plugin/cesium/sync/heatmapsynchronizer.js
@@ -2,6 +2,7 @@ goog.module('plugin.cesium.sync.HeatmapSynchronizer');
 
 const asserts = goog.require('goog.asserts');
 const Delay = goog.require('goog.async.Delay');
+const dispose = goog.require('goog.dispose');
 const EventType = goog.require('goog.events.EventType');
 const olEvents = goog.require('ol.events');
 const {scaleFromCenter} = goog.require('ol.extent');
@@ -14,23 +15,24 @@ const events = goog.require('os.ol.events');
 const cesium = goog.require('plugin.cesium');
 const CesiumSynchronizer = goog.require('plugin.cesium.sync.CesiumSynchronizer');
 const {EXTENT_SCALE_FACTOR} = goog.require('plugin.heatmap');
-const HeatmapPropertyType = goog.require('plugin.heatmap.HeatmapPropertyType');
 const HeatmapField = goog.require('plugin.heatmap.HeatmapField');
+const HeatmapPropertyType = goog.require('plugin.heatmap.HeatmapPropertyType');
 
 const GoogEvent = goog.requireType('goog.events.Event');
 const OLObject = goog.requireType('ol.Object');
 const PluggableMap = goog.requireType('ol.PluggableMap');
 const MapCanvasRenderer = goog.requireType('ol.renderer.canvas.Map');
+const Heatmap = goog.requireType('plugin.heatmap.Heatmap');
 
 /**
  * Synchronizes a single OpenLayers image layer to Cesium.
  *
- * @extends {CesiumSynchronizer<plugin.heatmap.Heatmap>}
+ * @extends {CesiumSynchronizer<Heatmap>}
  */
 class HeatmapSynchronizer extends CesiumSynchronizer {
   /**
    * Constructor.
-   * @param {!plugin.heatmap.Heatmap} layer The OpenLayers heatmap layer.
+   * @param {!Heatmap} layer The OpenLayers heatmap layer.
    * @param {!PluggableMap} map The OpenLayers map.
    * @param {!Cesium.Scene} scene The Cesium scene.
    */
@@ -77,7 +79,7 @@ class HeatmapSynchronizer extends CesiumSynchronizer {
    * @inheritDoc
    */
   disposeInternal() {
-    goog.dispose(this.syncDelay_);
+    dispose(this.syncDelay_);
     this.syncDelay_ = null;
 
     olEvents.unlisten(this.layer, EventType.PROPERTYCHANGE, this.onLayerPropertyChange_, this);

--- a/src/plugin/cesium/sync/heightreference.js
+++ b/src/plugin/cesium/sync/heightreference.js
@@ -1,15 +1,14 @@
 goog.module('plugin.cesium.sync.HeightReference');
 
-
-const {AltitudeMode} = goog.require('os.webgl');
 const RecordField = goog.require('os.data.RecordField');
 const implementz = goog.require('os.implements');
 const ISource = goog.require('os.source.ISource');
+const {AltitudeMode} = goog.require('os.webgl');
 
-const VectorSource = goog.requireType('os.source.Vector');
-const OLVectorLayer = goog.requireType('ol.layer.Vector');
 const Feature = goog.requireType('ol.Feature');
 const Geometry = goog.requireType('ol.geom.Geometry');
+const OLVectorLayer = goog.requireType('ol.layer.Vector');
+const VectorSource = goog.requireType('os.source.Vector');
 
 
 /**

--- a/src/plugin/cesium/sync/imagesynchronizer.js
+++ b/src/plugin/cesium/sync/imagesynchronizer.js
@@ -4,8 +4,8 @@ const googEventsEventType = goog.require('goog.events.EventType');
 const ImageState = goog.require('ol.ImageState');
 const OLObject = goog.require('ol.Object');
 const events = goog.require('ol.events');
-const olExtent = goog.require('ol.extent');
 const EventType = goog.require('ol.events.EventType');
+const olExtent = goog.require('ol.extent');
 const olProj = goog.require('ol.proj');
 
 const dispatcher = goog.require('os.Dispatcher');

--- a/src/plugin/cesium/sync/labelconverter.js
+++ b/src/plugin/cesium/sync/labelconverter.js
@@ -8,11 +8,11 @@ const SimpleGeometry = goog.require('ol.geom.SimpleGeometry');
 const olcsCore = goog.require('olcs.core');
 const osLabel = goog.require('os.style.label');
 const {GeometryInstanceId} = goog.require('plugin.cesium');
-const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
-const {getHeightReference} = goog.require('plugin.cesium.sync.HeightReference');
-const getTransformFunction = goog.require('plugin.cesium.sync.getTransformFunction');
 const {isPrimitiveShown} = goog.require('plugin.cesium.primitive');
 const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
+const {getHeightReference} = goog.require('plugin.cesium.sync.HeightReference');
+const getTransformFunction = goog.require('plugin.cesium.sync.getTransformFunction');
+const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
 
 const MultiPoint = goog.requireType('ol.geom.MultiPoint');
 const Point = goog.requireType('ol.geom.Point');

--- a/src/plugin/cesium/sync/linestring.js
+++ b/src/plugin/cesium/sync/linestring.js
@@ -1,19 +1,18 @@
 goog.module('plugin.cesium.sync.linestring');
 
-const olcsCore = goog.require('olcs.core');
-
-const GeometryType = goog.require('ol.geom.GeometryType');
-const InterpolationMethod = goog.require('os.interpolate.Method');
-const getTransformFunction = goog.require('plugin.cesium.sync.getTransformFunction');
-const interpolate = goog.require('os.interpolate');
-const {GeometryInstanceId} = goog.require('plugin.cesium');
 const {assert} = goog.require('goog.asserts');
-const {createGeometryInstance} = goog.require('plugin.cesium.primitive');
+const GeometryType = goog.require('ol.geom.GeometryType');
+const olcsCore = goog.require('olcs.core');
+const interpolate = goog.require('os.interpolate');
+const InterpolationMethod = goog.require('os.interpolate.Method');
 const {dashPatternToOptions} = goog.require('os.style');
-const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
+const {GeometryInstanceId} = goog.require('plugin.cesium');
+const {createGeometryInstance} = goog.require('plugin.cesium.primitive');
 const {getHeightReference} = goog.require('plugin.cesium.sync.HeightReference');
+const getTransformFunction = goog.require('plugin.cesium.sync.getTransformFunction');
+const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
 
-const Ellipse = goog.requireType('os.geom.Ellipse');
+const {Coordinate} = goog.requireType('ol');
 const Feature = goog.requireType('ol.Feature');
 const Geometry = goog.requireType('ol.geom.Geometry');
 const LineString = goog.requireType('ol.geom.LineString');
@@ -22,8 +21,8 @@ const MultiPolygon = goog.requireType('ol.geom.MultiPolygon');
 const Polygon = goog.requireType('ol.geom.Polygon');
 const Style = goog.requireType('ol.style.Style');
 const Text = goog.requireType('ol.style.Style');
+const Ellipse = goog.requireType('os.geom.Ellipse');
 const VectorContext = goog.requireType('plugin.cesium.VectorContext');
-const {Coordinate} = goog.requireType('ol');
 
 
 /**

--- a/src/plugin/cesium/sync/linestringconverter.js
+++ b/src/plugin/cesium/sync/linestringconverter.js
@@ -1,7 +1,7 @@
 goog.module('plugin.cesium.sync.LineStringConverter');
 
-const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
 const {updatePrimitive} = goog.require('plugin.cesium.primitive');
+const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
 const {createLineStringPrimitive, isLineWidthChanging, isDashChanging} = goog.require('plugin.cesium.sync.linestring');
 
 const LineString = goog.requireType('ol.geom.LineString');

--- a/src/plugin/cesium/sync/multilinestringconverter.js
+++ b/src/plugin/cesium/sync/multilinestringconverter.js
@@ -1,7 +1,7 @@
 goog.module('plugin.cesium.sync.MultiLineStringConverter');
 
-const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
 const {updatePrimitive} = goog.require('plugin.cesium.primitive');
+const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
 const {createLineStringPrimitive, isLineWidthChanging, isDashChanging} = goog.require('plugin.cesium.sync.linestring');
 
 const Feature = goog.requireType('ol.Feature');

--- a/src/plugin/cesium/sync/multipolygonconverter.js
+++ b/src/plugin/cesium/sync/multipolygonconverter.js
@@ -1,7 +1,7 @@
 goog.module('plugin.cesium.sync.MultiPolygonConverter');
 
-const {createAndAddPolygon} = goog.require('plugin.cesium.sync.polygon');
 const PolygonConverter = goog.require('plugin.cesium.sync.PolygonConverter');
+const {createAndAddPolygon} = goog.require('plugin.cesium.sync.polygon');
 
 const Feature = goog.requireType('ol.Feature');
 const MultiPolygon = goog.requireType('ol.geom.MultiPolygon');

--- a/src/plugin/cesium/sync/point.js
+++ b/src/plugin/cesium/sync/point.js
@@ -2,19 +2,19 @@ goog.module('plugin.cesium.sync.point');
 
 const {hashCode} = goog.require('goog.string');
 const {getUid} = goog.require('ol');
+const OLIconStyle = goog.require('ol.style.Icon');
+const OLRegularShape = goog.require('ol.style.RegularShape');
 const olcsCore = goog.require('olcs.core');
+const {ZoomScale} = goog.require('os.map');
+const OSIconStyle = goog.require('os.style.Icon');
 const {getHeightReference} = goog.require('plugin.cesium.sync.HeightReference');
 const getTransformFunction = goog.require('plugin.cesium.sync.getTransformFunction');
 const {drawShape} = goog.require('plugin.cesium.sync.shape');
-const OLIconStyle = goog.require('ol.style.Icon');
-const {ZoomScale} = goog.require('os.map');
-const OSIconStyle = goog.require('os.style.Icon');
-const OLRegularShape = goog.require('ol.style.RegularShape');
 
 const Feature = goog.requireType('ol.Feature');
 const MultiPoint = goog.requireType('ol.geom.MultiPoint');
-const OLImageStyle = goog.requireType('ol.style.Image');
 const Point = goog.requireType('ol.geom.Point');
+const OLImageStyle = goog.requireType('ol.style.Image');
 const Style = goog.requireType('ol.style.Style');
 const VectorContext = goog.requireType('plugin.cesium.VectorContext');
 

--- a/src/plugin/cesium/sync/pointconverter.js
+++ b/src/plugin/cesium/sync/pointconverter.js
@@ -1,7 +1,7 @@
 goog.module('plugin.cesium.sync.PointConverter');
 
-const {createBillboard, updateBillboard, updateStyleAfterLoad} = goog.require('plugin.cesium.sync.point');
 const BaseConverter = goog.require('plugin.cesium.sync.BaseConverter');
+const {createBillboard, updateBillboard, updateStyleAfterLoad} = goog.require('plugin.cesium.sync.point');
 
 const Point = goog.requireType('ol.geom.Point');
 

--- a/src/plugin/cesium/sync/polygon.js
+++ b/src/plugin/cesium/sync/polygon.js
@@ -4,11 +4,11 @@ const asserts = goog.require('goog.asserts');
 const olcsCore = goog.require('olcs.core');
 const geo = goog.require('os.geo');
 const {GeometryInstanceId} = goog.require('plugin.cesium');
-const getTransformFunction = goog.require('plugin.cesium.sync.getTransformFunction');
-const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
-const {getDashPattern} = goog.require('plugin.cesium.sync.linestring');
-const {getHeightReference} = goog.require('plugin.cesium.sync.HeightReference');
 const {createColoredPrimitive, createGeometryInstance} = goog.require('plugin.cesium.primitive');
+const {getHeightReference} = goog.require('plugin.cesium.sync.HeightReference');
+const getTransformFunction = goog.require('plugin.cesium.sync.getTransformFunction');
+const {getDashPattern} = goog.require('plugin.cesium.sync.linestring');
+const {getColor, getLineWidthFromStyle} = goog.require('plugin.cesium.sync.style');
 
 const Feature = goog.requireType('ol.Feature');
 const Geometry = goog.requireType('ol.geom.Geometry');

--- a/src/plugin/cesium/sync/polygonconverter.js
+++ b/src/plugin/cesium/sync/polygonconverter.js
@@ -1,8 +1,8 @@
 goog.module('plugin.cesium.sync.PolygonConverter');
 
 const {GeometryInstanceId} = goog.require('plugin.cesium');
-const {createAndAddPolygon} = goog.require('plugin.cesium.sync.polygon');
 const LineStringConverter = goog.require('plugin.cesium.sync.LineStringConverter');
+const {createAndAddPolygon} = goog.require('plugin.cesium.sync.polygon');
 const {getColor} = goog.require('plugin.cesium.sync.style');
 
 const Feature = goog.requireType('ol.Feature');

--- a/src/plugin/cesium/sync/rootsynchronizer.js
+++ b/src/plugin/cesium/sync/rootsynchronizer.js
@@ -1,9 +1,9 @@
 goog.module('plugin.cesium.sync.RootSynchronizer');
 
+const asserts = goog.require('goog.asserts');
 const dispatcher = goog.require('os.Dispatcher');
 const MapContainer = goog.require('os.MapContainer');
 const MapEvent = goog.require('os.MapEvent');
-const asserts = goog.require('goog.asserts');
 const Image = goog.require('os.layer.Image');
 const Tile = goog.require('os.layer.Tile');
 const Vector = goog.require('os.layer.Vector');
@@ -12,8 +12,8 @@ const AbstractRootSynchronizer = goog.require('os.webgl.AbstractRootSynchronizer
 
 const PluggableMap = goog.requireType('ol.PluggableMap');
 const OLLayer = goog.requireType('ol.layer.Layer');
-const ILayer = goog.requireType('os.layer.ILayer');
 const Group = goog.requireType('os.layer.Group');
+const ILayer = goog.requireType('os.layer.ILayer');
 const AbstractWebGLSynchronizer = goog.requireType('os.webgl.AbstractWebGLSynchronizer');
 
 

--- a/src/plugin/cesium/sync/tilesynchronizer.js
+++ b/src/plugin/cesium/sync/tilesynchronizer.js
@@ -2,6 +2,7 @@ goog.module('plugin.cesium.sync.TileSynchronizer');
 
 const asserts = goog.require('goog.asserts');
 const Delay = goog.require('goog.async.Delay');
+const dispose = goog.require('goog.dispose');
 const EventType = goog.require('goog.events.EventType');
 const googObject = goog.require('goog.object');
 const googString = goog.require('goog.string');
@@ -108,7 +109,7 @@ class TileSynchronizer extends CesiumSynchronizer {
    * @inheritDoc
    */
   disposeInternal() {
-    goog.dispose(this.syncDelay_);
+    dispose(this.syncDelay_);
     this.syncDelay_ = null;
 
     var view = MapContainer.getInstance().getMap().getView();

--- a/src/plugin/cesium/terrainlayer.js
+++ b/src/plugin/cesium/terrainlayer.js
@@ -2,8 +2,8 @@ goog.module('plugin.cesium.TerrainLayer');
 
 goog.require('plugin.basemap.terrainNodeUIDirective');
 
-const dispatcher = goog.require('os.Dispatcher');
 const log = goog.require('goog.log');
+const dispatcher = goog.require('os.Dispatcher');
 const MapEvent = goog.require('os.MapEvent');
 const LayerNode = goog.require('os.data.LayerNode');
 const LayerType = goog.require('os.layer.LayerType');

--- a/src/plugin/cesium/tilegridtilingscheme.js
+++ b/src/plugin/cesium/tilegridtilingscheme.js
@@ -1,10 +1,10 @@
 goog.module('plugin.cesium.TileGridTilingScheme');
 
+const asserts = goog.require('goog.asserts');
 const ol = goog.require('ol');
+const olProj = goog.require('ol.proj');
 const {toSize} = goog.require('ol.size');
 const geo = goog.require('os.geo');
-const asserts = goog.require('goog.asserts');
-const olProj = goog.require('ol.proj');
 const map = goog.require('os.map');
 const osProj = goog.require('os.proj');
 

--- a/src/plugin/cesium/tiles/cesium3dtilesimportui.js
+++ b/src/plugin/cesium/tiles/cesium3dtilesimportui.js
@@ -1,9 +1,9 @@
 goog.module('plugin.cesium.tiles.TilesetImportUI');
 
-const {directiveTag} = goog.require('plugin.cesium.tiles.TilesetImport');
 const FileImportUI = goog.require('os.ui.im.FileImportUI');
 const osWindow = goog.require('os.ui.window');
 const {TYPE} = goog.require('plugin.cesium.tiles');
+const {directiveTag} = goog.require('plugin.cesium.tiles.TilesetImport');
 
 
 /**

--- a/src/plugin/cesium/tiles/cesium3dtileslayer.js
+++ b/src/plugin/cesium/tiles/cesium3dtileslayer.js
@@ -20,8 +20,8 @@ const {
   SettingsKey,
   rectangleToExtent
 } = goog.require('plugin.cesium');
-const {ICON, TYPE} = goog.require('plugin.cesium.tiles');
 const PrimitiveLayer = goog.require('plugin.cesium.PrimitiveLayer');
+const {ICON, TYPE} = goog.require('plugin.cesium.tiles');
 const {directiveTag: layerUITag} = goog.require('plugin.cesium.tiles.Cesium3DTileLayerUI');
 
 const Logger = goog.requireType('goog.log.Logger');

--- a/src/plugin/cesium/vectorcontext.js
+++ b/src/plugin/cesium/vectorcontext.js
@@ -1,17 +1,18 @@
 goog.module('plugin.cesium.VectorContext');
 
 const Throttle = goog.require('goog.async.Throttle');
-const arrayUtils = goog.require('ol.array');
-const {getUid} = goog.require('ol');
+const dispose = goog.require('goog.dispose');
 const log = goog.require('goog.log');
+const {getUid} = goog.require('ol');
+const arrayUtils = goog.require('ol.array');
 const objectUtils = goog.require('os.object');
 const {isGroundPrimitive, isPrimitiveShown, setPrimitiveShown} = goog.require('plugin.cesium.primitive');
 
+const IDisposable = goog.requireType('goog.disposable.IDisposable');
 const Feature = goog.requireType('ol.Feature');
 const Geometry = goog.requireType('ol.geom.Geometry');
 const OLVectorLayer = goog.requireType('ol.layer.Vector');
 const Projection = goog.requireType('ol.proj.Projection');
-const IDisposable = goog.requireType('goog.disposable.IDisposable');
 
 
 /**
@@ -155,7 +156,7 @@ class VectorContext {
    */
   dispose() {
     if (!this.isDisposed()) {
-      goog.dispose(this.billboardCleanupThrottle);
+      dispose(this.billboardCleanupThrottle);
 
       try {
         this.billboards.destroyPrimitives = true;

--- a/src/plugin/track/track.js
+++ b/src/plugin/track/track.js
@@ -16,8 +16,10 @@ const osTrack = goog.require('os.track');
 const kml = goog.require('plugin.file.kml');
 const KMLNodeAdd = goog.require('plugin.file.kml.cmd.KMLNodeAdd');
 
+const Promise = goog.requireType('goog.Promise');
 const OlFeature = goog.requireType('ol.Feature');
 const OlGeometry = goog.requireType('ol.geom.Geometry');
+const ColumnDefinition = goog.requireType('os.data.ColumnDefinition');
 
 /**
  * Base logger for the track plugin.
@@ -324,7 +326,7 @@ const getMultiLineTime = osTrack.getMultiLineTime;
  *
  * @param {!OlFeature} feature The feature
  * @param {string=} opt_sortField The sort field
- * @return {!goog.Promise}
+ * @return {!Promise}
  *
  * @deprecated Please use `osTrack.getSortField` instead.
  */
@@ -334,7 +336,7 @@ const getSortField = osTrack.getSortField;
  * Prompt the user to choose a track title.
  *
  * @param {string=} opt_default The default value
- * @return {!goog.Promise}
+ * @return {!Promise}
  *
  * @deprecated Please use `osTrack.promptForTitle` instead.
  */
@@ -343,9 +345,9 @@ const promptForTitle = osTrack.promptForTitle;
 /**
  * Prompt the user to choose a track.
  *
- * @param {Array<os.data.ColumnDefinition>} columns The columns
+ * @param {Array<ColumnDefinition>} columns The columns
  * @param {string} prompt The dialog prompt
- * @return {!goog.Promise}
+ * @return {!Promise}
  *
  * @deprecated Please use `osTrack.promptForField` instead.
  */

--- a/src/plugin/vectortile/vectortilelayerconfig.js
+++ b/src/plugin/vectortile/vectortilelayerconfig.js
@@ -1,7 +1,6 @@
 goog.module('plugin.vectortile.VectorTileLayerConfig');
 
 const log = goog.require('goog.log');
-
 const {DEFAULT_MAX_ZOOM, DEFAULT_MIN_ZOOM} = goog.require('ol');
 const olColor = goog.require('ol.color');
 const olExtent = goog.require('ol.extent');
@@ -9,24 +8,26 @@ const VectorTileRenderType = goog.require('ol.layer.VectorTileRenderType');
 const {transformExtent} = goog.require('ol.proj');
 const Style = goog.require('ol.style.Style');
 
-const Settings = goog.require('os.config.Settings');
-const DisplaySetting = goog.require('os.config.DisplaySetting');
 const osColor = goog.require('os.color');
+const DisplaySetting = goog.require('os.config.DisplaySetting');
+const Settings = goog.require('os.config.Settings');
 const VectorTileLayer = goog.require('os.layer.VectorTile');
-const osMap = goog.require('os.map');
-const VectorTileSource = goog.require('os.ol.source.VectorTile');
 const AbstractLayerConfig = goog.require('os.layer.config.AbstractLayerConfig');
 const AbstractTileLayerConfig = goog.require('os.layer.config.AbstractTileLayerConfig');
+const osMap = goog.require('os.map');
 const net = goog.require('os.net');
 const CrossOrigin = goog.require('os.net.CrossOrigin');
 const Request = goog.require('os.net.Request');
+const VectorTileSource = goog.require('os.ol.source.VectorTile');
 const {addProxyWrapper, autoProxyCheck} = goog.require('os.ol.source.tileimage');
 const {getBestSupportedProjection, EPSG4326} = goog.require('os.proj');
 const StyleManager = goog.require('os.style.StyleManager');
 const {DEFAULT_FONT} = goog.require('os.style.label');
 const {getVectorTileFormat, VectorTileFormat} = goog.require('plugin.vectortile.format');
 
+const Feature = goog.requireType('ol.Feature');
 const Projection = goog.requireType('ol.proj.Projection');
+const RenderFeature = goog.requireType('ol.render.Feature');
 const OLVectorTileSource = goog.requireType('ol.source.VectorTile');
 
 
@@ -233,9 +234,9 @@ class VectorTileLayerConfig extends AbstractLayerConfig {
             const glStyleFunction = parseMapboxStyle(glStyle, sources, resolutions, getFonts);
 
             /**
-             * @param {ol.Feature|ol.render.Feature} feature
+             * @param {Feature|RenderFeature} feature
              * @param {number} resolution
-             * @return {ol.style.Style|Array<ol.style.Style>}
+             * @return {Style|Array<Style>}
              */
             const styleFunction = (feature, resolution) => {
               let styleConfig = glStyleFunction(feature.getProperties(), feature.getGeometry().getType(), resolution);

--- a/src/plugin/vectortools/copylayercmd.js
+++ b/src/plugin/vectortools/copylayercmd.js
@@ -2,12 +2,14 @@ goog.module('plugin.vectortools.CopyLayer');
 goog.module.declareLegacyNamespace();
 
 const MapContainer = goog.require('os.MapContainer');
+const AbstractSource = goog.require('os.command.AbstractSource');
+const State = goog.require('os.command.State');
 const VectorSource = goog.require('os.source.Vector');
 const vectortools = goog.require('plugin.vectortools');
 
-const AbstractSource = goog.require('os.command.AbstractSource');
-const State = goog.require('os.command.State');
 const ICommand = goog.requireType('os.command.ICommand');
+const VectorSource1 = goog.requireType('os.source.Vector');
+const Options = goog.requireType('plugin.vectortools.Options');
 
 
 /**
@@ -19,7 +21,7 @@ class CopyLayer extends AbstractSource {
   /**
    * Constructor.
    * @param {!string} sourceId The data source ID to copy
-   * @param {plugin.vectortools.Options=} opt_options The feature options
+   * @param {Options=} opt_options The feature options
    */
   constructor(sourceId, opt_options) {
     super(sourceId);
@@ -37,13 +39,13 @@ class CopyLayer extends AbstractSource {
 
       var s = this.getSource();
       if (s instanceof VectorSource) {
-        var source = /** @type {os.source.Vector} */ (s);
+        var source = /** @type {VectorSource1} */ (s);
 
         // add the new layer
         var newLayer = vectortools.addNewLayer(source.getId());
 
         // keep track of its ID, use it for revert
-        var newSource = /** @type {os.source.Vector} */ (newLayer.getSource());
+        var newSource = /** @type {VectorSource1} */ (newLayer.getSource());
         this.newLayerId_ = newSource.getId();
 
         // get a cloning function and use it to do the feature copy

--- a/src/plugin/vectortools/joinlayercmd.js
+++ b/src/plugin/vectortools/joinlayercmd.js
@@ -6,10 +6,14 @@ const MapContainer = goog.require('os.MapContainer');
 const osArray = goog.require('os.array');
 const AbstractSource = goog.require('os.command.AbstractSource');
 const State = goog.require('os.command.State');
-const ICommand = goog.requireType('os.command.ICommand');
 const RecordField = goog.require('os.data.RecordField');
 const layer = goog.require('os.layer');
 const vectortools = goog.require('plugin.vectortools');
+
+const Feature = goog.requireType('ol.Feature');
+const ICommand = goog.requireType('os.command.ICommand');
+const VectorSource = goog.requireType('os.source.Vector');
+const Options = goog.requireType('plugin.vectortools.Options');
 
 
 /**
@@ -24,7 +28,7 @@ class JoinLayer extends AbstractSource {
    * @param {!Array<string>} indexFields The field to use as the join index on each source
    * @param {string} indexerType The type of indexer this command uses
    * @param {string=} opt_name Optional name to give the merged layer
-   * @param {plugin.vectortools.Options=} opt_options The feature options
+   * @param {Options=} opt_options The feature options
    */
   constructor(sourceIds, indexFields, indexerType, opt_name, opt_options) {
     asserts.assert(sourceIds && indexFields && sourceIds.length === indexFields.length,
@@ -90,7 +94,7 @@ class JoinLayer extends AbstractSource {
       var sources = this.sourceIds_.map(this.mapSources_, this);
       if (sources) {
         var newLayer = vectortools.addNewLayer(sources[0].getId());
-        var newSource = /** @type {os.source.Vector} */ (newLayer.getSource());
+        var newSource = /** @type {VectorSource} */ (newLayer.getSource());
 
         this.newLayerId_ = newSource.getId();
         newLayer.setTitle(this.newLayerName_);
@@ -104,7 +108,7 @@ class JoinLayer extends AbstractSource {
 
         var sets = sources.map(
             /**
-             * @param {os.source.Vector} source The source
+             * @param {VectorSource} source The source
              * @param {number} i The source index
              * @return {osArray.JoinSet}
              */
@@ -214,8 +218,8 @@ class JoinLayer extends AbstractSource {
      * @return {Object} resulting object
      */
     var copy = function(from, to) {
-      var featureFrom = /** @type {ol.Feature} */ (from);
-      var featureTo = /** @type {ol.Feature} */ (to);
+      var featureFrom = /** @type {Feature} */ (from);
+      var featureTo = /** @type {Feature} */ (to);
 
       // non-destructive copy
       var fromValues = featureFrom.values_;
@@ -252,12 +256,12 @@ class JoinLayer extends AbstractSource {
 
   /**
    * @param {string} id The source id
-   * @return {os.source.Vector}
+   * @return {VectorSource}
    * @private
    */
   mapSources_(id) {
     this.sourceId = id;
-    return /** @type {os.source.Vector} */ (this.getSource());
+    return /** @type {VectorSource} */ (this.getSource());
   }
 
   /**
@@ -281,7 +285,7 @@ class JoinLayer extends AbstractSource {
    * @private
    */
   static exactAccessor_(obj, field) {
-    return /** @type {string|number} */ (/** @type {ol.Feature} */ (obj).get(field));
+    return /** @type {string|number} */ (/** @type {Feature} */ (obj).get(field));
   }
 
   /**
@@ -291,7 +295,7 @@ class JoinLayer extends AbstractSource {
    * @private
    */
   static caseInsensitiveAccessor_(obj, field) {
-    var val = /** @type {string|number} */ (/** @type {ol.Feature} */ (obj).get(field));
+    var val = /** @type {string|number} */ (/** @type {Feature} */ (obj).get(field));
     return val ? val.toString().toLowerCase() : val;
   }
 }

--- a/src/plugin/vectortools/joinwindow.js
+++ b/src/plugin/vectortools/joinwindow.js
@@ -4,16 +4,16 @@ goog.require('os.ui.util.validationMessageDirective');
 goog.require('plugin.vectortools.MappingCounterUI');
 
 const googString = goog.require('goog.string');
+const olArray = goog.require('ol.array');
+const os = goog.require('os');
 const CommandProcessor = goog.require('os.command.CommandProcessor');
+const OSDataManager = goog.require('os.data.OSDataManager');
+const SourceManager = goog.require('os.data.SourceManager');
 const ogc = goog.require('os.ogc');
 const PropertyChange = goog.require('os.source.PropertyChange');
 const ui = goog.require('os.ui');
-const WindowEventType = goog.require('os.ui.WindowEventType');
-
-const olArray = goog.require('ol.array');
-const os = goog.require('os');
-const SourceManager = goog.require('os.data.SourceManager');
 const Module = goog.require('os.ui.Module');
+const WindowEventType = goog.require('os.ui.WindowEventType');
 const osWindow = goog.require('os.ui.window');
 const JoinLayer = goog.require('plugin.vectortools.JoinLayer');
 
@@ -171,7 +171,7 @@ class Controller extends SourceManager {
     this['count'] = 0;
 
     for (var i = 0, ii = this.sourceIds_.length; i < ii; i++) {
-      var source = os.osDataManager.getSource(this.sourceIds_[i]);
+      var source = OSDataManager.getInstance().getSource(this.sourceIds_[i]);
       if (source) {
         this['count'] += source.getFeatures().length;
       }
@@ -242,7 +242,7 @@ class Controller extends SourceManager {
    * @protected
    */
   static mapSources(id) {
-    var source = os.osDataManager.getSource(id);
+    var source = OSDataManager.getInstance().getSource(id);
 
     return {
       'id': source.getId(),

--- a/src/plugin/vectortools/mappingcounter.js
+++ b/src/plugin/vectortools/mappingcounter.js
@@ -3,14 +3,13 @@ goog.module.declareLegacyNamespace();
 
 const EventType = goog.require('goog.events.EventType');
 const googObject = goog.require('goog.object');
-const ui = goog.require('os.ui');
-const ColumnMappingSettings = goog.require('os.ui.column.mapping.ColumnMappingSettings');
-const vectortools = goog.require('plugin.vectortools');
-
 const os = goog.require('os');
 const ColumnMappingManager = goog.require('os.column.ColumnMappingManager');
+const ui = goog.require('os.ui');
 const Module = goog.require('os.ui.Module');
+const ColumnMappingSettings = goog.require('os.ui.column.mapping.ColumnMappingSettings');
 const windows = goog.require('os.ui.menu.windows');
+const vectortools = goog.require('plugin.vectortools');
 
 
 /**

--- a/src/plugin/vectortools/mergelayercmd.js
+++ b/src/plugin/vectortools/mergelayercmd.js
@@ -1,16 +1,18 @@
 goog.module('plugin.vectortools.MergeLayer');
 goog.module.declareLegacyNamespace();
 
-const os = goog.require('os');
 const MapContainer = goog.require('os.MapContainer');
+const State = goog.require('os.command.State');
+const OSDataManager = goog.require('os.data.OSDataManager');
 const osFeature = goog.require('os.feature');
 const layer = goog.require('os.layer');
+const style = goog.require('os.style');
 const vectortools = goog.require('plugin.vectortools');
 
-const State = goog.require('os.command.State');
-const style = goog.require('os.style');
 const ICommand = goog.requireType('os.command.ICommand');
+const ISource = goog.requireType('os.source.ISource');
 const VectorSource = goog.requireType('os.source.Vector');
+const Options = goog.requireType('plugin.vectortools.Options');
 
 
 /**
@@ -23,7 +25,7 @@ class MergeLayer {
    * Constructor.
    * @param {!Array<string>} sourceIds The data source IDs to merge
    * @param {string=} opt_name Optional name to give the merged layer
-   * @param {plugin.vectortools.Options=} opt_options The options
+   * @param {Options=} opt_options The options
    */
   constructor(sourceIds, opt_name, opt_options) {
     /**
@@ -54,13 +56,13 @@ class MergeLayer {
   }
 
   /**
-   * @return {Array.<os.source.ISource>} The sources
+   * @return {Array.<ISource>} The sources
    */
   getSources() {
     // iterate thru all the sourceIds and get each of the sources
     var sources = Array(this.sourceIds.length);
     for (var i = 0; i < this.sourceIds.length; i++) {
-      sources[i] = os.osDataManager.getSource(this.sourceIds[i]);
+      sources[i] = OSDataManager.getInstance().getSource(this.sourceIds[i]);
     }
     return sources;
   }

--- a/src/plugin/vectortools/mergewindow.js
+++ b/src/plugin/vectortools/mergewindow.js
@@ -3,16 +3,16 @@ goog.module('plugin.vectortools.MergeUI');
 goog.require('os.ui.util.validationMessageDirective');
 goog.require('plugin.vectortools.MappingCounterUI');
 
-const CommandProcessor = goog.require('os.command.CommandProcessor');
-const ogc = goog.require('os.ogc');
-const ui = goog.require('os.ui');
-const WindowEventType = goog.require('os.ui.WindowEventType');
-
 const olArray = goog.require('ol.array');
 const os = goog.require('os');
+const CommandProcessor = goog.require('os.command.CommandProcessor');
+const OSDataManager = goog.require('os.data.OSDataManager');
 const SourceManager = goog.require('os.data.SourceManager');
+const ogc = goog.require('os.ogc');
 const PropertyChange = goog.require('os.source.PropertyChange');
+const ui = goog.require('os.ui');
 const Module = goog.require('os.ui.Module');
+const WindowEventType = goog.require('os.ui.WindowEventType');
 const osWindow = goog.require('os.ui.window');
 const MergeLayer = goog.require('plugin.vectortools.MergeLayer');
 
@@ -140,7 +140,7 @@ class Controller extends SourceManager {
     this['count'] = 0;
 
     for (var i = 0, ii = this.sourceIds_.length; i < ii; i++) {
-      var source = os.osDataManager.getSource(this.sourceIds_[i]);
+      var source = OSDataManager.getInstance().getSource(this.sourceIds_[i]);
       if (source) {
         this['count'] += source.getFeatures().length;
       }

--- a/src/plugin/vectortools/vectortools.js
+++ b/src/plugin/vectortools/vectortools.js
@@ -10,12 +10,14 @@ const RecordField = goog.require('os.data.RecordField');
 const IFilterable = goog.require('os.filter.IFilterable');
 const osImplements = goog.require('os.implements');
 const layer = goog.require('os.layer');
-const StyleType = goog.require('os.style.StyleType');
 const VectorLayer = goog.require('os.layer.Vector');
 const VectorSource = goog.require('os.source.Vector');
-
+const StyleType = goog.require('os.style.StyleType');
 const Options = goog.require('plugin.vectortools.Options');
 
+const Feature = goog.requireType('ol.Feature');
+const ColumnDefinition = goog.requireType('os.data.ColumnDefinition');
+const ILayer = goog.requireType('os.layer.ILayer');
 
 
 /**
@@ -44,7 +46,7 @@ const setOption = (value) => {
 /**
  * @param {VectorSource} source The vector source
  * @param {Options=} opt_which Which features to retrieve
- * @return {Array<!ol.Feature>} the features
+ * @return {Array<!Feature>} the features
  */
 const getFeatures = function(source, opt_which) {
   opt_which = opt_which || option;
@@ -67,12 +69,12 @@ const getFeatures = function(source, opt_which) {
 
 /**
  * @param {string} sourceId
- * @return {function(ol.Feature):ol.Feature} map function used for cloning lists of features
+ * @return {function(Feature):Feature} map function used for cloning lists of features
  */
 const getFeatureCloneFunction = function(sourceId) {
   /**
-   * @param {ol.Feature} feature Original feature
-   * @return {ol.Feature} copied feature
+   * @param {Feature} feature Original feature
+   * @return {Feature} copied feature
    */
   var cloneFunc = function(feature) {
     var newFeature = feature.clone();
@@ -109,7 +111,7 @@ const addNewLayer = function(opt_restoreFromIdOrConfig) {
   if (opt_restoreFromIdOrConfig) {
     if (typeof opt_restoreFromIdOrConfig === 'string') {
       // get the other layer and restore the new one from it
-      var otherLayer = /** @type {os.layer.ILayer} */ (mm.getLayer(opt_restoreFromIdOrConfig));
+      var otherLayer = /** @type {ILayer} */ (mm.getLayer(opt_restoreFromIdOrConfig));
       if (otherLayer) {
         newLayer.restore(otherLayer.persist());
 
@@ -227,7 +229,7 @@ const mapIdToFilterKey_ = function(id) {
   var d = DataManager.getInstance().getDescriptor(id);
 
   if (d && osImplements(d, IFilterable.ID)) {
-    return /** @type {os.filter.IFilterable} */ (d).getFilterKey();
+    return /** @type {IFilterable} */ (d).getFilterKey();
   }
 
   return id;
@@ -237,7 +239,7 @@ const mapIdToFilterKey_ = function(id) {
  * Runs a column mapping on a feature.
  *
  * @param {Object<string, string>} mapping
- * @param {ol.Feature} feature
+ * @param {Feature} feature
  */
 const runColumnMapping = function(mapping, feature) {
   if (mapping) {
@@ -259,7 +261,7 @@ const runColumnMapping = function(mapping, feature) {
  *
  * @param {!Array<!VectorSource>} sources
  * @param {!Object<string, !Object<string, string>>} mappings
- * @return {!Array<!os.data.ColumnDefinition|string>}
+ * @return {!Array<!ColumnDefinition|string>}
  */
 const getCombinedColumns = function(sources, mappings) {
   return sources.reduce(function(columns, source) {

--- a/src/plugin/vectortools/vectortoolsui.js
+++ b/src/plugin/vectortools/vectortoolsui.js
@@ -1,9 +1,10 @@
 goog.declareModuleId('plugin.vectortools.ui');
 
 const osWindow = goog.require('os.ui.window');
+const Icons = goog.require('plugin.vectortools.Icons');
 const {directiveTag: joinEl} = goog.require('plugin.vectortools.JoinUI');
 const {directiveTag: mergeEl} = goog.require('plugin.vectortools.MergeUI');
-const Icons = goog.require('plugin.vectortools.Icons');
+
 
 /**
  * Launches the Join Layer window.

--- a/src/plugin/weather/weatherplugin.js
+++ b/src/plugin/weather/weatherplugin.js
@@ -1,11 +1,13 @@
 goog.module('plugin.weather.WeatherPlugin');
 goog.module.declareLegacyNamespace();
 
+const olProj = goog.require('ol.proj');
 const settings = goog.require('os.config.Settings');
 const osMap = goog.require('os.map');
 const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
 const mapMenu = goog.require('os.ui.menu.map');
 
+const MenuEvent = goog.requireType('os.ui.menu.MenuEvent');
 
 /**
  * Provides a Weather menu option when right-clicking the map. The resulting location is then
@@ -68,7 +70,7 @@ const getWeatherUrl = function() {
 /**
  * Forecast menu option listener
  *
- * @param {os.ui.menu.MenuEvent<ol.Coordinate>} evt The menu event
+ * @param {MenuEvent<ol.Coordinate>} evt The menu event
  */
 const onLookup = function(evt) {
   launchForecast(evt.getContext());
@@ -82,7 +84,7 @@ const onLookup = function(evt) {
  */
 const launchForecast = function(coord) {
   var url = getWeatherUrl();
-  coord = ol.proj.toLonLat(coord, osMap.PROJECTION);
+  coord = olProj.toLonLat(coord, osMap.PROJECTION);
 
   if (url) {
     url = url.replace('{lon}', coord[0].toString());


### PR DESCRIPTION
Replaces remaining global references in the following plugins:
- cesium
- track
- vectortile
- vectortools
- weather

These references were primarily in JSDoc only, which are not automatically detected/fixed by `opensphere-jscodeshift`. This also sorts `goog.require` and `goog.requireType` statements by required module name, which was not previously done by the transform scripts.