### PR TITLE
fix(draw): normalize polygons/lines in current projection

### DIFF
--- a/src/os/ogc/filter/ogcspatialformatter.js
+++ b/src/os/ogc/filter/ogcspatialformatter.js
@@ -1,9 +1,11 @@
 goog.provide('os.ogc.filter.OGCSpatialFormatter');
+
 goog.require('ol.geom.GeometryType');
 goog.require('ol.geom.Polygon');
 goog.require('os.filter.ISpatialFormatter');
 goog.require('os.geo');
 goog.require('os.ogc.spatial');
+goog.require('os.proj');
 goog.require('os.xml');
 
 
@@ -62,6 +64,9 @@ os.ogc.filter.OGCSpatialFormatter.prototype.format = function(feature) {
         if (coords.length == 1 && os.geo.isRectangular(coords[0], geometry.getExtent())) {
           result = os.ogc.spatial.formatExtent(geometry.getExtent(), this.column_, name, description, id);
         } else {
+          // Some OGC services (like GeoServer) do not support polygons that cross the antimeridian, so split the
+          // geometry if it crosses.
+          geometry = os.geo.jsts.splitWithinWorldExtent(geometry, os.proj.EPSG4326);
           result = os.ogc.spatial.formatGMLIntersection(geometry, this.column_, name, description, id) || '';
         }
         break;

--- a/src/os/ogc/filter/ogcspatialformatter.js
+++ b/src/os/ogc/filter/ogcspatialformatter.js
@@ -4,6 +4,8 @@ goog.require('ol.geom.GeometryType');
 goog.require('ol.geom.Polygon');
 goog.require('os.filter.ISpatialFormatter');
 goog.require('os.geo');
+goog.require('os.geo.jsts');
+goog.require('os.interpolate');
 goog.require('os.ogc.spatial');
 goog.require('os.proj');
 goog.require('os.xml');
@@ -65,8 +67,10 @@ os.ogc.filter.OGCSpatialFormatter.prototype.format = function(feature) {
           result = os.ogc.spatial.formatExtent(geometry.getExtent(), this.column_, name, description, id);
         } else {
           // Some OGC services (like GeoServer) do not support polygons that cross the antimeridian, so split the
-          // geometry if it crosses.
+          // geometry if it crosses. Ensure the geometry has been interpolated so it is split properly.
+          os.interpolate.interpolateGeom(geometry);
           geometry = os.geo.jsts.splitWithinWorldExtent(geometry, os.proj.EPSG4326);
+
           result = os.ogc.spatial.formatGMLIntersection(geometry, this.column_, name, description, id) || '';
         }
         break;

--- a/src/os/ogc/filter/ogcspatialformatter.js
+++ b/src/os/ogc/filter/ogcspatialformatter.js
@@ -68,7 +68,10 @@ os.ogc.filter.OGCSpatialFormatter.prototype.format = function(feature) {
         } else {
           // Some OGC services (like GeoServer) do not support polygons that cross the antimeridian, so split the
           // geometry if it crosses. Ensure the geometry has been interpolated so it is split properly.
+          os.interpolate.beginTempInterpolation(os.proj.EPSG4326);
           os.interpolate.interpolateGeom(geometry);
+          os.interpolate.endTempInterpolation();
+
           geometry = os.geo.jsts.splitWithinWorldExtent(geometry, os.proj.EPSG4326);
 
           result = os.ogc.spatial.formatGMLIntersection(geometry, this.column_, name, description, id) || '';

--- a/src/os/ui/ol/interaction/drawpolygoninteraction.js
+++ b/src/os/ui/ol/interaction/drawpolygoninteraction.js
@@ -106,8 +106,7 @@ os.ui.ol.interaction.DrawPolygon.prototype.getGeometry = function() {
   geom.toLonLat();
 
   // normalize coordinates prior to validation, or polygons crossing the date line may be broken
-  var normalizationPoint = os.geo2.computeWindingOrder(geom.getCoordinates()[0]) ? 0 : undefined;
-  os.geo2.normalizeGeometryCoordinates(geom, normalizationPoint, os.proj.EPSG4326);
+  os.geo2.normalizeGeometryCoordinates(geom);
 
   // validate the geometry to ensure it's accepted in server queries
   geom = os.geo.jsts.validate(geom);
@@ -320,7 +319,7 @@ os.ui.ol.interaction.DrawPolygon.prototype.update2D = function() {
   }
 
   var geom = this.createGeometry();
-  os.geo2.normalizeGeometryCoordinates(geom, 0, os.proj.EPSG4326);
+  os.geo2.normalizeGeometryCoordinates(geom);
 
   this.line2D.setGeometry(geom);
   this.line2D.set(os.interpolate.ORIGINAL_GEOM_FIELD, undefined);

--- a/src/os/ui/ol/interaction/drawpolygoninteraction.js
+++ b/src/os/ui/ol/interaction/drawpolygoninteraction.js
@@ -103,15 +103,13 @@ os.ui.ol.interaction.DrawPolygon.prototype.getGeometry = function() {
   var geom = new ol.geom.Polygon([this.coords]);
   var method = os.interpolate.getMethod();
   geom.set(os.interpolate.METHOD_FIELD, method);
-  geom.toLonLat();
 
   // normalize coordinates prior to validation, or polygons crossing the date line may be broken
   os.geo2.normalizeGeometryCoordinates(geom);
 
   // validate the geometry to ensure it's accepted in server queries
-  geom = os.geo.jsts.validate(geom);
+  geom = /** @type {ol.geom.Polygon} */ (os.geo.jsts.validate(geom));
 
-  geom.osTransform();
   return geom;
 };
 

--- a/src/plugin/ogc/query/ogcspatialformatter.js
+++ b/src/plugin/ogc/query/ogcspatialformatter.js
@@ -18,8 +18,7 @@ goog.inherits(plugin.ogc.query.OGCSpatialFormatter, os.ogc.filter.OGCSpatialForm
  * @inheritDoc
  */
 plugin.ogc.query.OGCSpatialFormatter.prototype.getGeometry = function(feature) {
-  // Use the interpolated geometry, in case modifications need to be made (like splitting on the antimeridian).
-  var geom = feature.getGeometry();
+  var geom = /** @type {ol.geom.Geometry} */ (feature.get(os.interpolate.ORIGINAL_GEOM_FIELD)) || feature.getGeometry();
 
   if (geom) {
     geom = geom.clone().toLonLat();

--- a/src/plugin/ogc/query/ogcspatialformatter.js
+++ b/src/plugin/ogc/query/ogcspatialformatter.js
@@ -18,7 +18,8 @@ goog.inherits(plugin.ogc.query.OGCSpatialFormatter, os.ogc.filter.OGCSpatialForm
  * @inheritDoc
  */
 plugin.ogc.query.OGCSpatialFormatter.prototype.getGeometry = function(feature) {
-  var geom = /** @type {ol.geom.Geometry} */ (feature.get(os.interpolate.ORIGINAL_GEOM_FIELD)) || feature.getGeometry();
+  // Use the interpolated geometry, in case modifications need to be made (like splitting on the antimeridian).
+  var geom = feature.getGeometry();
 
   if (geom) {
     geom = geom.clone().toLonLat();


### PR DESCRIPTION
The line/polygon draw tools were not working in projections other than EPSG:4326 because the geometry was always normalized using that projection, instead of the current map/geometry projection.

We previously normalized the geometry using `x = 0` instead of the default (first geometry coordinate), which was causing rendering issues across the antimeridian. I believe this was intended to resolve issues with servers not accepting the coordinates in the geometry we send, so that solution will need to be reviewed.

[Test Deployment](https://os-fix-polygon-normalization.surge.sh/)

- Drawing lines/polygons across the antimeridian should work in both 2D and 3D, in both EPSG:4326 and EPSG:3857.
- Drawing large polygons (spanning more than half the world) should both display properly and query properly.
- When large/crossing polygons are drawn in 3D, switching to 2D should still render the geometry correctly.
- Polygons crossing the antimeridian should query properly with GeoServer. [This demo instance](https://demo.geo-solutions.it/geoserver/ows) can be used to test.
- While these queries already worked with Arc servers, we should verify they still work.