### PR TITLE
feat(add-data): adds support for turning on full providers from add data

### DIFF
--- a/src/os/structs/tristatetreenode.js
+++ b/src/os/structs/tristatetreenode.js
@@ -52,10 +52,10 @@ os.structs.TriStateTreeNode = function() {
 
   /**
    * Whether or not the checkbox should be disabled;
-   * @type {boolean}
+   * @type {?boolean}
    * @private
    */
-  this.disabled_ = false;
+  this.disabled_ = null;
 };
 goog.inherits(os.structs.TriStateTreeNode, os.structs.TreeNode);
 
@@ -230,7 +230,7 @@ os.structs.TriStateTreeNode.prototype.updateChild = function(child, state) {
 /**
  * Gets whether the checkbox should be disabled for this treenode.
  *
- * @return {boolean}
+ * @return {?boolean}
  */
 os.structs.TriStateTreeNode.prototype.getCheckboxDisabled = function() {
   return this.disabled_;
@@ -240,7 +240,7 @@ os.structs.TriStateTreeNode.prototype.getCheckboxDisabled = function() {
 /**
  * Sets whether the checkbox should be disabled for this treenode.
  *
- * @param {boolean} disabled
+ * @param {?boolean} disabled
  */
 os.structs.TriStateTreeNode.prototype.setCheckboxDisabled = function(disabled) {
   this.disabled_ = disabled;

--- a/src/os/ui/data/layercheckbox.js
+++ b/src/os/ui/data/layercheckbox.js
@@ -1,0 +1,119 @@
+goog.module('os.ui.data.LayerCheckboxUI');
+
+const ConfirmUI = goog.require('os.ui.window.ConfirmUI');
+const Module = goog.require('os.ui.Module');
+const TriState = goog.require('os.structs.TriState');
+const TriStateCheckboxCtrl = goog.require('os.ui.TriStateCheckboxCtrl');
+const triStateCheckboxDirective = goog.require('os.ui.triStateCheckboxDirective');
+
+const TriStateTreeNode = goog.requireType('os.structs.TriStateTreeNode');
+
+
+/**
+ * Tristate checkbox extension for enabling layers.
+ *
+ * @return {angular.Directive}
+ */
+const directive = () => {
+  const dir = triStateCheckboxDirective();
+  dir.controller = Controller;
+  return dir;
+};
+
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'layercheckbox';
+
+
+/**
+ * Add the directive to the module
+ */
+Module.directive(directiveTag, [directive]);
+
+
+
+/**
+ * Controller for the layer checkbox.
+ * @unrestricted
+ */
+class Controller extends TriStateCheckboxCtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope The Angular scope.
+   * @param {!angular.JQLite} $element The root DOM element.
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    super($scope, $element);
+
+    /**
+     * The minimum count of layers before prompting the user.
+     * @type {number}
+     */
+    this.minCount = $scope['minCount'] || 10;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  toggle(e) {
+    if (this.scope) {
+      const item = /** @type {TriStateTreeNode} */ (this.scope['item']);
+
+      if (!this.getDisabled(item)) {
+        const children = item.getChildren();
+        const state = item.getState();
+
+        if (state == TriState.OFF) {
+          if (children && children.length > this.minCount) {
+            // we're over the minimum, so confirm first
+            ConfirmUI.launchConfirm(/** @type {osx.window.ConfirmOptions} */ ({
+              confirm: this.toggleInternal.bind(this, TriState.ON),
+              prompt: `You are about to enable ${children.length} layers. Enabling too many layers at once can cause 
+                  performance issues. Are you sure?`.trim(),
+              yesText: 'OK',
+              noText: 'Cancel',
+              windowOptions: {
+                'label': `Enabling ${children.length} Layers`,
+                'icon': 'fa fa-warning',
+                'x': 'center',
+                'y': 'center',
+                'width': '335',
+                'height': 'auto',
+                'modal': 'true',
+                'headerClass': 'bg-warning u-bg-warning-text'
+              }
+            }));
+          } else {
+            // under the minimum, just activate
+            this.toggleInternal(TriState.ON);
+          }
+        } else {
+          // turn it off
+          this.toggleInternal(TriState.OFF);
+        }
+      }
+
+      e.stopPropagation();
+    }
+  }
+
+  /**
+   * Toggles the item on or off.
+   * @param {TriState} value The value to set.
+   */
+  toggleInternal(value) {
+    const item = /** @type {TriStateTreeNode} */ (this.scope['item']);
+    item.setState(value);
+    this.notifyDirty();
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
+};

--- a/src/os/ui/search/facetnode.js
+++ b/src/os/ui/search/facetnode.js
@@ -95,7 +95,7 @@ os.ui.search.FacetNode.prototype.formatValue = function(value) {
  * @inheritDoc
  */
 os.ui.search.FacetNode.prototype.getCheckboxDisabled = function() {
-  return !this.getCount();
+  return !this.getCount() || null;
 };
 
 

--- a/src/os/ui/slick/loadingnode.js
+++ b/src/os/ui/slick/loadingnode.js
@@ -52,7 +52,7 @@ os.ui.slick.LoadingNode.prototype.setLoading = function(value) {
  * @inheritDoc
  */
 os.ui.slick.LoadingNode.prototype.getCheckboxDisabled = function() {
-  return this.isLoading();
+  return this.isLoading() || null;
 };
 
 

--- a/src/os/ui/tristatecheckbox.js
+++ b/src/os/ui/tristatecheckbox.js
@@ -40,18 +40,16 @@ os.ui.Module.directive('tristatecheckbox', [os.ui.triStateCheckboxDirective]);
 os.ui.TriStateCheckboxCtrl = function($scope, $element) {
   /**
    * @type {?angular.Scope}
-   * @private
    */
-  this.scope_ = $scope;
+  this.scope = $scope;
 
   /**
    * @type {?angular.JQLite}
-   * @private
    */
-  this.element_ = $element;
+  this.element = $element;
 
-  var item = /** @type {os.structs.TriStateTreeNode} */ (this.scope_['item']);
-  if (this.getDisabled_(item)) {
+  var item = /** @type {os.structs.TriStateTreeNode} */ (this.scope['item']);
+  if (this.getDisabled(item)) {
     $element.addClass('disabled');
   }
 
@@ -65,8 +63,8 @@ os.ui.TriStateCheckboxCtrl = function($scope, $element) {
  * @private
  */
 os.ui.TriStateCheckboxCtrl.prototype.destroy_ = function() {
-  this.scope_ = null;
-  this.element_ = null;
+  this.scope = null;
+  this.element = null;
 };
 
 
@@ -77,14 +75,14 @@ os.ui.TriStateCheckboxCtrl.prototype.destroy_ = function() {
  * @export
  */
 os.ui.TriStateCheckboxCtrl.prototype.toggle = function(e) {
-  if (this.scope_) {
-    var item = /** @type {os.structs.TriStateTreeNode} */ (this.scope_['item']);
-    if (!this.getDisabled_(item)) {
+  if (this.scope) {
+    var item = /** @type {os.structs.TriStateTreeNode} */ (this.scope['item']);
+    if (!this.getDisabled(item)) {
       // on/both should toggle to the off state
       item.setState(item.getState() == os.structs.TriState.OFF ?
         os.structs.TriState.ON : os.structs.TriState.OFF);
 
-      this.notifyDirty_();
+      this.notifyDirty();
     }
 
     e.stopPropagation();
@@ -99,7 +97,7 @@ os.ui.TriStateCheckboxCtrl.prototype.toggle = function(e) {
  * @export
  */
 os.ui.TriStateCheckboxCtrl.prototype.onDblClick = function(e) {
-  if (!this.element_.hasClass('disabled')) {
+  if (!this.element.hasClass('disabled')) {
     // prevent double click from propagating further if the checkbox is enabled. clicks should only toggle the checkbox.
     e.stopPropagation();
   }
@@ -111,21 +109,29 @@ os.ui.TriStateCheckboxCtrl.prototype.onDblClick = function(e) {
  *
  * @param {?os.structs.TriStateTreeNode} item
  * @return {boolean}
- * @private
  */
-os.ui.TriStateCheckboxCtrl.prototype.getDisabled_ = function(item) {
-  return !!item && (item.getCheckboxDisabled() || (this.scope_['disableFolders'] && item.hasChildren()));
+os.ui.TriStateCheckboxCtrl.prototype.getDisabled = function(item) {
+  if (item) {
+    const disabled = item.getCheckboxDisabled();
+    if (disabled != null) {
+      // if disabled is explicitly true or false, treat it as an override
+      return disabled;
+    }
+
+    // if disabled is null, use the tree-level flag
+    return this.scope['disableFolders'] && item.hasChildren();
+  }
+
+  return false;
 };
 
 
 /**
  * Fire a dirty event on the scope to update parents.
- *
- * @private
  */
-os.ui.TriStateCheckboxCtrl.prototype.notifyDirty_ = function() {
-  if (this.scope_) {
-    this.scope_.$emit('dirty');
-    os.ui.apply(this.scope_);
+os.ui.TriStateCheckboxCtrl.prototype.notifyDirty = function() {
+  if (this.scope) {
+    this.scope.$emit('dirty');
+    os.ui.apply(this.scope);
   }
 };


### PR DESCRIPTION
Adds a new checkbox UI for layer providers/folders that allows for turning on full sets of layers. This UI will prompt the user to confirm when turning on more than a predefined number of layers with a single click for safety. This is currently only employed by the Geopackage plugin provider from opensphere-plugin-geopackage, but can be adapted to any provider we like.