### PR TITLE
fix(area-modify): do not require area manager just yet

### DIFF
--- a/src/os/ui/query/modifyarea.js
+++ b/src/os/ui/query/modifyarea.js
@@ -8,7 +8,6 @@ goog.require('os.command.CommandProcessor');
 goog.require('os.command.SequenceCommand');
 goog.require('os.geo.jsts');
 goog.require('os.interaction.Modify');
-goog.require('os.query.AreaManager');
 goog.require('os.ui.Module');
 goog.require('os.ui.help.Controls');
 goog.require('os.ui.query.cmd.AreaAdd');
@@ -169,7 +168,7 @@ os.ui.query.ModifyAreaCtrl = function($scope, $element) {
   // default the op and the tab to freeform
   $scope['op'] = $scope['op'] || os.ui.query.ModifyOp.ADD;
 
-  const am = os.query.AreaManager.getInstance();
+  const am = os.ui.areaManager;
   let showTabs = true;
   let feature;
   let initialTab = os.ui.query.ModifyType.FREEFORM;


### PR DESCRIPTION
This is causing issues due to internal tight dependency couplings that must be resolved properly at some point, but for now, this keeps it consistent with the original way the class functioned.