### PR TITLE
Upgrade Font Awesome to v5

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,10 +166,10 @@ const sharedResources = [
     scripts: ['crossfilter.min.js']
   },
   {
-    source: resolver.resolveModulePath('font-awesome', __dirname),
-    target: 'vendor/font-awesome',
-    css: ['css/font-awesome.min.css'],
-    files: ['fonts']
+    source: resolver.resolveModulePath('@fortawesome/fontawesome-free', __dirname),
+    target: 'vendor/fontawesome-free',
+    css: ['css/all.min.css', 'css/v4-shims.min.css'],
+    files: ['webfonts']
   },
   {
     source: resolver.resolveModulePath('moment/min', __dirname),
@@ -378,10 +378,10 @@ const oldResources = [
     scripts: ['browserCheck.js']
   },
   {
-    source: resolver.resolveModulePath('font-awesome', __dirname),
+    source: resolver.resolveModulePath('@fortawesome/fontawesome-free', __dirname),
     target: 'vendor/font-awesome',
-    css: ['css/font-awesome.min.css'],
-    files: ['fonts']
+    css: ['css/all.min.css', 'css/v4-shims.min.css'],
+    files: ['webfonts']
   }
 ];
 

--- a/old-template.html
+++ b/old-template.html
@@ -23,7 +23,8 @@
     }
 
     li:before {
-      font-family: 'FontAwesome';
+      font-family: 'Font Awesome 5 Free';
+      font-weight: 900;
       margin: 0 5px 0 -15px;
     }
 

--- a/package.json
+++ b/package.json
@@ -298,6 +298,7 @@
     "xmllint": "^0.1.1"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.15.3",
     "@toast-ui/editor": "^2.5.x",
     "angular": "~1.8.x",
     "angular-animate": "~1.8.x",
@@ -315,7 +316,6 @@
     "d3": "^3.5.17",
     "d3-tip": "=0.6.8",
     "file-saver": "^1.3.8",
-    "font-awesome": "^4.6.3",
     "google-closure-library": "^20210406.0.0",
     "html2canvas": "=1.0.0-rc.4",
     "jquery": "3.5.0",

--- a/scss/os/_mixins.scss
+++ b/scss/os/_mixins.scss
@@ -51,8 +51,12 @@
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   display: inline-block;
-  font: normal normal normal 14px/1 FontAwesome;
-  font-size: inherit;
+  // Fall back on the Font Awesome 4 font-family for backward compatibility.
+  font-family: 'Font Awesome 5 Free', 'FontAwesome';
+  font-style: normal;
+  font-variant: normal;
+  font-weight: 900;
+  line-height: 1;
   text-rendering: auto;
 }
 

--- a/scss/os/_overrides_slickgrid.scss
+++ b/scss/os/_overrides_slickgrid.scss
@@ -118,11 +118,9 @@
 }
 
 .slick-sort-indicator {
+  @include font-awesome();
   background: none;
   float: left;
-  font-family: FontAwesome;
-  font-style: normal;
-  font-weight: normal;
   height: inherit;
   margin: 0 2px 0 0;
 

--- a/src/os/ui/layer/layervisibility.js
+++ b/src/os/ui/layer/layervisibility.js
@@ -13,7 +13,7 @@ const LayerNode = goog.requireType('os.data.LayerNode');
  */
 const template = `
   <span ng-click="ctrl.toggle($event)" title="{{ctrl.getTooltip()}}">
-    <i class="fa" ng-class="ctrl.isVisible() ? 'fa-eye' : 'fa-eye-slash'"></i>
+    <i class="fa fa-fw" ng-class="ctrl.isVisible() ? 'fa-eye' : 'fa-eye-slash'"></i>
   </span>`;
 
 

--- a/src/os/ui/layersbutton.js
+++ b/src/os/ui/layersbutton.js
@@ -20,7 +20,7 @@ os.ui.layersButtonDirective = function() {
     template: '<button class="btn btn-primary" title="View Layers"' +
       ' ng-click="ctrl.toggle()"' +
       ' ng-class="{active: ctrl.isWindowActive()}">' +
-      '<i class="fa fa-align-justify" ng-class="{\'fa-fw\': puny}"></i> ' +
+      '<i class="fa fa-layer-group" ng-class="{\'fa-fw\': puny}"></i> ' +
       '<span ng-class="{\'d-none\': puny}">Layers</span>' +
       '</button>'
   };

--- a/src/os/ui/measurebutton.js
+++ b/src/os/ui/measurebutton.js
@@ -27,7 +27,7 @@ os.ui.measureButtonDirective = function() {
       '<button class="btn btn-secondary" id="measureButton" title="Measure between points"' +
       ' ng-click="ctrl.toggle()"' +
       ' ng-class="{active: measuring}">' +
-      '<i class="fa fa-fw fa-arrows-h"></i> {{showLabel ? \'Measure\' : \'\'}}' +
+      '<i class="fa fa-fw fa-drafting-compass"></i> {{showLabel ? \'Measure\' : \'\'}}' +
       '</button>' +
       '<button class="btn btn-secondary dropdown-toggle dropdown-toggle-split" ng-click="ctrl.openMenu()"' +
       ' ng-class="{active: menu}">' +

--- a/src/os/ui/menu/defaultwindowsmenu.js
+++ b/src/os/ui/menu/defaultwindowsmenu.js
@@ -35,7 +35,7 @@ os.ui.menu.windows.default.setup = function() {
 
   var layers = os.ui.menu.windows.addWindow('layers', {
     'key': 'layers',
-    'icon': 'fa fa-align-justify',
+    'icon': 'fa fa-layer-group',
     'label': 'Layers',
     'description': 'View and manipulate layers on the map',
     'x': '0',

--- a/src/os/ui/menu/spatialmenu.js
+++ b/src/os/ui/menu/spatialmenu.js
@@ -1156,7 +1156,7 @@ os.ui.menu.spatial.onLayerPicker_ = function(event) {
     var windowOptions = {
       'id': 'spatiallayerchooser',
       'label': 'Choose Layers',
-      'icon': 'fa fa-align-justify',
+      'icon': 'fa fa-layer-group',
       'x': 'center',
       'y': 'center',
       'width': '350',

--- a/yarn.lock
+++ b/yarn.lock
@@ -363,6 +363,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fortawesome/fontawesome-free@^5.15.3":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.3.tgz#c36ffa64a2a239bf948541a97b6ae8d729e09a9a"
+  integrity sha512-rFnSUN/QOtnOAgqFRooTA3H57JLDm0QEG/jPdk+tLQNL/eWd+Aok8g3qCI+Q1xuDPWpGW/i9JySpJVsq8Q0s9w==
+
 "@html-validate/stylish@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@html-validate/stylish/-/stylish-1.0.1.tgz#67cbb2084d67d4af443e00f856f069aaba640ba1"
@@ -4098,7 +4103,7 @@ debug@^3.1.0, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -5594,11 +5599,6 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
   integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
 
-font-awesome@^4.6.3:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
-  integrity sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=
-
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -6867,7 +6867,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -8464,11 +8464,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -8477,32 +8472,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -8573,11 +8546,6 @@ lodash.memoize@~3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
   integrity sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.result@^4.4.0:
   version "4.5.2"


### PR DESCRIPTION
This PR upgrades the Font Awesome library to the free version of v5. It includes the v4 shim for full backward compatibility, so apps using OpenSphere as a library may upgrade at their own leisure.

### Testing

[OpenSphere](https://os-fontawesome-5.surge.sh/)

1. Poke around the application and verify icons display correctly.
2. The Layers window/button icon was updated as well as the Measure button. Verify the new icons are acceptable over the old ones, and feel free to suggest others. I considered the ruler for measure, but the drafting compass seemed more precise for measuring distance/angle between points on a map.

### Other Changes

- The FA5 eye/eye-slash icons were not the same width, so the layer visibility toggle now has `fa-fw` to avoid width changes on toggle.
- Changed the Layers icon to `fa-layer-group` on the Layers button and in the Layers window header.
- Changed the Measure button icon to `fa-drafting-compass`.

Note the last two changes are breaking if apps are reusing these directives, using OpenSphere as a library, and still using FA4.

### Resources

- [Font Awesome 4 -> 5 Upgrade Guide](https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4)
- [Font Awesome 5 Icons](https://fontawesome.com/icons?d=gallery&p=2)

### Upgrade Steps

Apps wishing to perform the same upgrade should do the following:

1. Replace the `font-awesome` dependency with `@fortawesome/fontawesome-free`.
2. Update index files (ie, `index.js`) to reference the new resources. Include `all.min.css` to support all FA5 icons and `v4-shims.min.css` for backward compatibility with FA4 classes. See the upgrade guide for more details.
3. Any CSS using `font-family: FontAwesome` should instead use `font-family: 'Font Awesome 5 Free'`. If you need to maintain backward compatibility, use `font-family: 'Font Awesome 5 Free', 'FontAwesome';` or `@include font-awesome();` (from OpenSphere's `_mixins.scss`).
