### PR TITLE
fix: trash icon now appears consistently in the Add Data window

### DIFF
--- a/src/os/ui/data/descriptornodeui.js
+++ b/src/os/ui/data/descriptornodeui.js
@@ -16,7 +16,9 @@ os.ui.data.descriptorNodeUIDirective = function() {
   return {
     restrict: 'AE',
     replace: true,
-    templateUrl: os.ROOT + 'views/data/descriptornodeui.html',
+    template: '<span ng-if="nodeUi.show()" class="flex-shrink-0" ng-click="nodeUi.tryRemove()">' +
+      '<i class="fa fa-trash-o fa-fw c-glyph" title="Remove this layer from the application"></i>' +
+    '</span>',
     controller: os.ui.data.DescriptorNodeUICtrl,
     controllerAs: 'nodeUi'
   };

--- a/views/data/descriptornodeui.html
+++ b/views/data/descriptornodeui.html
@@ -1,3 +1,0 @@
-<span ng-if="nodeUi.show()" class="flex-shrink-0" ng-click="nodeUi.tryRemove()">
-  <i class="fa fa-trash-o fa-fw c-glyph" title="Remove this layer from the application"></i>
-</span>


### PR DESCRIPTION
`views/data/descriptornodeui.html` was deleted because it was no longer referenced and the HTML within was converted into a string in the last place that it was referenced