### PR TITLE
Transform file plugins to goog modules

### DIFF
--- a/.jscodeshift.json
+++ b/.jscodeshift.json
@@ -41,6 +41,7 @@
     "goog.events": "googEvents",
     "goog.events.Event": "GoogEvent",
     "goog.events.EventType": "GoogEventType",
+    "goog.fs.FileReader": "GoogFileReader",
     "goog.string": "googString",
     "goog.object": "googObject",
 
@@ -65,6 +66,7 @@
     "os.feature": "osFeature",
     "os.file": "osFile",
     "os.file.File": "OSFile",
+    "os.file.mime.zip": "mimeZip",
     "os.layer.Vector": "VectorLayer",
     "os.map": "osMap",
     "os.object": "osObject",

--- a/src/os/mixin/mixin.js
+++ b/src/os/mixin/mixin.js
@@ -22,6 +22,7 @@ goog.require('os.mixin.geometry');
 goog.require('os.mixin.layerbase');
 goog.require('os.mixin.map');
 goog.require('os.mixin.object');
+goog.require('os.mixin.polygon');
 goog.require('os.mixin.zoomscale');
 goog.require('os.net');
 goog.require('os.ol');

--- a/src/os/mixin/polygonmixin.js
+++ b/src/os/mixin/polygonmixin.js
@@ -1,12 +1,14 @@
 goog.provide('os.mixin.polygon');
 
 goog.require('ol.geom.Polygon');
+goog.requireType('ol.geom.LinearRing');
 
 
 (function() {
   var old = ol.geom.Polygon.prototype.getLinearRings;
 
   /**
+   * Assigns polygon metadata values to each ring.
    * @return {Array<ol.geom.LinearRing>}
    * @suppress {accessControls}
    */
@@ -14,7 +16,7 @@ goog.require('ol.geom.Polygon');
     var rings = old.call(this);
 
     for (var i = 0, n = rings.length; i < n; i++) {
-      ol.obj.assign(rings[i].values_, this.values_);
+      Object.assign(rings[i].values_, this.values_);
     }
 
     return rings;

--- a/src/os/ui/file/kml/abstractkmlexporter.js
+++ b/src/os/ui/file/kml/abstractkmlexporter.js
@@ -17,6 +17,7 @@ goog.require('os.time.TimeRange');
 goog.require('os.ui.file.kml');
 goog.require('os.ui.text.TuiEditor');
 goog.require('os.xml');
+goog.require('plugin.file.kml.JsonField');
 goog.require('plugin.file.kml.KMLField');
 
 

--- a/src/os/ui/screenoverlay.js
+++ b/src/os/ui/screenoverlay.js
@@ -1,5 +1,6 @@
 goog.provide('os.ui.ScreenOverlayCtrl');
-goog.provide('os.ui.screenOverlayDrective');
+goog.provide('os.ui.launchScreenOverlay');
+goog.provide('os.ui.screenOverlayDirective');
 
 goog.require('goog.events.KeyHandler');
 goog.require('os');
@@ -12,7 +13,7 @@ goog.require('os.ui.window');
  *
  * @return {angular.Directive}
  */
-os.ui.screenOverlayDrective = function() {
+os.ui.screenOverlayDirective = function() {
   return {
     restrict: 'E',
     transclude: true,
@@ -28,7 +29,7 @@ os.ui.screenOverlayDrective = function() {
 /**
  * Add the directive to the os module
  */
-os.ui.Module.directive('screenoverlay', [os.ui.screenOverlayDrective]);
+os.ui.Module.directive('screenoverlay', [os.ui.screenOverlayDirective]);
 
 
 /**

--- a/src/plugin/file/csv/csvdescriptor.js
+++ b/src/plugin/file/csv/csvdescriptor.js
@@ -1,198 +1,170 @@
-goog.provide('plugin.file.csv.CSVDescriptor');
+goog.module('plugin.file.csv.CSVDescriptor');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.FileDescriptor');
-goog.require('os.layer.LayerType');
-goog.require('os.ui.file.csv');
-goog.require('plugin.file.csv.CSVExporter');
-goog.require('plugin.file.csv.CSVParserConfig');
-goog.require('plugin.file.csv.CSVProvider');
-
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const LayerType = goog.require('os.layer.LayerType');
+const csv = goog.require('os.ui.file.csv');
+const CSVExporter = goog.require('plugin.file.csv.CSVExporter');
+const CSVParserConfig = goog.require('plugin.file.csv.CSVParserConfig');
 
 
 /**
  * CSV file descriptor.
- *
- * @param {plugin.file.csv.CSVParserConfig=} opt_config
- * @extends {os.data.FileDescriptor}
- * @constructor
  */
-plugin.file.csv.CSVDescriptor = function(opt_config) {
-  plugin.file.csv.CSVDescriptor.base(this, 'constructor');
-  this.descriptorType = 'csv';
-  this.parserConfig = opt_config || new plugin.file.csv.CSVParserConfig();
-};
-goog.inherits(plugin.file.csv.CSVDescriptor, os.data.FileDescriptor);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVDescriptor.prototype.getType = function() {
-  return os.layer.LayerType.FEATURES;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVDescriptor.prototype.getLayerOptions = function() {
-  var options = plugin.file.csv.CSVDescriptor.base(this, 'getLayerOptions');
-  options['type'] = 'CSV';
-  options['commentChar'] = this.getCommentChar();
-  options['dataRow'] = this.getDataRow();
-  options['delimiter'] = this.getDelimiter();
-  options['headerRow'] = this.getHeaderRow();
-  options['useHeader'] = this.getUseHeader();
-  return options;
-};
-
-
-/**
- * @return {string}
- */
-plugin.file.csv.CSVDescriptor.prototype.getCommentChar = function() {
-  return this.parserConfig['commentChar'];
-};
-
-
-/**
- * @param {string} commentChar
- */
-plugin.file.csv.CSVDescriptor.prototype.setCommentChar = function(commentChar) {
-  this.parserConfig['commentChar'] = commentChar;
-};
-
-
-/**
- * @return {number}
- */
-plugin.file.csv.CSVDescriptor.prototype.getDataRow = function() {
-  return this.parserConfig['dataRow'];
-};
-
-
-/**
- * @param {number} row
- */
-plugin.file.csv.CSVDescriptor.prototype.setDataRow = function(row) {
-  this.parserConfig['dataRow'] = row;
-};
-
-
-/**
- * @return {string}
- */
-plugin.file.csv.CSVDescriptor.prototype.getDelimiter = function() {
-  return this.parserConfig['delimiter'];
-};
-
-
-/**
- * @param {string} delimiter
- */
-plugin.file.csv.CSVDescriptor.prototype.setDelimiter = function(delimiter) {
-  this.parserConfig['delimiter'] = delimiter;
-};
-
-
-/**
- * @return {number}
- */
-plugin.file.csv.CSVDescriptor.prototype.getHeaderRow = function() {
-  return this.parserConfig['headerRow'];
-};
-
-
-/**
- * @param {number} row
- */
-plugin.file.csv.CSVDescriptor.prototype.setHeaderRow = function(row) {
-  this.parserConfig['headerRow'] = row;
-};
-
-
-/**
- * @return {number}
- */
-plugin.file.csv.CSVDescriptor.prototype.getUseHeader = function() {
-  return this.parserConfig['useHeader'];
-};
-
-
-/**
- * @param {boolean} useHeader
- */
-plugin.file.csv.CSVDescriptor.prototype.setUseHeader = function(useHeader) {
-  this.parserConfig['useHeader'] = useHeader;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVDescriptor.prototype.getExporter = function() {
-  return new plugin.file.csv.CSVExporter();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVDescriptor.prototype.onFileChange = function(options) {
-  plugin.file.csv.CSVDescriptor.base(this, 'onFileChange', options);
-
-  // update the parser config to match the default parser config
-  const conf = os.ui.file.csv.DEFAULT_CONFIG;
-  this.parserConfig['color'] = conf['color'];
-  this.parserConfig['commentChar'] = conf['commentChar'];
-  this.parserConfig['dataRow'] = conf['dataRow'];
-  this.parserConfig['delimiter'] = conf['delimiter'];
-  this.parserConfig['headerRow'] = conf['headerRow'];
-  this.parserConfig['useHeader'] = conf['useHeader'];
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVDescriptor.prototype.persist = function(opt_obj) {
-  if (!opt_obj) {
-    opt_obj = {};
+class CSVDescriptor extends FileDescriptor {
+  /**
+   * Constructor.
+   * @param {CSVParserConfig=} opt_config
+   */
+  constructor(opt_config) {
+    super();
+    this.descriptorType = 'csv';
+    this.parserConfig = opt_config || new CSVParserConfig();
   }
 
-  opt_obj['commentChar'] = this.getCommentChar();
-  opt_obj['dataRow'] = this.getDataRow();
-  opt_obj['delimiter'] = this.getDelimiter();
-  opt_obj['headerRow'] = this.getHeaderRow();
-  opt_obj['useHeader'] = this.getUseHeader();
+  /**
+   * @inheritDoc
+   */
+  getType() {
+    return LayerType.FEATURES;
+  }
 
-  return plugin.file.csv.CSVDescriptor.base(this, 'persist', opt_obj);
-};
+  /**
+   * @inheritDoc
+   */
+  getLayerOptions() {
+    var options = super.getLayerOptions();
+    options['type'] = 'CSV';
+    options['commentChar'] = this.getCommentChar();
+    options['dataRow'] = this.getDataRow();
+    options['delimiter'] = this.getDelimiter();
+    options['headerRow'] = this.getHeaderRow();
+    options['useHeader'] = this.getUseHeader();
+    return options;
+  }
 
+  /**
+   * @return {string}
+   */
+  getCommentChar() {
+    return this.parserConfig['commentChar'];
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVDescriptor.prototype.restore = function(conf) {
-  this.setCommentChar(conf['commentChar']);
-  this.setDataRow(conf['dataRow']);
-  this.setDelimiter(conf['delimiter']);
-  this.setHeaderRow(conf['headerRow']);
-  this.setUseHeader(conf['useHeader']);
+  /**
+   * @param {string} commentChar
+   */
+  setCommentChar(commentChar) {
+    this.parserConfig['commentChar'] = commentChar;
+  }
 
-  plugin.file.csv.CSVDescriptor.base(this, 'restore', conf);
-};
+  /**
+   * @return {number}
+   */
+  getDataRow() {
+    return this.parserConfig['dataRow'];
+  }
 
+  /**
+   * @param {number} row
+   */
+  setDataRow(row) {
+    this.parserConfig['dataRow'] = row;
+  }
 
-/**
- * Creates a new descriptor from a parser configuration.
- *
- * @param {!plugin.file.csv.CSVParserConfig} config
- * @return {!plugin.file.csv.CSVDescriptor}
- */
-plugin.file.csv.CSVDescriptor.createFromConfig = function(config) {
-  var provider = plugin.file.csv.CSVProvider.getInstance();
-  var descriptor = new plugin.file.csv.CSVDescriptor(config);
-  os.data.FileDescriptor.createFromConfig(descriptor, provider, config);
-  return descriptor;
-};
+  /**
+   * @return {string}
+   */
+  getDelimiter() {
+    return this.parserConfig['delimiter'];
+  }
+
+  /**
+   * @param {string} delimiter
+   */
+  setDelimiter(delimiter) {
+    this.parserConfig['delimiter'] = delimiter;
+  }
+
+  /**
+   * @return {number}
+   */
+  getHeaderRow() {
+    return this.parserConfig['headerRow'];
+  }
+
+  /**
+   * @param {number} row
+   */
+  setHeaderRow(row) {
+    this.parserConfig['headerRow'] = row;
+  }
+
+  /**
+   * @return {number}
+   */
+  getUseHeader() {
+    return this.parserConfig['useHeader'];
+  }
+
+  /**
+   * @param {boolean} useHeader
+   */
+  setUseHeader(useHeader) {
+    this.parserConfig['useHeader'] = useHeader;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getExporter() {
+    return new CSVExporter();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  onFileChange(options) {
+    super.onFileChange(options);
+
+    // update the parser config to match the default parser config
+    const conf = csv.DEFAULT_CONFIG;
+    this.parserConfig['color'] = conf['color'];
+    this.parserConfig['commentChar'] = conf['commentChar'];
+    this.parserConfig['dataRow'] = conf['dataRow'];
+    this.parserConfig['delimiter'] = conf['delimiter'];
+    this.parserConfig['headerRow'] = conf['headerRow'];
+    this.parserConfig['useHeader'] = conf['useHeader'];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  persist(opt_obj) {
+    if (!opt_obj) {
+      opt_obj = {};
+    }
+
+    opt_obj['commentChar'] = this.getCommentChar();
+    opt_obj['dataRow'] = this.getDataRow();
+    opt_obj['delimiter'] = this.getDelimiter();
+    opt_obj['headerRow'] = this.getHeaderRow();
+    opt_obj['useHeader'] = this.getUseHeader();
+
+    return super.persist(opt_obj);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  restore(conf) {
+    this.setCommentChar(conf['commentChar']);
+    this.setDataRow(conf['dataRow']);
+    this.setDelimiter(conf['delimiter']);
+    this.setHeaderRow(conf['headerRow']);
+    this.setUseHeader(conf['useHeader']);
+
+    super.restore(conf);
+  }
+}
+
+exports = CSVDescriptor;

--- a/src/plugin/file/csv/csvexporter.js
+++ b/src/plugin/file/csv/csvexporter.js
@@ -1,220 +1,219 @@
-goog.provide('plugin.file.csv.CSVExporter');
-goog.require('goog.log');
-goog.require('ol.Feature');
-goog.require('ol.format.WKT');
-goog.require('ol.geom.SimpleGeometry');
-goog.require('os.Fields');
-goog.require('os.data.RecordField');
-goog.require('os.geo');
-goog.require('os.object');
-goog.require('os.ol.wkt');
-goog.require('os.style');
-goog.require('os.ui.file.csv.AbstractCSVExporter');
-goog.require('plugin.file.csv.ui.csvExportDirective');
+goog.module('plugin.file.csv.CSVExporter');
+goog.module.declareLegacyNamespace();
 
+const log = goog.require('goog.log');
+const Point = goog.require('ol.geom.Point');
+const Fields = goog.require('os.Fields');
+const RecordField = goog.require('os.data.RecordField');
+const osFeature = goog.require('os.feature');
+const instanceOf = goog.require('os.instanceOf');
+const osMap = goog.require('os.map');
+const osObject = goog.require('os.object');
+const wkt = goog.require('os.ol.wkt');
+const osProj = goog.require('os.proj');
+const TimeRange = goog.require('os.time.TimeRange');
+const AbstractCSVExporter = goog.require('os.ui.file.csv.AbstractCSVExporter');
+const {directiveTag: exportUi} = goog.require('plugin.file.csv.ui.CSVExportUI');
+
+const Logger = goog.requireType('goog.log.Logger');
+const Feature = goog.requireType('ol.Feature');
+const SimpleGeometry = goog.requireType('ol.geom.SimpleGeometry');
 
 
 /**
  * The CSV exporter.
  *
- * @extends {os.ui.file.csv.AbstractCSVExporter.<ol.Feature>}
- * @constructor
+ * @extends {AbstractCSVExporter.<Feature>}
  */
-plugin.file.csv.CSVExporter = function() {
-  plugin.file.csv.CSVExporter.base(this, 'constructor');
-  this.log = plugin.file.csv.CSVExporter.LOGGER_;
+class CSVExporter extends AbstractCSVExporter {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.log = logger;
+
+    /**
+     * Export the ellipses
+     * @type {boolean}
+     * @private
+     */
+    this.exportEllipses_ = false;
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.alwaysIncludeWkt_ = true;
+  }
 
   /**
-   * Export the ellipses
-   * @type {boolean}
-   * @private
+   * Get if ellipses should be exported.
+   *
+   * @return {boolean}
    */
-  this.exportEllipses_ = false;
+  getExportEllipses() {
+    return this.exportEllipses_;
+  }
 
   /**
-   * @type {boolean}
-   * @private
+   * Set if ellipses should be exported.
+   *
+   * @param {boolean} value
    */
-  this.alwaysIncludeWkt_ = true;
-};
-goog.inherits(plugin.file.csv.CSVExporter, os.ui.file.csv.AbstractCSVExporter);
+  setExportEllipses(value) {
+    this.exportEllipses_ = value;
+  }
 
+  /**
+   * Get the geometry for a feature.
+   *
+   * @param {Feature} feature The feature
+   * @return {ol.geom.GeometryCollection|SimpleGeometry|undefined}
+   */
+  getGeometry_(feature) {
+    var geometry;
+    if (feature) {
+      geometry = /** @type {(SimpleGeometry|undefined)} */ (feature.get(RecordField.GEOM));
+
+      if (geometry) {
+        geometry = /** @type {(SimpleGeometry|undefined)} */ (geometry.clone().toLonLat());
+
+        if (this.exportEllipses_) {
+          var ellipse = osFeature.createEllipse(feature);
+          if (ellipse && !(ellipse instanceof Point)) {
+            geometry = /** @type {(SimpleGeometry|undefined)} */ (ellipse);
+          }
+        }
+      }
+    }
+
+    return geometry;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getUI() {
+    return `<${exportUi} exporter="exporter"></${exportUi}>`;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  processItem(item) {
+    var result = item == null ? null : {};
+
+    if (this.fields) {
+      for (var i = 0, n = this.fields.length; i < n; i++) {
+        var field = this.fields[i];
+        if (field === RecordField.TIME) {
+          this.writeTime(item, result);
+        } else if (!(field in result)) {
+          var value = item.get(this.fields[i]);
+          if (value == null) {
+            value = '';
+          }
+
+          if (osObject.isPrimitive(value) && !Array.isArray(value)) {
+            result[field] = value;
+          }
+        }
+      }
+    }
+
+    this.writeGeometry(item, result);
+
+    return result;
+  }
+
+  /**
+   * Get whether to always include WKT geometry in the export
+   *
+   * @return {boolean} If true, WKT geometry will always be included in the export
+   */
+  getAlwaysIncludeWkt() {
+    return this.alwaysIncludeWkt_;
+  }
+
+  /**
+   * Set wheather to always include WKT geometry in the export
+   *
+   * @param {boolean} newValue Set to true if WKT geometry should always be included in the export
+   */
+  setAlwaysIncludeWkt(newValue) {
+    this.alwaysIncludeWkt_ = newValue;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  supportsTime() {
+    return true;
+  }
+
+  /**
+   * Conditionally writes the time field(s) to the result object
+   *
+   * @param {T} item The items
+   * @param {Object.<string, string>} result The Papa item
+   * @protected
+   * @template T
+   */
+  writeTime(item, result) {
+    var time = item ? /** @type {os.time.ITime|undefined} */ (item.get(RecordField.TIME)) : null;
+    if (time != null) {
+      if (instanceOf(time, TimeRange.NAME)) {
+        // time ranges need to be put into two separate fields so that we can reimport our own exports
+        result[CSVExporter.FIELDS.START_TIME] = time.getStartISOString();
+        result[CSVExporter.FIELDS.END_TIME] = time.getEndISOString();
+      } else {
+        result[Fields.TIME] = time.toISOString();
+      }
+    }
+  }
+
+  /**
+   * Conditionally writes the geometry field to the result object
+   *
+   * @param {T} item The items
+   * @param {Object.<string, string>} result The Papa item
+   * @protected
+   * @template T
+   */
+  writeGeometry(item, result) {
+    var geom = item ? /** @type {SimpleGeometry|undefined} */ (item.getGeometry()) : null;
+    if (this.alwaysIncludeWkt_ && geom != null) {
+      geom = /** @type {SimpleGeometry|undefined} */ (geom.clone().toLonLat());
+      result[Fields.GEOMETRY] = wkt.FORMAT.writeFeature(item, {
+        dataProjection: osProj.EPSG4326,
+        featureProjection: osMap.PROJECTION
+      });
+
+      if (this.exportEllipses_) {
+        result[Fields.SEMI_MAJOR] = item.get(Fields.SEMI_MAJOR);
+        result[Fields.SEMI_MINOR] = item.get(Fields.SEMI_MINOR);
+      }
+    }
+  }
+}
 
 /**
  * Logger
- * @type {goog.log.Logger}
- * @private
- * @const
+ * @type {Logger}
  */
-plugin.file.csv.CSVExporter.LOGGER_ = goog.log.getLogger('plugin.file.csv.CSVExporter');
+const logger = log.getLogger('plugin.file.csv.CSVExporter');
 
 
 /**
  * Fields for CSV export.
  * @enum {string}
  */
-plugin.file.csv.CSVExporter.FIELDS = {
+CSVExporter.FIELDS = {
   START_TIME: 'START_TIME',
   END_TIME: 'END_TIME'
 };
 
 
 
-/**
- * Get if ellipses should be exported.
- *
- * @return {boolean}
- */
-plugin.file.csv.CSVExporter.prototype.getExportEllipses = function() {
-  return this.exportEllipses_;
-};
-
-
-/**
- * Set if ellipses should be exported.
- *
- * @param {boolean} value
- */
-plugin.file.csv.CSVExporter.prototype.setExportEllipses = function(value) {
-  this.exportEllipses_ = value;
-};
-
-
-/**
- * Get the geometry for a feature.
- *
- * @param {ol.Feature} feature The feature
- * @return {ol.geom.GeometryCollection|ol.geom.SimpleGeometry|undefined}
- */
-plugin.file.csv.CSVExporter.prototype.getGeometry_ = function(feature) {
-  var geometry;
-  if (feature) {
-    geometry = /** @type {(ol.geom.SimpleGeometry|undefined)} */ (feature.get(os.data.RecordField.GEOM));
-
-    if (geometry) {
-      geometry = /** @type {(ol.geom.SimpleGeometry|undefined)} */ (geometry.clone().toLonLat());
-
-      if (this.exportEllipses_) {
-        var ellipse = os.feature.createEllipse(feature);
-        if (ellipse && !(ellipse instanceof ol.geom.Point)) {
-          geometry = /** @type {(ol.geom.SimpleGeometry|undefined)} */ (ellipse);
-        }
-      }
-    }
-  }
-
-  return geometry;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVExporter.prototype.getUI = function() {
-  return '<csvexport exporter="exporter"></csvexport>';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVExporter.prototype.processItem = function(item) {
-  var result = item == null ? null : {};
-
-  if (this.fields) {
-    for (var i = 0, n = this.fields.length; i < n; i++) {
-      var field = this.fields[i];
-      if (field === os.data.RecordField.TIME) {
-        this.writeTime(item, result);
-      } else if (!(field in result)) {
-        var value = item.get(this.fields[i]);
-        if (value == null) {
-          value = '';
-        }
-
-        if (os.object.isPrimitive(value) && !Array.isArray(value)) {
-          result[field] = value;
-        }
-      }
-    }
-  }
-
-  this.writeGeometry(item, result);
-
-  return result;
-};
-
-
-/**
- * Get whether to always include WKT geometry in the export
- *
- * @return {boolean} If true, WKT geometry will always be included in the export
- */
-plugin.file.csv.CSVExporter.prototype.getAlwaysIncludeWkt = function() {
-  return this.alwaysIncludeWkt_;
-};
-
-
-/**
- * Set wheather to always include WKT geometry in the export
- *
- * @param {boolean} newValue Set to true if WKT geometry should always be included in the export
- */
-plugin.file.csv.CSVExporter.prototype.setAlwaysIncludeWkt = function(newValue) {
-  this.alwaysIncludeWkt_ = newValue;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVExporter.prototype.supportsTime = function() {
-  return true;
-};
-
-
-/**
- * Conditionally writes the time field(s) to the result object
- *
- * @param {T} item The items
- * @param {Object.<string, string>} result The Papa item
- * @protected
- * @template T
- */
-plugin.file.csv.CSVExporter.prototype.writeTime = function(item, result) {
-  var time = item ? /** @type {os.time.ITime|undefined} */ (item.get(os.data.RecordField.TIME)) : null;
-  if (time != null) {
-    if (os.instanceOf(time, os.time.TimeRange.NAME)) {
-      // time ranges need to be put into two separate fields so that we can reimport our own exports
-      result[plugin.file.csv.CSVExporter.FIELDS.START_TIME] = time.getStartISOString();
-      result[plugin.file.csv.CSVExporter.FIELDS.END_TIME] = time.getEndISOString();
-    } else {
-      result[os.Fields.TIME] = time.toISOString();
-    }
-  }
-};
-
-
-/**
- * Conditionally writes the geometry field to the result object
- *
- * @param {T} item The items
- * @param {Object.<string, string>} result The Papa item
- * @protected
- * @template T
- */
-plugin.file.csv.CSVExporter.prototype.writeGeometry = function(item, result) {
-  var geom = item ? /** @type {ol.geom.SimpleGeometry|undefined} */ (item.getGeometry()) : null;
-  if (this.alwaysIncludeWkt_ && geom != null) {
-    geom = /** @type {ol.geom.SimpleGeometry|undefined} */ (geom.clone().toLonLat());
-    result[os.Fields.GEOMETRY] = os.ol.wkt.FORMAT.writeFeature(item, {
-      dataProjection: os.proj.EPSG4326,
-      featureProjection: os.map.PROJECTION
-    });
-
-    if (this.exportEllipses_) {
-      result[os.Fields.SEMI_MAJOR] = item.get(os.Fields.SEMI_MAJOR);
-      result[os.Fields.SEMI_MINOR] = item.get(os.Fields.SEMI_MINOR);
-    }
-  }
-};
+exports = CSVExporter;

--- a/src/plugin/file/csv/csvlayerconfig.js
+++ b/src/plugin/file/csv/csvlayerconfig.js
@@ -1,85 +1,87 @@
-goog.provide('plugin.file.csv.CSVLayerConfig');
-goog.require('os.layer.config.AbstractDataSourceLayerConfig');
-goog.require('plugin.file.csv.CSVParser');
-goog.require('plugin.file.csv.CSVParserConfig');
+goog.module('plugin.file.csv.CSVLayerConfig');
+goog.module.declareLegacyNamespace();
 
+const AbstractDataSourceLayerConfig = goog.require('os.layer.config.AbstractDataSourceLayerConfig');
+const CSVParser = goog.require('plugin.file.csv.CSVParser');
+const CSVParserConfig = goog.require('plugin.file.csv.CSVParserConfig');
 
 
 /**
- * @extends {os.layer.config.AbstractDataSourceLayerConfig}
- * @constructor
  */
-plugin.file.csv.CSVLayerConfig = function() {
-  plugin.file.csv.CSVLayerConfig.base(this, 'constructor');
+class CSVLayerConfig extends AbstractDataSourceLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    /**
+     * @type {CSVParserConfig}
+     * @protected
+     */
+    this.parserConfig = new CSVParserConfig();
+  }
 
   /**
-   * @type {plugin.file.csv.CSVParserConfig}
-   * @protected
+   * @inheritDoc
    */
-  this.parserConfig = new plugin.file.csv.CSVParserConfig();
-};
-goog.inherits(plugin.file.csv.CSVLayerConfig, os.layer.config.AbstractDataSourceLayerConfig);
+  initializeConfig(options) {
+    super.initializeConfig(options);
 
+    if (options['parserConfig'] != null) {
+      this.parserConfig = /** @type {CSVParserConfig} */ (options['parserConfig']);
+    } else {
+      // when loading from a state file, these will be inline in the base options instead of in a parser config object
+      if (options['commentChar'] != null) {
+        this.parserConfig['commentChar'] = options['commentChar'];
+      }
 
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVLayerConfig.prototype.initializeConfig = function(options) {
-  plugin.file.csv.CSVLayerConfig.superClass_.initializeConfig.call(this, options);
+      if (options['dataRow'] != null) {
+        this.parserConfig['dataRow'] = options['dataRow'];
+      }
 
-  if (options['parserConfig'] != null) {
-    this.parserConfig = /** @type {plugin.file.csv.CSVParserConfig} */ (options['parserConfig']);
-  } else {
-    // when loading from a state file, these will be inline in the base options instead of in a parser config object
-    if (options['commentChar'] != null) {
-      this.parserConfig['commentChar'] = options['commentChar'];
-    }
+      if (options['delimiter'] != null) {
+        this.parserConfig['delimiter'] = options['delimiter'];
+      }
 
-    if (options['dataRow'] != null) {
-      this.parserConfig['dataRow'] = options['dataRow'];
-    }
+      if (options['headerRow'] != null) {
+        this.parserConfig['headerRow'] = options['headerRow'];
+      }
 
-    if (options['delimiter'] != null) {
-      this.parserConfig['delimiter'] = options['delimiter'];
-    }
+      if (options['useHeader'] != null) {
+        this.parserConfig['useHeader'] = options['useHeader'];
+      }
 
-    if (options['headerRow'] != null) {
-      this.parserConfig['headerRow'] = options['headerRow'];
-    }
+      if (options['mappings'] != null) {
+        this.parserConfig['mappings'] = options['mappings'];
+      }
 
-    if (options['useHeader'] != null) {
-      this.parserConfig['useHeader'] = options['useHeader'];
-    }
+      if (options['skipTimeMappings'] != null) {
+        this.parserConfig['skipTimeMappings'] = options['skipTimeMappings'];
+      }
 
-    if (options['mappings'] != null) {
-      this.parserConfig['mappings'] = options['mappings'];
-    }
-
-    if (options['skipTimeMappings'] != null) {
-      this.parserConfig['skipTimeMappings'] = options['skipTimeMappings'];
-    }
-
-    if (options['skipGeoMappings'] != null) {
-      this.parserConfig['skipGeoMappings'] = options['skipGeoMappings'];
+      if (options['skipGeoMappings'] != null) {
+        this.parserConfig['skipGeoMappings'] = options['skipGeoMappings'];
+      }
     }
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  getImporter(options) {
+    var importer = super.getImporter(options);
+    // indicate the mappings we have already configured based on the user
+    importer.setExecMappings(this.parserConfig['mappings']);
+    return importer;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVLayerConfig.prototype.getImporter = function(options) {
-  var importer = plugin.file.csv.CSVLayerConfig.base(this, 'getImporter', options);
-  // indicate the mappings we have already configured based on the user
-  importer.setExecMappings(this.parserConfig['mappings']);
-  return importer;
-};
+  /**
+   * @inheritDoc
+   */
+  getParser(options) {
+    return new CSVParser(this.parserConfig);
+  }
+}
 
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVLayerConfig.prototype.getParser = function(options) {
-  return new plugin.file.csv.CSVParser(this.parserConfig);
-};
+exports = CSVLayerConfig;

--- a/src/plugin/file/csv/csvparser.js
+++ b/src/plugin/file/csv/csvparser.js
@@ -1,138 +1,147 @@
-goog.provide('plugin.file.csv.CSVParser');
+goog.module('plugin.file.csv.CSVParser');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.array');
-goog.require('ol.Feature');
-goog.require('os.data.ColumnDefinition');
-goog.require('os.data.RecordField');
-goog.require('os.ui.file.csv.AbstractCsvParser');
+const googString = goog.require('goog.string');
+const ol = goog.require('ol');
 
+const Feature = goog.require('ol.Feature');
+const ColumnDefinition = goog.require('os.data.ColumnDefinition');
+const RecordField = goog.require('os.data.RecordField');
+const osFeature = goog.require('os.feature');
+const LatMapping = goog.require('os.im.mapping.LatMapping');
+const LonMapping = goog.require('os.im.mapping.LonMapping');
+const PositionMapping = goog.require('os.im.mapping.PositionMapping');
+const WKTMapping = goog.require('os.im.mapping.WKTMapping');
+const AbstractCsvParser = goog.require('os.ui.file.csv.AbstractCsvParser');
 
 
 /**
  * A CSV parser driven by PapaParse.
  *
- * @param {plugin.file.csv.CSVParserConfig} config
- * @extends {os.ui.file.csv.AbstractCsvParser.<ol.Feature>}
- * @constructor
+ * @extends {AbstractCsvParser.<Feature>}
  */
-plugin.file.csv.CSVParser = function(config) {
-  plugin.file.csv.CSVParser.base(this, 'constructor', config);
-};
-goog.inherits(plugin.file.csv.CSVParser, os.ui.file.csv.AbstractCsvParser);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVParser.prototype.parsePreview = function(source, opt_mappings) {
-  this.columns.length = 0;
-
-  // parse a subset of the source for immediate consumption
-  source = this.prepareSource(source);
-  var results = Papa.parse(source, {
-    'comments': this.config['commentChar'] || false,
-    'preview': os.ui.file.csv.AbstractCsvParser.PREVIEW_SIZE,
-    'delimiter': this.config['delimiter'],
-    'dynamicTyping': false,
-    'header': this.config['useHeader']
-  });
-
-  var features = [];
-  if (results && results.data && results.data.length > 0) {
-    this.preprocessResults(results);
-
-    for (var i = 0, n = results.data.length; i < n; i++) {
-      var feature = this.processResult(results.data[i], opt_mappings);
-      if (feature) {
-        features.push(feature);
-      }
-    }
-
-    if (opt_mappings) {
-      if (features && features.length > 0) {
-        this.updateColumnsFromFeature_(features[0]);
-      }
-    } else {
-      this.updateColumnsFromResults(results);
-    }
+class CSVParser extends AbstractCsvParser {
+  /**
+   * Constructor.
+   * @param {plugin.file.csv.CSVParserConfig} config
+   */
+  constructor(config) {
+    super(config);
   }
 
-  return features;
-};
+  /**
+   * @inheritDoc
+   */
+  parsePreview(source, opt_mappings) {
+    this.columns.length = 0;
 
+    // parse a subset of the source for immediate consumption
+    source = this.prepareSource(source);
+    var results = Papa.parse(source, {
+      'comments': this.config['commentChar'] || false,
+      'preview': AbstractCsvParser.PREVIEW_SIZE,
+      'delimiter': this.config['delimiter'],
+      'dynamicTyping': false,
+      'header': this.config['useHeader']
+    });
 
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVParser.prototype.processResult = function(result, opt_mappings) {
-  var feature = new ol.Feature(result);
+    var features = [];
+    if (results && results.data && results.data.length > 0) {
+      this.preprocessResults(results);
 
-  if (this.config['ignoreMissingGeomRows']) {
-    var mappings = opt_mappings != null ? opt_mappings : this.config['mappings'];
-    var latField = os.im.mapping.LatMapping.ID;
-    var lonField = os.im.mapping.LonMapping.ID;
-
-    if (mappings) { // see if lat lon was mapped to something else
-      for (var i = 0; i < mappings.length; i++) {
-        if (mappings[i].getId() == os.im.mapping.LatMapping.ID) {
-          latField = mappings[i].field;
-        } else if (mappings[i].getId() == os.im.mapping.LonMapping.ID) {
-          lonField = mappings[i].field;
-        } else if (mappings[i] instanceof os.im.mapping.PositionMapping ||
-            mappings[i] instanceof os.im.mapping.WKTMapping) {
-          latField = mappings[i].field;
-          lonField = mappings[i].field;
+      for (var i = 0, n = results.data.length; i < n; i++) {
+        var feature = this.processResult(results.data[i], opt_mappings);
+        if (feature) {
+          features.push(feature);
         }
       }
+
+      if (opt_mappings) {
+        if (features && features.length > 0) {
+          this.updateColumnsFromFeature_(features[0]);
+        }
+      } else {
+        this.updateColumnsFromResults(results);
+      }
     }
 
-    var lat = /** @type {string} */ (feature.get(latField));
-    var lon = /** @type {string} */ (feature.get(lonField));
+    return features;
+  }
 
-    // if both lat and lon aren't set, throw the feature out
-    if (lat != null && lon != null) {
-      if (goog.string.isEmptyOrWhitespace(lat) || goog.string.isEmptyOrWhitespace(lon)) {
+  /**
+   * @inheritDoc
+   */
+  processResult(result, opt_mappings) {
+    var feature = new Feature(result);
+
+    if (this.config['ignoreMissingGeomRows']) {
+      var mappings = opt_mappings != null ? opt_mappings : this.config['mappings'];
+      var latField = LatMapping.ID;
+      var lonField = LonMapping.ID;
+
+      if (mappings) { // see if lat lon was mapped to something else
+        for (var i = 0; i < mappings.length; i++) {
+          if (mappings[i].getId() == LatMapping.ID) {
+            latField = mappings[i].field;
+          } else if (mappings[i].getId() == LonMapping.ID) {
+            lonField = mappings[i].field;
+          } else if (mappings[i] instanceof PositionMapping ||
+              mappings[i] instanceof WKTMapping) {
+            latField = mappings[i].field;
+            lonField = mappings[i].field;
+          }
+        }
+      }
+
+      var lat = /** @type {string} */ (feature.get(latField));
+      var lon = /** @type {string} */ (feature.get(lonField));
+
+      // if both lat and lon aren't set, throw the feature out
+      if (lat != null && lon != null) {
+        if (googString.isEmptyOrWhitespace(lat) || googString.isEmptyOrWhitespace(lon)) {
+          return null;
+        }
+      } else {
         return null;
       }
-    } else {
-      return null;
+    }
+
+    feature.setId(String(ol.getUid(feature)));
+    return feature;
+  }
+
+  /**
+   * Determines columns from a feature. Useful when mappings are applied that change the feature properties.
+   *
+   * @param {Feature} feature
+   * @private
+   */
+  updateColumnsFromFeature_(feature) {
+    this.columns.length = 0;
+
+    var hasTime = false;
+
+    if (feature.get(RecordField.TIME) != null) {
+      var timeColumn = new ColumnDefinition(RecordField.TIME);
+      timeColumn['id'] = 'TIME';
+      timeColumn['name'] = 'TIME';
+      timeColumn['selectable'] = false;
+      timeColumn['sortable'] = false;
+      this.columns.push(timeColumn);
+
+      hasTime = true;
+    }
+
+    var properties = feature.getProperties();
+    for (var key in properties) {
+      if (!osFeature.isInternalField(key) && (!hasTime || key != 'TIME')) {
+        var col = new ColumnDefinition(key);
+        col['selectable'] = false;
+        col['sortable'] = false;
+        this.columns.push(col);
+      }
     }
   }
+}
 
-  feature.setId(String(ol.getUid(feature)));
-  return feature;
-};
-
-
-/**
- * Determines columns from a feature. Useful when mappings are applied that change the feature properties.
- *
- * @param {ol.Feature} feature
- * @private
- */
-plugin.file.csv.CSVParser.prototype.updateColumnsFromFeature_ = function(feature) {
-  this.columns.length = 0;
-
-  var hasTime = false;
-
-  if (feature.get(os.data.RecordField.TIME) != null) {
-    var timeColumn = new os.data.ColumnDefinition(os.data.RecordField.TIME);
-    timeColumn['id'] = 'TIME';
-    timeColumn['name'] = 'TIME';
-    timeColumn['selectable'] = false;
-    timeColumn['sortable'] = false;
-    this.columns.push(timeColumn);
-
-    hasTime = true;
-  }
-
-  var properties = feature.getProperties();
-  for (var key in properties) {
-    if (!os.feature.isInternalField(key) && (!hasTime || key != 'TIME')) {
-      var col = new os.data.ColumnDefinition(key);
-      col['selectable'] = false;
-      col['sortable'] = false;
-      this.columns.push(col);
-    }
-  }
-};
+exports = CSVParser;

--- a/src/plugin/file/csv/csvparserconfig.js
+++ b/src/plugin/file/csv/csvparserconfig.js
@@ -1,38 +1,43 @@
-goog.provide('plugin.file.csv.CSVParserConfig');
-goog.require('ol.Feature');
-goog.require('os.parse.csv.CsvParserConfig');
-goog.require('os.ui.slick.column');
-goog.require('plugin.file.csv.CSVParser');
+goog.module('plugin.file.csv.CSVParserConfig');
+goog.module.declareLegacyNamespace();
 
+const CsvParserConfig = goog.require('os.parse.csv.CsvParserConfig');
+const osUiSlickColumn = goog.require('os.ui.slick.column');
+const CSVParser = goog.require('plugin.file.csv.CSVParser');
+const Feature = goog.requireType('ol.Feature');
 
 
 /**
  * Configuration for a CSV parser.
- *
- * @extends {os.parse.csv.CsvParserConfig.<ol.Feature>}
- * @constructor
+ * @extends {CsvParserConfig<Feature>}
+ * @unrestricted
  */
-plugin.file.csv.CSVParserConfig = function() {
-  plugin.file.csv.CSVParserConfig.base(this, 'constructor');
-};
-goog.inherits(plugin.file.csv.CSVParserConfig, os.parse.csv.CsvParserConfig);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVParserConfig.prototype.updatePreview = function(opt_mappings) {
-  var parser = new plugin.file.csv.CSVParser(this);
-  var features = parser.parsePreview(this['file'].getContent(), opt_mappings);
-
-  this['preview'] = features || [];
-  this['columns'] = parser.getColumns() || [];
-
-  for (var i = 0, n = this['columns'].length; i < n; i++) {
-    var column = this['columns'][i];
-    column['width'] = 0;
-    os.ui.slick.column.autoSizeColumn(column);
+class CSVParserConfig extends CsvParserConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
 
-  parser.dispose();
-};
+  /**
+   * @inheritDoc
+   */
+  updatePreview(opt_mappings) {
+    var parser = new CSVParser(this);
+    var features = parser.parsePreview(this['file'].getContent(), opt_mappings);
+
+    this['preview'] = features || [];
+    this['columns'] = parser.getColumns() || [];
+
+    for (var i = 0, n = this['columns'].length; i < n; i++) {
+      var column = this['columns'][i];
+      column['width'] = 0;
+      osUiSlickColumn.autoSizeColumn(column);
+    }
+
+    parser.dispose();
+  }
+}
+
+exports = CSVParserConfig;

--- a/src/plugin/file/csv/csvplugin.js
+++ b/src/plugin/file/csv/csvplugin.js
@@ -1,73 +1,71 @@
-goog.provide('plugin.file.csv.CSVPlugin');
+goog.module('plugin.file.csv.CSVPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.DataManager');
-goog.require('os.data.ProviderEntry');
-goog.require('os.file.mime.csv');
-goog.require('os.layer.config.LayerConfigManager');
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.ui.im.ImportManager');
-goog.require('plugin.file.csv.CSVDescriptor');
-goog.require('plugin.file.csv.CSVExporter');
-goog.require('plugin.file.csv.CSVLayerConfig');
-goog.require('plugin.file.csv.CSVParser');
-goog.require('plugin.file.csv.CSVProvider');
-goog.require('plugin.file.csv.ui.CSVImportUI');
-
+const DataManager = goog.require('os.data.DataManager');
+const ProviderEntry = goog.require('os.data.ProviderEntry');
+const csv = goog.require('os.file.mime.csv');
+const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const exportManager = goog.require('os.ui.exportManager');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const CSVDescriptor = goog.require('plugin.file.csv.CSVDescriptor');
+const CSVExporter = goog.require('plugin.file.csv.CSVExporter');
+const CSVLayerConfig = goog.require('plugin.file.csv.CSVLayerConfig');
+const CSVParser = goog.require('plugin.file.csv.CSVParser');
+const CSVProvider = goog.require('plugin.file.csv.CSVProvider');
+const CSVImportUI = goog.require('plugin.file.csv.ui.CSVImportUI');
 
 
 /**
  * Provides CSV support
- *
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.file.csv.CSVPlugin = function() {
-  plugin.file.csv.CSVPlugin.base(this, 'constructor');
-  this.id = plugin.file.csv.CSVPlugin.ID;
-};
-goog.inherits(plugin.file.csv.CSVPlugin, os.plugin.AbstractPlugin);
+class CSVPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = ID;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    var dm = DataManager.getInstance();
+
+    // register csv provider type
+    dm.registerProviderType(new ProviderEntry(ID, CSVProvider, TYPE, TYPE));
+
+    // register the csv descriptor type
+    dm.registerDescriptorType(this.id, CSVDescriptor);
+
+    // register the csv layer config
+    var lcm = LayerConfigManager.getInstance();
+    lcm.registerLayerConfig('CSV', CSVLayerConfig);
+
+    // register the csv import ui
+    var im = ImportManager.getInstance();
+    im.registerImportDetails('CSV', true);
+    im.registerImportUI(csv.TYPE, new CSVImportUI());
+    im.registerParser(this.id, CSVParser);
+
+    // register the csv exporter
+    exportManager.registerExportMethod(new CSVExporter());
+  }
+}
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.csv.CSVPlugin.ID = 'csv';
+const ID = 'csv';
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.csv.CSVPlugin.TYPE = 'CSV Layers';
+const TYPE = 'CSV Layers';
 
 
-/**
- * @inheritDoc
- */
-plugin.file.csv.CSVPlugin.prototype.init = function() {
-  var dm = os.dataManager;
-
-  // register csv provider type
-  dm.registerProviderType(new os.data.ProviderEntry(
-      plugin.file.csv.CSVPlugin.ID,
-      plugin.file.csv.CSVProvider,
-      plugin.file.csv.CSVPlugin.TYPE,
-      plugin.file.csv.CSVPlugin.TYPE));
-
-  // register the csv descriptor type
-  dm.registerDescriptorType(this.id, plugin.file.csv.CSVDescriptor);
-
-  // register the csv layer config
-  var lcm = os.layer.config.LayerConfigManager.getInstance();
-  lcm.registerLayerConfig('CSV', plugin.file.csv.CSVLayerConfig);
-
-  // register the csv import ui
-  var im = os.ui.im.ImportManager.getInstance();
-  im.registerImportDetails('CSV', true);
-  im.registerImportUI(os.file.mime.csv.TYPE, new plugin.file.csv.ui.CSVImportUI());
-  im.registerParser(this.id, plugin.file.csv.CSVParser);
-
-  // register the csv exporter
-  os.ui.exportManager.registerExportMethod(new plugin.file.csv.CSVExporter());
-};
+exports = CSVPlugin;

--- a/src/plugin/file/csv/csvprovider.js
+++ b/src/plugin/file/csv/csvprovider.js
@@ -23,32 +23,8 @@ class CSVProvider extends FileProvider {
     this.setId('csv');
     this.setLabel('CSV Files');
   }
-
-  /**
-   * Get the global instance.
-   * @return {!CSVProvider}
-   */
-  static getInstance() {
-    if (!instance) {
-      instance = new CSVProvider();
-    }
-
-    return instance;
-  }
-
-  /**
-   * Set the global instance.
-   * @param {CSVProvider} value
-   */
-  static setInstance(value) {
-    instance = value;
-  }
 }
+goog.addSingletonGetter(CSVProvider);
 
-/**
- * Global instance.
- * @type {CSVProvider|undefined}
- */
-let instance;
 
 exports = CSVProvider;

--- a/src/plugin/file/csv/csvprovider.js
+++ b/src/plugin/file/csv/csvprovider.js
@@ -1,26 +1,54 @@
-goog.provide('plugin.file.csv.CSVProvider');
-goog.require('os.data.FileProvider');
+goog.module('plugin.file.csv.CSVProvider');
+goog.module.declareLegacyNamespace();
 
+const FileProvider = goog.require('os.data.FileProvider');
 
 
 /**
  * CSV file provider
- *
- * @extends {os.data.FileProvider}
- * @constructor
  */
-plugin.file.csv.CSVProvider = function() {
-  plugin.file.csv.CSVProvider.base(this, 'constructor');
-};
-goog.inherits(plugin.file.csv.CSVProvider, os.data.FileProvider);
-goog.addSingletonGetter(plugin.file.csv.CSVProvider);
+class CSVProvider extends FileProvider {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
 
+  /**
+   * @inheritDoc
+   */
+  configure(config) {
+    super.configure(config);
+    this.setId('csv');
+    this.setLabel('CSV Files');
+  }
+
+  /**
+   * Get the global instance.
+   * @return {!CSVProvider}
+   */
+  static getInstance() {
+    if (!instance) {
+      instance = new CSVProvider();
+    }
+
+    return instance;
+  }
+
+  /**
+   * Set the global instance.
+   * @param {CSVProvider} value
+   */
+  static setInstance(value) {
+    instance = value;
+  }
+}
 
 /**
- * @inheritDoc
+ * Global instance.
+ * @type {CSVProvider|undefined}
  */
-plugin.file.csv.CSVProvider.prototype.configure = function(config) {
-  plugin.file.csv.CSVProvider.base(this, 'configure', config);
-  this.setId('csv');
-  this.setLabel('CSV Files');
-};
+let instance;
+
+exports = CSVProvider;

--- a/src/plugin/file/csv/ui/csvexportui.js
+++ b/src/plugin/file/csv/ui/csvexportui.js
@@ -1,10 +1,8 @@
-goog.provide('plugin.file.csv.ui.CSVExportCtrl');
-goog.provide('plugin.file.csv.ui.csvExportDirective');
-goog.require('os');
-goog.require('os.ui.Module');
-goog.require('os.ui.icon.IconPickerCtrl');
-goog.require('os.ui.icon.iconPickerDirective');
+goog.module('plugin.file.csv.ui.CSVExportUI');
+goog.module.declareLegacyNamespace();
 
+const {ROOT} = goog.require('os');
+const Module = goog.require('os.ui.Module');
 
 
 /**
@@ -14,83 +12,95 @@ goog.require('os.ui.icon.iconPickerDirective');
  *
  * @return {angular.Directive}
  */
-plugin.file.csv.ui.csvExportDirective = function() {
-  return {
-    restrict: 'E',
-    scope: {
-      'exporter': '='
-    },
-    templateUrl: os.ROOT + 'views/plugin/csv/csvexport.html',
-    controller: plugin.file.csv.ui.CSVExportCtrl,
-    controllerAs: 'csvexport'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  scope: {
+    'exporter': '='
+  },
+  templateUrl: ROOT + 'views/plugin/csv/csvexport.html',
+  controller: Controller,
+  controllerAs: 'csvexport'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'csvexport';
 
 
 /**
  * Add the directive to the module.
  */
-os.ui.Module.directive('csvexport', [plugin.file.csv.ui.csvExportDirective]);
+Module.directive('csvexport', [directive]);
 
 
 
 /**
  * Controller function for the csvexport directive
- *
- * @param {!angular.Scope} $scope
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.file.csv.ui.CSVExportCtrl = function($scope) {
+class Controller {
   /**
-   * @type {?angular.Scope}
-   * @private
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @ngInject
    */
-  this.scope_ = $scope;
+  constructor($scope) {
+    /**
+     * @type {?angular.Scope}
+     * @private
+     */
+    this.scope_ = $scope;
 
-  /**
-   * @type {plugin.file.csv.CSVExporter}
-   * @private
-   */
-  this.exporter_ = /** @type {plugin.file.csv.CSVExporter} */ ($scope['exporter']);
+    /**
+     * @type {plugin.file.csv.CSVExporter}
+     * @private
+     */
+    this.exporter_ = /** @type {plugin.file.csv.CSVExporter} */ ($scope['exporter']);
 
-  /**
-   * @type {boolean}
-   */
-  $scope['exportEllipses'] = this.exporter_.getExportEllipses();
+    /**
+     * @type {boolean}
+     */
+    $scope['exportEllipses'] = this.exporter_.getExportEllipses();
 
-  /**
-   * @type {boolean}
-   */
-  $scope['alwaysIncludeWkt'] = this.exporter_.getAlwaysIncludeWkt();
+    /**
+     * @type {boolean}
+     */
+    $scope['alwaysIncludeWkt'] = this.exporter_.getAlwaysIncludeWkt();
 
-  $scope.$watch('exportEllipses', this.updateExporter_.bind(this));
-  $scope.$watch('alwaysIncludeWkt', this.updateExporter_.bind(this));
-  $scope.$on('$destroy', this.destroy_.bind(this));
+    $scope.$watch('exportEllipses', this.updateExporter_.bind(this));
+    $scope.$watch('alwaysIncludeWkt', this.updateExporter_.bind(this));
+    $scope.$on('$destroy', this.destroy_.bind(this));
 
-  this.updateExporter_();
-};
-
-
-/**
- * Clean up.
- *
- * @private
- */
-plugin.file.csv.ui.CSVExportCtrl.prototype.destroy_ = function() {
-  this.scope_ = null;
-  this.exporter_ = null;
-};
-
-
-/**
- * Updates the CSV exporter with the current UI configuration.
- *
- * @private
- */
-plugin.file.csv.ui.CSVExportCtrl.prototype.updateExporter_ = function() {
-  if (this.exporter_ && this.scope_) {
-    this.exporter_.setExportEllipses(this.scope_['exportEllipses']);
-    this.exporter_.setAlwaysIncludeWkt(this.scope_['alwaysIncludeWkt']);
+    this.updateExporter_();
   }
+
+  /**
+   * Clean up.
+   *
+   * @private
+   */
+  destroy_() {
+    this.scope_ = null;
+    this.exporter_ = null;
+  }
+
+  /**
+   * Updates the CSV exporter with the current UI configuration.
+   *
+   * @private
+   */
+  updateExporter_() {
+    if (this.exporter_ && this.scope_) {
+      this.exporter_.setExportEllipses(this.scope_['exportEllipses']);
+      this.exporter_.setAlwaysIncludeWkt(this.scope_['alwaysIncludeWkt']);
+    }
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/file/csv/ui/csvimport.js
+++ b/src/plugin/file/csv/ui/csvimport.js
@@ -1,78 +1,91 @@
-goog.provide('plugin.file.csv.ui.CSVImportCtrl');
-goog.provide('plugin.file.csv.ui.csvImportDirective');
+goog.module('plugin.file.csv.ui.CSVImport');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.DataManager');
-goog.require('os.file.FileStorage');
-goog.require('os.ui.Module');
-goog.require('os.ui.im.FileImportWizard');
-goog.require('os.ui.wiz.wizardDirective');
-goog.require('plugin.file.csv.CSVDescriptor');
-goog.require('plugin.file.csv.CSVParserConfig');
-goog.require('plugin.file.csv.CSVProvider');
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const Module = goog.require('os.ui.Module');
+const FileImportWizard = goog.require('os.ui.im.FileImportWizard');
+const wizardDirective = goog.require('os.ui.wiz.wizardDirective');
+const CSVDescriptor = goog.require('plugin.file.csv.CSVDescriptor');
+const CSVProvider = goog.require('plugin.file.csv.CSVProvider');
+const CSVParserConfig = goog.requireType('plugin.file.csv.CSVParserConfig');
 
 
 /**
  * Controller for the CSV import wizard window
  *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout
- * @param {!Object.<string, string>} $attrs
- * @extends {os.ui.im.FileImportWizard.<!plugin.file.csv.CSVParserConfig,!plugin.file.csv.CSVDescriptor>}
- * @constructor
- * @ngInject
+ * @extends {FileImportWizard.<!CSVParserConfig,!CSVDescriptor>}
+ * @unrestricted
  */
-plugin.file.csv.ui.CSVImportCtrl = function($scope, $element, $timeout, $attrs) {
-  plugin.file.csv.ui.CSVImportCtrl.base(this, 'constructor', $scope, $element, $timeout, $attrs);
-};
-goog.inherits(plugin.file.csv.ui.CSVImportCtrl, os.ui.im.FileImportWizard);
+class Controller extends FileImportWizard {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @param {!angular.$timeout} $timeout
+   * @param {!Object.<string, string>} $attrs
+   * @ngInject
+   */
+  constructor($scope, $element, $timeout, $attrs) {
+    super($scope, $element, $timeout, $attrs);
+  }
 
+  /**
+   * @param {!CSVDescriptor} descriptor
+   * @protected
+   * @override
+   */
+  addDescriptorToProvider(descriptor) {
+    CSVProvider.getInstance().addDescriptor(descriptor);
+  }
 
-/**
- * @param {!plugin.file.csv.CSVDescriptor} descriptor
- * @protected
- * @override
- */
-plugin.file.csv.ui.CSVImportCtrl.prototype.addDescriptorToProvider = function(descriptor) {
-  plugin.file.csv.CSVProvider.getInstance().addDescriptor(descriptor);
-};
+  /**
+   * @param {!CSVParserConfig} config
+   * @return {!CSVDescriptor}
+   * @protected
+   * @override
+   */
+  createFromConfig(config) {
+    const descriptor = new CSVDescriptor(this.config);
+    FileDescriptor.createFromConfig(descriptor, CSVProvider.getInstance(), this.config);
+    return descriptor;
+  }
 
-
-/**
- * @param {!plugin.file.csv.CSVParserConfig} config
- * @return {!plugin.file.csv.CSVDescriptor}
- * @protected
- * @override
- */
-plugin.file.csv.ui.CSVImportCtrl.prototype.createFromConfig = function(config) {
-  return plugin.file.csv.CSVDescriptor.createFromConfig(this.config);
-};
-
-
-/**
- * @param {!plugin.file.csv.CSVDescriptor} descriptor
- * @param {!plugin.file.csv.CSVParserConfig} config
- * @protected
- * @override
- */
-plugin.file.csv.ui.CSVImportCtrl.prototype.updateFromConfig = function(descriptor, config) {
-  descriptor.updateFromConfig(config);
-};
-
+  /**
+   * @param {!CSVDescriptor} descriptor
+   * @param {!CSVParserConfig} config
+   * @protected
+   * @override
+   */
+  updateFromConfig(descriptor, config) {
+    descriptor.updateFromConfig(config);
+  }
+}
 
 /**
  * The CSV import wizard directive.
  *
  * @return {angular.Directive}
  */
-plugin.file.csv.ui.csvImportDirective = function() {
-  var dir = os.ui.wiz.wizardDirective();
-  dir.controller = plugin.file.csv.ui.CSVImportCtrl;
+const directive = () => {
+  var dir = wizardDirective();
+  dir.controller = Controller;
   return dir;
 };
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'csvimport';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('csvimport', [plugin.file.csv.ui.csvImportDirective]);
+Module.directive('csvimport', [directive]);
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
+};

--- a/src/plugin/file/csv/ui/csvimportui.js
+++ b/src/plugin/file/csv/ui/csvimportui.js
@@ -1,149 +1,155 @@
-goog.provide('plugin.file.csv.ui.CSVImportUI');
+goog.module('plugin.file.csv.ui.CSVImportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.DataManager');
-goog.require('os.ui.file.csv');
-goog.require('os.ui.file.ui.csv.ConfigStep');
-goog.require('os.ui.im.FileImportUI');
-goog.require('os.ui.window');
-goog.require('os.ui.wiz.GeometryStep');
-goog.require('os.ui.wiz.OptionsStep');
-goog.require('os.ui.wiz.step.TimeStep');
-goog.require('plugin.file.csv.CSVDescriptor');
-goog.require('plugin.file.csv.CSVParserConfig');
-goog.require('plugin.file.csv.CSVProvider');
-goog.require('plugin.file.csv.ui.csvImportDirective');
-
-
-
-/**
- * @extends {os.ui.im.FileImportUI.<plugin.file.csv.CSVParserConfig>}
- * @constructor
- */
-plugin.file.csv.ui.CSVImportUI = function() {
-  plugin.file.csv.ui.CSVImportUI.base(this, 'constructor');
-};
-goog.inherits(plugin.file.csv.ui.CSVImportUI, os.ui.im.FileImportUI);
+const DataManager = goog.require('os.data.DataManager');
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const MappingManager = goog.require('os.im.mapping.MappingManager');
+const csv = goog.require('os.ui.file.csv');
+const ConfigStep = goog.require('os.ui.file.ui.csv.ConfigStep');
+const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const osWindow = goog.require('os.ui.window');
+const windowSelector = goog.require('os.ui.windowSelector');
+const GeometryStep = goog.require('os.ui.wiz.GeometryStep');
+const OptionsStep = goog.require('os.ui.wiz.OptionsStep');
+const TimeStep = goog.require('os.ui.wiz.step.TimeStep');
+const CSVDescriptor = goog.require('plugin.file.csv.CSVDescriptor');
+const CSVParserConfig = goog.require('plugin.file.csv.CSVParserConfig');
+const CSVProvider = goog.require('plugin.file.csv.CSVProvider');
+const {directiveTag: importUi} = goog.require('plugin.file.csv.ui.CSVImport');
 
 
 /**
- * @inheritDoc
+ * @extends {FileImportUI.<CSVParserConfig>}
  */
-plugin.file.csv.ui.CSVImportUI.prototype.getTitle = function() {
-  return 'CSV';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.ui.CSVImportUI.prototype.launchUI = function(file, opt_config) {
-  plugin.file.csv.ui.CSVImportUI.base(this, 'launchUI', file, opt_config);
-
-  const config = new plugin.file.csv.CSVParserConfig();
-
-  if (opt_config) {
-    this.mergeConfig(opt_config, config);
+class CSVImportUI extends FileImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
 
-  config['file'] = file;
-  config['title'] = file.getFileName();
-  config.updateLinePreview();
-
-  if (opt_config && opt_config['defaultImport']) {
-    this.handleDefaultImport(file, config);
-    return;
+  /**
+   * @inheritDoc
+   */
+  getTitle() {
+    return 'CSV';
   }
 
-  const steps = [
-    new os.ui.file.ui.csv.ConfigStep(),
-    new os.ui.wiz.GeometryStep(),
-    new os.ui.wiz.step.TimeStep(),
-    new os.ui.wiz.OptionsStep()
-  ];
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    super.launchUI(file, opt_config);
 
-  const scopeOptions = {
-    'config': config,
-    'steps': steps
-  };
-  const windowOptions = {
-    'label': 'CSV Import',
-    'icon': 'fa fa-sign-in',
-    'x': 'center',
-    'y': 'center',
-    'width': '900',
-    'min-width': '500',
-    'max-width': '2000',
-    'height': '700',
-    'min-height': '500',
-    'max-height': '2000',
-    'modal': true,
-    'show-close': true
-  };
-  const template = '<csvimport resize-with="' + os.ui.windowSelector.WINDOW + '"></csvimport>';
-  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
-};
+    const config = new CSVParserConfig();
 
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.ui.CSVImportUI.prototype.mergeConfig = function(from, to) {
-  plugin.file.csv.ui.CSVImportUI.base(this, 'mergeConfig', from, to);
-
-  to['commentChar'] = from['commentChar'];
-  to['dataRow'] = from['dataRow'];
-  to['delimiter'] = from['delimiter'];
-  to['headerRow'] = from['headerRow'];
-  to['useHeader'] = from['useHeader'];
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.ui.CSVImportUI.prototype.getDefaultConfig = function(file, config) {
-  // use the default expected CSV config values before doing the preview and mapping autodetection
-  const conf = os.ui.file.csv.DEFAULT_CONFIG;
-  config['color'] = conf['color'];
-  config['commentChar'] = conf['commentChar'];
-  config['dataRow'] = conf['dataRow'];
-  config['delimiter'] = conf['delimiter'];
-  config['headerRow'] = conf['headerRow'];
-  config['useHeader'] = conf['useHeader'];
-
-  try {
-    config.updatePreview();
-
-    const features = config['preview'];
-    if ((!config['mappings'] || config['mappings'].length <= 0) && features && features.length > 0) {
-      // no mappings have been set yet, so try to auto detect them
-      const mm = os.im.mapping.MappingManager.getInstance();
-      const mappings = mm.autoDetect(features);
-      if (mappings && mappings.length > 0) {
-        config['mappings'] = mappings;
-      }
+    if (opt_config) {
+      this.mergeConfig(opt_config, config);
     }
-  } catch (e) {
+
+    config['file'] = file;
+    config['title'] = file.getFileName();
+    config.updateLinePreview();
+
+    if (opt_config && opt_config['defaultImport']) {
+      this.handleDefaultImport(file, config);
+      return;
+    }
+
+    const steps = [
+      new ConfigStep(),
+      new GeometryStep(),
+      new TimeStep(),
+      new OptionsStep()
+    ];
+
+    const scopeOptions = {
+      'config': config,
+      'steps': steps
+    };
+    const windowOptions = {
+      'label': 'CSV Import',
+      'icon': 'fa fa-sign-in',
+      'x': 'center',
+      'y': 'center',
+      'width': '900',
+      'min-width': '500',
+      'max-width': '2000',
+      'height': '700',
+      'min-height': '500',
+      'max-height': '2000',
+      'modal': true,
+      'show-close': true
+    };
+    const template = `<${importUi} resize-with="${windowSelector.WINDOW}"></${importUi}>`;
+    osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
   }
 
-  return config;
-};
+  /**
+   * @inheritDoc
+   */
+  mergeConfig(from, to) {
+    super.mergeConfig(from, to);
 
-
-/**
- * @inheritDoc
- */
-plugin.file.csv.ui.CSVImportUI.prototype.handleDefaultImport = function(file, config) {
-  config['file'] = file;
-  config['title'] = file.getFileName();
-
-  config = this.getDefaultConfig(file, config);
-
-  // create the descriptor and add it
-  if (config) {
-    const descriptor = plugin.file.csv.CSVDescriptor.createFromConfig(config);
-    plugin.file.csv.CSVProvider.getInstance().addDescriptor(descriptor);
-    os.data.DataManager.getInstance().addDescriptor(descriptor);
-    descriptor.setActive(true);
+    to['commentChar'] = from['commentChar'];
+    to['dataRow'] = from['dataRow'];
+    to['delimiter'] = from['delimiter'];
+    to['headerRow'] = from['headerRow'];
+    to['useHeader'] = from['useHeader'];
   }
-};
+
+  /**
+   * @inheritDoc
+   */
+  getDefaultConfig(file, config) {
+    // use the default expected CSV config values before doing the preview and mapping autodetection
+    const conf = csv.DEFAULT_CONFIG;
+    config['color'] = conf['color'];
+    config['commentChar'] = conf['commentChar'];
+    config['dataRow'] = conf['dataRow'];
+    config['delimiter'] = conf['delimiter'];
+    config['headerRow'] = conf['headerRow'];
+    config['useHeader'] = conf['useHeader'];
+
+    try {
+      config.updatePreview();
+
+      const features = config['preview'];
+      if ((!config['mappings'] || config['mappings'].length <= 0) && features && features.length > 0) {
+        // no mappings have been set yet, so try to auto detect them
+        const mm = MappingManager.getInstance();
+        const mappings = mm.autoDetect(features);
+        if (mappings && mappings.length > 0) {
+          config['mappings'] = mappings;
+        }
+      }
+    } catch (e) {
+    }
+
+    return config;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handleDefaultImport(file, config) {
+    config['file'] = file;
+    config['title'] = file.getFileName();
+
+    config = this.getDefaultConfig(file, config);
+
+    // create the descriptor and add it
+    if (config) {
+      const provider = CSVProvider.getInstance();
+      const descriptor = new CSVDescriptor(config);
+      FileDescriptor.createFromConfig(descriptor, provider, config);
+
+      provider.addDescriptor(descriptor);
+      DataManager.getInstance().addDescriptor(descriptor);
+      descriptor.setActive(true);
+    }
+  }
+}
+
+exports = CSVImportUI;

--- a/src/plugin/file/geojson/geojsondescriptor.js
+++ b/src/plugin/file/geojson/geojsondescriptor.js
@@ -1,63 +1,48 @@
-goog.provide('plugin.file.geojson.GeoJSONDescriptor');
+goog.module('plugin.file.geojson.GeoJSONDescriptor');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.FileDescriptor');
-goog.require('os.layer.LayerType');
-goog.require('plugin.file.geojson.GeoJSONExporter');
-goog.require('plugin.file.geojson.GeoJSONParserConfig');
-goog.require('plugin.file.geojson.GeoJSONProvider');
-
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const LayerType = goog.require('os.layer.LayerType');
+const GeoJSONExporter = goog.require('plugin.file.geojson.GeoJSONExporter');
+const GeoJSONParserConfig = goog.require('plugin.file.geojson.GeoJSONParserConfig');
 
 
 /**
  * GeoJSON file descriptor.
- *
- * @param {plugin.file.geojson.GeoJSONParserConfig=} opt_config
- * @extends {os.data.FileDescriptor}
- * @constructor
  */
-plugin.file.geojson.GeoJSONDescriptor = function(opt_config) {
-  plugin.file.geojson.GeoJSONDescriptor.base(this, 'constructor');
-  this.descriptorType = 'geojson';
-  this.parserConfig = opt_config || new plugin.file.geojson.GeoJSONParserConfig();
-};
-goog.inherits(plugin.file.geojson.GeoJSONDescriptor, os.data.FileDescriptor);
+class GeoJSONDescriptor extends FileDescriptor {
+  /**
+   * Constructor.
+   * @param {GeoJSONParserConfig=} opt_config
+   */
+  constructor(opt_config) {
+    super();
+    this.descriptorType = 'geojson';
+    this.parserConfig = opt_config || new GeoJSONParserConfig();
+  }
 
+  /**
+   * @inheritDoc
+   */
+  getType() {
+    return LayerType.FEATURES;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONDescriptor.prototype.getType = function() {
-  return os.layer.LayerType.FEATURES;
-};
+  /**
+   * @inheritDoc
+   */
+  getLayerOptions() {
+    var options = super.getLayerOptions();
+    options['type'] = 'GeoJSON';
+    return options;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  getExporter() {
+    return new GeoJSONExporter();
+  }
+}
 
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONDescriptor.prototype.getLayerOptions = function() {
-  var options = plugin.file.geojson.GeoJSONDescriptor.base(this, 'getLayerOptions');
-  options['type'] = 'GeoJSON';
-  return options;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONDescriptor.prototype.getExporter = function() {
-  return new plugin.file.geojson.GeoJSONExporter();
-};
-
-
-/**
- * Creates a new descriptor from a parser configuration.
- *
- * @param {!plugin.file.geojson.GeoJSONParserConfig} config
- * @return {!plugin.file.geojson.GeoJSONDescriptor}
- */
-plugin.file.geojson.GeoJSONDescriptor.createFromConfig = function(config) {
-  var provider = plugin.file.geojson.GeoJSONProvider.getInstance();
-  var descriptor = new plugin.file.geojson.GeoJSONDescriptor(config);
-  os.data.FileDescriptor.createFromConfig(descriptor, provider, config);
-  return descriptor;
-};
+exports = GeoJSONDescriptor;

--- a/src/plugin/file/geojson/geojsonexporter.js
+++ b/src/plugin/file/geojson/geojsonexporter.js
@@ -1,94 +1,104 @@
-goog.provide('plugin.file.geojson.GeoJSONExporter');
+goog.module('plugin.file.geojson.GeoJSONExporter');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.log');
-goog.require('ol.format.GeoJSON');
-goog.require('os.Fields');
-goog.require('os.data.RecordField');
-goog.require('os.ex.AbstractExporter');
-goog.require('os.map');
+const log = goog.require('goog.log');
+const GeoJSON = goog.require('ol.format.GeoJSON');
+const Fields = goog.require('os.Fields');
+const RecordField = goog.require('os.data.RecordField');
+const AbstractExporter = goog.require('os.ex.AbstractExporter');
+const instanceOf = goog.require('os.instanceOf');
+const osMap = goog.require('os.map');
+
+
+const osProj = goog.require('os.proj');
+const TimeRange = goog.require('os.time.TimeRange');
+
 
 /**
  * The GeoJSON exporter.
  *
- * @extends {os.ex.AbstractExporter.<ol.Feature>}
- * @constructor
+ * @extends {AbstractExporter.<ol.Feature>}
  */
-plugin.file.geojson.GeoJSONExporter = function() {
-  plugin.file.geojson.GeoJSONExporter.base(this, 'constructor');
-  this.log = plugin.file.geojson.GeoJSONExporter.LOGGER_;
-};
-goog.inherits(plugin.file.geojson.GeoJSONExporter, os.ex.AbstractExporter);
+class GeoJSONExporter extends AbstractExporter {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.log = logger;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLabel() {
+    return 'GeoJSON';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getExtension() {
+    return 'geojson';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getMimeType() {
+    return 'application/vnd.geo+json';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  process() {
+    // Insert calculated TIME to each item if present
+    var timeAdded = false;
+    var timeRangeAdded = false;
+    for (var i = 0, n = this.items.length; i < n; i++) {
+      var time = /** @type {os.time.ITime|undefined} */ (this.items[i].get(RecordField.TIME));
+      if (time) {
+        if (instanceOf(time, TimeRange.NAME)) {
+          this.items[i].set(GeoJSONExporter.FIELDS.START_TIME, time.getStartISOString());
+          this.items[i].set(GeoJSONExporter.FIELDS.END_TIME, time.getEndISOString());
+          if (!timeRangeAdded) {
+            this.fields.push(GeoJSONExporter.FIELDS.START_TIME);
+            this.fields.push(GeoJSONExporter.FIELDS.END_TIME);
+            timeRangeAdded = true;
+          }
+        } else {
+          this.items[i].set(Fields.TIME, time.toISOString());
+          if (!timeAdded) {
+            this.fields.push(Fields.TIME);
+            timeAdded = true;
+          }
+        }
+      }
+    }
+
+    var format = new GeoJSON();
+    this.output = format.writeFeatures(this.items, {
+      featureProjection: osMap.PROJECTION,
+      dataProjection: osProj.EPSG4326,
+      fields: this.fields
+    });
+  }
+}
 
 /**
  * Logger
- * @type {goog.log.Logger}
- * @private
- * @const
+ * @type {log.Logger}
  */
-plugin.file.geojson.GeoJSONExporter.LOGGER_ = goog.log.getLogger('plugin.file.geojson.GeoJSONExporter');
+const logger = log.getLogger('plugin.file.geojson.GeoJSONExporter');
 
 /**
  * Fields for GeoJson export.
  * @enum {string}
  */
-plugin.file.geojson.GeoJSONExporter.FIELDS = {
+GeoJSONExporter.FIELDS = {
   START_TIME: 'START_TIME',
   END_TIME: 'END_TIME'
 };
 
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONExporter.prototype.getLabel = function() {
-  return 'GeoJSON';
-};
-
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONExporter.prototype.getExtension = function() {
-  return 'geojson';
-};
-
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONExporter.prototype.getMimeType = function() {
-  return 'application/vnd.geo+json';
-};
-
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONExporter.prototype.process = function() {
-  // Insert calculated TIME to each item if present
-  var timeAdded = false;
-  var timeRangeAdded = false;
-  for (var i = 0, n = this.items.length; i < n; i++) {
-    var time = /** @type {os.time.ITime|undefined} */ (this.items[i].get(os.data.RecordField.TIME));
-    if (time) {
-      if (os.instanceOf(time, os.time.TimeRange.NAME)) {
-        this.items[i].set(plugin.file.geojson.GeoJSONExporter.FIELDS.START_TIME, time.getStartISOString());
-        this.items[i].set(plugin.file.geojson.GeoJSONExporter.FIELDS.END_TIME, time.getEndISOString());
-        if (!timeRangeAdded) {
-          this.fields.push(plugin.file.geojson.GeoJSONExporter.FIELDS.START_TIME);
-          this.fields.push(plugin.file.geojson.GeoJSONExporter.FIELDS.END_TIME);
-          timeRangeAdded = true;
-        }
-      } else {
-        this.items[i].set(os.Fields.TIME, time.toISOString());
-        if (!timeAdded) {
-          this.fields.push(os.Fields.TIME);
-          timeAdded = true;
-        }
-      }
-    }
-  }
-
-  var format = new ol.format.GeoJSON();
-  this.output = format.writeFeatures(this.items, {
-    featureProjection: os.map.PROJECTION,
-    dataProjection: os.proj.EPSG4326,
-    fields: this.fields
-  });
-};
+exports = GeoJSONExporter;

--- a/src/plugin/file/geojson/geojsonimport.js
+++ b/src/plugin/file/geojson/geojsonimport.js
@@ -1,76 +1,90 @@
-goog.provide('plugin.file.geojson.GeoJSONImportCtrl');
-goog.provide('plugin.file.geojson.geojsonImportDirective');
+goog.module('plugin.file.geojson.GeoJSONImport');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.ui.Module');
-goog.require('os.ui.im.FileImportWizard');
-goog.require('os.ui.wiz.wizardDirective');
-goog.require('plugin.file.geojson.GeoJSONDescriptor');
-goog.require('plugin.file.geojson.GeoJSONProvider');
-
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const Module = goog.require('os.ui.Module');
+const FileImportWizard = goog.require('os.ui.im.FileImportWizard');
+const wizardDirective = goog.require('os.ui.wiz.wizardDirective');
+const GeoJSONDescriptor = goog.require('plugin.file.geojson.GeoJSONDescriptor');
+const GeoJSONProvider = goog.require('plugin.file.geojson.GeoJSONProvider');
 
 
 /**
  * Controller for the GeoJSON import wizard window
  *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout
- * @param {!Object.<string, string>} $attrs
- * @extends {os.ui.im.FileImportWizard.<!plugin.file.geojson.GeoJSONParserConfig, !plugin.file.geojson.GeoJSONDescriptor>}
- * @constructor
- * @ngInject
+ * @extends {FileImportWizard.<!plugin.file.geojson.GeoJSONParserConfig, !GeoJSONDescriptor>}
+ * @unrestricted
  */
-plugin.file.geojson.GeoJSONImportCtrl = function($scope, $element, $timeout, $attrs) {
-  plugin.file.geojson.GeoJSONImportCtrl.base(this, 'constructor', $scope, $element, $timeout, $attrs);
-};
-goog.inherits(plugin.file.geojson.GeoJSONImportCtrl, os.ui.im.FileImportWizard);
+class Controller extends FileImportWizard {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @param {!angular.$timeout} $timeout
+   * @param {!Object.<string, string>} $attrs
+   * @ngInject
+   */
+  constructor($scope, $element, $timeout, $attrs) {
+    super($scope, $element, $timeout, $attrs);
+  }
 
+  /**
+   * @param {!GeoJSONDescriptor} descriptor
+   * @protected
+   * @override
+   */
+  addDescriptorToProvider(descriptor) {
+    GeoJSONProvider.getInstance().addDescriptor(descriptor);
+  }
 
-/**
- * @param {!plugin.file.geojson.GeoJSONDescriptor} descriptor
- * @protected
- * @override
- */
-plugin.file.geojson.GeoJSONImportCtrl.prototype.addDescriptorToProvider = function(descriptor) {
-  plugin.file.geojson.GeoJSONProvider.getInstance().addDescriptor(descriptor);
-};
+  /**
+   * @param {!plugin.file.geojson.GeoJSONParserConfig} config
+   * @return {!GeoJSONDescriptor}
+   * @protected
+   * @override
+   */
+  createFromConfig(config) {
+    const descriptor = new GeoJSONDescriptor(this.config);
+    FileDescriptor.createFromConfig(descriptor, GeoJSONProvider.getInstance(), this.config);
+    return descriptor;
+  }
 
-
-/**
- * @param {!plugin.file.geojson.GeoJSONParserConfig} config
- * @return {!plugin.file.geojson.GeoJSONDescriptor}
- * @protected
- * @override
- */
-plugin.file.geojson.GeoJSONImportCtrl.prototype.createFromConfig = function(config) {
-  return plugin.file.geojson.GeoJSONDescriptor.createFromConfig(this.config);
-};
-
-
-/**
- * @param {!plugin.file.geojson.GeoJSONDescriptor} descriptor
- * @param {!plugin.file.geojson.GeoJSONParserConfig} config
- * @protected
- * @override
- */
-plugin.file.geojson.GeoJSONImportCtrl.prototype.updateFromConfig = function(descriptor, config) {
-  descriptor.updateFromConfig(config);
-};
-
+  /**
+   * @param {!GeoJSONDescriptor} descriptor
+   * @param {!plugin.file.geojson.GeoJSONParserConfig} config
+   * @protected
+   * @override
+   */
+  updateFromConfig(descriptor, config) {
+    descriptor.updateFromConfig(config);
+  }
+}
 
 /**
  * The GeoJSON import wizard directive.
  *
  * @return {angular.Directive}
  */
-plugin.file.geojson.geojsonImportDirective = function() {
-  var dir = os.ui.wiz.wizardDirective();
-  dir.controller = plugin.file.geojson.GeoJSONImportCtrl;
+const directive = () => {
+  var dir = wizardDirective();
+  dir.controller = Controller;
   return dir;
 };
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'geojsonimport';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('geojsonimport', [plugin.file.geojson.geojsonImportDirective]);
+Module.directive('geojsonimport', [directive]);
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
+};

--- a/src/plugin/file/geojson/geojsonimporthandler.js
+++ b/src/plugin/file/geojson/geojsonimporthandler.js
@@ -1,11 +1,12 @@
 goog.module('plugin.file.geojson.GeoJSONImportHandler');
 
 const DataManager = goog.require('os.data.DataManager');
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const MappingManager = goog.require('os.im.mapping.MappingManager');
 const FileImportUI = goog.require('os.ui.im.FileImportUI');
 const GeoJSONDescriptor = goog.require('plugin.file.geojson.GeoJSONDescriptor');
 const GeoJSONParserConfig = goog.require('plugin.file.geojson.GeoJSONParserConfig');
 const GeoJSONProvider = goog.require('plugin.file.geojson.GeoJSONProvider');
-const MappingManager = goog.require('os.im.mapping.MappingManager');
 
 
 /**
@@ -57,8 +58,11 @@ class GeoJSONImportHandler extends FileImportUI {
     }
 
     // create the descriptor and add it
-    const descriptor = GeoJSONDescriptor.createFromConfig(config);
-    GeoJSONProvider.getInstance().addDescriptor(descriptor);
+    const provider = GeoJSONProvider.getInstance();
+    const descriptor = new GeoJSONDescriptor(config);
+    FileDescriptor.createFromConfig(descriptor, provider, config);
+
+    provider.addDescriptor(descriptor);
     DataManager.getInstance().addDescriptor(descriptor);
     descriptor.setActive(true);
   }

--- a/src/plugin/file/geojson/geojsonlayerconfig.js
+++ b/src/plugin/file/geojson/geojsonlayerconfig.js
@@ -1,63 +1,70 @@
-goog.provide('plugin.file.geojson.GeoJSONLayerConfig');
-goog.require('os.layer.config.AbstractDataSourceLayerConfig');
-goog.require('os.ui.im.ImportManager');
-goog.require('plugin.file.geojson.GeoJSONParser');
-goog.require('plugin.file.geojson.GeoJSONParserConfig');
+goog.module('plugin.file.geojson.GeoJSONLayerConfig');
+goog.module.declareLegacyNamespace();
 
+const AltMapping = goog.require('os.im.mapping.AltMapping');
+const OrientationMapping = goog.require('os.im.mapping.OrientationMapping');
+const SemiMajorMapping = goog.require('os.im.mapping.SemiMajorMapping');
+const SemiMinorMapping = goog.require('os.im.mapping.SemiMinorMapping');
+const DateTimeMapping = goog.require('os.im.mapping.time.DateTimeMapping');
+
+const AbstractDataSourceLayerConfig = goog.require('os.layer.config.AbstractDataSourceLayerConfig');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const GeoJSONParserConfig = goog.require('plugin.file.geojson.GeoJSONParserConfig');
 
 
 /**
- * @extends {os.layer.config.AbstractDataSourceLayerConfig}
- * @constructor
  */
-plugin.file.geojson.GeoJSONLayerConfig = function() {
-  plugin.file.geojson.GeoJSONLayerConfig.base(this, 'constructor');
+class GeoJSONLayerConfig extends AbstractDataSourceLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    /**
+     * @type {os.parse.FileParserConfig}
+     * @protected
+     */
+    this.parserConfig = new GeoJSONParserConfig();
+  }
 
   /**
-   * @type {os.parse.FileParserConfig}
-   * @protected
+   * @inheritDoc
    */
-  this.parserConfig = new plugin.file.geojson.GeoJSONParserConfig();
-};
-goog.inherits(plugin.file.geojson.GeoJSONLayerConfig, os.layer.config.AbstractDataSourceLayerConfig);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONLayerConfig.prototype.initializeConfig = function(options) {
-  plugin.file.geojson.GeoJSONLayerConfig.base(this, 'initializeConfig', options);
-  this.parserConfig = options['parserConfig'] || new plugin.file.geojson.GeoJSONParserConfig();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONLayerConfig.prototype.getImporter = function(options) {
-  var importer = plugin.file.geojson.GeoJSONLayerConfig.base(this, 'getImporter', options);
-  if (this.parserConfig['mappings'] == null || this.parserConfig['mappings'].length == 0) {
-    // there was no user interaction, so default the mappings to a set the importer would have used
-    importer.selectAutoMappings([
-      os.im.mapping.AltMapping.ID,
-      os.im.mapping.OrientationMapping.ID,
-      os.im.mapping.SemiMajorMapping.ID,
-      os.im.mapping.SemiMinorMapping.ID,
-      os.im.mapping.time.DateTimeMapping.ID]);
-  } else {
-    // setAutoMappings() ignores manual configs (e.g. custom Datetime format) since it re-autodetects
-    importer.setExecMappings(this.parserConfig['mappings']);
+  initializeConfig(options) {
+    super.initializeConfig(options);
+    this.parserConfig = options['parserConfig'] || new GeoJSONParserConfig();
   }
-  return importer;
-};
 
+  /**
+   * @inheritDoc
+   */
+  getImporter(options) {
+    var importer = super.getImporter(options);
+    if (this.parserConfig['mappings'] == null || this.parserConfig['mappings'].length == 0) {
+      // there was no user interaction, so default the mappings to a set the importer would have used
+      importer.selectAutoMappings([
+        AltMapping.ID,
+        OrientationMapping.ID,
+        SemiMajorMapping.ID,
+        SemiMinorMapping.ID,
+        DateTimeMapping.ID]);
+    } else {
+      // setAutoMappings() ignores manual configs (e.g. custom Datetime format) since it re-autodetects
+      importer.setExecMappings(this.parserConfig['mappings']);
+    }
+    return importer;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONLayerConfig.prototype.getParser = function(options) {
-  var im = os.ui.im.ImportManager.getInstance();
-  var parser = im.getParser('geojson');
-  parser.setSourceId(this.id);
-  return parser;
-};
+  /**
+   * @inheritDoc
+   */
+  getParser(options) {
+    var im = ImportManager.getInstance();
+    var parser = im.getParser('geojson');
+    parser.setSourceId(this.id);
+    return parser;
+  }
+}
+
+exports = GeoJSONLayerConfig;

--- a/src/plugin/file/geojson/geojsonmixin.js
+++ b/src/plugin/file/geojson/geojsonmixin.js
@@ -1,51 +1,69 @@
-goog.provide('plugin.file.geojson.mixin');
+goog.module('plugin.file.geojson.mixin');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.format.GeoJSON');
+const GeoJSON = goog.require('ol.format.GeoJSON');
 
-(function() {
-  /**
-   * Encode a feature as a GeoJSON Feature object.
-   *
-   * @param {ol.Feature} feature Feature.
-   * @param {olx.format.WriteOptions=} opt_options Write options.
-   * @return {GeoJSONFeature} Object.
-   * @override
-   * @suppress {accessControls,duplicate}
-   */
-  ol.format.GeoJSON.prototype.writeFeatureObject = function(feature, opt_options) {
-    opt_options = this.adaptOptions(opt_options);
+const Feature = goog.requireType('ol.Feature');
 
-    var object = /** @type {GeoJSONFeature} */ ({
-      'type': 'Feature'
-    });
-    var id = feature.getId();
-    if (id !== undefined) {
-      object.id = id;
-    }
-    var geometry = feature.getGeometry();
-    if (geometry) {
-      object.geometry =
-          ol.format.GeoJSON.writeGeometry_(geometry, opt_options);
-    } else {
-      object.geometry = null;
-    }
 
-    var properties = feature.values_;
-    var fields = opt_options.fields;
-    for (var key in properties) {
-      // exclude private keys, any fields passed in, and any non-primitive value
-      if ((opt_options.includePrivateFields || key.indexOf('_') !== 0) &&
-          ((!fields || fields.indexOf(key) > -1) &&
-          Object(properties[key]) !== properties[key])) {
-        if (!object.properties) {
-          object.properties = {};
-        }
+/**
+ * If the mixin has been initialized.
+ * @type {boolean}
+ */
+let initialized = false;
 
-        object.properties[key] = properties[key];
+
+/**
+ * Initialize the mixin.
+ */
+const init = () => {
+  if (!initialized) {
+    initialized = true;
+
+    /**
+     * Encode a feature as a GeoJSON Feature object.
+     *
+     * @param {Feature} feature Feature.
+     * @param {olx.format.WriteOptions=} opt_options Write options.
+     * @return {GeoJSONFeature} Object.
+     * @override
+     * @suppress {accessControls,duplicate}
+     */
+    GeoJSON.prototype.writeFeatureObject = function(feature, opt_options) {
+      opt_options = this.adaptOptions(opt_options);
+
+      var object = /** @type {GeoJSONFeature} */ ({
+        'type': 'Feature'
+      });
+      var id = feature.getId();
+      if (id !== undefined) {
+        object.id = id;
       }
-    }
+      var geometry = feature.getGeometry();
+      if (geometry) {
+        object.geometry = GeoJSON.writeGeometry_(geometry, opt_options);
+      } else {
+        object.geometry = null;
+      }
 
-    return object;
-  };
-})();
+      var properties = feature.values_;
+      var fields = opt_options.fields;
+      for (var key in properties) {
+        // exclude private keys, any fields passed in, and any non-primitive value
+        if ((opt_options.includePrivateFields || key.indexOf('_') !== 0) &&
+            ((!fields || fields.indexOf(key) > -1) &&
+            Object(properties[key]) !== properties[key])) {
+          if (!object.properties) {
+            object.properties = {};
+          }
 
+          object.properties[key] = properties[key];
+        }
+      }
+
+      return object;
+    };
+  }
+};
+
+exports = {init};

--- a/src/plugin/file/geojson/geojsonplugin.js
+++ b/src/plugin/file/geojson/geojsonplugin.js
@@ -1,76 +1,77 @@
-goog.provide('plugin.file.geojson.GeoJSONPlugin');
+goog.module('plugin.file.geojson.GeoJSONPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.DataManager');
-goog.require('os.data.ProviderEntry');
-goog.require('os.layer.config.LayerConfigManager');
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.ui.im.ImportManager');
-goog.require('plugin.file.geojson.GeoJSONDescriptor');
-goog.require('plugin.file.geojson.GeoJSONExporter');
-goog.require('plugin.file.geojson.GeoJSONImportUI');
-goog.require('plugin.file.geojson.GeoJSONLayerConfig');
-goog.require('plugin.file.geojson.GeoJSONParser');
-goog.require('plugin.file.geojson.GeoJSONProvider');
-goog.require('plugin.file.geojson.GeoJSONSimpleStyleParser');
-goog.require('plugin.file.geojson.mime');
-goog.require('plugin.file.geojson.mixin');
+const DataManager = goog.require('os.data.DataManager');
+const ProviderEntry = goog.require('os.data.ProviderEntry');
+const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const exportManager = goog.require('os.ui.exportManager');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const GeoJSONDescriptor = goog.require('plugin.file.geojson.GeoJSONDescriptor');
+const GeoJSONExporter = goog.require('plugin.file.geojson.GeoJSONExporter');
+const GeoJSONImportUI = goog.require('plugin.file.geojson.GeoJSONImportUI');
+const GeoJSONLayerConfig = goog.require('plugin.file.geojson.GeoJSONLayerConfig');
+const GeoJSONProvider = goog.require('plugin.file.geojson.GeoJSONProvider');
+const GeoJSONSimpleStyleParser = goog.require('plugin.file.geojson.GeoJSONSimpleStyleParser');
+const mime = goog.require('plugin.file.geojson.mime');
+const GeoJSONMixin = goog.require('plugin.file.geojson.mixin');
 
+
+// Initialize the GeoJSON mixin.
+GeoJSONMixin.init();
 
 
 /**
  * Provides GeoJSON support
- *
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.file.geojson.GeoJSONPlugin = function() {
-  plugin.file.geojson.GeoJSONPlugin.base(this, 'constructor');
-  this.id = plugin.file.geojson.GeoJSONPlugin.ID;
-};
-goog.inherits(plugin.file.geojson.GeoJSONPlugin, os.plugin.AbstractPlugin);
+class GeoJSONPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = ID;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    var dm = DataManager.getInstance();
+
+    // register geojson provider type
+    dm.registerProviderType(new ProviderEntry(ID, GeoJSONProvider, TYPE, TYPE));
+
+    // register the geojson descriptor type
+    dm.registerDescriptorType(this.id, GeoJSONDescriptor);
+
+    // register the geojson layer config
+    var lcm = LayerConfigManager.getInstance();
+    lcm.registerLayerConfig('GeoJSON', GeoJSONLayerConfig);
+
+    // register the geojson import ui
+    var im = ImportManager.getInstance();
+    im.registerImportDetails('GeoJSON', true);
+    im.registerImportUI(mime.TYPE, new GeoJSONImportUI());
+    im.registerParser(this.id, GeoJSONSimpleStyleParser);
+    im.registerParser(this.id + '-simplespec', GeoJSONSimpleStyleParser);
+
+    // register the geojson exporter
+    exportManager.registerExportMethod(new GeoJSONExporter());
+  }
+}
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.geojson.GeoJSONPlugin.ID = 'geojson';
+const ID = 'geojson';
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.geojson.GeoJSONPlugin.TYPE = 'GeoJSON Layers';
+const TYPE = 'GeoJSON Layers';
 
 
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONPlugin.prototype.init = function() {
-  var dm = os.dataManager;
-
-  // register geojson provider type
-  dm.registerProviderType(new os.data.ProviderEntry(
-      plugin.file.geojson.GeoJSONPlugin.ID,
-      plugin.file.geojson.GeoJSONProvider,
-      plugin.file.geojson.GeoJSONPlugin.TYPE,
-      plugin.file.geojson.GeoJSONPlugin.TYPE));
-
-  // register the geojson descriptor type
-  dm.registerDescriptorType(this.id, plugin.file.geojson.GeoJSONDescriptor);
-
-  // register the geojson layer config
-  var lcm = os.layer.config.LayerConfigManager.getInstance();
-  lcm.registerLayerConfig('GeoJSON', plugin.file.geojson.GeoJSONLayerConfig);
-
-  // register the geojson import ui
-  var im = os.ui.im.ImportManager.getInstance();
-  im.registerImportDetails('GeoJSON', true);
-  im.registerImportUI(plugin.file.geojson.mime.TYPE, new plugin.file.geojson.GeoJSONImportUI());
-  im.registerParser(this.id, plugin.file.geojson.GeoJSONSimpleStyleParser);
-  im.registerParser(this.id + '-simplespec', plugin.file.geojson.GeoJSONSimpleStyleParser);
-
-  // register the geojson exporter
-  os.ui.exportManager.registerExportMethod(new plugin.file.geojson.GeoJSONExporter());
-};
+exports = GeoJSONPlugin;

--- a/src/plugin/file/geojson/geojsonprovider.js
+++ b/src/plugin/file/geojson/geojsonprovider.js
@@ -23,32 +23,8 @@ class GeoJSONProvider extends FileProvider {
     this.setId('geojson');
     this.setLabel('GeoJSON Files');
   }
-
-  /**
-   * Get the global instance.
-   * @return {!GeoJSONProvider}
-   */
-  static getInstance() {
-    if (!instance) {
-      instance = new GeoJSONProvider();
-    }
-
-    return instance;
-  }
-
-  /**
-   * Set the global instance.
-   * @param {GeoJSONProvider} value
-   */
-  static setInstance(value) {
-    instance = value;
-  }
 }
+goog.addSingletonGetter(GeoJSONProvider);
 
-/**
- * Global instance.
- * @type {GeoJSONProvider|undefined}
- */
-let instance;
 
 exports = GeoJSONProvider;

--- a/src/plugin/file/geojson/geojsonprovider.js
+++ b/src/plugin/file/geojson/geojsonprovider.js
@@ -1,26 +1,54 @@
-goog.provide('plugin.file.geojson.GeoJSONProvider');
-goog.require('os.data.FileProvider');
+goog.module('plugin.file.geojson.GeoJSONProvider');
+goog.module.declareLegacyNamespace();
 
+const FileProvider = goog.require('os.data.FileProvider');
 
 
 /**
  * GeoJSON file provider
- *
- * @extends {os.data.FileProvider}
- * @constructor
  */
-plugin.file.geojson.GeoJSONProvider = function() {
-  plugin.file.geojson.GeoJSONProvider.base(this, 'constructor');
-};
-goog.inherits(plugin.file.geojson.GeoJSONProvider, os.data.FileProvider);
-goog.addSingletonGetter(plugin.file.geojson.GeoJSONProvider);
+class GeoJSONProvider extends FileProvider {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
 
+  /**
+   * @inheritDoc
+   */
+  configure(config) {
+    super.configure(config);
+    this.setId('geojson');
+    this.setLabel('GeoJSON Files');
+  }
+
+  /**
+   * Get the global instance.
+   * @return {!GeoJSONProvider}
+   */
+  static getInstance() {
+    if (!instance) {
+      instance = new GeoJSONProvider();
+    }
+
+    return instance;
+  }
+
+  /**
+   * Set the global instance.
+   * @param {GeoJSONProvider} value
+   */
+  static setInstance(value) {
+    instance = value;
+  }
+}
 
 /**
- * @inheritDoc
+ * Global instance.
+ * @type {GeoJSONProvider|undefined}
  */
-plugin.file.geojson.GeoJSONProvider.prototype.configure = function(config) {
-  plugin.file.geojson.GeoJSONProvider.base(this, 'configure', config);
-  this.setId('geojson');
-  this.setLabel('GeoJSON Files');
-};
+let instance;
+
+exports = GeoJSONProvider;

--- a/src/plugin/file/geojson/geojsonsimplestyleparser.js
+++ b/src/plugin/file/geojson/geojsonsimplestyleparser.js
@@ -1,165 +1,169 @@
-goog.provide('plugin.file.geojson.GeoJSONSimpleStyleParser');
-goog.require('goog.Uri');
-goog.require('ol.Feature');
-goog.require('ol.style.Icon');
-goog.require('os.color');
-goog.require('os.im.mapping.time.DateMapping');
-goog.require('os.im.mapping.time.DateTimeMapping');
-goog.require('os.net');
-goog.require('os.style');
-goog.require('os.ui.file.maki');
-goog.require('plugin.file.geojson.GeoJSONParser');
+goog.module('plugin.file.geojson.GeoJSONSimpleStyleParser');
+goog.module.declareLegacyNamespace();
 
+const log = goog.require('goog.log');
+const osColor = goog.require('os.color');
+const osStyle = goog.require('os.style');
+const maki = goog.require('os.ui.file.maki');
+const GeoJSONParser = goog.require('plugin.file.geojson.GeoJSONParser');
+
+const Logger = goog.requireType('goog.log.Logger');
+const Feature = goog.requireType('ol.Feature');
 
 
 /**
  * A GeoJSON parser that supports the custom extensions to the GeoJSON format described in
  * https://github.com/mapbox/simplestyle-spec
  *
- * @extends {plugin.file.geojson.GeoJSONParser<ol.Feature>}
- * @constructor
+ * @extends {GeoJSONParser<Feature>}
  */
-plugin.file.geojson.GeoJSONSimpleStyleParser = function() {
-  plugin.file.geojson.GeoJSONSimpleStyleParser.base(this, 'constructor');
-};
-goog.inherits(plugin.file.geojson.GeoJSONSimpleStyleParser, plugin.file.geojson.GeoJSONParser);
+class GeoJSONSimpleStyleParser extends GeoJSONParser {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  parseNext() {
+    var features = super.parseNext();
+    features.forEach(this.process, this);
+    return features;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  process(feature) {
+    super.process(feature);
+
+    try {
+      // Extract all simplestyle-spec values.
+      // These are not used to style.
+      // var title = feature.get('title') || '';
+      // var description = feature.get('description') || '';
+      var markersize = feature.get('marker-size');
+      // An icon id from the Maki project http://mapbox.com/maki/
+      var markersymbol = feature.get('marker-symbol');
+      // colors can be short #ace or long #aaccee
+      var markercolor = /** @type {string} */ (feature.get('marker-color'));
+      var stroke = /** @type {string} */ (feature.get('stroke'));
+      var strokeopacity = /** @type {number} */ (feature.get('stroke-opacity'));
+      var strokewidth = /** @type {number} */ (feature.get('stroke-width'));
+      var fill = /** @type {string} */ (feature.get('fill'));
+      var fillopacity = /** @type {number} */ (feature.get('fill-opacity'));
+
+      // If there are no simplestyle settings, then this must not be a simple style! Return.
+      if (!(markersize || markersymbol || markercolor ||
+          stroke || strokeopacity || strokewidth ||
+          fill || fillopacity)) {
+        return;
+      }
+
+      var config = {};
+
+      // Convert to RGBA
+      var strokeRGBA = osColor.toRgbArray(stroke);
+      var fillRGBA = osColor.toRgbArray(fill);
+      var markerRGBA = osColor.toRgbArray(markercolor);
+
+      var fillColor;
+      if (fillRGBA) {
+        fillColor = 'rgba(' + fillRGBA[0] + ',' + fillRGBA[1] + ',' + fillRGBA[2] + ',' + fillopacity + ')';
+      }
+
+      var strokeColor;
+      if (strokeRGBA) {
+        strokeColor = 'rgba(' + strokeRGBA[0] + ',' + strokeRGBA[1] + ',' + strokeRGBA[2] + ',' + strokeopacity + ')';
+      }
+
+      // The current polygons do not support using both fill and stroke attributes for color.
+      var foundFill = false;
+
+      // Prefer to use the fill color before the stroke color.
+      if (fillRGBA && 85 != fillRGBA[0] || 85 != fillRGBA[1] || 85 != fillRGBA[2]) {
+        config['fill'] = {
+          'color': fillColor
+        };
+        foundFill = true;
+      }
+
+      // Always safe to set the stroke width.
+      config['stroke'] = {
+        'width': strokewidth
+      };
+
+      // Set the stroke color if you have not set a fill color.
+      if (!foundFill) {
+        config['stroke'] = {
+          'color': strokeColor
+        };
+      }
+
+      // A marker was defined, so set an icon.
+      if (markersymbol && markerRGBA) {
+        var png = markersymbol + '-24.png';
+
+        // Marker symbols can be the integers 1 - 9
+        // The character a - z
+        // Or an icon id from the maki set.
+        if (typeof markersymbol === 'number' || markersymbol.match(/^[a-z0-9]$/)) {
+          png = 'marker-24.png';
+        }
+
+        var scale = .8;
+        if ('medium' === markersize) {
+          scale = .8;
+        } else if ('small' === markersize) {
+          scale = .6;
+        } else if ('large' === markersize) {
+          scale = 1;
+        }
+
+        config['image'] = {
+          'color': 'rgba(' + markerRGBA[0] + ',' + markerRGBA[1] + ',' + markerRGBA[2] + ',1)',
+          'type': 'icon',
+          'anchor': [0.5, 0.5],
+          'scale': scale,
+          'src': maki.ICON_PATH + png
+        };
+        config['zIndex'] = 151;
+      } else {
+        config['image'] = {
+          'color': strokeColor,
+          'stroke': {
+            'color': strokeColor,
+            'width': strokewidth
+          },
+          'fill': {
+            'color': fillColor
+          }
+        };
+      }
+
+      if (this.sourceId) {
+        // merge in the layer config to set anything that wasn't provided by the simplestyle spec
+        var layerConfig = osStyle.StyleManager.getInstance().getLayerConfig(this.sourceId);
+        osStyle.mergeConfig(layerConfig, config);
+      }
+
+      feature.set(osStyle.StyleType.FEATURE, config);
+      osStyle.setFeatureStyle(feature);
+    } catch (e) {
+      log.error(logger, 'Failed to style the feature!', e);
+    }
+  }
+}
 
 
 /**
  * Logger
- * @type {goog.log.Logger}
- * @private
- * @const
+ * @type {Logger}
  */
-plugin.file.geojson.GeoJSONSimpleStyleParser.LOGGER_ =
-    goog.log.getLogger('plugin.file.geojson.GeoJSONSimpleStyleParser');
+const logger = log.getLogger('plugin.file.geojson.GeoJSONSimpleStyleParser');
 
 
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONSimpleStyleParser.prototype.parseNext = function() {
-  var features = plugin.file.geojson.GeoJSONSimpleStyleParser.base(this, 'parseNext');
-  features.forEach(this.process, this);
-  return features;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONSimpleStyleParser.prototype.process = function(feature) {
-  plugin.file.geojson.GeoJSONSimpleStyleParser.base(this, 'process', feature);
-
-  try {
-    // Extract all simplestyle-spec values.
-    // These are not used to style.
-    // var title = feature.get('title') || '';
-    // var description = feature.get('description') || '';
-    var markersize = feature.get('marker-size');
-    // An icon id from the Maki project http://mapbox.com/maki/
-    var markersymbol = feature.get('marker-symbol');
-    // colors can be short #ace or long #aaccee
-    var markercolor = /** @type {string} */ (feature.get('marker-color'));
-    var stroke = /** @type {string} */ (feature.get('stroke'));
-    var strokeopacity = /** @type {number} */ (feature.get('stroke-opacity'));
-    var strokewidth = /** @type {number} */ (feature.get('stroke-width'));
-    var fill = /** @type {string} */ (feature.get('fill'));
-    var fillopacity = /** @type {number} */ (feature.get('fill-opacity'));
-
-    // If there are no simplestyle settings, then this must not be a simple style! Return.
-    if (!(markersize || markersymbol || markercolor || stroke || strokeopacity || strokewidth || fill || fillopacity)) {
-      return;
-    }
-
-    var config = {};
-
-    // Convert to RGBA
-    var strokeRGBA = os.color.toRgbArray(stroke);
-    var fillRGBA = os.color.toRgbArray(fill);
-    var markerRGBA = os.color.toRgbArray(markercolor);
-
-    if (fillRGBA) {
-      var fillColor = 'rgba(' + fillRGBA[0] + ',' + fillRGBA[1] + ',' + fillRGBA[2] + ',' + fillopacity + ')';
-    }
-
-    if (strokeRGBA) {
-      var strokeColor = 'rgba(' + strokeRGBA[0] + ',' + strokeRGBA[1] + ',' + strokeRGBA[2] + ',' + strokeopacity + ')';
-    }
-
-    // The current polygons do not support using both fill and stroke attributes for color.
-    var foundFill = false;
-
-    // Prefer to use the fill color before the stroke color.
-    if (fillRGBA && 85 != fillRGBA[0] || 85 != fillRGBA[1] || 85 != fillRGBA[2]) {
-      config['fill'] = {
-        'color': fillColor
-      };
-      foundFill = true;
-    }
-
-    // Always safe to set the stroke width.
-    config['stroke'] = {
-      'width': strokewidth
-    };
-
-    // Set the stroke color if you have not set a fill color.
-    if (!foundFill) {
-      config['stroke'] = {
-        'color': strokeColor
-      };
-    }
-
-    // A marker was defined, so set an icon.
-    if (markersymbol && markerRGBA) {
-      var png = markersymbol + '-24.png';
-
-      // Marker symbols can be the integers 1 - 9
-      // The character a - z
-      // Or an icon id from the maki set.
-      if (typeof markersymbol === 'number' || markersymbol.match(/^[a-z0-9]$/)) {
-        png = 'marker-24.png';
-      }
-
-      var scale = .8;
-      if ('medium' === markersize) {
-        scale = .8;
-      } else if ('small' === markersize) {
-        scale = .6;
-      } else if ('large' === markersize) {
-        scale = 1;
-      }
-
-      config['image'] = {
-        'color': 'rgba(' + markerRGBA[0] + ',' + markerRGBA[1] + ',' + markerRGBA[2] + ',1)',
-        'type': 'icon',
-        'anchor': [0.5, 0.5],
-        'scale': scale,
-        'src': os.ui.file.maki.ICON_PATH + png
-      };
-      config['zIndex'] = 151;
-    } else {
-      config['image'] = {
-        'color': strokeColor,
-        'stroke': {
-          'color': strokeColor,
-          'width': strokewidth
-        },
-        'fill': {
-          'color': fillColor
-        }
-      };
-    }
-
-    if (this.sourceId) {
-      // merge in the layer config to set anything that wasn't provided by the simplestyle spec
-      var layerConfig = os.style.StyleManager.getInstance().getLayerConfig(this.sourceId);
-      os.style.mergeConfig(layerConfig, config);
-    }
-
-    feature.set(os.style.StyleType.FEATURE, config);
-    os.style.setFeatureStyle(feature);
-  } catch (e) {
-    goog.log.error(plugin.file.geojson.GeoJSONSimpleStyleParser.LOGGER_, 'Failed to style the feature!', e);
-  }
-};
+exports = GeoJSONSimpleStyleParser;

--- a/src/plugin/file/geojson/mime.js
+++ b/src/plugin/file/geojson/mime.js
@@ -1,41 +1,41 @@
-goog.provide('plugin.file.geojson.mime');
+goog.module('plugin.file.geojson.mime');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Promise');
-goog.require('os.file.mime.json');
+const Promise = goog.require('goog.Promise');
+const GeoJSON = goog.require('ol.format.GeoJSON');
+const mime = goog.require('os.file.mime');
+const json = goog.require('os.file.mime.json');
+
 
 /**
- * @const
  * @type {string}
  */
-plugin.file.geojson.mime.TYPE = 'application/vnd.geo+json';
-
+const TYPE = 'application/vnd.geo+json';
 
 /**
  * @param {ArrayBuffer} buffer
  * @param {os.file.File=} opt_file
  * @param {*=} opt_context
- * @return {!goog.Promise<*|undefined>}
+ * @return {!Promise<*|undefined>}
  */
-plugin.file.geojson.mime.isGeoJSON = function(buffer, opt_file, opt_context) {
+const isGeoJSON = function(buffer, opt_file, opt_context) {
   var retVal;
 
-  if (opt_context && plugin.file.geojson.mime.find_(/** @type {Object|null} */ (opt_context))) {
+  if (opt_context && find_(/** @type {Object|null} */ (opt_context))) {
     retVal = opt_context;
   }
 
-  return goog.Promise.resolve(retVal);
+  return Promise.resolve(retVal);
 };
-
 
 /**
  * @param {Array|Object} obj
  * @return {boolean}
- * @private
  * @suppress {accessControls}
  */
-plugin.file.geojson.mime.find_ = function(obj) {
+const find_ = function(obj) {
   var type = obj['type'];
-  if (type === 'FeatureCollection' || type === 'Feature' || type in ol.format.GeoJSON.GEOMETRY_READERS_) {
+  if (type === 'FeatureCollection' || type === 'Feature' || type in GeoJSON.GEOMETRY_READERS_) {
     return true;
   }
 
@@ -43,7 +43,7 @@ plugin.file.geojson.mime.find_ = function(obj) {
     if (obj.hasOwnProperty(key)) {
       var val = obj[key];
       if (goog.isObject(val) || Array.isArray(val)) {
-        var retVal = plugin.file.geojson.mime.find_(val);
+        var retVal = find_(val);
         if (retVal) {
           return retVal;
         }
@@ -55,4 +55,9 @@ plugin.file.geojson.mime.find_ = function(obj) {
 };
 
 
-os.file.mime.register(plugin.file.geojson.mime.TYPE, plugin.file.geojson.mime.isGeoJSON, 0, os.file.mime.json.TYPE);
+mime.register(TYPE, isGeoJSON, 0, json.TYPE);
+
+exports = {
+  TYPE,
+  isGeoJSON
+};

--- a/src/plugin/file/geojsonparserconfig.js
+++ b/src/plugin/file/geojsonparserconfig.js
@@ -1,38 +1,42 @@
-goog.provide('plugin.file.geojson.GeoJSONParserConfig');
-goog.require('os.parse.FileParserConfig');
-goog.require('os.ui.im.ImportManager');
-goog.require('os.ui.slick.column');
+goog.module('plugin.file.geojson.GeoJSONParserConfig');
+goog.module.declareLegacyNamespace();
 
+const FileParserConfig = goog.require('os.parse.FileParserConfig');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const osUiSlickColumn = goog.require('os.ui.slick.column');
 
 
 /**
  * Configuration for a GeoJSON parser.
- *
- * @extends {os.parse.FileParserConfig}
- * @constructor
+ * @unrestricted
  */
-plugin.file.geojson.GeoJSONParserConfig = function() {
-  plugin.file.geojson.GeoJSONParserConfig.base(this, 'constructor');
-};
-goog.inherits(plugin.file.geojson.GeoJSONParserConfig, os.parse.FileParserConfig);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.geojson.GeoJSONParserConfig.prototype.updatePreview = function(opt_mappings) {
-  var im = os.ui.im.ImportManager.getInstance();
-  var parser = /** @type {plugin.file.geojson.GeoJSONParser} */ (im.getParser('geojson'));
-  var features = parser.parsePreview(this['file'].getContent(), opt_mappings);
-
-  this['preview'] = features || [];
-  this['columns'] = parser.getColumns() || [];
-
-  for (var i = 0, n = this['columns'].length; i < n; i++) {
-    var column = this['columns'][i];
-    column['width'] = 0;
-    os.ui.slick.column.autoSizeColumn(column);
+class GeoJSONParserConfig extends FileParserConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
 
-  parser.dispose();
-};
+  /**
+   * @inheritDoc
+   */
+  updatePreview(opt_mappings) {
+    var im = ImportManager.getInstance();
+    var parser = /** @type {plugin.file.geojson.GeoJSONParser} */ (im.getParser('geojson'));
+    var features = parser.parsePreview(this['file'].getContent(), opt_mappings);
+
+    this['preview'] = features || [];
+    this['columns'] = parser.getColumns() || [];
+
+    for (var i = 0, n = this['columns'].length; i < n; i++) {
+      var column = this['columns'][i];
+      column['width'] = 0;
+      osUiSlickColumn.autoSizeColumn(column);
+    }
+
+    parser.dispose();
+  }
+}
+
+exports = GeoJSONParserConfig;

--- a/src/plugin/file/gml/gmldescriptor.js
+++ b/src/plugin/file/gml/gmldescriptor.js
@@ -1,56 +1,44 @@
-goog.provide('plugin.file.gml.GMLDescriptor');
-goog.require('os.data.FileDescriptor');
-goog.require('os.layer.LayerType');
-goog.require('plugin.file.gml.GMLParserConfig');
-goog.require('plugin.file.gml.GMLProvider');
+goog.module('plugin.file.gml.GMLDescriptor');
+goog.module.declareLegacyNamespace();
 
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const layer = goog.require('os.layer');
+const LayerType = goog.require('os.layer.LayerType');
+const GMLParserConfig = goog.require('plugin.file.gml.GMLParserConfig');
 
 
 /**
  * GML file descriptor.
- *
- * @param {plugin.file.gml.GMLParserConfig=} opt_config
- * @extends {os.data.FileDescriptor}
- * @constructor
  */
-plugin.file.gml.GMLDescriptor = function(opt_config) {
-  plugin.file.gml.GMLDescriptor.base(this, 'constructor');
-  this.descriptorType = 'gml';
-  this.parserConfig = opt_config || new plugin.file.gml.GMLParserConfig();
-};
-goog.inherits(plugin.file.gml.GMLDescriptor, os.data.FileDescriptor);
+class GMLDescriptor extends FileDescriptor {
+  /**
+   * Constructor.
+   * @param {GMLParserConfig=} opt_config
+   */
+  constructor(opt_config) {
+    super();
+    this.descriptorType = 'gml';
+    this.parserConfig = opt_config || new GMLParserConfig();
+  }
 
+  /**
+   * @inheritDoc
+   */
+  getType() {
+    return LayerType.FEATURES;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.gml.GMLDescriptor.prototype.getType = function() {
-  return os.layer.LayerType.FEATURES;
-};
+  /**
+   * @inheritDoc
+   */
+  getLayerOptions() {
+    var options = super.getLayerOptions();
+    options['type'] = 'GML';
 
+    // show the option to replace feature colors with the layer color
+    options[layer.LayerOption.SHOW_FORCE_COLOR] = true;
+    return options;
+  }
+}
 
-/**
- * @inheritDoc
- */
-plugin.file.gml.GMLDescriptor.prototype.getLayerOptions = function() {
-  var options = plugin.file.gml.GMLDescriptor.base(this, 'getLayerOptions');
-  options['type'] = 'GML';
-
-  // show the option to replace feature colors with the layer color
-  options[os.layer.LayerOption.SHOW_FORCE_COLOR] = true;
-  return options;
-};
-
-
-/**
- * Creates a new descriptor from a parser configuration.
- *
- * @param {!plugin.file.gml.GMLParserConfig} config
- * @return {!plugin.file.gml.GMLDescriptor}
- */
-plugin.file.gml.GMLDescriptor.createFromConfig = function(config) {
-  var provider = plugin.file.gml.GMLProvider.getInstance();
-  var descriptor = new plugin.file.gml.GMLDescriptor(config);
-  os.data.FileDescriptor.createFromConfig(descriptor, provider, config);
-  return descriptor;
-};
+exports = GMLDescriptor;

--- a/src/plugin/file/gml/gmlimport.js
+++ b/src/plugin/file/gml/gmlimport.js
@@ -1,12 +1,13 @@
-goog.provide('plugin.file.gml.GMLImportCtrl');
-goog.provide('plugin.file.gml.gmlImportDirective');
+goog.module('plugin.file.gml.GMLImport');
+goog.module.declareLegacyNamespace();
 
-goog.require('os');
-goog.require('os.ui.Module');
-goog.require('os.ui.file.ui.AbstractFileImportCtrl');
-goog.require('plugin.file.gml.GMLDescriptor');
-goog.require('plugin.file.gml.GMLParserConfig');
-goog.require('plugin.file.gml.GMLProvider');
+const {ROOT} = goog.require('os');
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const Module = goog.require('os.ui.Module');
+const AbstractFileImportCtrl = goog.require('os.ui.file.ui.AbstractFileImportCtrl');
+const GMLDescriptor = goog.require('plugin.file.gml.GMLDescriptor');
+const GMLProvider = goog.require('plugin.file.gml.GMLProvider');
+const GMLParserConfig = goog.requireType('plugin.file.gml.GMLParserConfig');
 
 
 /**
@@ -14,61 +15,74 @@ goog.require('plugin.file.gml.GMLProvider');
  *
  * @return {angular.Directive}
  */
-plugin.file.gml.gmlImportDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    scope: true,
-    templateUrl: os.ROOT + 'views/file/genericfileimport.html',
-    controller: plugin.file.gml.GMLImportCtrl,
-    controllerAs: 'ctrl'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  scope: true,
+  templateUrl: ROOT + 'views/file/genericfileimport.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'gmlimport';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('gmlimport', [plugin.file.gml.gmlImportDirective]);
+Module.directive('gmlimport', [directive]);
 
 
 
 /**
  * Controller for the GML import dialog
  *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @extends {os.ui.file.ui.AbstractFileImportCtrl<!plugin.file.gml.GMLParserConfig,!plugin.file.gml.GMLDescriptor>}
- * @constructor
- * @ngInject
+ * @extends {AbstractFileImportCtrl<!GMLParserConfig,!GMLDescriptor>}
+ * @unrestricted
  */
-plugin.file.gml.GMLImportCtrl = function($scope, $element) {
-  plugin.file.gml.GMLImportCtrl.base(this, 'constructor', $scope, $element);
-};
-goog.inherits(plugin.file.gml.GMLImportCtrl, os.ui.file.ui.AbstractFileImportCtrl);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.gml.GMLImportCtrl.prototype.createDescriptor = function() {
-  var descriptor = null;
-  if (this.config['descriptor']) {
-    // existing descriptor, update it
-    descriptor = /** @type {!plugin.file.gml.GMLDescriptor} */ (this.config['descriptor']);
-    descriptor.updateFromConfig(this.config);
-  } else {
-    // this is a new import
-    descriptor = plugin.file.gml.GMLDescriptor.createFromConfig(this.config);
+class Controller extends AbstractFileImportCtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    super($scope, $element);
   }
 
-  return descriptor;
-};
+  /**
+   * @inheritDoc
+   */
+  createDescriptor() {
+    var descriptor = null;
+    if (this.config['descriptor']) {
+      // existing descriptor, update it
+      descriptor = /** @type {!GMLDescriptor} */ (this.config['descriptor']);
+      descriptor.updateFromConfig(this.config);
+    } else {
+      // this is a new import
+      descriptor = new GMLDescriptor(this.config);
+      FileDescriptor.createFromConfig(descriptor, GMLProvider.getInstance(), this.config);
+    }
 
+    return descriptor;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.gml.GMLImportCtrl.prototype.getProvider = function() {
-  return plugin.file.gml.GMLProvider.getInstance();
+  /**
+   * @inheritDoc
+   */
+  getProvider() {
+    return GMLProvider.getInstance();
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/file/gml/gmlimportui.js
+++ b/src/plugin/file/gml/gmlimportui.js
@@ -1,62 +1,64 @@
-goog.provide('plugin.file.gml.GMLImportUI');
-goog.require('os.ui.im.FileImportUI');
-goog.require('os.ui.window');
-goog.require('os.ui.wiz.OptionsStep');
-goog.require('os.ui.wiz.step.TimeStep');
-goog.require('plugin.file.gml.GMLParserConfig');
-goog.require('plugin.file.gml.gmlImportDirective');
+goog.module('plugin.file.gml.GMLImportUI');
+goog.module.declareLegacyNamespace();
 
-
-
-/**
- * @extends {os.ui.im.FileImportUI.<plugin.file.gml.GMLParserConfig>}
- * @constructor
- */
-plugin.file.gml.GMLImportUI = function() {
-  plugin.file.gml.GMLImportUI.base(this, 'constructor');
-};
-goog.inherits(plugin.file.gml.GMLImportUI, os.ui.im.FileImportUI);
+const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const osWindow = goog.require('os.ui.window');
+const {directiveTag: gmlImportUi} = goog.require('plugin.file.gml.GMLImport');
+const GMLParserConfig = goog.require('plugin.file.gml.GMLParserConfig');
 
 
 /**
- * @inheritDoc
+ * @extends {FileImportUI.<GMLParserConfig>}
  */
-plugin.file.gml.GMLImportUI.prototype.getTitle = function() {
-  return 'GML';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.gml.GMLImportUI.prototype.launchUI = function(file, opt_config) {
-  plugin.file.gml.GMLImportUI.base(this, 'launchUI', file, opt_config);
-
-  var config = new plugin.file.gml.GMLParserConfig();
-
-  // if an existing config was provided, merge it in
-  if (opt_config) {
-    this.mergeConfig(opt_config, config);
+class GMLImportUI extends FileImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
 
-  config['file'] = file;
-  config['title'] = file.getFileName();
+  /**
+   * @inheritDoc
+   */
+  getTitle() {
+    return 'GML';
+  }
 
-  var scopeOptions = {
-    'config': config
-  };
-  var windowOptions = {
-    'label': 'Import GML',
-    'icon': 'fa fa-file-text',
-    'x': 'center',
-    'y': 'center',
-    'width': 400,
-    'min-width': 400,
-    'max-width': 800,
-    'height': 'auto',
-    'modal': true,
-    'show-close': true
-  };
-  var template = '<gmlimport></gmlimport>';
-  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
-};
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    super.launchUI(file, opt_config);
+
+    var config = new GMLParserConfig();
+
+    // if an existing config was provided, merge it in
+    if (opt_config) {
+      this.mergeConfig(opt_config, config);
+    }
+
+    config['file'] = file;
+    config['title'] = file.getFileName();
+
+    var scopeOptions = {
+      'config': config
+    };
+    var windowOptions = {
+      'label': 'Import GML',
+      'icon': 'fa fa-file-text',
+      'x': 'center',
+      'y': 'center',
+      'width': 400,
+      'min-width': 400,
+      'max-width': 800,
+      'height': 'auto',
+      'modal': true,
+      'show-close': true
+    };
+    var template = `<${gmlImportUi}></${gmlImportUi}>`;
+    osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+  }
+}
+
+exports = GMLImportUI;

--- a/src/plugin/file/gml/gmllayerconfig.js
+++ b/src/plugin/file/gml/gmllayerconfig.js
@@ -1,61 +1,68 @@
-goog.provide('plugin.file.gml.GMLLayerConfig');
-goog.require('os.layer.config.AbstractDataSourceLayerConfig');
-goog.require('os.ui.im.ImportManager');
-goog.require('plugin.file.gml.GMLParser');
-goog.require('plugin.file.gml.GMLParserConfig');
+goog.module('plugin.file.gml.GMLLayerConfig');
+goog.module.declareLegacyNamespace();
 
+const AltMapping = goog.require('os.im.mapping.AltMapping');
+const OrientationMapping = goog.require('os.im.mapping.OrientationMapping');
+const SemiMajorMapping = goog.require('os.im.mapping.SemiMajorMapping');
+const SemiMinorMapping = goog.require('os.im.mapping.SemiMinorMapping');
+const DateTimeMapping = goog.require('os.im.mapping.time.DateTimeMapping');
+
+const AbstractDataSourceLayerConfig = goog.require('os.layer.config.AbstractDataSourceLayerConfig');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const GMLParserConfig = goog.require('plugin.file.gml.GMLParserConfig');
 
 
 /**
- * @extends {os.layer.config.AbstractDataSourceLayerConfig}
- * @constructor
  */
-plugin.file.gml.GMLLayerConfig = function() {
-  plugin.file.gml.GMLLayerConfig.base(this, 'constructor');
+class GMLLayerConfig extends AbstractDataSourceLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    /**
+     * @type {os.parse.FileParserConfig}
+     * @protected
+     */
+    this.parserConfig = new GMLParserConfig();
+  }
 
   /**
-   * @type {os.parse.FileParserConfig}
-   * @protected
+   * @inheritDoc
    */
-  this.parserConfig = new plugin.file.gml.GMLParserConfig();
-};
-goog.inherits(plugin.file.gml.GMLLayerConfig, os.layer.config.AbstractDataSourceLayerConfig);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.gml.GMLLayerConfig.prototype.initializeConfig = function(options) {
-  plugin.file.gml.GMLLayerConfig.base(this, 'initializeConfig', options);
-  this.parserConfig = options['parserConfig'] || new plugin.file.gml.GMLParserConfig();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.gml.GMLLayerConfig.prototype.getImporter = function(options) {
-  var importer = plugin.file.gml.GMLLayerConfig.base(this, 'getImporter', options);
-  if (this.parserConfig['mappings'] != null && this.parserConfig['mappings'].length) {
-    // setAutoMappings() ignores manual configs (e.g. custom Datetime format) since it re-autodetects
-    importer.setExecMappings(this.parserConfig['mappings']);
-  } else {
-    // there was no user interaction, so default the mappings to a set the importer would have used
-    importer.selectAutoMappings([
-      os.im.mapping.AltMapping.ID,
-      os.im.mapping.OrientationMapping.ID,
-      os.im.mapping.SemiMajorMapping.ID,
-      os.im.mapping.SemiMinorMapping.ID,
-      os.im.mapping.time.DateTimeMapping.ID]);
+  initializeConfig(options) {
+    super.initializeConfig(options);
+    this.parserConfig = options['parserConfig'] || new GMLParserConfig();
   }
-  return importer;
-};
 
+  /**
+   * @inheritDoc
+   */
+  getImporter(options) {
+    var importer = super.getImporter(options);
+    if (this.parserConfig['mappings'] != null && this.parserConfig['mappings'].length) {
+      // setAutoMappings() ignores manual configs (e.g. custom Datetime format) since it re-autodetects
+      importer.setExecMappings(this.parserConfig['mappings']);
+    } else {
+      // there was no user interaction, so default the mappings to a set the importer would have used
+      importer.selectAutoMappings([
+        AltMapping.ID,
+        OrientationMapping.ID,
+        SemiMajorMapping.ID,
+        SemiMinorMapping.ID,
+        DateTimeMapping.ID]);
+    }
+    return importer;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.gml.GMLLayerConfig.prototype.getParser = function(options) {
-  var im = os.ui.im.ImportManager.getInstance();
-  return im.getParser('gml');
-};
+  /**
+   * @inheritDoc
+   */
+  getParser(options) {
+    var im = ImportManager.getInstance();
+    return im.getParser('gml');
+  }
+}
+
+exports = GMLLayerConfig;

--- a/src/plugin/file/gml/gmlmixin.js
+++ b/src/plugin/file/gml/gmlmixin.js
@@ -1,20 +1,45 @@
-goog.provide('plugin.file.gml.GMLMixin');
+goog.module('plugin.file.gml.GMLMixin');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.format.GMLBase');
+const dom = goog.require('goog.dom');
+
+const GMLBase = goog.require('ol.format.GMLBase');
+
+const olProj = goog.require('ol.proj');
+
+const Projection = goog.requireType('ol.proj.Projection');
 
 
 /**
- * The OL3 GML format does not correctly read srsName values from older WFS responses, so we've
- * overridden it here.
- *
- * @param {Node} node
- * @suppress {accessControls|duplicate}
- * @return {ol.proj.Projection}
- * @override
+ * If the mixin has been initialized.
+ * @type {boolean}
  */
-ol.format.GMLBase.prototype.readProjectionFromNode = function(node) {
-  var attr = 'srsName';
-  return ol.proj.get(this.srsName ||
-      goog.dom.getFirstElementChild(node).getAttribute(attr) ||
-      node.querySelector('[' + attr + ']').getAttribute(attr));
+let initialized = false;
+
+
+/**
+ * Initialize the mixin.
+ */
+const init = () => {
+  if (!initialized) {
+    initialized = true;
+
+    /**
+     * The OL GML format does not correctly read srsName values from older WFS responses, so we've
+     * overridden it here.
+     *
+     * @param {Node} node
+     * @suppress {accessControls|duplicate}
+     * @return {Projection}
+     * @override
+     */
+    GMLBase.prototype.readProjectionFromNode = function(node) {
+      var attr = 'srsName';
+      return olProj.get(this.srsName ||
+          dom.getFirstElementChild(node).getAttribute(attr) ||
+          node.querySelector('[' + attr + ']').getAttribute(attr));
+    };
+  }
 };
+
+exports = {init};

--- a/src/plugin/file/gml/gmlparser.js
+++ b/src/plugin/file/gml/gmlparser.js
@@ -1,22 +1,131 @@
-goog.provide('plugin.file.gml.GMLParser');
+goog.module('plugin.file.gml.GMLParser');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.log');
-goog.require('ol.format.GML2');
-goog.require('ol.format.GML3');
-goog.require('os.data.ColumnDefinition');
-goog.require('os.parse.IParser');
-goog.require('os.ui.file.gml.GMLParser');
+const ol = goog.require('ol');
+const Fields = goog.require('os.Fields');
 
+const ColumnDefinition = goog.require('os.data.ColumnDefinition');
+const RecordField = goog.require('os.data.RecordField');
+const osFeature = goog.require('os.feature');
+const osMap = goog.require('os.map');
+const BaseGMLParser = goog.require('os.ui.file.gml.GMLParser');
+
+const Feature = goog.requireType('ol.Feature');
+const Projection = goog.requireType('ol.proj.Projection');
+const IMapping = goog.requireType('os.im.mapping.IMapping');
 
 
 /**
- * @extends {os.ui.file.gml.GMLParser}
- * @constructor
  */
-plugin.file.gml.GMLParser = function() {
-  plugin.file.gml.GMLParser.base(this, 'constructor');
-};
-goog.inherits(plugin.file.gml.GMLParser, os.ui.file.gml.GMLParser);
+class GMLParser extends BaseGMLParser {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    /**
+     * Array of column definitions.
+     * @type {Array<!ColumnDefinition>}
+     */
+    this.columns_ = null;
+
+    /**
+     * Map of column field to the column definition.
+     * @type {Object<string, !ColumnDefinition>}
+     * @private
+     */
+    this.columnMap_ = null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getProjection() {
+    return /** @type {!Projection} */ (osMap.PROJECTION);
+  }
+
+  /**
+   * dispose
+   */
+  dispose() {
+    this.cleanup();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  cleanup() {
+    this.features = null;
+    this.nextIndex = 0;
+  }
+
+  /**
+   * Parse a limited set of results from the source
+   *
+   * @param {Object|null|string} source
+   * @param {Array<IMapping>=} opt_mappings The set of mappings to apply to parsed features
+   * @return {!Array<!Feature>}
+   */
+  parsePreview(source, opt_mappings) {
+    this.setSource(source);
+    var count = 25;
+    var features = [];
+    this.columnMap_ = {};
+
+    while (this.hasNext() && count--) {
+      var featureSet = this.parseNext();
+
+      if (Array.isArray(featureSet)) {
+        for (var i = 0, n = featureSet.length; i < n; i++) {
+          var feature = featureSet[i];
+          feature.setId(String(ol.getUid(feature)));
+          features.push(feature);
+        }
+      }
+
+      var keys = feature.getKeys();
+      for (i = 0, n = keys.length; i < n; i++) {
+        var field = keys[i];
+
+        if (field && !osFeature.isInternalField(field) && !(field in this.columnMap_)) {
+          var col = new ColumnDefinition(field);
+          col['selectable'] = true;
+          col['sortable'] = true;
+
+          this.columnMap_[field] = col;
+        }
+      }
+    }
+
+    return features;
+  }
+
+  /**
+   * Get columns detected in the GML
+   *
+   * @return {Array<!ColumnDefinition>}
+   */
+  getColumns() {
+    if (!this.columns_ && this.columnMap_) {
+      // translate the column map into slickgrid columns
+      this.columns_ = [];
+
+      for (var column in this.columnMap_) {
+        if (column === RecordField.TIME) {
+          // display the recordTime field as TIME
+          this.columns_.push(new ColumnDefinition(Fields.TIME, RecordField.TIME));
+        } else if (!GMLParser.SKIPPED_COLUMNS_.test(column)) {
+          this.columns_.push(new ColumnDefinition(column));
+        }
+      }
+
+      this.columnMap_ = null;
+    }
+
+    return this.columns_;
+  }
+}
 
 
 /**
@@ -25,97 +134,7 @@ goog.inherits(plugin.file.gml.GMLParser, os.ui.file.gml.GMLParser);
  * @private
  * @const
  */
-plugin.file.gml.GMLParser.SKIPPED_COLUMNS_ = /^(geometry|recordtime|time|styleurl)$/i;
+GMLParser.SKIPPED_COLUMNS_ = /^(geometry|recordtime|time|styleurl)$/i;
 
 
-/**
- * @inheritDoc
- */
-plugin.file.gml.GMLParser.prototype.getProjection = function() {
-  return /** @type {!ol.proj.Projection} */ (os.map.PROJECTION);
-};
-
-
-/**
- * dispose
- */
-plugin.file.gml.GMLParser.prototype.dispose = function() {
-  this.cleanup();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.gml.GMLParser.prototype.cleanup = function() {
-  this.features = null;
-  this.nextIndex = 0;
-};
-
-
-/**
- * Parse a limited set of results from the source
- *
- * @param {Object|null|string} source
- * @param {Array<os.im.mapping.IMapping>=} opt_mappings The set of mappings to apply to parsed features
- * @return {!Array<!ol.Feature>}
- */
-plugin.file.gml.GMLParser.prototype.parsePreview = function(source, opt_mappings) {
-  this.setSource(source);
-  var count = 25;
-  var features = [];
-  this.columns_ = {};
-
-  while (this.hasNext() && count--) {
-    var featureSet = this.parseNext();
-
-    if (Array.isArray(featureSet)) {
-      for (var i = 0, n = featureSet.length; i < n; i++) {
-        var feature = featureSet[i];
-        feature.setId(String(ol.getUid(feature)));
-        features.push(feature);
-      }
-    }
-
-    var keys = feature.getKeys();
-    for (i = 0, n = keys.length; i < n; i++) {
-      var field = keys[i];
-
-      if (field && !os.feature.isInternalField(field) && !(field in this.columns_)) {
-        var col = new os.data.ColumnDefinition(field);
-        col['selectable'] = true;
-        col['sortable'] = true;
-
-        this.columns_[field] = col;
-      }
-    }
-  }
-
-  return features;
-};
-
-
-/**
- * Get columns detected in the GML
- *
- * @return {Array<!os.data.ColumnDefinition>}
- */
-plugin.file.gml.GMLParser.prototype.getColumns = function() {
-  if (!this.columns_ && this.columnMap_) {
-    // translate the column map into slickgrid columns
-    this.columns_ = [];
-
-    for (var column in this.columnMap_) {
-      if (column === os.data.RecordField.TIME) {
-        // display the recordTime field as TIME
-        this.columns_.push(new os.data.ColumnDefinition(os.Fields.TIME, os.data.RecordField.TIME));
-      } else if (!plugin.file.gml.GMLParser.SKIPPED_COLUMNS_.test(column)) {
-        this.columns_.push(new os.data.ColumnDefinition(column));
-      }
-    }
-
-    this.columnMap_ = null;
-  }
-
-  return this.columns_;
-};
+exports = GMLParser;

--- a/src/plugin/file/gml/gmlparserconfig.js
+++ b/src/plugin/file/gml/gmlparserconfig.js
@@ -1,38 +1,42 @@
-goog.provide('plugin.file.gml.GMLParserConfig');
-goog.require('os.parse.FileParserConfig');
-goog.require('os.ui.im.ImportManager');
-goog.require('os.ui.slick.column');
+goog.module('plugin.file.gml.GMLParserConfig');
+goog.module.declareLegacyNamespace();
 
+const FileParserConfig = goog.require('os.parse.FileParserConfig');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const osUiSlickColumn = goog.require('os.ui.slick.column');
 
 
 /**
  * Configuration for a GML parser.
- *
- * @extends {os.parse.FileParserConfig}
- * @constructor
+ * @unrestricted
  */
-plugin.file.gml.GMLParserConfig = function() {
-  plugin.file.gml.GMLParserConfig.base(this, 'constructor');
-};
-goog.inherits(plugin.file.gml.GMLParserConfig, os.parse.FileParserConfig);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.gml.GMLParserConfig.prototype.updatePreview = function(opt_mappings) {
-  var im = os.ui.im.ImportManager.getInstance();
-  var parser = /** @type {plugin.file.gml.GMLParser} */ (im.getParser('gml'));
-  var features = parser.parsePreview(this['file'].getContent(), opt_mappings);
-
-  this['preview'] = features || [];
-  this['columns'] = parser.getColumns() || [];
-
-  for (var i = 0, n = this['columns'].length; i < n; i++) {
-    var column = this['columns'][i];
-    column['width'] = 0;
-    os.ui.slick.column.autoSizeColumn(column);
+class GMLParserConfig extends FileParserConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
 
-  parser.dispose();
-};
+  /**
+   * @inheritDoc
+   */
+  updatePreview(opt_mappings) {
+    var im = ImportManager.getInstance();
+    var parser = /** @type {plugin.file.gml.GMLParser} */ (im.getParser('gml'));
+    var features = parser.parsePreview(this['file'].getContent(), opt_mappings);
+
+    this['preview'] = features || [];
+    this['columns'] = parser.getColumns() || [];
+
+    for (var i = 0, n = this['columns'].length; i < n; i++) {
+      var column = this['columns'][i];
+      column['width'] = 0;
+      osUiSlickColumn.autoSizeColumn(column);
+    }
+
+    parser.dispose();
+  }
+}
+
+exports = GMLParserConfig;

--- a/src/plugin/file/gml/gmlplugin.js
+++ b/src/plugin/file/gml/gmlplugin.js
@@ -1,70 +1,71 @@
-goog.provide('plugin.file.gml.GMLPlugin');
+goog.module('plugin.file.gml.GMLPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.DataManager');
-goog.require('os.data.ProviderEntry');
-goog.require('os.layer.config.LayerConfigManager');
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.ui.im.ImportManager');
-goog.require('plugin.file.gml.GMLDescriptor');
-goog.require('plugin.file.gml.GMLImportUI');
-goog.require('plugin.file.gml.GMLLayerConfig');
-goog.require('plugin.file.gml.GMLMixin');
-goog.require('plugin.file.gml.GMLParser');
-goog.require('plugin.file.gml.GMLProvider');
-goog.require('plugin.file.gml.mime');
+const DataManager = goog.require('os.data.DataManager');
+const ProviderEntry = goog.require('os.data.ProviderEntry');
+const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const GMLDescriptor = goog.require('plugin.file.gml.GMLDescriptor');
+const GMLImportUI = goog.require('plugin.file.gml.GMLImportUI');
+const GMLLayerConfig = goog.require('plugin.file.gml.GMLLayerConfig');
+const GMLMixin = goog.require('plugin.file.gml.GMLMixin');
+const GMLParser = goog.require('plugin.file.gml.GMLParser');
+const GMLProvider = goog.require('plugin.file.gml.GMLProvider');
+const mime = goog.require('plugin.file.gml.mime');
 
+
+// Initialize the GML mixin.
+GMLMixin.init();
 
 
 /**
  * Provides GML support
- *
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.file.gml.GMLPlugin = function() {
-  plugin.file.gml.GMLPlugin.base(this, 'constructor');
-  this.id = plugin.file.gml.GMLPlugin.ID;
-};
-goog.inherits(plugin.file.gml.GMLPlugin, os.plugin.AbstractPlugin);
+class GMLPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = ID;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    const dm = DataManager.getInstance();
+
+    // register gml provider type
+    dm.registerProviderType(new ProviderEntry(ID, GMLProvider, TYPE, TYPE));
+
+    // register the gml descriptor type
+    dm.registerDescriptorType(this.id, GMLDescriptor);
+
+    // register the gml layer config
+    const lcm = LayerConfigManager.getInstance();
+    lcm.registerLayerConfig(this.id, GMLLayerConfig);
+
+    // register the gml import ui
+    const im = ImportManager.getInstance();
+    im.registerImportDetails(this.id.toUpperCase(), true);
+    im.registerImportUI(mime.TYPE, new GMLImportUI());
+    im.registerParser(this.id, GMLParser);
+  }
+}
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.gml.GMLPlugin.ID = 'gml';
+const ID = 'gml';
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.gml.GMLPlugin.TYPE = 'GML Layers';
+const TYPE = 'GML Layers';
 
 
-/**
- * @inheritDoc
- */
-plugin.file.gml.GMLPlugin.prototype.init = function() {
-  var dm = os.dataManager;
-
-  // register gml provider type
-  dm.registerProviderType(new os.data.ProviderEntry(
-      plugin.file.gml.GMLPlugin.ID,
-      plugin.file.gml.GMLProvider,
-      plugin.file.gml.GMLPlugin.TYPE,
-      plugin.file.gml.GMLPlugin.TYPE));
-
-  // register the gml descriptor type
-  dm.registerDescriptorType(this.id, plugin.file.gml.GMLDescriptor);
-
-  // register the gml layer config
-  var lcm = os.layer.config.LayerConfigManager.getInstance();
-  lcm.registerLayerConfig(this.id, plugin.file.gml.GMLLayerConfig);
-
-  // register the gml import ui
-  var im = os.ui.im.ImportManager.getInstance();
-  im.registerImportDetails(this.id.toUpperCase(), true);
-  im.registerImportUI(plugin.file.gml.mime.TYPE, new plugin.file.gml.GMLImportUI());
-  im.registerParser(this.id, plugin.file.gml.GMLParser);
-};
+exports = GMLPlugin;

--- a/src/plugin/file/gml/gmlprovider.js
+++ b/src/plugin/file/gml/gmlprovider.js
@@ -1,26 +1,54 @@
-goog.provide('plugin.file.gml.GMLProvider');
-goog.require('os.data.FileProvider');
+goog.module('plugin.file.gml.GMLProvider');
+goog.module.declareLegacyNamespace();
 
+const FileProvider = goog.require('os.data.FileProvider');
 
 
 /**
  * GML file provider
- *
- * @extends {os.data.FileProvider}
- * @constructor
  */
-plugin.file.gml.GMLProvider = function() {
-  plugin.file.gml.GMLProvider.base(this, 'constructor');
-};
-goog.inherits(plugin.file.gml.GMLProvider, os.data.FileProvider);
-goog.addSingletonGetter(plugin.file.gml.GMLProvider);
+class GMLProvider extends FileProvider {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
 
+  /**
+   * @inheritDoc
+   */
+  configure(config) {
+    super.configure(config);
+    this.setId('gml');
+    this.setLabel('GML Files');
+  }
+
+  /**
+   * Get the global instance.
+   * @return {!GMLProvider}
+   */
+  static getInstance() {
+    if (!instance) {
+      instance = new GMLProvider();
+    }
+
+    return instance;
+  }
+
+  /**
+   * Set the global instance.
+   * @param {GMLProvider} value
+   */
+  static setInstance(value) {
+    instance = value;
+  }
+}
 
 /**
- * @inheritDoc
+ * Global instance.
+ * @type {GMLProvider|undefined}
  */
-plugin.file.gml.GMLProvider.prototype.configure = function(config) {
-  plugin.file.gml.GMLProvider.base(this, 'configure', config);
-  this.setId('gml');
-  this.setLabel('GML Files');
-};
+let instance;
+
+exports = GMLProvider;

--- a/src/plugin/file/gml/gmlprovider.js
+++ b/src/plugin/file/gml/gmlprovider.js
@@ -23,32 +23,8 @@ class GMLProvider extends FileProvider {
     this.setId('gml');
     this.setLabel('GML Files');
   }
-
-  /**
-   * Get the global instance.
-   * @return {!GMLProvider}
-   */
-  static getInstance() {
-    if (!instance) {
-      instance = new GMLProvider();
-    }
-
-    return instance;
-  }
-
-  /**
-   * Set the global instance.
-   * @param {GMLProvider} value
-   */
-  static setInstance(value) {
-    instance = value;
-  }
 }
+goog.addSingletonGetter(GMLProvider);
 
-/**
- * Global instance.
- * @type {GMLProvider|undefined}
- */
-let instance;
 
 exports = GMLProvider;

--- a/src/plugin/file/gml/mime.js
+++ b/src/plugin/file/gml/mime.js
@@ -1,14 +1,21 @@
-goog.provide('plugin.file.gml.mime');
+goog.module('plugin.file.gml.mime');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.file.mime.xml');
+const mime = goog.require('os.file.mime');
+
+const xml = goog.require('os.file.mime.xml');
+
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.gml.mime.TYPE = 'application/gml+xml';
+const TYPE = 'application/gml+xml';
 
-os.file.mime.register(
-    plugin.file.gml.mime.TYPE,
-    os.file.mime.xml.createDetect(/^(gml|featurecollection)$/i, /\/(gml|wfs)/i),
-    0, os.file.mime.xml.TYPE);
+mime.register(
+    TYPE,
+    xml.createDetect(/^(gml|featurecollection)$/i, /\/(gml|wfs)/i),
+    0, xml.TYPE);
+
+exports = {
+  TYPE
+};

--- a/src/plugin/file/gpx/gpxdescriptor.js
+++ b/src/plugin/file/gpx/gpxdescriptor.js
@@ -1,51 +1,37 @@
-goog.provide('plugin.file.gpx.GPXDescriptor');
-goog.require('os.data.FileDescriptor');
-goog.require('os.layer.LayerType');
-goog.require('os.style');
-goog.require('plugin.file.gpx.GPXProvider');
+goog.module('plugin.file.gpx.GPXDescriptor');
+goog.module.declareLegacyNamespace();
 
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const LayerType = goog.require('os.layer.LayerType');
 
 
 /**
  * GPX file descriptor.
- *
- * @extends {os.data.FileDescriptor}
- * @constructor
  */
-plugin.file.gpx.GPXDescriptor = function() {
-  plugin.file.gpx.GPXDescriptor.base(this, 'constructor');
-  this.descriptorType = 'gpx';
-};
-goog.inherits(plugin.file.gpx.GPXDescriptor, os.data.FileDescriptor);
+class GPXDescriptor extends FileDescriptor {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.descriptorType = 'gpx';
+  }
 
+  /**
+   * @inheritDoc
+   */
+  getType() {
+    return LayerType.FEATURES;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.gpx.GPXDescriptor.prototype.getType = function() {
-  return os.layer.LayerType.FEATURES;
-};
+  /**
+   * @inheritDoc
+   */
+  getLayerOptions() {
+    var options = super.getLayerOptions();
+    options['type'] = 'GPX';
+    return options;
+  }
+}
 
-
-/**
- * @inheritDoc
- */
-plugin.file.gpx.GPXDescriptor.prototype.getLayerOptions = function() {
-  var options = plugin.file.gpx.GPXDescriptor.base(this, 'getLayerOptions');
-  options['type'] = 'GPX';
-  return options;
-};
-
-
-/**
- * Creates a new descriptor from a parser configuration.
- *
- * @param {!os.parse.FileParserConfig} config
- * @return {!plugin.file.gpx.GPXDescriptor}
- */
-plugin.file.gpx.GPXDescriptor.createFromConfig = function(config) {
-  var provider = plugin.file.gpx.GPXProvider.getInstance();
-  var descriptor = new plugin.file.gpx.GPXDescriptor();
-  os.data.FileDescriptor.createFromConfig(descriptor, provider, config);
-  return descriptor;
-};
+exports = GPXDescriptor;

--- a/src/plugin/file/gpx/gpxlayerconfig.js
+++ b/src/plugin/file/gpx/gpxlayerconfig.js
@@ -1,64 +1,65 @@
-goog.provide('plugin.file.gpx.GPXLayerConfig');
-goog.require('goog.net.XhrIo.ResponseType');
-goog.require('goog.userAgent');
-goog.require('os.layer.config.AbstractDataSourceLayerConfig');
-goog.require('os.source.Request');
-goog.require('plugin.file.gpx.GPXParser');
+goog.module('plugin.file.gpx.GPXLayerConfig');
+goog.module.declareLegacyNamespace();
 
-
-
-/**
- * @extends {os.layer.config.AbstractDataSourceLayerConfig}
- * @constructor
- */
-plugin.file.gpx.GPXLayerConfig = function() {
-  plugin.file.gpx.GPXLayerConfig.base(this, 'constructor');
-};
-goog.inherits(plugin.file.gpx.GPXLayerConfig, os.layer.config.AbstractDataSourceLayerConfig);
+const ResponseType = goog.require('goog.net.XhrIo.ResponseType');
+const userAgent = goog.require('goog.userAgent');
+const AbstractDataSourceLayerConfig = goog.require('os.layer.config.AbstractDataSourceLayerConfig');
+const RequestSource = goog.require('os.source.Request');
+const GPXParser = goog.require('plugin.file.gpx.GPXParser');
 
 
 /**
- * @inheritDoc
  */
-plugin.file.gpx.GPXLayerConfig.prototype.getParser = function(options) {
-  return new plugin.file.gpx.GPXParser(options);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.gpx.GPXLayerConfig.prototype.getRequest = function(options) {
-  var request = plugin.file.gpx.GPXLayerConfig.base(this, 'getRequest', options);
-
-  // instruct the handler to return a Document in the response, so the parsing is done in the request handler (where
-  // supported) instead of the importer. this was slightly faster in testing. IE9 doesn't support this.
-  if (!goog.userAgent.IE || goog.userAgent.isVersionOrHigher(10)) {
-    request.setResponseType(goog.net.XhrIo.ResponseType.DOCUMENT);
+class GPXLayerConfig extends AbstractDataSourceLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
 
-  return request;
-};
+  /**
+   * @inheritDoc
+   */
+  getParser(options) {
+    return new GPXParser(options);
+  }
 
+  /**
+   * @inheritDoc
+   */
+  getRequest(options) {
+    var request = super.getRequest(options);
 
-/**
- * @inheritDoc
- */
-plugin.file.gpx.GPXLayerConfig.prototype.getImporter = function(options) {
-  var importer = plugin.file.gpx.GPXLayerConfig.base(this, 'getImporter', options);
-  // enable autodetection using the default set of mappings (i.e. all of them)
-  importer.setAutoDetect(true);
-  return importer;
-};
+    // instruct the handler to return a Document in the response, so the parsing is done in the request handler (where
+    // supported) instead of the importer. this was slightly faster in testing. IE9 doesn't support this.
+    if (!userAgent.IE || userAgent.isVersionOrHigher(10)) {
+      request.setResponseType(ResponseType.DOCUMENT);
+    }
 
+    return request;
+  }
 
-/**
- * Up the default column autodetect limit for GPX source.
- *
- * @inheritDoc
- */
-plugin.file.gpx.GPXLayerConfig.prototype.getSource = function(options) {
-  var source = new os.source.Request();
-  source.setColumnAutoDetectLimit(100);
-  return source;
-};
+  /**
+   * @inheritDoc
+   */
+  getImporter(options) {
+    var importer = super.getImporter(options);
+    // enable autodetection using the default set of mappings (i.e. all of them)
+    importer.setAutoDetect(true);
+    return importer;
+  }
+
+  /**
+   * Up the default column autodetect limit for GPX source.
+   *
+   * @inheritDoc
+   */
+  getSource(options) {
+    var source = new RequestSource();
+    source.setColumnAutoDetectLimit(100);
+    return source;
+  }
+}
+
+exports = GPXLayerConfig;

--- a/src/plugin/file/gpx/gpxparser.js
+++ b/src/plugin/file/gpx/gpxparser.js
@@ -2,169 +2,174 @@
  * @fileoverview Parser
  * @suppress {accessControls|duplicate|unusedPrivateMembers}
  */
+goog.module('plugin.file.gpx.GPXParser');
 
-goog.provide('plugin.file.gpx.GPXParser');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.Feature');
-goog.require('ol.format.GPX');
-goog.require('ol.geom.Point');
-goog.require('ol.xml');
-goog.require('os.file.mime.text');
-goog.require('os.map');
-goog.require('os.parse.IParser');
+const dom = goog.require('goog.dom');
 
+const Feature = goog.require('ol.Feature');
+const GPX = goog.require('ol.format.GPX');
+const XSD = goog.require('ol.format.XSD');
+const LineString = goog.require('ol.geom.LineString');
+const MultiLineString = goog.require('ol.geom.MultiLineString');
+const Point = goog.require('ol.geom.Point');
+const SimpleGeometry = goog.require('ol.geom.SimpleGeometry');
+const xml = goog.require('ol.xml');
+const text = goog.require('os.file.mime.text');
+const osMap = goog.require('os.map');
+const IParser = goog.requireType('os.parse.IParser');
 
 
 /**
  * Simple GPX parser that extracts features from a GPX file.
  *
- * @param {Object<string, *>} options Layer configuration options.
- * @implements {os.parse.IParser<ol.Feature>}
+ * @implements {IParser<Feature>}
  * @template T
- * @constructor
  */
-plugin.file.gpx.GPXParser = function(options) {
+class GPXParser {
   /**
-   * @type {ol.format.GPX}
-   * @private
+   * Constructor.
+   * @param {Object<string, *>} options Layer configuration options.
    */
-  this.format_ = new ol.format.GPX();
+  constructor(options) {
+    /**
+     * @type {GPX}
+     * @private
+     */
+    this.format_ = new GPX();
 
-  /**
-   * @type {?Document}
-   * @private
-   */
-  this.document_ = null;
-
-  /**
-   * @type {number}
-   * @private
-   */
-  this.trackId_ = 0;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.gpx.GPXParser.prototype.setSource = function(source) {
-  if (source instanceof ArrayBuffer) {
-    source = os.file.mime.text.getText(source) || null;
-  }
-
-  if (ol.xml.isDocument(source)) {
-    this.document_ = /** @type {Document} */ (source);
-  } else if (typeof source === 'string') {
-    this.document_ = ol.xml.parse(source);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.gpx.GPXParser.prototype.cleanup = function() {
-  this.document_ = null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.gpx.GPXParser.prototype.hasNext = function() {
-  return this.document_ != null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.gpx.GPXParser.prototype.parseNext = function() {
-  var features = null;
-  if (this.document_) {
-    // make sure the document reference is cleared so errors don't result in hasNext continuing to return true. the
-    // importer will catch and report the error so we don't do it here.
-    var doc = this.document_;
+    /**
+     * @type {?Document}
+     * @private
+     */
     this.document_ = null;
 
-    // let OL3 do the bulk of the parsing
-    features = this.format_.readFeatures(doc, {
-      featureProjection: os.map.PROJECTION
-    });
+    /**
+     * @type {number}
+     * @private
+     */
+    this.trackId_ = 0;
+  }
 
-    if (features) {
-      // we have results, so go through each feature and expand out any LineString or MultiLineString geometries
-      var trackFeatures = [];
-      for (var i = features.length - 1; i >= 0; i--) {
-        var feature = features[i];
-        var geometry = feature.getGeometry();
-        if (geometry instanceof ol.geom.SimpleGeometry) {
-          var coordinates = geometry.getCoordinates();
-          if (coordinates) {
-            if (geometry instanceof ol.geom.LineString || geometry instanceof ol.geom.MultiLineString) {
-              // take the original feature out, we're expanding it into a feature per coordinate
-              features.splice(i, 1);
+  /**
+   * @inheritDoc
+   */
+  setSource(source) {
+    if (source instanceof ArrayBuffer) {
+      source = text.getText(source) || null;
+    }
 
-              // wrap a lineString in an array then loop over the lineStrings, this handles multiple trksegs
-              var lineStrings = geometry instanceof ol.geom.LineString ? [coordinates] : coordinates;
+    if (xml.isDocument(source)) {
+      this.document_ = /** @type {Document} */ (source);
+    } else if (typeof source === 'string') {
+      this.document_ = xml.parse(source);
+    }
+  }
 
-              lineStrings.forEach(function(lineString) {
-                this.trackId_++;
-                lineString.forEach(function(coordinate) {
-                  var f = new ol.Feature();
+  /**
+   * @inheritDoc
+   */
+  cleanup() {
+    this.document_ = null;
+  }
 
-                  // parse metadata and set a trackId on each feature to allow for easy track recreation
-                  this.parseMetadata(f, coordinate);
-                  f.set('TRACK_ID', this.trackId_);
+  /**
+   * @inheritDoc
+   */
+  hasNext() {
+    return this.document_ != null;
+  }
 
-                  trackFeatures.push(f);
+  /**
+   * @inheritDoc
+   */
+  parseNext() {
+    var features = null;
+    if (this.document_) {
+      // make sure the document reference is cleared so errors don't result in hasNext continuing to return true. the
+      // importer will catch and report the error so we don't do it here.
+      var doc = this.document_;
+      this.document_ = null;
+
+      // let OL3 do the bulk of the parsing
+      features = this.format_.readFeatures(doc, {
+        featureProjection: osMap.PROJECTION
+      });
+
+      if (features) {
+        // we have results, so go through each feature and expand out any LineString or MultiLineString geometries
+        var trackFeatures = [];
+        for (var i = features.length - 1; i >= 0; i--) {
+          var feature = features[i];
+          var geometry = feature.getGeometry();
+          if (geometry instanceof SimpleGeometry) {
+            var coordinates = geometry.getCoordinates();
+            if (coordinates) {
+              if (geometry instanceof LineString || geometry instanceof MultiLineString) {
+                // take the original feature out, we're expanding it into a feature per coordinate
+                features.splice(i, 1);
+
+                // wrap a lineString in an array then loop over the lineStrings, this handles multiple trksegs
+                var lineStrings = geometry instanceof LineString ? [coordinates] : coordinates;
+
+                lineStrings.forEach(function(lineString) {
+                  this.trackId_++;
+                  lineString.forEach(function(coordinate) {
+                    var f = new Feature();
+
+                    // parse metadata and set a trackId on each feature to allow for easy track recreation
+                    this.parseMetadata(f, coordinate);
+                    f.set('TRACK_ID', this.trackId_);
+
+                    trackFeatures.push(f);
+                  }, this);
                 }, this);
-              }, this);
-            } else if (geometry instanceof ol.geom.Point) {
-              // simply modify the feature in place to add its metadata
-              this.parseMetadata(feature, coordinates);
+              } else if (geometry instanceof Point) {
+                // simply modify the feature in place to add its metadata
+                this.parseMetadata(feature, coordinates);
+              }
             }
           }
         }
-      }
 
-      features = features.concat(trackFeatures);
-    }
-  }
-
-  return features;
-};
-
-
-/**
- * Extracts metadata from a features' coordinates and sets them as properties.
- *
- * @param {ol.Feature} feature
- * @param {ol.Coordinate} coordinate
- */
-plugin.file.gpx.GPXParser.prototype.parseMetadata = function(feature, coordinate) {
-  var m = coordinate[3];
-  var geometry = new ol.geom.Point(coordinate.slice(0, 3));
-  feature.setGeometry(geometry);
-
-  if (m) {
-    // extensions contain metadata, so pull it off and add it to the feature
-    var extensions = /** @type {Element} */ (m['extensions']);
-    if (extensions) {
-      var items = goog.dom.getChildren(extensions);
-      for (var i = 0, ii = items.length; i < ii; i++) {
-        var item = items[i];
-        feature.set(item.localName, item.textContent);
+        features = features.concat(trackFeatures);
       }
     }
 
-    // set the time. GPX time uses seconds from epoch, so convert to milliseconds.
-    var time = /** @type {number} */ (m['time']);
-    if (time != null) {
-      feature.set('time', (new Date(1000 * time)).toISOString());
+    return features;
+  }
+
+  /**
+   * Extracts metadata from a features' coordinates and sets them as properties.
+   *
+   * @param {Feature} feature
+   * @param {ol.Coordinate} coordinate
+   */
+  parseMetadata(feature, coordinate) {
+    var m = coordinate[3];
+    var geometry = new Point(coordinate.slice(0, 3));
+    feature.setGeometry(geometry);
+
+    if (m) {
+      // extensions contain metadata, so pull it off and add it to the feature
+      var extensions = /** @type {Element} */ (m['extensions']);
+      if (extensions) {
+        var items = dom.getChildren(extensions);
+        for (var i = 0, ii = items.length; i < ii; i++) {
+          var item = items[i];
+          feature.set(item.localName, item.textContent);
+        }
+      }
+
+      // set the time. GPX time uses seconds from epoch, so convert to milliseconds.
+      var time = /** @type {number} */ (m['time']);
+      if (time != null) {
+        feature.set('time', (new Date(1000 * time)).toISOString());
+      }
     }
   }
-};
+}
 
 
 /**
@@ -177,11 +182,11 @@ plugin.file.gpx.GPXParser.prototype.parseMetadata = function(feature, coordinate
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GPX.TRKPT_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GPX.NAMESPACE_URIS_, {
-      'ele': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'time': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDateTime),
-      'extensions': ol.format.GPX.parseExtensions_
+GPX.TRKPT_PARSERS_ = xml.makeStructureNS(
+    GPX.NAMESPACE_URIS_, {
+      'ele': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'time': xml.makeObjectPropertySetter(XSD.readDateTime),
+      'extensions': GPX.parseExtensions_
     });
 
 
@@ -190,11 +195,11 @@ ol.format.GPX.TRKPT_PARSERS_ = ol.xml.makeStructureNS(
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GPX.TRKPT_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GPX.NAMESPACE_URIS_, {
-      'ele': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'time': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDateTime),
-      'extensions': ol.format.GPX.parseExtensions_
+GPX.TRKPT_PARSERS_ = xml.makeStructureNS(
+    GPX.NAMESPACE_URIS_, {
+      'ele': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'time': xml.makeObjectPropertySetter(XSD.readDateTime),
+      'extensions': GPX.parseExtensions_
     });
 
 
@@ -210,7 +215,7 @@ ol.format.GPX.TRKPT_PARSERS_ = ol.xml.makeStructureNS(
  * @return {Array} Flat coordinates.
  * @private
  */
-ol.format.GPX.appendCoordinate_ = function(flatCoordinates, layoutOptions, node, values) {
+GPX.appendCoordinate_ = function(flatCoordinates, layoutOptions, node, values) {
   // always include altitude, defaulting to 0
   var altitude = 0;
   layoutOptions.hasZ = true;
@@ -234,10 +239,11 @@ ol.format.GPX.appendCoordinate_ = function(flatCoordinates, layoutOptions, node,
     delete values['time'];
     layoutOptions.hasM = true;
   } else {
-    // ol.format.GPX.applyLayoutOptions_ assumes coordinates are parsed as XYZM and adjusts accordingly, so always
+    // GPX.applyLayoutOptions_ assumes coordinates are parsed as XYZM and adjusts accordingly, so always
     // add a time component to the coordinates
     flatCoordinates.push(0);
   }
 
   return flatCoordinates;
 };
+exports = GPXParser;

--- a/src/plugin/file/gpx/gpxplugin.js
+++ b/src/plugin/file/gpx/gpxplugin.js
@@ -1,69 +1,66 @@
-goog.provide('plugin.file.gpx.GPXPlugin');
+goog.module('plugin.file.gpx.GPXPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.DataManager');
-goog.require('os.data.ProviderEntry');
-goog.require('os.layer.config.LayerConfigManager');
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.ui.im.ImportManager');
-goog.require('plugin.file.gpx.GPXDescriptor');
-goog.require('plugin.file.gpx.GPXLayerConfig');
-goog.require('plugin.file.gpx.GPXParser');
-goog.require('plugin.file.gpx.GPXProvider');
-goog.require('plugin.file.gpx.mime');
-goog.require('plugin.file.gpx.ui.GPXImportUI');
-
+const DataManager = goog.require('os.data.DataManager');
+const ProviderEntry = goog.require('os.data.ProviderEntry');
+const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const GPXDescriptor = goog.require('plugin.file.gpx.GPXDescriptor');
+const GPXLayerConfig = goog.require('plugin.file.gpx.GPXLayerConfig');
+const GPXParser = goog.require('plugin.file.gpx.GPXParser');
+const GPXProvider = goog.require('plugin.file.gpx.GPXProvider');
+const mime = goog.require('plugin.file.gpx.mime');
+const GPXImportUI = goog.require('plugin.file.gpx.ui.GPXImportUI');
 
 
 /**
  * Provides GPX support
- *
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.file.gpx.GPXPlugin = function() {
-  plugin.file.gpx.GPXPlugin.base(this, 'constructor');
-  this.id = plugin.file.gpx.GPXPlugin.ID;
-};
-goog.inherits(plugin.file.gpx.GPXPlugin, os.plugin.AbstractPlugin);
+class GPXPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = ID;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    var dm = DataManager.getInstance();
+
+    // register kml provider type
+    dm.registerProviderType(new ProviderEntry(ID, GPXProvider, TYPE, TYPE));
+
+    // register the kml descriptor type
+    dm.registerDescriptorType(this.id, GPXDescriptor);
+
+    // register the kml layer config
+    var lcm = LayerConfigManager.getInstance();
+    lcm.registerLayerConfig(this.id, GPXLayerConfig);
+
+    // register the kml import ui
+    var im = ImportManager.getInstance();
+    im.registerImportDetails(this.id.toUpperCase(), true);
+    im.registerImportUI(mime.TYPE, new GPXImportUI());
+    im.registerParser(this.id, GPXParser);
+  }
+}
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.gpx.GPXPlugin.ID = 'gpx';
+const ID = 'gpx';
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.gpx.GPXPlugin.TYPE = 'GPX Layers';
+const TYPE = 'GPX Layers';
 
 
-/**
- * @inheritDoc
- */
-plugin.file.gpx.GPXPlugin.prototype.init = function() {
-  var dm = os.dataManager;
-
-  // register kml provider type
-  dm.registerProviderType(new os.data.ProviderEntry(
-      plugin.file.gpx.GPXPlugin.ID,
-      plugin.file.gpx.GPXProvider,
-      plugin.file.gpx.GPXPlugin.TYPE,
-      plugin.file.gpx.GPXPlugin.TYPE));
-
-  // register the kml descriptor type
-  dm.registerDescriptorType(this.id, plugin.file.gpx.GPXDescriptor);
-
-  // register the kml layer config
-  var lcm = os.layer.config.LayerConfigManager.getInstance();
-  lcm.registerLayerConfig(this.id, plugin.file.gpx.GPXLayerConfig);
-
-  // register the kml import ui
-  var im = os.ui.im.ImportManager.getInstance();
-  im.registerImportDetails(this.id.toUpperCase(), true);
-  im.registerImportUI(plugin.file.gpx.mime.TYPE, new plugin.file.gpx.ui.GPXImportUI());
-  im.registerParser(this.id, plugin.file.gpx.GPXParser);
-};
+exports = GPXPlugin;

--- a/src/plugin/file/gpx/gpxprovider.js
+++ b/src/plugin/file/gpx/gpxprovider.js
@@ -23,32 +23,8 @@ class GPXProvider extends FileProvider {
     this.setId('gpx');
     this.setLabel('GPX Files');
   }
-
-  /**
-   * Get the global instance.
-   * @return {!GPXProvider}
-   */
-  static getInstance() {
-    if (!instance) {
-      instance = new GPXProvider();
-    }
-
-    return instance;
-  }
-
-  /**
-   * Set the global instance.
-   * @param {GPXProvider} value
-   */
-  static setInstance(value) {
-    instance = value;
-  }
 }
+goog.addSingletonGetter(GPXProvider);
 
-/**
- * Global instance.
- * @type {GPXProvider|undefined}
- */
-let instance;
 
 exports = GPXProvider;

--- a/src/plugin/file/gpx/gpxprovider.js
+++ b/src/plugin/file/gpx/gpxprovider.js
@@ -1,26 +1,54 @@
-goog.provide('plugin.file.gpx.GPXProvider');
-goog.require('os.data.FileProvider');
+goog.module('plugin.file.gpx.GPXProvider');
+goog.module.declareLegacyNamespace();
 
+const FileProvider = goog.require('os.data.FileProvider');
 
 
 /**
  * GPX file provider
- *
- * @extends {os.data.FileProvider}
- * @constructor
  */
-plugin.file.gpx.GPXProvider = function() {
-  plugin.file.gpx.GPXProvider.base(this, 'constructor');
-};
-goog.inherits(plugin.file.gpx.GPXProvider, os.data.FileProvider);
-goog.addSingletonGetter(plugin.file.gpx.GPXProvider);
+class GPXProvider extends FileProvider {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
 
+  /**
+   * @inheritDoc
+   */
+  configure(config) {
+    super.configure(config);
+    this.setId('gpx');
+    this.setLabel('GPX Files');
+  }
+
+  /**
+   * Get the global instance.
+   * @return {!GPXProvider}
+   */
+  static getInstance() {
+    if (!instance) {
+      instance = new GPXProvider();
+    }
+
+    return instance;
+  }
+
+  /**
+   * Set the global instance.
+   * @param {GPXProvider} value
+   */
+  static setInstance(value) {
+    instance = value;
+  }
+}
 
 /**
- * @inheritDoc
+ * Global instance.
+ * @type {GPXProvider|undefined}
  */
-plugin.file.gpx.GPXProvider.prototype.configure = function(config) {
-  plugin.file.gpx.GPXProvider.base(this, 'configure', config);
-  this.setId('gpx');
-  this.setLabel('GPX Files');
-};
+let instance;
+
+exports = GPXProvider;

--- a/src/plugin/file/gpx/mime.js
+++ b/src/plugin/file/gpx/mime.js
@@ -1,14 +1,21 @@
-goog.provide('plugin.file.gpx.mime');
+goog.module('plugin.file.gpx.mime');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.file.mime.xml');
+const mime = goog.require('os.file.mime');
+
+const xml = goog.require('os.file.mime.xml');
+
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.gpx.mime.TYPE = 'application/vnd.gpx+xml';
+const TYPE = 'application/vnd.gpx+xml';
 
-os.file.mime.register(
-    plugin.file.gpx.mime.TYPE,
-    os.file.mime.xml.createDetect(/^gpx$/i, /\/gpx\//i),
-    0, os.file.mime.xml.TYPE);
+mime.register(
+    TYPE,
+    xml.createDetect(/^gpx$/i, /\/gpx\//i),
+    0, xml.TYPE);
+
+exports = {
+  TYPE
+};

--- a/src/plugin/file/gpx/ui/gpximport.js
+++ b/src/plugin/file/gpx/ui/gpximport.js
@@ -1,11 +1,12 @@
-goog.provide('plugin.file.gpx.ui.GPXImportCtrl');
-goog.provide('plugin.file.gpx.ui.gpxImportDirective');
+goog.module('plugin.file.gpx.ui.GPXImport');
+goog.module.declareLegacyNamespace();
 
-goog.require('os');
-goog.require('os.ui.Module');
-goog.require('os.ui.file.ui.AbstractFileImportCtrl');
-goog.require('plugin.file.gpx.GPXDescriptor');
-goog.require('plugin.file.gpx.GPXProvider');
+const {ROOT} = goog.require('os');
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const Module = goog.require('os.ui.Module');
+const AbstractFileImportCtrl = goog.require('os.ui.file.ui.AbstractFileImportCtrl');
+const GPXDescriptor = goog.require('plugin.file.gpx.GPXDescriptor');
+const GPXProvider = goog.require('plugin.file.gpx.GPXProvider');
 
 
 /**
@@ -13,62 +14,75 @@ goog.require('plugin.file.gpx.GPXProvider');
  *
  * @return {angular.Directive}
  */
-plugin.file.gpx.ui.gpxImportDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    scope: true,
-    templateUrl: os.ROOT + 'views/file/genericfileimport.html',
-    controller: plugin.file.gpx.ui.GPXImportCtrl,
-    controllerAs: 'ctrl'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  scope: true,
+  templateUrl: ROOT + 'views/file/genericfileimport.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'gpximport';
 
 
 /**
  * Add the directive to the module.
  */
-os.ui.Module.directive('gpximport', [plugin.file.gpx.ui.gpxImportDirective]);
+Module.directive('gpximport', [directive]);
 
 
 
 /**
  * Controller for the GPX import dialog.
  *
- * @param {!angular.Scope} $scope The Angular scope.
- * @param {!angular.JQLite} $element The root DOM element.
- * @extends {os.ui.file.ui.AbstractFileImportCtrl<!os.parse.FileParserConfig, !plugin.file.gpx.GPXDescriptor>}
- * @constructor
- * @ngInject
+ * @extends {AbstractFileImportCtrl<!os.parse.FileParserConfig, !GPXDescriptor>}
+ * @unrestricted
  */
-plugin.file.gpx.ui.GPXImportCtrl = function($scope, $element) {
-  plugin.file.gpx.ui.GPXImportCtrl.base(this, 'constructor', $scope, $element);
-};
-goog.inherits(plugin.file.gpx.ui.GPXImportCtrl, os.ui.file.ui.AbstractFileImportCtrl);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.gpx.ui.GPXImportCtrl.prototype.createDescriptor = function() {
-  var descriptor = null;
-  if (this.config['descriptor']) {
-    // existing descriptor. deactivate the descriptor, then update it
-    descriptor = this.config['descriptor'];
-    descriptor.setActive(false);
-    descriptor.updateFromConfig(this.config);
-  } else {
-    // this is a new import
-    descriptor = plugin.file.gpx.GPXDescriptor.createFromConfig(this.config);
+class Controller extends AbstractFileImportCtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope The Angular scope.
+   * @param {!angular.JQLite} $element The root DOM element.
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    super($scope, $element);
   }
 
-  return descriptor;
-};
+  /**
+   * @inheritDoc
+   */
+  createDescriptor() {
+    var descriptor = null;
+    if (this.config['descriptor']) {
+      // existing descriptor. deactivate the descriptor, then update it
+      descriptor = this.config['descriptor'];
+      descriptor.setActive(false);
+      descriptor.updateFromConfig(this.config);
+    } else {
+      // this is a new import
+      descriptor = new GPXDescriptor();
+      FileDescriptor.createFromConfig(descriptor, GPXProvider.getInstance(), this.config);
+    }
 
+    return descriptor;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.gpx.ui.GPXImportCtrl.prototype.getProvider = function() {
-  return plugin.file.gpx.GPXProvider.getInstance();
+  /**
+   * @inheritDoc
+   */
+  getProvider() {
+    return GPXProvider.getInstance();
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/file/gpx/ui/gpximportui.js
+++ b/src/plugin/file/gpx/ui/gpximportui.js
@@ -1,60 +1,63 @@
-goog.provide('plugin.file.gpx.ui.GPXImportUI');
-goog.require('os.parse.FileParserConfig');
-goog.require('os.ui.im.FileImportUI');
-goog.require('os.ui.window');
-goog.require('plugin.file.gpx.ui.gpxImportDirective');
+goog.module('plugin.file.gpx.ui.GPXImportUI');
+goog.module.declareLegacyNamespace();
 
-
-
-/**
- * @extends {os.ui.im.FileImportUI}
- * @constructor
- */
-plugin.file.gpx.ui.GPXImportUI = function() {
-  plugin.file.gpx.ui.GPXImportUI.base(this, 'constructor');
-};
-goog.inherits(plugin.file.gpx.ui.GPXImportUI, os.ui.im.FileImportUI);
+const FileParserConfig = goog.require('os.parse.FileParserConfig');
+const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const osWindow = goog.require('os.ui.window');
+const {directiveTag: gpxImportUi} = goog.require('plugin.file.gpx.ui.GPXImport');
 
 
 /**
- * @inheritDoc
  */
-plugin.file.gpx.ui.GPXImportUI.prototype.getTitle = function() {
-  return 'GPX';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.gpx.ui.GPXImportUI.prototype.launchUI = function(file, opt_config) {
-  plugin.file.gpx.ui.GPXImportUI.base(this, 'launchUI', file, opt_config);
-
-  var config = new os.parse.FileParserConfig();
-
-  // if an existing config was provided, merge it in
-  if (opt_config) {
-    this.mergeConfig(opt_config, config);
+class GPXImportUI extends FileImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
 
-  config['file'] = file;
-  config['title'] = file.getFileName();
+  /**
+   * @inheritDoc
+   */
+  getTitle() {
+    return 'GPX';
+  }
 
-  var scopeOptions = {
-    'config': config
-  };
-  var windowOptions = {
-    'label': 'Import GPX',
-    'icon': 'fa fa-file-text',
-    'x': 'center',
-    'y': 'center',
-    'width': 400,
-    'min-width': 400,
-    'max-width': 800,
-    'height': 'auto',
-    'modal': true,
-    'show-close': true
-  };
-  var template = '<gpximport></gpximport>';
-  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
-};
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    super.launchUI(file, opt_config);
+
+    var config = new FileParserConfig();
+
+    // if an existing config was provided, merge it in
+    if (opt_config) {
+      this.mergeConfig(opt_config, config);
+    }
+
+    config['file'] = file;
+    config['title'] = file.getFileName();
+
+    var scopeOptions = {
+      'config': config
+    };
+    var windowOptions = {
+      'label': 'Import GPX',
+      'icon': 'fa fa-file-text',
+      'x': 'center',
+      'y': 'center',
+      'width': 400,
+      'min-width': 400,
+      'max-width': 800,
+      'height': 'auto',
+      'modal': true,
+      'show-close': true
+    };
+    var template = `<${gpxImportUi}></${gpxImportUi}>`;
+    osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+  }
+}
+
+exports = GPXImportUI;

--- a/src/plugin/file/kml/abstractkmlmanager.js
+++ b/src/plugin/file/kml/abstractkmlmanager.js
@@ -1,15 +1,17 @@
 goog.module('plugin.file.kml.AbstractKMLManager');
 
 const Delay = goog.require('goog.async.Delay');
+const dispose = goog.require('goog.dispose');
 const GoogEventTarget = goog.require('goog.events.EventTarget');
 const GoogEventType = goog.require('goog.events.EventType');
 const log = goog.require('goog.log');
+const events = goog.require('ol.events');
+const MapContainer = goog.require('os.MapContainer');
 const AlertManager = goog.require('os.alert.AlertManager');
 const ConfigEventType = goog.require('os.config.EventType');
 const OsEventType = goog.require('os.events.EventType');
 const {createFromContent} = goog.require('os.file');
 const FileStorage = goog.require('os.file.FileStorage');
-const MapContainer = goog.require('os.MapContainer');
 const PropertyChange = goog.require('os.source.PropertyChange');
 const KMLLayerConfig = goog.require('plugin.file.kml.KMLLayerConfig');
 
@@ -224,7 +226,7 @@ class AbstractKMLManager extends GoogEventTarget {
       this.setupLayer(this.layer_, options);
 
       this.source_ = /** @type {KMLSource} */ (this.layer_.getSource());
-      ol.events.listen(this.source_, GoogEventType.PROPERTYCHANGE, this.onSourcePropertyChange_, this);
+      events.listen(this.source_, GoogEventType.PROPERTYCHANGE, this.onSourcePropertyChange_, this);
 
       if (!this.source_.isLoading()) {
         this.onSourceLoaded_();
@@ -253,7 +255,7 @@ class AbstractKMLManager extends GoogEventTarget {
    */
   clear() {
     this.removeLayer();
-    goog.dispose(this.layer_);
+    dispose(this.layer_);
     this.layer_ = null;
     this.source_ = null;
     this.root_ = null;

--- a/src/plugin/file/kml/cmd/abstractkmlnodecmd.js
+++ b/src/plugin/file/kml/cmd/abstractkmlnodecmd.js
@@ -1,187 +1,185 @@
-goog.provide('plugin.file.kml.cmd.AbstractKMLNode');
+goog.module('plugin.file.kml.cmd.AbstractKMLNode');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Disposable');
-goog.require('os.command.ICommand');
-goog.require('os.command.State');
-
+const Disposable = goog.require('goog.Disposable');
+const dispose = goog.require('goog.dispose');
+const State = goog.require('os.command.State');
+const ICommand = goog.requireType('os.command.ICommand');
 
 
 /**
  * Abstract command for adding/removing KML nodes.
  *
  * @abstract
- * @param {!plugin.file.kml.ui.KMLNode} node The KML node
- * @param {plugin.file.kml.ui.KMLNode} parent The parent node
  *
- * @implements {os.command.ICommand}
- * @extends {goog.Disposable}
- *
- * @constructor
+ * @implements {ICommand}
  */
-plugin.file.kml.cmd.AbstractKMLNode = function(node, parent) {
-  plugin.file.kml.cmd.AbstractKMLNode.base(this, 'constructor');
+class AbstractKMLNode extends Disposable {
+  /**
+   * Constructor.
+   * @param {!plugin.file.kml.ui.KMLNode} node The KML node
+   * @param {plugin.file.kml.ui.KMLNode} parent The parent node
+   */
+  constructor(node, parent) {
+    super();
+
+    /**
+     * The details of the command.
+     * @type {?string}
+     */
+    this.details = null;
+
+    /**
+     * Whether or not the command is asynchronous.
+     * @type {boolean}
+     */
+    this.isAsync = false;
+
+    /**
+     * Return the current state of the command.
+     * @type {!State}
+     */
+    this.state = State.READY;
+
+    /**
+     * The title of the command.
+     * @type {?string}
+     */
+    this.title = 'Add/Remove KML Node';
+
+    /**
+     * The node to add/remove
+     * @type {plugin.file.kml.ui.KMLNode}
+     * @protected
+     */
+    this.node = node;
+
+    /**
+     * The parent of the node to add/remove
+     * @type {plugin.file.kml.ui.KMLNode}
+     * @protected
+     */
+    this.parent = parent;
+  }
 
   /**
-   * The details of the command.
-   * @type {?string}
+   * @abstract
+   * @inheritDoc
    */
-  this.details = null;
+  execute() {}
 
   /**
-   * Whether or not the command is asynchronous.
-   * @type {boolean}
+   * @abstract
+   * @inheritDoc
    */
-  this.isAsync = false;
+  revert() {}
 
   /**
-   * Return the current state of the command.
-   * @type {!os.command.State}
+   * @inheritDoc
    */
-  this.state = os.command.State.READY;
+  disposeInternal() {
+    super.disposeInternal();
 
-  /**
-   * The title of the command.
-   * @type {?string}
-   */
-  this.title = 'Add/Remove KML Node';
+    if (this.node) {
+      // only dispose of the node if it doesn't have a parent or its parent has been disposed
+      var parent = this.node.getParent();
+      if (!parent || parent.isDisposed()) {
+        dispose(this.node);
+      }
 
-  /**
-   * The node to add/remove
-   * @type {plugin.file.kml.ui.KMLNode}
-   * @protected
-   */
-  this.node = node;
-
-  /**
-   * The parent of the node to add/remove
-   * @type {plugin.file.kml.ui.KMLNode}
-   * @protected
-   */
-  this.parent = parent;
-};
-goog.inherits(plugin.file.kml.cmd.AbstractKMLNode, goog.Disposable);
-
-
-/**
- * @abstract
- * @inheritDoc
- */
-plugin.file.kml.cmd.AbstractKMLNode.prototype.execute = function() {};
-
-
-/**
- * @abstract
- * @inheritDoc
- */
-plugin.file.kml.cmd.AbstractKMLNode.prototype.revert = function() {};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.cmd.AbstractKMLNode.prototype.disposeInternal = function() {
-  plugin.file.kml.cmd.AbstractKMLNode.base(this, 'disposeInternal');
-
-  if (this.node) {
-    // only dispose of the node if it doesn't have a parent or its parent has been disposed
-    var parent = this.node.getParent();
-    if (!parent || parent.isDisposed()) {
-      goog.dispose(this.node);
+      this.node = null;
     }
-
-    this.node = null;
-  }
-};
-
-
-/**
- * Checks if the command is ready to execute.
- *
- * @return {boolean}
- */
-plugin.file.kml.cmd.AbstractKMLNode.prototype.canExecute = function() {
-  if (this.state !== os.command.State.READY) {
-    this.details = 'Command not in ready state.';
-    return false;
   }
 
-  if (!this.node) {
-    this.state = os.command.State.ERROR;
-    this.details = 'Node has not been provided.';
-    return false;
-  }
-
-  if (this.node.isDisposed()) {
-    this.state = os.command.State.ERROR;
-    this.details = 'Node has been disposed.';
-    return false;
-  }
-
-  if (!this.parent) {
-    this.state = os.command.State.ERROR;
-    this.details = 'Parent node has not been provided.';
-    return false;
-  }
-
-  if (this.parent.isDisposed()) {
-    this.state = os.command.State.ERROR;
-    this.details = 'Parent node has been disposed.';
-    return false;
-  }
-
-  return true;
-};
-
-
-/**
- * Adds the node to the parent.
- *
- * @return {boolean} If the add succeeded or not.
- */
-plugin.file.kml.cmd.AbstractKMLNode.prototype.add = function() {
-  if (this.node && this.parent) {
-    var source = this.parent.getSource();
-    if (source) {
-      source.addNodes([this.node], true);
-    } else {
-      this.state = os.command.State.ERROR;
-      this.details = 'Node source is not available.';
+  /**
+   * Checks if the command is ready to execute.
+   *
+   * @return {boolean}
+   */
+  canExecute() {
+    if (this.state !== State.READY) {
+      this.details = 'Command not in ready state.';
       return false;
     }
 
-    this.parent.addChild(this.node);
-    return true;
-  }
+    if (!this.node) {
+      this.state = State.ERROR;
+      this.details = 'Node has not been provided.';
+      return false;
+    }
 
-  this.state = os.command.State.ERROR;
-  this.details = 'Node/parent are not available.';
-  return false;
-};
+    if (this.node.isDisposed()) {
+      this.state = State.ERROR;
+      this.details = 'Node has been disposed.';
+      return false;
+    }
 
+    if (!this.parent) {
+      this.state = State.ERROR;
+      this.details = 'Parent node has not been provided.';
+      return false;
+    }
 
-/**
- * Removes the node from its parent.
- *
- * @return {boolean} If the remove succeeded or not.
- */
-plugin.file.kml.cmd.AbstractKMLNode.prototype.remove = function() {
-  if (this.node && this.parent) {
-    // remove the node from the tree first, so it isn't included in getFeatures calls on other nodes in the tree
-    this.parent.removeChild(this.node);
-
-    var source = this.node.getSource();
-    if (source) {
-      source.clearNode(this.node, false);
-    } else {
-      this.state = os.command.State.ERROR;
-      this.details = 'Node source is not available.';
+    if (this.parent.isDisposed()) {
+      this.state = State.ERROR;
+      this.details = 'Parent node has been disposed.';
       return false;
     }
 
     return true;
   }
 
-  this.state = os.command.State.ERROR;
-  this.details = 'Node/parent are not available.';
-  return false;
-};
+  /**
+   * Adds the node to the parent.
+   *
+   * @return {boolean} If the add succeeded or not.
+   */
+  add() {
+    if (this.node && this.parent) {
+      var source = this.parent.getSource();
+      if (source) {
+        source.addNodes([this.node], true);
+      } else {
+        this.state = State.ERROR;
+        this.details = 'Node source is not available.';
+        return false;
+      }
+
+      this.parent.addChild(this.node);
+      return true;
+    }
+
+    this.state = State.ERROR;
+    this.details = 'Node/parent are not available.';
+    return false;
+  }
+
+  /**
+   * Removes the node from its parent.
+   *
+   * @return {boolean} If the remove succeeded or not.
+   */
+  remove() {
+    if (this.node && this.parent) {
+      // remove the node from the tree first, so it isn't included in getFeatures calls on other nodes in the tree
+      this.parent.removeChild(this.node);
+
+      var source = this.node.getSource();
+      if (source) {
+        source.clearNode(this.node, false);
+      } else {
+        this.state = State.ERROR;
+        this.details = 'Node source is not available.';
+        return false;
+      }
+
+      return true;
+    }
+
+    this.state = State.ERROR;
+    this.details = 'Node/parent are not available.';
+    return false;
+  }
+}
+
+exports = AbstractKMLNode;

--- a/src/plugin/file/kml/cmd/kmlnodeaddcmd.js
+++ b/src/plugin/file/kml/cmd/kmlnodeaddcmd.js
@@ -1,58 +1,58 @@
-goog.provide('plugin.file.kml.cmd.KMLNodeAdd');
+goog.module('plugin.file.kml.cmd.KMLNodeAdd');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.command.State');
-goog.require('plugin.file.kml.cmd.AbstractKMLNode');
-
+const State = goog.require('os.command.State');
+const AbstractKMLNode = goog.require('plugin.file.kml.cmd.AbstractKMLNode');
 
 
 /**
  * Command to add a KML node to a parent.
- *
- * @param {!plugin.file.kml.ui.KMLNode} node The KML node
- * @param {!plugin.file.kml.ui.KMLNode} parent The parent node
- *
- * @extends {plugin.file.kml.cmd.AbstractKMLNode}
- * @constructor
  */
-plugin.file.kml.cmd.KMLNodeAdd = function(node, parent) {
-  plugin.file.kml.cmd.KMLNodeAdd.base(this, 'constructor', node, parent);
-  this.title = 'Add KML Node';
+class KMLNodeAdd extends AbstractKMLNode {
+  /**
+   * Constructor.
+   * @param {!plugin.file.kml.ui.KMLNode} node The KML node
+   * @param {!plugin.file.kml.ui.KMLNode} parent The parent node
+   */
+  constructor(node, parent) {
+    super(node, parent);
+    this.title = 'Add KML Node';
 
-  var label = node.getLabel();
-  if (label) {
-    this.title += ' "' + label + '"';
-  }
-};
-goog.inherits(plugin.file.kml.cmd.KMLNodeAdd, plugin.file.kml.cmd.AbstractKMLNode);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.cmd.KMLNodeAdd.prototype.execute = function() {
-  if (this.canExecute()) {
-    this.state = os.command.State.EXECUTING;
-
-    if (this.add()) {
-      this.state = os.command.State.SUCCESS;
-      return true;
+    var label = node.getLabel();
+    if (label) {
+      this.title += ' "' + label + '"';
     }
   }
 
-  return false;
-};
+  /**
+   * @inheritDoc
+   */
+  execute() {
+    if (this.canExecute()) {
+      this.state = State.EXECUTING;
 
+      if (this.add()) {
+        this.state = State.SUCCESS;
+        return true;
+      }
+    }
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.cmd.KMLNodeAdd.prototype.revert = function() {
-  this.state = os.command.State.REVERTING;
-
-  if (this.remove()) {
-    this.state = os.command.State.READY;
-    return true;
+    return false;
   }
 
-  return false;
-};
+  /**
+   * @inheritDoc
+   */
+  revert() {
+    this.state = State.REVERTING;
+
+    if (this.remove()) {
+      this.state = State.READY;
+      return true;
+    }
+
+    return false;
+  }
+}
+
+exports = KMLNodeAdd;

--- a/src/plugin/file/kml/cmd/kmlnoderemovecmd.js
+++ b/src/plugin/file/kml/cmd/kmlnoderemovecmd.js
@@ -1,58 +1,59 @@
-goog.provide('plugin.file.kml.cmd.KMLNodeRemove');
+goog.module('plugin.file.kml.cmd.KMLNodeRemove');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.command.State');
-goog.require('plugin.file.kml.cmd.AbstractKMLNode');
+const State = goog.require('os.command.State');
+const AbstractKMLNode = goog.require('plugin.file.kml.cmd.AbstractKMLNode');
 
+const KMLNode = goog.requireType('plugin.file.kml.ui.KMLNode');
 
 
 /**
  * Command to remove a KML node from its parent.
- *
- * @param {!plugin.file.kml.ui.KMLNode} node The KML node
- *
- * @extends {plugin.file.kml.cmd.AbstractKMLNode}
- * @constructor
  */
-plugin.file.kml.cmd.KMLNodeRemove = function(node) {
-  plugin.file.kml.cmd.KMLNodeRemove.base(this, 'constructor',
-      node, /** @type {plugin.file.kml.ui.KMLNode} */ (node.getParent()));
-  this.title = 'Remove KML Node';
+class KMLNodeRemove extends AbstractKMLNode {
+  /**
+   * Constructor.
+   * @param {!KMLNode} node The KML node
+   */
+  constructor(node) {
+    super(node, /** @type {KMLNode} */ (node.getParent()));
+    this.title = 'Remove KML Node';
 
-  var label = node.getLabel();
-  if (label) {
-    this.title += ' "' + label + '"';
-  }
-};
-goog.inherits(plugin.file.kml.cmd.KMLNodeRemove, plugin.file.kml.cmd.AbstractKMLNode);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.cmd.KMLNodeRemove.prototype.execute = function() {
-  if (this.canExecute()) {
-    this.state = os.command.State.EXECUTING;
-
-    if (this.remove()) {
-      this.state = os.command.State.SUCCESS;
-      return true;
+    var label = node.getLabel();
+    if (label) {
+      this.title += ' "' + label + '"';
     }
   }
 
-  return false;
-};
+  /**
+   * @inheritDoc
+   */
+  execute() {
+    if (this.canExecute()) {
+      this.state = State.EXECUTING;
 
+      if (this.remove()) {
+        this.state = State.SUCCESS;
+        return true;
+      }
+    }
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.cmd.KMLNodeRemove.prototype.revert = function() {
-  this.state = os.command.State.REVERTING;
-
-  if (this.add()) {
-    this.state = os.command.State.READY;
-    return true;
+    return false;
   }
 
-  return false;
-};
+  /**
+   * @inheritDoc
+   */
+  revert() {
+    this.state = State.REVERTING;
+
+    if (this.add()) {
+      this.state = State.READY;
+      return true;
+    }
+
+    return false;
+  }
+}
+
+exports = KMLNodeRemove;

--- a/src/plugin/file/kml/jsonfield.js
+++ b/src/plugin/file/kml/jsonfield.js
@@ -1,0 +1,15 @@
+goog.module('plugin.file.kml.JsonField');
+goog.module.declareLegacyNamespace();
+
+const annotation = goog.require('os.annotation');
+const RecordField = goog.require('os.data.RecordField');
+
+
+/**
+ * Fields that are known to contain specialized JSON data.
+ * @type {!Array<string>}
+ */
+exports = [
+  annotation.OPTIONS_FIELD,
+  RecordField.RING_OPTIONS
+];

--- a/src/plugin/file/kml/kml.js
+++ b/src/plugin/file/kml/kml.js
@@ -2,88 +2,143 @@
  * @fileoverview KML parser convenience functions, parsers, etc.
  * @suppress {accessControls}
  */
-goog.provide('plugin.file.kml');
+goog.module('plugin.file.kml');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
-goog.require('ol.extent');
-goog.require('ol.format.KML');
-goog.require('ol.format.XSD');
-goog.require('ol.geom.GeometryCollection');
-goog.require('ol.style.Icon');
-goog.require('ol.style.IconAnchorUnits');
-goog.require('ol.style.IconOrigin');
-goog.require('ol.style.Style');
-goog.require('ol.xml');
-goog.require('os.data.RecordField');
-goog.require('os.geo');
-goog.require('os.mixin');
-goog.require('os.mixin.polygon');
-goog.require('os.object');
-goog.require('os.time.TimeInstant');
-goog.require('os.time.TimeRange');
-goog.require('os.ui.file.kml');
-goog.require('os.xml');
+const Uri = goog.require('goog.Uri');
+
+const asserts = goog.require('goog.asserts');
+const NodeType = goog.require('goog.dom.NodeType');
+const googObject = goog.require('goog.object');
+const olColor = goog.require('ol.color');
+const olExtent = goog.require('ol.extent');
+const KML = goog.require('ol.format.KML');
+const XSD = goog.require('ol.format.XSD');
+const GeometryCollection = goog.require('ol.geom.GeometryCollection');
+const GeometryLayout = goog.require('ol.geom.GeometryLayout');
+const GeometryType = goog.require('ol.geom.GeometryType');
+const LineString = goog.require('ol.geom.LineString');
+const MultiLineString = goog.require('ol.geom.MultiLineString');
+const SimpleGeometry = goog.require('ol.geom.SimpleGeometry');
+const inflate = goog.require('ol.geom.flat.inflate');
+const math = goog.require('ol.math');
+const Icon = goog.require('ol.style.Icon');
+const IconAnchorUnits = goog.require('ol.style.IconAnchorUnits');
+const IconOrigin = goog.require('ol.style.IconOrigin');
+const Style = goog.require('ol.style.Style');
+const olXml = goog.require('ol.xml');
+const Fields = goog.require('os.Fields');
+const annotation = goog.require('os.annotation');
+const RecordField = goog.require('os.data.RecordField');
+const geo = goog.require('os.geo');
+const net = goog.require('os.net');
+const CrossOrigin = goog.require('os.net.CrossOrigin');
+const osObject = goog.require('os.object');
+const osStyle = goog.require('os.style');
+const StyleField = goog.require('os.style.StyleField');
+const StyleManager = goog.require('os.style.StyleManager');
+const TimeInstant = goog.require('os.time.TimeInstant');
+const TimeRange = goog.require('os.time.TimeRange');
+const kml = goog.require('os.ui.file.kml');
+const slickColumn = goog.require('os.ui.slick.column');
+const xml = goog.require('os.xml');
+const KMLField = goog.require('plugin.file.kml.KMLField');
+
 
 /**
  * Key used to store the parsed KML style on features.
  * @type {string}
  */
-plugin.file.kml.STYLE_KEY = '_kmlStyle';
-
+const STYLE_KEY = '_kmlStyle';
 
 /**
  * Namespace URI used for KML nodes.
  * @type {string}
- * @const
  */
-plugin.file.kml.KML_NS = 'http://www.opengis.net/kml/2.2';
-
+const KML_NS = 'http://www.opengis.net/kml/2.2';
 
 /**
  * Namespace URI used for gx nodes.
  * @type {string}
- * @const
  */
-plugin.file.kml.GX_NS = 'http://www.google.com/kml/ext/2.2';
-
+const GX_NS = 'http://www.google.com/kml/ext/2.2';
 
 /**
  * Namespace URI used for gx nodes.
  * @type {string}
- * @const
  */
-plugin.file.kml.OS_NS = 'http://opensphere.io/kml/ext/1.0';
-
+const OS_NS = 'http://opensphere.io/kml/ext/1.0';
 
 /**
  * The default KML style
  * @type {Object<string, *>}
  */
-plugin.file.kml.DEFAULT_STYLE = {
+const DEFAULT_STYLE = {
   'image': {
     'type': 'icon',
-    'anchorOrigin': ol.style.IconOrigin.BOTTOM_LEFT,
-    'anchorXUnits': ol.style.IconAnchorUnits.FRACTION,
-    'anchorYUnits': ol.style.IconAnchorUnits.FRACTION,
-    'crossOrigin': os.net.CrossOrigin.ANONYMOUS,
+    'anchorOrigin': IconOrigin.BOTTOM_LEFT,
+    'anchorXUnits': IconAnchorUnits.FRACTION,
+    'anchorYUnits': IconAnchorUnits.FRACTION,
+    'crossOrigin': CrossOrigin.ANONYMOUS,
     'rotation': 0,
-    'src': os.ui.file.kml.DEFAULT_ICON_PATH
+    'src': kml.DEFAULT_ICON_PATH
   },
   'fill': {
-    'color': os.style.DEFAULT_LAYER_COLOR
+    'color': osStyle.DEFAULT_LAYER_COLOR
   },
   'stroke': {
-    'color': os.style.DEFAULT_LAYER_COLOR,
-    'width': os.style.DEFAULT_STROKE_WIDTH
+    'color': osStyle.DEFAULT_LAYER_COLOR,
+    'width': osStyle.DEFAULT_STROKE_WIDTH
   }
 };
-
 
 /**
  * @type {Array<Object<string, *>>}
  */
-plugin.file.kml.DEFAULT_STYLE_ARRAY = [plugin.file.kml.DEFAULT_STYLE];
+const DEFAULT_STYLE_ARRAY = [DEFAULT_STYLE];
 
+/**
+ * Fields that should be displayed on the source.
+ *
+ * @type {!Array<string>}
+ */
+const SOURCE_FIELDS = [
+  KMLField.NAME,
+  KMLField.DESCRIPTION,
+  annotation.OPTIONS_FIELD,
+  Fields.BEARING,
+  Fields.LAT,
+  Fields.LON,
+  Fields.LAT_DDM,
+  Fields.LON_DDM,
+  Fields.LAT_DMS,
+  Fields.LON_DMS,
+  Fields.MGRS,
+  Fields.SEMI_MAJOR,
+  Fields.SEMI_MINOR,
+  Fields.SEMI_MAJOR_UNITS,
+  Fields.SEMI_MINOR_UNITS,
+  Fields.TIME,
+  Fields.ORIENTATION,
+  StyleField.CENTER_SHAPE,
+  StyleField.SHAPE,
+  StyleField.LABELS,
+  StyleField.LABEL_COLOR,
+  StyleField.LABEL_SIZE,
+  StyleField.FILL_COLOR,
+  StyleField.SHOW_LABELS
+];
+
+// extend column auto size rules to include KML columns
+Object.assign(slickColumn.fix, {
+  'name': {
+    order: -60,
+    width: 200
+  },
+  'description': {
+    order: -55
+  }
+});
 
 /**
  * Replaces parsers in an Openlayers KML parser map.
@@ -91,9 +146,8 @@ plugin.file.kml.DEFAULT_STYLE_ARRAY = [plugin.file.kml.DEFAULT_STYLE];
  * @param {Object<string, Object<string, ol.XmlParser>>} obj The parser object with namespace keys
  * @param {string} field The field to replace
  * @param {ol.XmlParser} parser The new parser
- * @private
  */
-plugin.file.kml.replaceParsers_ = function(obj, field, parser) {
+const replaceParsers_ = function(obj, field, parser) {
   for (var ns in obj) {
     if (obj[ns]) {
       obj[ns][field] = parser;
@@ -101,38 +155,36 @@ plugin.file.kml.replaceParsers_ = function(obj, field, parser) {
   }
 };
 
-
 /**
  * Create default OpenLayers styles along with OpenSphere overrides.
  * @suppress {accessControls, const}
  */
-plugin.file.kml.createStyleDefaults = function() {
-  if (!ol.format.KML.DEFAULT_STYLE_ARRAY_) {
-    ol.format.KML.createStyleDefaults_();
+const createStyleDefaults = function() {
+  if (!KML.DEFAULT_STYLE_ARRAY_) {
+    KML.createStyleDefaults_();
   }
 
-  if (ol.format.KML.DEFAULT_IMAGE_STYLE_SRC_ != os.ui.file.kml.DEFAULT_ICON_PATH) {
+  if (KML.DEFAULT_IMAGE_STYLE_SRC_ != kml.DEFAULT_ICON_PATH) {
     // use OpenSphere's default icon, and update all properties to size/position it properly
-    ol.format.KML.DEFAULT_IMAGE_STYLE_SRC_ = os.ui.file.kml.DEFAULT_ICON_PATH;
-    ol.format.KML.DEFAULT_IMAGE_SCALE_MULTIPLIER_ = 1;
-    ol.format.KML.DEFAULT_IMAGE_STYLE_SIZE_ = [32, 32];
-    ol.format.KML.DEFAULT_IMAGE_STYLE_ANCHOR_ = [16, 16];
+    KML.DEFAULT_IMAGE_STYLE_SRC_ = kml.DEFAULT_ICON_PATH;
+    KML.DEFAULT_IMAGE_SCALE_MULTIPLIER_ = 1;
+    KML.DEFAULT_IMAGE_STYLE_SIZE_ = [32, 32];
+    KML.DEFAULT_IMAGE_STYLE_ANCHOR_ = [16, 16];
 
     // replace the icon style with the new defaults
-    ol.format.KML.DEFAULT_IMAGE_STYLE_ = new ol.style.Icon({
-      anchor: ol.format.KML.DEFAULT_IMAGE_STYLE_ANCHOR_,
-      anchorOrigin: ol.style.IconOrigin.BOTTOM_LEFT,
-      anchorXUnits: ol.format.KML.DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS_,
-      anchorYUnits: ol.format.KML.DEFAULT_IMAGE_STYLE_ANCHOR_Y_UNITS_,
+    KML.DEFAULT_IMAGE_STYLE_ = new Icon({
+      anchor: KML.DEFAULT_IMAGE_STYLE_ANCHOR_,
+      anchorOrigin: IconOrigin.BOTTOM_LEFT,
+      anchorXUnits: KML.DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS_,
+      anchorYUnits: KML.DEFAULT_IMAGE_STYLE_ANCHOR_Y_UNITS_,
       crossOrigin: 'anonymous',
       rotation: 0,
-      scale: ol.format.KML.DEFAULT_IMAGE_SCALE_MULTIPLIER_,
-      size: ol.format.KML.DEFAULT_IMAGE_STYLE_SIZE_,
-      src: ol.format.KML.DEFAULT_IMAGE_STYLE_SRC_
+      scale: KML.DEFAULT_IMAGE_SCALE_MULTIPLIER_,
+      size: KML.DEFAULT_IMAGE_STYLE_SIZE_,
+      src: KML.DEFAULT_IMAGE_STYLE_SRC_
     });
   }
 };
-
 
 /**
  * Accessor for private Openlayers code.
@@ -140,10 +192,9 @@ plugin.file.kml.createStyleDefaults = function() {
  * @return {function(this: T, *, Array<*>, (string|undefined)): (Node|undefined)}
  * @template T
  */
-plugin.file.kml.OL_GEOMETRY_NODE_FACTORY = function() {
-  return ol.format.KML.GEOMETRY_NODE_FACTORY_;
+const OL_GEOMETRY_NODE_FACTORY = function() {
+  return KML.GEOMETRY_NODE_FACTORY_;
 };
-
 
 /**
  * Accessor for private Openlayers code.
@@ -151,99 +202,89 @@ plugin.file.kml.OL_GEOMETRY_NODE_FACTORY = function() {
  * @return {Object<string, Object<string, ol.XmlParser>>}
  * @template T
  */
-plugin.file.kml.OL_ICON_STYLE_PARSERS = function() {
-  return ol.format.KML.ICON_STYLE_PARSERS_;
+const OL_ICON_STYLE_PARSERS = function() {
+  return KML.ICON_STYLE_PARSERS_;
 };
-
 
 /**
  * Accessor for private Openlayers code.
  *
  * @return {Object<string, Object<string, ol.XmlParser>>}
  */
-plugin.file.kml.OL_LINK_PARSERS = function() {
-  return ol.format.KML.LINK_PARSERS_;
+const OL_LINK_PARSERS = function() {
+  return KML.LINK_PARSERS_;
 };
-
 
 /**
  * Accessor for private Openlayers code.
  *
  * @return {Array<string>}
  */
-plugin.file.kml.OL_NAMESPACE_URIS = function() {
-  return ol.format.KML.NAMESPACE_URIS_;
+const OL_NAMESPACE_URIS = function() {
+  return KML.NAMESPACE_URIS_;
 };
-
 
 /**
  * Accessor for private Openlayers code.
  *
  * @return {Array<string>}
  */
-plugin.file.kml.OL_GX_NAMESPACE_URIS = function() {
-  return ol.format.KML.GX_NAMESPACE_URIS_;
+const OL_GX_NAMESPACE_URIS = function() {
+  return KML.GX_NAMESPACE_URIS_;
 };
-
 
 /**
  * Accessor for private Openlayers code.
  *
  * @return {Object<string, Object<string, ol.XmlParser>>}
  */
-plugin.file.kml.OL_NETWORK_LINK_PARSERS = function() {
-  return ol.format.KML.NETWORK_LINK_PARSERS_;
+const OL_NETWORK_LINK_PARSERS = function() {
+  return KML.NETWORK_LINK_PARSERS_;
 };
-
 
 /**
  * Accessor for private Openlayers code.
  *
  * @return {Object<string, Object<string, ol.XmlParser>>}
  */
-plugin.file.kml.OL_PAIR_PARSERS = function() {
-  return ol.format.KML.PAIR_PARSERS_;
+const OL_PAIR_PARSERS = function() {
+  return KML.PAIR_PARSERS_;
 };
-
 
 /**
  * Accessor for private Openlayers code.
  * @return {Object<string, Object<string, ol.XmlParser>>}
  */
-plugin.file.kml.OL_PLACEMARK_PARSERS = function() {
-  return ol.format.KML.PLACEMARK_PARSERS_;
+const OL_PLACEMARK_PARSERS = function() {
+  return KML.PLACEMARK_PARSERS_;
 };
-
 
 /**
  * Access for private Openlayers code.
  *
  * @return {Object<string, Object<string, ol.XmlSerializer>>}
  */
-plugin.file.kml.OL_PLACEMARK_SERIALIZERS = function() {
-  return ol.format.KML.PLACEMARK_SERIALIZERS_;
+const OL_PLACEMARK_SERIALIZERS = function() {
+  return KML.PLACEMARK_SERIALIZERS_;
 };
-
 
 /**
  * Access for private Openlayers code.
  *
  * @return {Object<string, Object<string, ol.XmlSerializer>>}
  */
-plugin.file.kml.OL_MULTI_GEOMETRY_SERIALIZERS = function() {
-  return ol.format.KML.MULTI_GEOMETRY_SERIALIZERS_;
+const OL_MULTI_GEOMETRY_SERIALIZERS = function() {
+  return KML.MULTI_GEOMETRY_SERIALIZERS_;
 };
-
 
 /**
  * Access for private Openlayers code.
  *
  * @return {Object<string, Object<string, ol.XmlParser>>}
  */
-plugin.file.kml.OL_STYLE_PARSERS = function() {
-  return ol.format.KML.STYLE_PARSERS_;
+const OL_STYLE_PARSERS = function() {
+  return KML.STYLE_PARSERS_;
 };
-
 
 /**
  * Openlayers' opacity parsing can result in 16 decimal precision, which breaks when converting to a string then back
@@ -251,11 +292,10 @@ plugin.file.kml.OL_STYLE_PARSERS = function() {
  * which we have overridden to fix opacity to 2 decimal places.
  *
  * @param {Node} node Node.
- * @private
  * @return {ol.Color|undefined} Color.
  */
-plugin.file.kml.readColor_ = function(node) {
-  var s = ol.xml.getAllTextContent(node, false);
+const readColor_ = function(node) {
+  var s = olXml.getAllTextContent(node, false);
   // The KML specification states that colors should not include a leading `#`
   // but we tolerate them.
   var m = /^\s*#?\s*([0-9A-Fa-f]{8})\s*$/.exec(s);
@@ -267,17 +307,18 @@ plugin.file.kml.readColor_ = function(node) {
       parseInt(hexColor.substr(2, 2), 16),
       parseInt(hexColor.substr(0, 2), 16) / 255
     ];
-    return ol.color.normalize(color, color);
+    return olColor.normalize(color, color);
   } else {
     return undefined;
   }
 };
-plugin.file.kml.replaceParsers_(ol.format.KML.LABEL_STYLE_PARSERS_, 'color',
-    ol.xml.makeObjectPropertySetter(plugin.file.kml.readColor_));
-plugin.file.kml.replaceParsers_(ol.format.KML.LINE_STYLE_PARSERS_, 'color',
-    ol.xml.makeObjectPropertySetter(plugin.file.kml.readColor_));
-plugin.file.kml.replaceParsers_(ol.format.KML.POLY_STYLE_PARSERS_, 'color',
-    ol.xml.makeObjectPropertySetter(plugin.file.kml.readColor_));
+
+replaceParsers_(KML.LABEL_STYLE_PARSERS_, 'color',
+    olXml.makeObjectPropertySetter(readColor_));
+replaceParsers_(KML.LINE_STYLE_PARSERS_, 'color',
+    olXml.makeObjectPropertySetter(readColor_));
+replaceParsers_(KML.POLY_STYLE_PARSERS_, 'color',
+    olXml.makeObjectPropertySetter(readColor_));
 
 
 /**
@@ -287,33 +328,33 @@ plugin.file.kml.replaceParsers_(ol.format.KML.POLY_STYLE_PARSERS_, 'color',
  * @param {Array<*>} objectStack Object stack.
  * @return {Object} style config
  */
-plugin.file.kml.readStyle = function(node, objectStack) {
-  var styleObject = ol.xml.pushParseAndPop(
-      {}, ol.format.KML.STYLE_PARSERS_, node, objectStack);
-  if (!styleObject || goog.object.isEmpty(styleObject)) {
+const readStyle = function(node, objectStack) {
+  var styleObject = olXml.pushParseAndPop(
+      {}, KML.STYLE_PARSERS_, node, objectStack);
+  if (!styleObject || googObject.isEmpty(styleObject)) {
     // don't create a style config if nothing was parsed from the element
     return null;
   }
   var fillStyle = /** @type {ol.style.Fill} */
       ('fillStyle' in styleObject ?
-        styleObject['fillStyle'] : ol.format.KML.DEFAULT_FILL_STYLE_);
+        styleObject['fillStyle'] : KML.DEFAULT_FILL_STYLE_);
   var fill = /** @type {boolean|undefined} */ (styleObject['fill']);
   var imageStyle = /** @type {ol.style.Image} */
       ('imageStyle' in styleObject ?
-        styleObject['imageStyle'] : ol.format.KML.DEFAULT_IMAGE_STYLE_);
-  if (imageStyle == ol.format.KML.DEFAULT_NO_IMAGE_STYLE_) {
+        styleObject['imageStyle'] : KML.DEFAULT_IMAGE_STYLE_);
+  if (imageStyle == KML.DEFAULT_NO_IMAGE_STYLE_) {
     imageStyle = undefined;
   }
   var textStyle = /** @type {ol.style.Text} */
       ('textStyle' in styleObject ?
-        styleObject['textStyle'] : ol.format.KML.DEFAULT_TEXT_STYLE_);
+        styleObject['textStyle'] : KML.DEFAULT_TEXT_STYLE_);
   var strokeStyle = /** @type {ol.style.Stroke} */
       ('strokeStyle' in styleObject ?
-        styleObject['strokeStyle'] : ol.format.KML.DEFAULT_STROKE_STYLE_);
+        styleObject['strokeStyle'] : KML.DEFAULT_STROKE_STYLE_);
   var outline = /** @type {boolean|undefined} */
       (styleObject['outline']);
 
-  var config = os.style.StyleManager.getInstance().toConfig(new ol.style.Style({
+  var config = StyleManager.getInstance().toConfig(new Style({
     fill: fillStyle,
     image: imageStyle,
     stroke: strokeStyle,
@@ -336,44 +377,53 @@ plugin.file.kml.readStyle = function(node, objectStack) {
   return config;
 };
 
+/**
+ * @type {Object<string, Object<string, ol.XmlParser>>}
+ */
+const PAIR_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'Style': olXml.makeObjectPropertySetter(readStyle)
+    });
+
+osObject.merge(PAIR_PARSERS, OL_PAIR_PARSERS(), true);
+
 
 /**
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.PAIR_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'Style': ol.xml.makeObjectPropertySetter(plugin.file.kml.readStyle)
+const PLACEMARK_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'Style': olXml.makeObjectPropertySetter(readStyle)
     });
 
-os.object.merge(plugin.file.kml.PAIR_PARSERS, plugin.file.kml.OL_PAIR_PARSERS(), true);
-
-
-/**
- * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
- */
-plugin.file.kml.PLACEMARK_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'Style': ol.xml.makeObjectPropertySetter(plugin.file.kml.readStyle)
-    });
-
-os.object.merge(plugin.file.kml.PLACEMARK_PARSERS, plugin.file.kml.OL_PLACEMARK_PARSERS(), true);
+osObject.merge(PLACEMARK_PARSERS, OL_PLACEMARK_PARSERS(), true);
 
 
 /**
  * Property parsers for BalloonStyle Style.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.BALLOON_PROPERTY_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'bgColor': ol.xml.makeObjectPropertySetter(plugin.file.kml.readColor_),
-      'textColor': ol.xml.makeObjectPropertySetter(plugin.file.kml.readColor_),
-      'text': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString),
-      'displayMode': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString)
+const BALLOON_PROPERTY_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'bgColor': olXml.makeObjectPropertySetter(readColor_),
+      'textColor': olXml.makeObjectPropertySetter(readColor_),
+      'text': olXml.makeObjectPropertySetter(XSD.readString),
+      'displayMode': olXml.makeObjectPropertySetter(XSD.readString)
     });
 
+/**
+ * Parse JSON data from the node.
+ *
+ * @param {Node} node Node.
+ * @return {Object|null}
+ */
+const readJson = function(node) {
+  var str = XSD.readString(node);
+  if (str) {
+    return /** @type {Object} */ (JSON.parse(str));
+  }
+  return null;
+};
 
 /**
  * Parses a time node.
@@ -382,56 +432,50 @@ plugin.file.kml.BALLOON_PROPERTY_PARSERS = ol.xml.makeStructureNS(
  * @param {Array<*>} objectStack Object stack.
  * @return {os.time.ITime} The parsed time, or null if none could be parsed
  */
-plugin.file.kml.readTime = function(node, objectStack) {
-  goog.asserts.assert(node.localName == 'TimeStamp' || node.localName == 'TimeSpan',
+const readTime = function(node, objectStack) {
+  asserts.assert(node.localName == 'TimeStamp' || node.localName == 'TimeSpan',
       'localName should be TimeStamp or TimeSpan');
 
-  var timeObj = ol.xml.pushParseAndPop({}, plugin.file.kml.TIMEFIELD_PARSERS, node, []);
+  var timeObj = olXml.pushParseAndPop({}, TIMEFIELD_PARSERS, node, []);
   var time = null;
   if (timeObj['when'] != null) {
-    time = new os.time.TimeInstant(timeObj['when']);
+    time = new TimeInstant(timeObj['when']);
   } else if (timeObj['begin'] != null || timeObj['end'] != null) {
-    time = new os.time.TimeRange(timeObj['begin'], timeObj['end']);
+    time = new TimeRange(timeObj['begin'], timeObj['end']);
   }
 
   return time;
 };
 
-
 /**
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.LINK_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'refreshInterval': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'refreshMode': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString),
-      'viewRefreshMode': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString),
-      'viewRefreshTime': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal)
+const LINK_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'refreshInterval': olXml.makeObjectPropertySetter(XSD.readDecimal),
+      'refreshMode': olXml.makeObjectPropertySetter(XSD.readString),
+      'viewRefreshMode': olXml.makeObjectPropertySetter(XSD.readString),
+      'viewRefreshTime': olXml.makeObjectPropertySetter(XSD.readDecimal)
     });
 
 
 /**
  * Extend link parsers to include refresh options.
  */
-os.object.merge(plugin.file.kml.LINK_PARSERS, plugin.file.kml.OL_LINK_PARSERS(), false);
+osObject.merge(LINK_PARSERS, OL_LINK_PARSERS(), false);
 
 
-plugin.file.kml.OS_NAMESPACE_URIS_ = [
-  plugin.file.kml.OS_NS
-];
-
+const OS_NAMESPACE_URIS = [OS_NS];
 
 /**
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.ICON_STYLE_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'color': ol.xml.makeObjectPropertySetter(plugin.file.kml.readColor_)
-    }, ol.xml.makeStructureNS(
-        plugin.file.kml.OS_NAMESPACE_URIS_, {
-          'iconOptions': plugin.file.kml.readJson_
+const ICON_STYLE_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'color': olXml.makeObjectPropertySetter(readColor_)
+    }, olXml.makeStructureNS(
+        OS_NAMESPACE_URIS, {
+          'iconOptions': readJson
         }
     ));
 
@@ -439,31 +483,28 @@ plugin.file.kml.ICON_STYLE_PARSERS = ol.xml.makeStructureNS(
 /**
  * Extend link parsers to include refresh options.
  */
-os.object.merge(plugin.file.kml.ICON_STYLE_PARSERS, plugin.file.kml.OL_ICON_STYLE_PARSERS(), false);
+osObject.merge(ICON_STYLE_PARSERS, OL_ICON_STYLE_PARSERS(), false);
 
 
 /**
  * Parse KML time nodes to a os.time.ITime object.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.TIME_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'TimeStamp': ol.xml.makeObjectPropertySetter(plugin.file.kml.readTime, os.data.RecordField.TIME),
-      'TimeSpan': ol.xml.makeObjectPropertySetter(plugin.file.kml.readTime, os.data.RecordField.TIME)
+const TIME_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'TimeStamp': olXml.makeObjectPropertySetter(readTime, RecordField.TIME),
+      'TimeSpan': olXml.makeObjectPropertySetter(readTime, RecordField.TIME)
     });
-
 
 /**
  * Parse Date objects from KML.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.TIMEFIELD_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'when': ol.xml.makeObjectPropertySetter(os.xml.readDateTime),
-      'begin': ol.xml.makeObjectPropertySetter(os.xml.readDateTime),
-      'end': ol.xml.makeObjectPropertySetter(os.xml.readDateTime)
+const TIMEFIELD_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'when': olXml.makeObjectPropertySetter(xml.readDateTime),
+      'begin': olXml.makeObjectPropertySetter(xml.readDateTime),
+      'end': olXml.makeObjectPropertySetter(xml.readDateTime)
     });
 
 
@@ -471,7 +512,7 @@ plugin.file.kml.TIMEFIELD_PARSERS = ol.xml.makeStructureNS(
  * Add time parsers to the Openlayers Placemark parsers. These will parse kml:TimeStamp into a time instant and
  * kml:TimeSpan into a time range.
  */
-os.object.merge(plugin.file.kml.TIME_PARSERS, plugin.file.kml.OL_PLACEMARK_PARSERS(), false);
+osObject.merge(TIME_PARSERS, OL_PLACEMARK_PARSERS(), false);
 
 
 /**
@@ -481,10 +522,10 @@ os.object.merge(plugin.file.kml.TIME_PARSERS, plugin.file.kml.OL_PLACEMARK_PARSE
  * @param {Array<*>} objectStack Object stack.
  * @return {ol.geom.MultiLineString|undefined} MultiLineString.
  */
-plugin.file.kml.readMultiTrack = function(node, objectStack) {
-  var geometry = ol.format.KML.readGxMultiTrack_(node, objectStack);
+const readMultiTrack = function(node, objectStack) {
+  var geometry = KML.readGxMultiTrack_(node, objectStack);
 
-  var properties = ol.xml.pushParseAndPop({}, plugin.file.kml.MULTITRACK_PROPERTY_PARSERS, node, objectStack);
+  var properties = olXml.pushParseAndPop({}, MULTITRACK_PROPERTY_PARSERS, node, objectStack);
   if (properties) {
     geometry.setProperties(properties);
   }
@@ -492,80 +533,72 @@ plugin.file.kml.readMultiTrack = function(node, objectStack) {
   return geometry;
 };
 
-
 /**
  * Geometry parsers for MultiTrack nodes.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.MULTITRACK_GEOMETRY_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
+const MULTITRACK_GEOMETRY_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
       // add kml:Track parser to support the 2.3 spec
-      'Track': ol.xml.makeArrayPusher(ol.format.KML.readGxTrack_)
+      'Track': olXml.makeArrayPusher(KML.readGxTrack_)
     });
-
 
 /**
  * Property parsers for MultiTrack nodes.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.MULTITRACK_PROPERTY_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'altitudeMode': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString),
-      'interpolate': ol.xml.makeObjectPropertySetter(ol.format.XSD.readBoolean)
-    }, ol.xml.makeStructureNS(
-        plugin.file.kml.OL_GX_NAMESPACE_URIS(), {
+const MULTITRACK_PROPERTY_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'altitudeMode': olXml.makeObjectPropertySetter(XSD.readString),
+      'interpolate': olXml.makeObjectPropertySetter(XSD.readBoolean)
+    }, olXml.makeStructureNS(
+        OL_GX_NAMESPACE_URIS(), {
           // also include gx:interpolate to support 2.2 extension values
-          'interpolate': ol.xml.makeObjectPropertySetter(ol.format.XSD.readBoolean)
+          'interpolate': olXml.makeObjectPropertySetter(XSD.readBoolean)
         }
     ));
-
 
 /**
  * Track/MultiTrack parsers for Placemark nodes.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.PLACEMARK_TRACK_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
+const PLACEMARK_TRACK_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
       // add kml:Track and kml:MultiTrack parsers to support the 2.3 spec
-      'MultiTrack': ol.xml.makeObjectPropertySetter(plugin.file.kml.readMultiTrack, 'geometry'),
-      'Track': ol.xml.makeObjectPropertySetter(ol.format.KML.readGxTrack_, 'geometry')
-    }, ol.xml.makeStructureNS(
-        plugin.file.kml.OL_GX_NAMESPACE_URIS(), {
+      'MultiTrack': olXml.makeObjectPropertySetter(readMultiTrack, 'geometry'),
+      'Track': olXml.makeObjectPropertySetter(KML.readGxTrack_, 'geometry')
+    }, olXml.makeStructureNS(
+        OL_GX_NAMESPACE_URIS(), {
           // replace gx:MultiTrack parser with ours
-          'MultiTrack': ol.xml.makeObjectPropertySetter(plugin.file.kml.readMultiTrack, 'geometry')
+          'MultiTrack': olXml.makeObjectPropertySetter(readMultiTrack, 'geometry')
         }
     ));
 
-
 /**
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.GX_TRACK_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'coord': ol.format.KML.gxCoordParser_
+const GX_TRACK_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'coord': KML.gxCoordParser_
     });
 
 
 /**
  * Extend the Openlayers MultiTrack geometry parsers.
  */
-os.object.merge(plugin.file.kml.MULTITRACK_GEOMETRY_PARSERS, ol.format.KML.GX_MULTITRACK_GEOMETRY_PARSERS_, false);
+osObject.merge(MULTITRACK_GEOMETRY_PARSERS, KML.GX_MULTITRACK_GEOMETRY_PARSERS_, false);
 
 
 /**
  * Extend the Openlayers Track node parsers.
  */
-os.object.merge(plugin.file.kml.GX_TRACK_PARSERS, ol.format.KML.GX_TRACK_PARSERS_, false);
+osObject.merge(GX_TRACK_PARSERS, KML.GX_TRACK_PARSERS_, false);
 
 
 /**
  * Add/replace Track/MultiTrack parsers for Placemark nodes.
  */
-os.object.merge(plugin.file.kml.PLACEMARK_TRACK_PARSERS, plugin.file.kml.OL_PLACEMARK_PARSERS(), true);
+osObject.merge(PLACEMARK_TRACK_PARSERS, OL_PLACEMARK_PARSERS(), true);
 
 
 /**
@@ -573,10 +606,9 @@ os.object.merge(plugin.file.kml.PLACEMARK_TRACK_PARSERS, plugin.file.kml.OL_PLAC
  *
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @private
  */
-plugin.file.kml.readLatLonBox_ = function(node, objectStack) {
-  var object = ol.xml.pushParseAndPop({}, plugin.file.kml.LAT_LON_BOX_PARSERS, node, objectStack);
+const readLatLonBox_ = function(node, objectStack) {
+  var object = olXml.pushParseAndPop({}, LAT_LON_BOX_PARSERS, node, objectStack);
   if (!object) {
     return;
   }
@@ -592,16 +624,14 @@ plugin.file.kml.readLatLonBox_ = function(node, objectStack) {
   targetObject['rotation'] = parseFloat(object['rotation'] || 0);
 };
 
-
 /**
  * Read a LatLonQuad node and add extent to the last object on the stack.
  *
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @private
  */
-plugin.file.kml.readLatLonQuad_ = function(node, objectStack) {
-  var flatCoords = ol.xml.pushParseAndPop([], plugin.file.kml.LAT_LON_QUAD_PARSERS, node, objectStack);
+const readLatLonQuad_ = function(node, objectStack) {
+  var flatCoords = olXml.pushParseAndPop([], LAT_LON_QUAD_PARSERS, node, objectStack);
   if (flatCoords && flatCoords.length) {
     // LatLonQuad is not (necessarily) a bounding box. We will only support rectangular LatLonQuads
     // (aka they should've used LatLonBox).
@@ -609,20 +639,20 @@ plugin.file.kml.readLatLonQuad_ = function(node, objectStack) {
     // I believe you need non-affine transforms (which the canvas 2d context does not support) in
     // order to draw the image properly. This is something that we could opt to do ourselves since
     // the image would only need to be redrawn once.
-    var coordinates = ol.geom.flat.inflate.coordinates(flatCoords, 0, flatCoords.length, 3);
+    var coordinates = inflate.coordinates(flatCoords, 0, flatCoords.length, 3);
     if (coordinates.length === 4) {
       var extent = coordinates.reduce(function(extent, coord) {
-        ol.extent.extendCoordinate(extent, coord);
+        olExtent.extendCoordinate(extent, coord);
         return extent;
-      }, ol.extent.createEmpty());
+      }, olExtent.createEmpty());
 
       var targetObject = /** @type {Object} */ (objectStack[objectStack.length - 1]);
 
-      if (!os.geo.isClosed(coordinates)) {
+      if (!geo.isClosed(coordinates)) {
         coordinates.push(coordinates[0].slice());
       }
 
-      if (os.geo.isRectangular(coordinates, extent)) {
+      if (geo.isRectangular(coordinates, extent)) {
         targetObject['extent'] = extent;
       } else {
         targetObject['error'] = 'Non-rectangular gx:LatLonQuad values are not supported! ' +
@@ -632,76 +662,68 @@ plugin.file.kml.readLatLonQuad_ = function(node, objectStack) {
   }
 };
 
-
 /**
  * Property parsers for GroundOverlay.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.GROUND_OVERLAY_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'Icon': ol.xml.makeObjectPropertySetter(ol.format.KML.readIcon_),
-      'color': ol.xml.makeObjectPropertySetter(plugin.file.kml.readColor_),
-      'drawOrder': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'altitude': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'altitudeMode': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString),
-      'LatLonBox': plugin.file.kml.readLatLonBox_,
-      'LatLonQuad': plugin.file.kml.readLatLonQuad_,
-      'TimeStamp': ol.xml.makeObjectPropertySetter(plugin.file.kml.readTime, os.data.RecordField.TIME),
-      'TimeSpan': ol.xml.makeObjectPropertySetter(plugin.file.kml.readTime, os.data.RecordField.TIME)
-    }, ol.xml.makeStructureNS(
-        plugin.file.kml.OL_GX_NAMESPACE_URIS(), {
+const GROUND_OVERLAY_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'Icon': olXml.makeObjectPropertySetter(KML.readIcon_),
+      'color': olXml.makeObjectPropertySetter(readColor_),
+      'drawOrder': olXml.makeObjectPropertySetter(XSD.readDecimal),
+      'altitude': olXml.makeObjectPropertySetter(XSD.readDecimal),
+      'altitudeMode': olXml.makeObjectPropertySetter(XSD.readString),
+      'LatLonBox': readLatLonBox_,
+      'LatLonQuad': readLatLonQuad_,
+      'TimeStamp': olXml.makeObjectPropertySetter(readTime, RecordField.TIME),
+      'TimeSpan': olXml.makeObjectPropertySetter(readTime, RecordField.TIME)
+    }, olXml.makeStructureNS(
+        OL_GX_NAMESPACE_URIS(), {
           // also include gx:LatLonQuad to support 2.2 extension values
-          'LatLonQuad': plugin.file.kml.readLatLonQuad_
+          'LatLonQuad': readLatLonQuad_
         }
     ));
-
 
 /**
  * Property parsers for LatLonBox.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.LAT_LON_BOX_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'north': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'south': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'east': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'west': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'rotation': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal)
+const LAT_LON_BOX_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'north': olXml.makeObjectPropertySetter(XSD.readDecimal),
+      'south': olXml.makeObjectPropertySetter(XSD.readDecimal),
+      'east': olXml.makeObjectPropertySetter(XSD.readDecimal),
+      'west': olXml.makeObjectPropertySetter(XSD.readDecimal),
+      'rotation': olXml.makeObjectPropertySetter(XSD.readDecimal)
     });
-
 
 /**
  * Property parsers for LatLonQuad.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.LAT_LON_QUAD_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'coordinates': ol.xml.makeReplacer(ol.format.KML.readFlatCoordinates_)
+const LAT_LON_QUAD_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'coordinates': olXml.makeReplacer(KML.readFlatCoordinates_)
     });
-
 
 /**
  * Property parsers for ScreenOverlay.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @const
  */
-plugin.file.kml.SCREEN_OVERLAY_PARSERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'name': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString),
-      'visibility': ol.xml.makeObjectPropertySetter(ol.format.XSD.readBoolean),
-      'Icon': ol.xml.makeObjectPropertySetter(ol.format.KML.readIcon_),
-      'color': ol.xml.makeObjectPropertySetter(plugin.file.kml.readColor_),
-      'drawOrder': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'overlayXY': ol.xml.makeObjectPropertySetter(ol.format.KML.readVec2_),
-      'screenXY': ol.xml.makeObjectPropertySetter(ol.format.KML.readVec2_),
-      'rotationXY': ol.xml.makeObjectPropertySetter(ol.format.KML.readVec2_),
-      'size': ol.xml.makeObjectPropertySetter(ol.format.KML.readVec2_),
-      'rotation': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'TimeStamp': ol.xml.makeObjectPropertySetter(plugin.file.kml.readTime, os.data.RecordField.TIME),
-      'TimeSpan': ol.xml.makeObjectPropertySetter(plugin.file.kml.readTime, os.data.RecordField.TIME)
+const SCREEN_OVERLAY_PARSERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'name': olXml.makeObjectPropertySetter(XSD.readString),
+      'visibility': olXml.makeObjectPropertySetter(XSD.readBoolean),
+      'Icon': olXml.makeObjectPropertySetter(KML.readIcon_),
+      'color': olXml.makeObjectPropertySetter(readColor_),
+      'drawOrder': olXml.makeObjectPropertySetter(XSD.readDecimal),
+      'overlayXY': olXml.makeObjectPropertySetter(KML.readVec2_),
+      'screenXY': olXml.makeObjectPropertySetter(KML.readVec2_),
+      'rotationXY': olXml.makeObjectPropertySetter(KML.readVec2_),
+      'size': olXml.makeObjectPropertySetter(KML.readVec2_),
+      'rotation': olXml.makeObjectPropertySetter(XSD.readDecimal),
+      'TimeStamp': olXml.makeObjectPropertySetter(readTime, RecordField.TIME),
+      'TimeSpan': olXml.makeObjectPropertySetter(readTime, RecordField.TIME)
     });
 
 
@@ -715,28 +737,28 @@ plugin.file.kml.SCREEN_OVERLAY_PARSERS = ol.xml.makeStructureNS(
  *
  * @suppress {duplicate}
  */
-ol.format.KML.GEOMETRY_NODE_FACTORY_ = function(value, objectStack, opt_nodeName) {
+KML.GEOMETRY_NODE_FACTORY_ = function(value, objectStack, opt_nodeName) {
   var parentNode = objectStack[objectStack.length - 1].node;
   var namespaceURI = parentNode.namespaceURI;
   var geometryType = value.getType();
-  var nodeType = ol.format.KML.GEOMETRY_TYPE_TO_NODENAME_[geometryType];
+  var nodeType = KML.GEOMETRY_TYPE_TO_NODENAME_[geometryType];
 
-  if (value instanceof ol.geom.SimpleGeometry) {
+  if (value instanceof SimpleGeometry) {
     // check if we can transform it into a track
     var layout = value.getLayout();
 
-    if (layout === ol.geom.GeometryLayout.XYM || layout === ol.geom.GeometryLayout.XYZM) {
-      if (geometryType === ol.geom.GeometryType.LINE_STRING) {
+    if (layout === GeometryLayout.XYM || layout === GeometryLayout.XYZM) {
+      if (geometryType === GeometryType.LINE_STRING) {
         nodeType = 'gx:Track';
-        namespaceURI = plugin.file.kml.GX_NS;
-      } else if (geometryType === ol.geom.GeometryType.MULTI_LINE_STRING) {
+        namespaceURI = GX_NS;
+      } else if (geometryType === GeometryType.MULTI_LINE_STRING) {
         nodeType = 'gx:MultiTrack';
-        namespaceURI = plugin.file.kml.GX_NS;
+        namespaceURI = GX_NS;
       }
     }
   }
 
-  return ol.xml.createElementNS(namespaceURI, nodeType);
+  return olXml.createElementNS(namespaceURI, nodeType);
 };
 
 
@@ -750,8 +772,8 @@ ol.format.KML.GEOMETRY_NODE_FACTORY_ = function(value, objectStack, opt_nodeName
  * @return {string} URI
  * @protected
  */
-plugin.file.kml.readURI = function(node) {
-  var s = ol.xml.getAllTextContent(node, false).trim();
+const readURI = function(node) {
+  var s = olXml.getAllTextContent(node, false).trim();
 
   // find the asset map
   var assetMap = null;
@@ -771,25 +793,26 @@ plugin.file.kml.readURI = function(node) {
       return replaced;
     }
 
-    return goog.Uri.resolve(node.baseURI, s).toString();
+    return Uri.resolve(node.baseURI, s).toString();
   }
 
   return s;
 };
-plugin.file.kml.replaceParsers_(ol.format.KML.PLACEMARK_PARSERS_, 'styleUrl',
-    ol.xml.makeObjectPropertySetter(plugin.file.kml.readURI));
+
+replaceParsers_(KML.PLACEMARK_PARSERS_, 'styleUrl',
+    olXml.makeObjectPropertySetter(readURI));
 
 
 /**
  * Override for HREF parsing so that it will use our own readURI function above
  */
-plugin.file.kml.HREF_OVERRIDE = ol.xml.makeStructureNS(
-    ol.format.KML.NAMESPACE_URIS_, {
-      'href': ol.xml.makeObjectPropertySetter(plugin.file.kml.readURI)
+const HREF_OVERRIDE = olXml.makeStructureNS(
+    KML.NAMESPACE_URIS_, {
+      'href': olXml.makeObjectPropertySetter(readURI)
     });
 
-os.object.merge(plugin.file.kml.HREF_OVERRIDE, ol.format.KML.LINK_PARSERS_, true);
-os.object.merge(plugin.file.kml.HREF_OVERRIDE, ol.format.KML.ICON_PARSERS_, true);
+osObject.merge(HREF_OVERRIDE, KML.LINK_PARSERS_, true);
+osObject.merge(HREF_OVERRIDE, KML.ICON_PARSERS_, true);
 
 
 /**
@@ -797,34 +820,30 @@ os.object.merge(plugin.file.kml.HREF_OVERRIDE, ol.format.KML.ICON_PARSERS_, true
  * @param {Node} node Node.
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {Array<*>} objectStack Object stack.
- * @private
  */
-plugin.file.kml.olWriteMultiGeometry_ = ol.format.KML.writeMultiGeometry_;
-
+const olWriteMultiGeometry_ = KML.writeMultiGeometry_;
 
 /**
- * Adds support for writing geometries in a {@link ol.geom.GeometryCollection} to a kml:MultiGeometry node.
+ * Adds support for writing geometries in a {@link GeometryCollection} to a kml:MultiGeometry node.
  *
  * @param {Node} node Node.
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {Array<*>} objectStack Object stack.
- * @private
  */
-plugin.file.kml.writeMultiGeometry_ = function(node, geometry, objectStack) {
-  if (geometry instanceof ol.geom.GeometryCollection) {
+const writeMultiGeometry_ = function(node, geometry, objectStack) {
+  if (geometry instanceof GeometryCollection) {
     // this part should be PR'ed back to Openlayers
     var /** @type {ol.XmlNodeStackItem} */ context = {node: node};
     var geometries = geometry.getGeometries();
     for (var i = 0, n = geometries.length; i < n; i++) {
-      ol.xml.pushSerializeAndPop(context, plugin.file.kml.OL_PLACEMARK_SERIALIZERS(),
-          plugin.file.kml.OL_GEOMETRY_NODE_FACTORY(), [geometries[i]], objectStack);
+      olXml.pushSerializeAndPop(context, OL_PLACEMARK_SERIALIZERS(),
+          OL_GEOMETRY_NODE_FACTORY(), [geometries[i]], objectStack);
     }
   } else {
     // call the original function for everything else
-    plugin.file.kml.olWriteMultiGeometry_(node, geometry, objectStack);
+    olWriteMultiGeometry_(node, geometry, objectStack);
   }
 };
-
 
 /**
  * Adds support for writing Track nodes.
@@ -832,45 +851,41 @@ plugin.file.kml.writeMultiGeometry_ = function(node, geometry, objectStack) {
  * @param {Node} node Node.
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {Array<*>} objectStack Object stack.
- * @private
  */
-plugin.file.kml.writeMultiTrack_ = function(node, geometry, objectStack) {
-  if (geometry instanceof ol.geom.MultiLineString) {
+const writeMultiTrack_ = function(node, geometry, objectStack) {
+  if (geometry instanceof MultiLineString) {
     var lineStrings = geometry.getLineStrings();
     for (var i = 0; i < lineStrings.length; i++) {
-      var trackNode = ol.xml.createElementNS(plugin.file.kml.GX_NS, 'gx:Track');
-      plugin.file.kml.writeTrack_(trackNode, lineStrings[i], objectStack);
+      var trackNode = olXml.createElementNS(GX_NS, 'gx:Track');
+      writeTrack_(trackNode, lineStrings[i], objectStack);
       node.appendChild(trackNode);
     }
   }
 };
 
-
-
 /**
  * Adds support for writing Track nodes.
  *
  * @param {Node} node Node.
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {Array<*>} objectStack Object stack.
- * @private
  */
-plugin.file.kml.writeTrack_ = function(node, geometry, objectStack) {
-  if (geometry instanceof ol.geom.LineString) {
+const writeTrack_ = function(node, geometry, objectStack) {
+  if (geometry instanceof LineString) {
     var flatCoordinates = geometry.getFlatCoordinates();
     var stride = geometry.getStride();
 
     for (var i = 0; i < flatCoordinates.length; i += stride) {
-      var coordNode = ol.xml.createElementNS(plugin.file.kml.GX_NS, 'gx:coord');
+      var coordNode = olXml.createElementNS(GX_NS, 'gx:coord');
       var coordText = flatCoordinates[i] + ' ' + flatCoordinates[i + 1];
       if (stride > 3) {
         coordText += ' ' + flatCoordinates[i + 2];
       }
-      ol.format.XSD.writeStringTextNode(coordNode, coordText);
+      XSD.writeStringTextNode(coordNode, coordText);
 
-      var whenNode = ol.xml.createElementNS(plugin.file.kml.KML_NS, 'when');
+      var whenNode = olXml.createElementNS(KML_NS, 'when');
       var whenText = new Date(flatCoordinates[i + stride - 1]).toISOString();
-      ol.format.XSD.writeStringTextNode(whenNode, whenText);
+      XSD.writeStringTextNode(whenNode, whenText);
 
       node.appendChild(coordNode);
       node.appendChild(whenNode);
@@ -878,23 +893,22 @@ plugin.file.kml.writeTrack_ = function(node, geometry, objectStack) {
   }
 };
 
-
 /**
  * Override the Openlayers Placemark serializers to add additional support.
  * @type {Object<string, Object<string, ol.XmlSerializer>>}
- * @const
  */
-plugin.file.kml.PLACEMARK_SERIALIZERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'MultiGeometry': ol.xml.makeChildAppender(plugin.file.kml.writeMultiGeometry_)
-    }, ol.xml.makeStructureNS(
-        plugin.file.kml.OL_GX_NAMESPACE_URIS(), {
+const PLACEMARK_SERIALIZERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'MultiGeometry': olXml.makeChildAppender(writeMultiGeometry_)
+    }, olXml.makeStructureNS(
+        OL_GX_NAMESPACE_URIS(), {
           // add serializers for gx:Track and gx:MultiTrack
-          'MultiTrack': ol.xml.makeChildAppender(plugin.file.kml.writeMultiTrack_),
-          'Track': ol.xml.makeChildAppender(plugin.file.kml.writeTrack_)
+          'MultiTrack': olXml.makeChildAppender(writeMultiTrack_),
+          'Track': olXml.makeChildAppender(writeTrack_)
         }
     ));
-os.object.merge(plugin.file.kml.PLACEMARK_SERIALIZERS, plugin.file.kml.OL_PLACEMARK_SERIALIZERS(), true);
+
+osObject.merge(PLACEMARK_SERIALIZERS, OL_PLACEMARK_SERIALIZERS(), true);
 
 
 
@@ -902,39 +916,36 @@ os.object.merge(plugin.file.kml.PLACEMARK_SERIALIZERS, plugin.file.kml.OL_PLACEM
  * @param {Node} node Node.
  * @param {ol.geom.Polygon} polygon Polygon.
  * @param {Array<*>} objectStack Object stack
- * @private
  */
-plugin.file.kml.writePolygon_ = function(node, polygon, objectStack) {
-  ol.format.KML.writePolygon_(node, polygon, objectStack);
+const writePolygon_ = function(node, polygon, objectStack) {
+  KML.writePolygon_(node, polygon, objectStack);
 
   var context = /** @type {ol.XmlNodeStackItem} */ ({node: node});
   var properties = polygon.getProperties();
   var parentNode = objectStack[objectStack.length - 1].node;
-  var orderedKeys = ol.format.KML.PRIMITIVE_GEOMETRY_SEQUENCE_[parentNode.namespaceURI];
-  var values = ol.xml.makeSequence(properties, orderedKeys);
-  ol.xml.pushSerializeAndPop(context, ol.format.KML.PRIMITIVE_GEOMETRY_SERIALIZERS_,
-      ol.xml.OBJECT_PROPERTY_NODE_FACTORY, values, objectStack, orderedKeys);
+  var orderedKeys = KML.PRIMITIVE_GEOMETRY_SEQUENCE_[parentNode.namespaceURI];
+  var values = olXml.makeSequence(properties, orderedKeys);
+  olXml.pushSerializeAndPop(context, KML.PRIMITIVE_GEOMETRY_SERIALIZERS_,
+      olXml.OBJECT_PROPERTY_NODE_FACTORY, values, objectStack, orderedKeys);
 };
-
 
 /**
  * @type {Object<string, Object<string, ol.XmlSerializer>>}
- * @const
  */
-plugin.file.kml.POLYGON_SERIALIZERS = ol.xml.makeStructureNS(
-    plugin.file.kml.OL_NAMESPACE_URIS(), {
-      'Polygon': ol.xml.makeChildAppender(plugin.file.kml.writePolygon_)
+const POLYGON_SERIALIZERS = olXml.makeStructureNS(
+    OL_NAMESPACE_URIS(), {
+      'Polygon': olXml.makeChildAppender(writePolygon_)
     });
 
-os.object.merge(plugin.file.kml.POLYGON_SERIALIZERS, plugin.file.kml.OL_PLACEMARK_SERIALIZERS(), true);
-os.object.merge(plugin.file.kml.POLYGON_SERIALIZERS,
-    plugin.file.kml.OL_MULTI_GEOMETRY_SERIALIZERS(), true);
+osObject.merge(POLYGON_SERIALIZERS, OL_PLACEMARK_SERIALIZERS(), true);
+osObject.merge(POLYGON_SERIALIZERS,
+    OL_MULTI_GEOMETRY_SERIALIZERS(), true);
 
 
 /**
- * {@link ol.geom.GeometryCollection} should be serialized as a kml:MultiGeometry.
+ * {@link GeometryCollection} should be serialized as a kml:MultiGeometry.
  */
-ol.format.KML.GEOMETRY_TYPE_TO_NODENAME_['GeometryCollection'] = 'MultiGeometry';
+KML.GEOMETRY_TYPE_TO_NODENAME_['GeometryCollection'] = 'MultiGeometry';
 
 
 /**
@@ -947,8 +958,8 @@ ol.format.KML.GEOMETRY_TYPE_TO_NODENAME_['GeometryCollection'] = 'MultiGeometry'
  *
  * @suppress {duplicate}
  */
-ol.format.KML.readFlatCoordinates_ = function(node) {
-  var s = ol.xml.getAllTextContent(node, false);
+KML.readFlatCoordinates_ = function(node) {
+  var s = olXml.getAllTextContent(node, false);
   var flatCoordinates = [];
 
   // The KML specification states that coordinate tuples should not include
@@ -968,10 +979,10 @@ ol.format.KML.readFlatCoordinates_ = function(node) {
   // }
   return flatCoordinates;
 };
-plugin.file.kml.replaceParsers_(ol.format.KML.FLAT_LINEAR_RING_PARSERS_, 'coordinates',
-    ol.xml.makeReplacer(ol.format.KML.readFlatCoordinates_));
-plugin.file.kml.replaceParsers_(ol.format.KML.GEOMETRY_FLAT_COORDINATES_PARSERS_, 'coordinates',
-    ol.xml.makeReplacer(ol.format.KML.readFlatCoordinates_));
+replaceParsers_(KML.FLAT_LINEAR_RING_PARSERS_, 'coordinates',
+    olXml.makeReplacer(KML.readFlatCoordinates_));
+replaceParsers_(KML.GEOMETRY_FLAT_COORDINATES_PARSERS_, 'coordinates',
+    olXml.makeReplacer(KML.readFlatCoordinates_));
 
 
 /**
@@ -979,33 +990,17 @@ plugin.file.kml.replaceParsers_(ol.format.KML.GEOMETRY_FLAT_COORDINATES_PARSERS_
  *
  * @param {Node} node Node.
  * @return {number|undefined} Scale.
- * @private
  */
-plugin.file.kml.readScale_ = function(node) {
-  return ol.format.XSD.readDecimal(node);
+const readScale_ = function(node) {
+  return XSD.readDecimal(node);
 };
-plugin.file.kml.replaceParsers_(ol.format.KML.ICON_STYLE_PARSERS_, 'scale',
-    ol.xml.makeObjectPropertySetter(plugin.file.kml.readScale_));
-plugin.file.kml.replaceParsers_(ol.format.KML.LABEL_STYLE_PARSERS_, 'scale',
-    ol.xml.makeObjectPropertySetter(plugin.file.kml.readScale_));
 
-
-/**
- * Parse JSON data from the node.
- *
- * @param {Node} node Node.
- * @return {Object|null}
- * @private
- */
-plugin.file.kml.readJson_ = function(node) {
-  var str = ol.format.XSD.readString(node);
-  if (str) {
-    return /** @type {Object} */ (JSON.parse(str));
-  }
-  return null;
-};
-plugin.file.kml.replaceParsers_(ol.format.KML.ICON_STYLE_PARSERS_, 'iconOptions',
-    ol.xml.makeObjectPropertySetter(plugin.file.kml.readJson_));
+replaceParsers_(KML.ICON_STYLE_PARSERS_, 'scale',
+    olXml.makeObjectPropertySetter(readScale_));
+replaceParsers_(KML.LABEL_STYLE_PARSERS_, 'scale',
+    olXml.makeObjectPropertySetter(readScale_));
+replaceParsers_(KML.ICON_STYLE_PARSERS_, 'iconOptions',
+    olXml.makeObjectPropertySetter(readJson));
 
 
 /**
@@ -1013,15 +1008,15 @@ plugin.file.kml.replaceParsers_(ol.format.KML.ICON_STYLE_PARSERS_, 'iconOptions'
  *
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @private
  */
-plugin.file.kml.UrlParser_ = function(node, objectStack) {
-  goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT,
+const UrlParser_ = function(node, objectStack) {
+  asserts.assert(node.nodeType == NodeType.ELEMENT,
       'node.nodeType should be ELEMENT');
-  goog.asserts.assert(node.localName == 'Url', 'localName should be Url');
-  ol.xml.parseNode(plugin.file.kml.OL_LINK_PARSERS(), node, objectStack);
+  asserts.assert(node.localName == 'Url', 'localName should be Url');
+  olXml.parseNode(OL_LINK_PARSERS(), node, objectStack);
 };
-plugin.file.kml.replaceParsers_(plugin.file.kml.OL_NETWORK_LINK_PARSERS(), 'Url', plugin.file.kml.UrlParser_);
+
+replaceParsers_(OL_NETWORK_LINK_PARSERS(), 'Url', UrlParser_);
 
 
 /**
@@ -1029,30 +1024,29 @@ plugin.file.kml.replaceParsers_(plugin.file.kml.OL_NETWORK_LINK_PARSERS(), 'Url'
  *
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @private
  */
-plugin.file.kml.IconStyleParser_ = function(node, objectStack) {
-  goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT, 'node.nodeType should be an ELEMENT');
-  goog.asserts.assert(node.localName == 'IconStyle', 'localName should be IconStyle');
+const IconStyleParser_ = function(node, objectStack) {
+  asserts.assert(node.nodeType == NodeType.ELEMENT, 'node.nodeType should be an ELEMENT');
+  asserts.assert(node.localName == 'IconStyle', 'localName should be IconStyle');
   // FIXME refreshMode
   // FIXME refreshInterval
   // FIXME viewRefreshTime
   // FIXME viewBoundScale
   // FIXME viewFormat
   // FIXME httpQuery
-  var object = ol.xml.pushParseAndPop({}, ol.format.KML.ICON_STYLE_PARSERS_, node, objectStack);
+  var object = olXml.pushParseAndPop({}, KML.ICON_STYLE_PARSERS_, node, objectStack);
   if (!object) {
     return;
   }
   var styleObject = /** @type {Object} */ (objectStack[objectStack.length - 1]);
-  goog.asserts.assert(goog.isObject(styleObject), 'styleObject should be an Object');
+  asserts.assert(goog.isObject(styleObject), 'styleObject should be an Object');
   var IconObject = 'Icon' in object ? object['Icon'] : {};
   var src;
   var href = /** @type {string|undefined} */ (IconObject['href']);
   if (href) {
     src = href;
   } else {
-    src = os.object.IGNORE_VAL;
+    src = osObject.IGNORE_VAL;
   }
 
   var anchor;
@@ -1082,7 +1076,7 @@ plugin.file.kml.IconStyleParser_ = function(node, objectStack) {
   var rotation;
   var heading = /** @type {number} */ (object['heading']);
   if (heading !== undefined) {
-    rotation = ol.math.toRadians(heading);
+    rotation = math.toRadians(heading);
   }
 
   var scale = /** @type {number|undefined} */ (object['scale']);
@@ -1090,22 +1084,22 @@ plugin.file.kml.IconStyleParser_ = function(node, objectStack) {
   var options = /** @type {Object|undefined} */ (object['iconOptions']);
 
   // determine the crossOrigin from the provided URL. if 'none', use undefined so the attribute isn't set on the image.
-  var crossOrigin = src ? os.net.getCrossOrigin(src) : undefined;
-  if (crossOrigin == os.net.CrossOrigin.NONE) {
+  var crossOrigin = src ? net.getCrossOrigin(src) : undefined;
+  if (crossOrigin == CrossOrigin.NONE) {
     crossOrigin = undefined;
   }
 
   var color = /** @type {ol.Color} */ (object['color']);
 
-  var imageStyle = new ol.style.Icon({
+  var imageStyle = new Icon({
     anchor: anchor,
-    anchorOrigin: ol.style.IconOrigin.BOTTOM_LEFT,
+    anchorOrigin: IconOrigin.BOTTOM_LEFT,
     anchorXUnits: anchorXUnits,
     anchorYUnits: anchorYUnits,
     color: color,
     crossOrigin: crossOrigin,
     offset: offset,
-    offsetOrigin: ol.style.IconOrigin.BOTTOM_LEFT,
+    offsetOrigin: IconOrigin.BOTTOM_LEFT,
     rotation: rotation,
     scale: scale,
     size: size,
@@ -1115,4 +1109,49 @@ plugin.file.kml.IconStyleParser_ = function(node, objectStack) {
 
   styleObject['imageStyle'] = imageStyle;
 };
-plugin.file.kml.replaceParsers_(plugin.file.kml.OL_STYLE_PARSERS(), 'IconStyle', plugin.file.kml.IconStyleParser_);
+
+replaceParsers_(OL_STYLE_PARSERS(), 'IconStyle', IconStyleParser_);
+
+exports = {
+  BALLOON_PROPERTY_PARSERS,
+  DEFAULT_STYLE,
+  DEFAULT_STYLE_ARRAY,
+  GROUND_OVERLAY_PARSERS,
+  GX_NS,
+  GX_TRACK_PARSERS,
+  HREF_OVERRIDE,
+  ICON_STYLE_PARSERS,
+  KML_NS,
+  LAT_LON_BOX_PARSERS,
+  LAT_LON_QUAD_PARSERS,
+  LINK_PARSERS,
+  MULTITRACK_GEOMETRY_PARSERS,
+  MULTITRACK_PROPERTY_PARSERS,
+  OL_GEOMETRY_NODE_FACTORY,
+  OL_GX_NAMESPACE_URIS,
+  OL_ICON_STYLE_PARSERS,
+  OL_LINK_PARSERS,
+  OL_MULTI_GEOMETRY_SERIALIZERS,
+  OL_NAMESPACE_URIS,
+  OL_NETWORK_LINK_PARSERS,
+  OL_PAIR_PARSERS,
+  OL_PLACEMARK_PARSERS,
+  OL_PLACEMARK_SERIALIZERS,
+  OL_STYLE_PARSERS,
+  OS_NS,
+  PAIR_PARSERS,
+  PLACEMARK_PARSERS,
+  PLACEMARK_SERIALIZERS,
+  PLACEMARK_TRACK_PARSERS,
+  POLYGON_SERIALIZERS,
+  SCREEN_OVERLAY_PARSERS,
+  SOURCE_FIELDS,
+  STYLE_KEY,
+  TIMEFIELD_PARSERS,
+  TIME_PARSERS,
+  createStyleDefaults,
+  readMultiTrack,
+  readStyle,
+  readTime,
+  readURI
+};

--- a/src/plugin/file/kml/kmldescriptor.js
+++ b/src/plugin/file/kml/kmldescriptor.js
@@ -1,70 +1,55 @@
-goog.provide('plugin.file.kml.KMLDescriptor');
+goog.module('plugin.file.kml.KMLDescriptor');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.FileDescriptor');
-goog.require('os.layer');
-goog.require('os.layer.LayerType');
-goog.require('os.style');
-goog.require('os.ui.ControlType');
-goog.require('plugin.file.kml.KMLExporter');
-goog.require('plugin.file.kml.KMLProvider');
-
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const layer = goog.require('os.layer');
+const LayerType = goog.require('os.layer.LayerType');
+const ColorControlType = goog.require('os.ui.ColorControlType');
+const ControlType = goog.require('os.ui.ControlType');
+const KMLExporter = goog.require('plugin.file.kml.KMLExporter');
 
 
 /**
  * KML file descriptor.
- *
- * @extends {os.data.FileDescriptor}
- * @constructor
  */
-plugin.file.kml.KMLDescriptor = function() {
-  plugin.file.kml.KMLDescriptor.base(this, 'constructor');
-  this.descriptorType = 'kml';
-};
-goog.inherits(plugin.file.kml.KMLDescriptor, os.data.FileDescriptor);
+class KMLDescriptor extends FileDescriptor {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.descriptorType = 'kml';
+  }
 
+  /**
+   * @inheritDoc
+   */
+  getType() {
+    return LayerType.FEATURES;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLDescriptor.prototype.getType = function() {
-  return os.layer.LayerType.FEATURES;
-};
+  /**
+   * @inheritDoc
+   */
+  getLayerOptions() {
+    var options = super.getLayerOptions();
+    options['type'] = 'KML';
 
+    // allow resetting the layer color to the default
+    options[ControlType.COLOR] = ColorControlType.PICKER_RESET;
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLDescriptor.prototype.getLayerOptions = function() {
-  var options = plugin.file.kml.KMLDescriptor.base(this, 'getLayerOptions');
-  options['type'] = 'KML';
+    // show the option to replace feature colors with the layer color
+    options[layer.LayerOption.SHOW_FORCE_COLOR] = true;
 
-  // allow resetting the layer color to the default
-  options[os.ui.ControlType.COLOR] = os.ui.ColorControlType.PICKER_RESET;
+    return options;
+  }
 
-  // show the option to replace feature colors with the layer color
-  options[os.layer.LayerOption.SHOW_FORCE_COLOR] = true;
+  /**
+   * @inheritDoc
+   */
+  getExporter() {
+    return new KMLExporter();
+  }
+}
 
-  return options;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLDescriptor.prototype.getExporter = function() {
-  return new plugin.file.kml.KMLExporter();
-};
-
-
-/**
- * Creates a new descriptor from a parser configuration.
- *
- * @param {!os.parse.FileParserConfig} config
- * @return {!plugin.file.kml.KMLDescriptor}
- */
-plugin.file.kml.KMLDescriptor.createFromConfig = function(config) {
-  var provider = plugin.file.kml.KMLProvider.getInstance();
-  var descriptor = new plugin.file.kml.KMLDescriptor();
-  os.data.FileDescriptor.createFromConfig(descriptor, provider, config);
-  return descriptor;
-};
+exports = KMLDescriptor;

--- a/src/plugin/file/kml/kmlexport.js
+++ b/src/plugin/file/kml/kmlexport.js
@@ -1,8 +1,9 @@
-goog.provide('plugin.file.kml.export');
+goog.module('plugin.file.kml.export');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.annotation');
-goog.require('os.style');
-goog.require('os.style.StyleField');
+const annotation = goog.require('os.annotation');
+const osStyle = goog.require('os.style');
+const StyleField = goog.require('os.style.StyleField');
 
 
 /**
@@ -11,23 +12,23 @@ goog.require('os.style.StyleField');
  * @param {ol.Feature} feature The feature.
  * @return {?osx.annotation.KMLBalloon} The balloon options.
  */
-plugin.file.kml.export.getBalloonOptions = function(feature) {
+const getBalloonOptions = function(feature) {
   var balloonOptions = null;
 
   if (feature) {
-    var annotationOptions = /** @type {osx.annotation.Options} */ (feature.get(os.annotation.OPTIONS_FIELD));
+    var annotationOptions = /** @type {osx.annotation.Options} */ (feature.get(annotation.OPTIONS_FIELD));
     if (annotationOptions && annotationOptions.show) {
       var balloonParts = [];
 
       if (annotationOptions.showName) {
-        var name = os.annotation.getNameText(feature);
+        var name = annotation.getNameText(feature);
         if (name) {
           balloonParts.push(name);
         }
       }
 
       if (annotationOptions.showDescription) {
-        var description = os.annotation.getDescriptionText(feature);
+        var description = annotation.getDescriptionText(feature);
         if (description) {
           balloonParts.push(description);
         }
@@ -47,21 +48,20 @@ plugin.file.kml.export.getBalloonOptions = function(feature) {
   return balloonOptions;
 };
 
-
 /**
  * Get the icon rotation column for an OpenLayers feature.
  *
  * @param {ol.Feature} feature The feature.
  * @return {string|undefined} The column.
  */
-plugin.file.kml.export.getRotationColumn = function(feature) {
+const getRotationColumn = function(feature) {
   var rotColumn;
   if (feature) {
-    rotColumn = /** @type {string|undefined} */ (feature.get(os.style.StyleField.ROTATION_COLUMN));
+    rotColumn = /** @type {string|undefined} */ (feature.get(StyleField.ROTATION_COLUMN));
 
-    var layerConfig = os.style.getLayerConfig(feature);
-    if ((!rotColumn && layerConfig) || (layerConfig && layerConfig[os.style.StyleField.REPLACE_STYLE])) {
-      rotColumn = layerConfig[os.style.StyleField.ROTATION_COLUMN];
+    var layerConfig = osStyle.getLayerConfig(feature);
+    if ((!rotColumn && layerConfig) || (layerConfig && layerConfig[StyleField.REPLACE_STYLE])) {
+      rotColumn = layerConfig[StyleField.ROTATION_COLUMN];
     }
   }
 
@@ -75,10 +75,16 @@ plugin.file.kml.export.getRotationColumn = function(feature) {
  * @param {ol.Feature} feature The feature.
  * @return {Array<number>|null|undefined} The line dash.
  */
-plugin.file.kml.export.getLineDash = function(feature) {
+const getLineDash = function(feature) {
   if (feature) {
-    var layerConfig = os.style.getBaseFeatureConfig(feature);
-    return os.style.getConfigLineDash(Array.isArray(layerConfig) ? layerConfig[0] : layerConfig);
+    var layerConfig = osStyle.getBaseFeatureConfig(feature);
+    return osStyle.getConfigLineDash(Array.isArray(layerConfig) ? layerConfig[0] : layerConfig);
   }
   return undefined;
+};
+
+exports = {
+  getBalloonOptions,
+  getRotationColumn,
+  getLineDash
 };

--- a/src/plugin/file/kml/kmlfeatureparser.js
+++ b/src/plugin/file/kml/kmlfeatureparser.js
@@ -1,82 +1,85 @@
-goog.provide('plugin.file.kml.KMLFeatureParser');
+goog.module('plugin.file.kml.KMLFeatureParser');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.format.KML');
-goog.require('ol.xml');
-goog.require('os.file.mime.text');
-goog.require('os.parse.IParser');
-
+const KML = goog.require('ol.format.KML');
+const xml = goog.require('ol.xml');
+const text = goog.require('os.file.mime.text');
+const osMap = goog.require('os.map');
+const IParser = goog.requireType('os.parse.IParser');
 
 
 /**
  * Simple KML parser that extracts features from a KML.
  *
- * @implements {os.parse.IParser<ol.Feature>}
- * @constructor
+ * @implements {IParser<ol.Feature>}
  */
-plugin.file.kml.KMLFeatureParser = function() {
+class KMLFeatureParser {
   /**
-   * @type {ol.format.KML}
-   * @private
+   * Constructor.
    */
-  this.format_ = new ol.format.KML({
-    showPointNames: false
-  });
-
-  /**
-   * @type {?Document}
-   * @private
-   */
-  this.document_ = null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLFeatureParser.prototype.setSource = function(source) {
-  if (source instanceof ArrayBuffer) {
-    source = os.file.mime.text.getText(source) || null;
-  }
-
-  if (ol.xml.isDocument(source)) {
-    this.document_ = /** @type {Document} */ (source);
-  } else if (typeof source === 'string') {
-    this.document_ = ol.xml.parse(source);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLFeatureParser.prototype.cleanup = function() {
-  this.document_ = null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLFeatureParser.prototype.hasNext = function() {
-  return this.document_ != null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLFeatureParser.prototype.parseNext = function() {
-  var features = null;
-  if (this.document_) {
-    // make sure the document reference is cleared so errors don't result in hasNext continuing to return true. the
-    // importer will catch and report the error so we don't do it here.
-    var doc = this.document_;
-    this.document_ = null;
-
-    features = this.format_.readFeatures(doc, {
-      featureProjection: os.map.PROJECTION
+  constructor() {
+    /**
+     * @type {KML}
+     * @private
+     */
+    this.format_ = new KML({
+      showPointNames: false
     });
+
+    /**
+     * @type {?Document}
+     * @private
+     */
+    this.document_ = null;
   }
 
-  return features;
-};
+  /**
+   * @inheritDoc
+   */
+  setSource(source) {
+    if (source instanceof ArrayBuffer) {
+      source = text.getText(source) || null;
+    }
+
+    if (xml.isDocument(source)) {
+      this.document_ = /** @type {Document} */ (source);
+    } else if (typeof source === 'string') {
+      this.document_ = xml.parse(source);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  cleanup() {
+    this.document_ = null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  hasNext() {
+    return this.document_ != null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  parseNext() {
+    var features = null;
+    if (this.document_) {
+      // make sure the document reference is cleared so errors don't result in hasNext continuing to return true. the
+      // importer will catch and report the error so we don't do it here.
+      var doc = this.document_;
+      this.document_ = null;
+
+      features = this.format_.readFeatures(doc, {
+        featureProjection: osMap.PROJECTION
+      });
+    }
+
+    return features;
+  }
+}
+
+exports = KMLFeatureParser;

--- a/src/plugin/file/kml/kmlfield.js
+++ b/src/plugin/file/kml/kmlfield.js
@@ -1,74 +1,15 @@
-goog.provide('plugin.file.kml.JsonField');
-goog.provide('plugin.file.kml.KMLField');
-
-goog.require('os.Fields');
-goog.require('os.annotation');
-goog.require('os.style');
-goog.require('os.ui.slick.column');
+goog.module('plugin.file.kml.KMLField');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * @enum {string}
  */
-plugin.file.kml.KMLField = {
+const KMLField = {
   BALLOON_TEXT: '_balloonText',
   DESCRIPTION: 'description',
   MD_DESCRIPTION: '_mdDescription',
   NAME: 'name'
 };
 
-
-// extend column auto size rules to include KML columns
-Object.assign(os.ui.slick.column.fix, {
-  'name': {
-    order: -60,
-    width: 200
-  },
-  'description': {
-    order: -55
-  }
-});
-
-
-/**
- * Fields that should be displayed on the source.
- *
- * @type {!Array<string>}
- * @const
- */
-plugin.file.kml.SOURCE_FIELDS = [
-  plugin.file.kml.KMLField.NAME,
-  plugin.file.kml.KMLField.DESCRIPTION,
-  os.annotation.OPTIONS_FIELD,
-  os.Fields.BEARING,
-  os.Fields.LAT,
-  os.Fields.LON,
-  os.Fields.LAT_DDM,
-  os.Fields.LON_DDM,
-  os.Fields.LAT_DMS,
-  os.Fields.LON_DMS,
-  os.Fields.MGRS,
-  os.Fields.SEMI_MAJOR,
-  os.Fields.SEMI_MINOR,
-  os.Fields.SEMI_MAJOR_UNITS,
-  os.Fields.SEMI_MINOR_UNITS,
-  os.Fields.TIME,
-  os.Fields.ORIENTATION,
-  os.style.StyleField.CENTER_SHAPE,
-  os.style.StyleField.SHAPE,
-  os.style.StyleField.LABELS,
-  os.style.StyleField.LABEL_COLOR,
-  os.style.StyleField.LABEL_SIZE,
-  os.style.StyleField.FILL_COLOR,
-  os.style.StyleField.SHOW_LABELS
-];
-
-
-/**
- * Fields that are known to contain specialized JSON data.
- * @type {!Array<string>}
- */
-plugin.file.kml.JsonField = [
-  os.annotation.OPTIONS_FIELD,
-  os.data.RecordField.RING_OPTIONS
-];
+exports = KMLField;

--- a/src/plugin/file/kml/kmlimporter.js
+++ b/src/plugin/file/kml/kmlimporter.js
@@ -1,159 +1,166 @@
-goog.provide('plugin.file.kml.KMLImporter');
+goog.module('plugin.file.kml.KMLImporter');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.im.FeatureImporter');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
 
+const AlertManager = goog.require('os.alert.AlertManager');
+const osFeature = goog.require('os.feature');
+const FeatureImporter = goog.require('os.im.FeatureImporter');
+
+
+const osStyle = goog.require('os.style');
+const StyleField = goog.require('os.style.StyleField');
+const StyleType = goog.require('os.style.StyleType');
+const SlickTreeNode = goog.require('os.ui.slick.SlickTreeNode');
 
 
 /**
  * Imports a set of KML items
  *
- * @param {plugin.file.kml.KMLParser} parser The parser
- * @extends {os.im.FeatureImporter.<plugin.file.kml.ui.KMLNode>}
- * @constructor
+ * @extends {FeatureImporter.<plugin.file.kml.ui.KMLNode>}
  */
-plugin.file.kml.KMLImporter = function(parser) {
-  plugin.file.kml.KMLImporter.base(this, 'constructor', parser);
+class KMLImporter extends FeatureImporter {
+  /**
+   * Constructor.
+   * @param {plugin.file.kml.KMLParser} parser The parser
+   */
+  constructor(parser) {
+    super(parser);
+
+    /**
+     * The last parsed KML root node
+     * @type {plugin.file.kml.ui.KMLNode}
+     * @private
+     */
+    this.rootNode_ = null;
+
+    /**
+     * Columns detected in the KML
+     * @type {Array<!os.data.ColumnDefinition>}
+     * @private
+     */
+    this.columns_ = null;
+
+    /**
+     * minimum refresh interval from the NetworkLinkControl
+     * @type {number}
+     * @private
+     */
+    this.minRefreshPeriod_ = 0;
+
+    /**
+     * Number of invalid polygons detected on import
+     * @type {number}
+     * @private
+     */
+    this.invalidCount_ = 0;
+  }
 
   /**
-   * The last parsed KML root node
-   * @type {plugin.file.kml.ui.KMLNode}
-   * @private
+   * @inheritDoc
    */
-  this.rootNode_ = null;
-
-  /**
-   * Columns detected in the KML
-   * @type {Array<!os.data.ColumnDefinition>}
-   * @private
-   */
-  this.columns_ = null;
-
-  /**
-   * minimum refresh interval from the NetworkLinkControl
-   * @type {number}
-   * @private
-   */
-  this.minRefreshPeriod_ = 0;
-
-  /**
-   * Number of invalid polygons detected on import
-   * @type {number}
-   * @private
-   */
-  this.invalidCount_ = 0;
-};
-goog.inherits(plugin.file.kml.KMLImporter, os.im.FeatureImporter);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLImporter.prototype.disposeInternal = function() {
-  plugin.file.kml.KMLImporter.base(this, 'disposeInternal');
-  this.rootNode_ = null;
-};
-
-
-/**
- * Get the root KML tree node.
- * @param {boolean=} opt_clear If the root node should be cleared on call.
- * @return {plugin.file.kml.ui.KMLNode}
- */
-plugin.file.kml.KMLImporter.prototype.getRootNode = function(opt_clear = false) {
-  var rootNode = this.rootNode_;
-  if (opt_clear) {
+  disposeInternal() {
+    super.disposeInternal();
     this.rootNode_ = null;
   }
-  return rootNode;
-};
 
-
-/**
- * Get columns detected in the KML.
- *
- * @return {Array<!os.data.ColumnDefinition>}
- */
-plugin.file.kml.KMLImporter.prototype.getColumns = function() {
-  return this.columns_;
-};
-
-
-/**
- * Get columns detected in the KML.
- *
- * @return {number}
- */
-plugin.file.kml.KMLImporter.prototype.getMinRefreshPeriod = function() {
-  return this.minRefreshPeriod_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLImporter.prototype.onParserReady = function(opt_event) {
-  // if a KML tree was previously parsed, set it on the parser so the tree is merged
-  this.parser.setRootNode(this.rootNode_);
-
-  plugin.file.kml.KMLImporter.base(this, 'onParserReady', opt_event);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLImporter.prototype.onParsingComplete = function(opt_event) {
-  // grab the newly parsed KML tree before it's removed by parser cleanup
-  this.rootNode_ = this.parser.getRootNode();
-  this.columns_ = this.parser.getColumns();
-  this.minRefreshPeriod_ = this.parser.getMinRefreshPeriod();
-
-  if (this.invalidCount_ > 0) {
-    var msg = this.invalidCount_ === 1 ? 'An area was' : (this.invalidCount_ + ' areas were');
-    os.alertManager.sendAlert(msg + ' removed from the original due to invalid topology. One possible ' +
-        ' reason is a repeating or invalid coordinate.',
-    os.alert.AlertEventSeverity.WARNING);
+  /**
+   * Get the root KML tree node.
+   * @param {boolean=} opt_clear If the root node should be cleared on call.
+   * @return {plugin.file.kml.ui.KMLNode}
+   */
+  getRootNode(opt_clear = false) {
+    var rootNode = this.rootNode_;
+    if (opt_clear) {
+      this.rootNode_ = null;
+    }
+    return rootNode;
   }
 
-  plugin.file.kml.KMLImporter.base(this, 'onParsingComplete', opt_event);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLImporter.prototype.sanitize = function(item) {
-  var feature = null;
-  if ((item instanceof os.ui.slick.SlickTreeNode) && (item.getFeature())) {
-    feature = /** @type {ol.Feature} */ (item.getFeature());
+  /**
+   * Get columns detected in the KML.
+   *
+   * @return {Array<!os.data.ColumnDefinition>}
+   */
+  getColumns() {
+    return this.columns_;
   }
 
-  if (feature) {
-    this.invalidCount_ += os.feature.validateGeometries(feature, false);
-    plugin.file.kml.KMLImporter.base(this, 'sanitize', feature);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLImporter.prototype.performMappings = function(item) {
-  var feature = null;
-  if (item.getFeature()) {
-    feature = /** @type {ol.Feature} */ (item.getFeature());
+  /**
+   * Get columns detected in the KML.
+   *
+   * @return {number}
+   */
+  getMinRefreshPeriod() {
+    return this.minRefreshPeriod_;
   }
 
-  if (feature && (this.mappings || this.autoMappings)) {
-    plugin.file.kml.KMLImporter.base(this, 'performMappings', feature);
+  /**
+   * @inheritDoc
+   */
+  onParserReady(opt_event) {
+    // if a KML tree was previously parsed, set it on the parser so the tree is merged
+    this.parser.setRootNode(this.rootNode_);
 
-    // line dash isn't part of kml spec, translate it here
-    var lineDash = /** @type {string} */ (feature.get(os.style.StyleField.LINE_DASH));
-    if (lineDash) {
-      var dash = /** @type {Array<number>} */ (JSON.parse(lineDash));
-      var config = os.style.getBaseFeatureConfig(feature);
-      os.style.setConfigLineDash(config, dash);
-      feature.set(os.style.StyleType.FEATURE, config);
+    super.onParserReady(opt_event);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  onParsingComplete(opt_event) {
+    // grab the newly parsed KML tree before it's removed by parser cleanup
+    this.rootNode_ = this.parser.getRootNode();
+    this.columns_ = this.parser.getColumns();
+    this.minRefreshPeriod_ = this.parser.getMinRefreshPeriod();
+
+    if (this.invalidCount_ > 0) {
+      var msg = this.invalidCount_ === 1 ? 'An area was' : (this.invalidCount_ + ' areas were');
+      AlertManager.getInstance().sendAlert(msg + ' removed from the original due to invalid topology. One possible ' +
+          ' reason is a repeating or invalid coordinate.',
+      AlertEventSeverity.WARNING);
+    }
+
+    super.onParsingComplete(opt_event);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  sanitize(item) {
+    var feature = null;
+    if ((item instanceof SlickTreeNode) && (item.getFeature())) {
+      feature = /** @type {ol.Feature} */ (item.getFeature());
+    }
+
+    if (feature) {
+      this.invalidCount_ += osFeature.validateGeometries(feature, false);
+      super.sanitize(feature);
     }
   }
-};
+
+  /**
+   * @inheritDoc
+   */
+  performMappings(item) {
+    var feature = null;
+    if (item.getFeature()) {
+      feature = /** @type {ol.Feature} */ (item.getFeature());
+    }
+
+    if (feature && (this.mappings || this.autoMappings)) {
+      super.performMappings(feature);
+
+      // line dash isn't part of kml spec, translate it here
+      var lineDash = /** @type {string} */ (feature.get(StyleField.LINE_DASH));
+      if (lineDash) {
+        var dash = /** @type {Array<number>} */ (JSON.parse(lineDash));
+        var config = osStyle.getBaseFeatureConfig(feature);
+        osStyle.setConfigLineDash(config, dash);
+        feature.set(StyleType.FEATURE, config);
+      }
+    }
+  }
+}
+
+exports = KMLImporter;

--- a/src/plugin/file/kml/kmllayer.js
+++ b/src/plugin/file/kml/kmllayer.js
@@ -1,100 +1,100 @@
-goog.provide('plugin.file.kml.KMLLayer');
-goog.require('os.events.PropertyChangeEvent');
-goog.require('os.layer.Vector');
-goog.require('os.structs.ITreeNodeSupplier');
-goog.require('plugin.file.kml.ui.KMLLayerNode');
+goog.module('plugin.file.kml.KMLLayer');
+goog.module.declareLegacyNamespace();
 
-
-
-/**
- * @param {olx.layer.VectorOptions} options Vector layer options
- * @extends {os.layer.Vector}
- * @implements {os.structs.ITreeNodeSupplier}
- * @constructor
- */
-plugin.file.kml.KMLLayer = function(options) {
-  plugin.file.kml.KMLLayer.base(this, 'constructor', options);
-
-  /**
-   * If the tree node should be created in the collapsed state.
-   * @type {boolean}
-   */
-  this.collapsed = false;
-
-  /**
-   * If the KML can be edited.
-   * @type {boolean}
-   */
-  this.editable = false;
-
-  /**
-   * If the KML root node should be displayed, or just its children.
-   * @type {boolean}
-   */
-  this.showRoot = true;
-};
-goog.inherits(plugin.file.kml.KMLLayer, os.layer.Vector);
+const VectorLayer = goog.require('os.layer.Vector');
+const KMLLayerNode = goog.require('plugin.file.kml.ui.KMLLayerNode');
+const ITreeNodeSupplier = goog.requireType('os.structs.ITreeNodeSupplier');
 
 
 /**
- * @inheritDoc
+ * @implements {ITreeNodeSupplier}
  */
-plugin.file.kml.KMLLayer.prototype.disposeInternal = function() {
-  // clear potential KMZ assets stored by the parser
-  var source = /** @type {plugin.file.kml.KMLSource} */ (this.getSource());
-  if (source) {
-    var importer = source.getImporter();
-    if (importer) {
-      var parser = /** @type {plugin.file.kml.KMLParser} */ (importer.getParser());
-      if (parser) {
-        parser.clearAssets();
+class KMLLayer extends VectorLayer {
+  /**
+   * Constructor.
+   * @param {olx.layer.VectorOptions} options Vector layer options
+   */
+  constructor(options) {
+    super(options);
+
+    /**
+     * If the tree node should be created in the collapsed state.
+     * @type {boolean}
+     */
+    this.collapsed = false;
+
+    /**
+     * If the KML can be edited.
+     * @type {boolean}
+     */
+    this.editable = false;
+
+    /**
+     * If the KML root node should be displayed, or just its children.
+     * @type {boolean}
+     */
+    this.showRoot = true;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    // clear potential KMZ assets stored by the parser
+    var source = /** @type {plugin.file.kml.KMLSource} */ (this.getSource());
+    if (source) {
+      var importer = source.getImporter();
+      if (importer) {
+        var parser = /** @type {plugin.file.kml.KMLParser} */ (importer.getParser());
+        if (parser) {
+          parser.clearAssets();
+        }
       }
     }
+
+    super.disposeInternal();
   }
 
-  plugin.file.kml.KMLLayer.base(this, 'disposeInternal');
-};
+  /**
+   * @inheritDoc
+   */
+  getTreeNode() {
+    var node = new KMLLayerNode(this);
+    node.collapsed = this.collapsed;
 
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLLayer.prototype.getTreeNode = function() {
-  var node = new plugin.file.kml.ui.KMLLayerNode(this);
-  node.collapsed = this.collapsed;
-
-  return node;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLLayer.prototype.persist = function(opt_to) {
-  var config = plugin.file.kml.KMLLayer.base(this, 'persist', opt_to);
-
-  config['collapsed'] = this.collapsed;
-  config['editable'] = this.editable;
-  config['showRoot'] = this.showRoot;
-  return config;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLLayer.prototype.restore = function(config) {
-  plugin.file.kml.KMLLayer.base(this, 'restore', config);
-
-  if (config['collapsed'] != null) {
-    this.collapsed = config['collapsed'];
+    return node;
   }
 
-  if (config['editable'] != null) {
-    this.editable = config['editable'];
+  /**
+   * @inheritDoc
+   */
+  persist(opt_to) {
+    var config = super.persist(opt_to);
+
+    config['collapsed'] = this.collapsed;
+    config['editable'] = this.editable;
+    config['showRoot'] = this.showRoot;
+    return config;
   }
 
-  if (config['showRoot'] != null) {
-    this.showRoot = config['showRoot'];
+  /**
+   * @inheritDoc
+   */
+  restore(config) {
+    super.restore(config);
+
+    if (config['collapsed'] != null) {
+      this.collapsed = config['collapsed'];
+    }
+
+    if (config['editable'] != null) {
+      this.editable = config['editable'];
+    }
+
+    if (config['showRoot'] != null) {
+      this.showRoot = config['showRoot'];
+    }
   }
-};
+}
+
+exports = KMLLayer;

--- a/src/plugin/file/kml/kmllayerconfig.js
+++ b/src/plugin/file/kml/kmllayerconfig.js
@@ -1,84 +1,87 @@
-goog.provide('plugin.file.kml.KMLLayerConfig');
+goog.module('plugin.file.kml.KMLLayerConfig');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.net.XhrIo.ResponseType');
-goog.require('goog.userAgent');
-goog.require('os.data.DataManager');
-goog.require('os.layer.config.AbstractDataSourceLayerConfig');
-goog.require('os.net');
-goog.require('plugin.file.kml.KMLImporter');
-goog.require('plugin.file.kml.KMLLayer');
-goog.require('plugin.file.kml.KMLParser');
-goog.require('plugin.file.kml.KMLSource');
-
-
-
-/**
- * @extends {os.layer.config.AbstractDataSourceLayerConfig.<plugin.file.kml.ui.KMLNode>}
- * @constructor
- */
-plugin.file.kml.KMLLayerConfig = function() {
-  plugin.file.kml.KMLLayerConfig.base(this, 'constructor');
-};
-goog.inherits(plugin.file.kml.KMLLayerConfig, os.layer.config.AbstractDataSourceLayerConfig);
+const ResponseType = goog.require('goog.net.XhrIo.ResponseType');
+const userAgent = goog.require('goog.userAgent');
+const AltMapping = goog.require('os.im.mapping.AltMapping');
+const OrientationMapping = goog.require('os.im.mapping.OrientationMapping');
+const SemiMajorMapping = goog.require('os.im.mapping.SemiMajorMapping');
+const SemiMinorMapping = goog.require('os.im.mapping.SemiMinorMapping');
+const AbstractDataSourceLayerConfig = goog.require('os.layer.config.AbstractDataSourceLayerConfig');
+const net = goog.require('os.net');
+const KMLImporter = goog.require('plugin.file.kml.KMLImporter');
+const KMLLayer = goog.require('plugin.file.kml.KMLLayer');
+const KMLParser = goog.require('plugin.file.kml.KMLParser');
+const KMLSource = goog.require('plugin.file.kml.KMLSource');
 
 
 /**
- * @inheritDoc
+ * @extends {AbstractDataSourceLayerConfig.<plugin.file.kml.ui.KMLNode>}
  */
-plugin.file.kml.KMLLayerConfig.prototype.getImporter = function(options) {
-  var importer = new plugin.file.kml.KMLImporter(/** @type {plugin.file.kml.KMLParser} */ (this.getParser(options)));
-  importer.setTrustHTML(os.net.isTrustedUri(/** @type {string|undefined} */ (options['url'])));
-
-  // select the mappings we want to perform autodetection
-  importer.selectAutoMappings([
-    os.im.mapping.AltMapping.ID,
-    os.im.mapping.OrientationMapping.ID,
-    os.im.mapping.SemiMajorMapping.ID,
-    os.im.mapping.SemiMinorMapping.ID]);
-
-  return importer;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLLayerConfig.prototype.getLayer = function(source) {
-  return new plugin.file.kml.KMLLayer({
-    source: source
-  });
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLLayerConfig.prototype.getParser = function(options) {
-  return new plugin.file.kml.KMLParser(options);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLLayerConfig.prototype.getRequest = function(options) {
-  var request = plugin.file.kml.KMLLayerConfig.base(this, 'getRequest', options);
-
-  // requesting a Document in the response was slightly faster in testing, but only works for KML (not KMZ). if we run
-  // into related issues of parsing speed, we should try to determine the content type ahead of time and change this.
-  if (!goog.userAgent.IE || goog.userAgent.isVersionOrHigher(10)) {
-    request.setResponseType(goog.net.XhrIo.ResponseType.ARRAY_BUFFER);
+class KMLLayerConfig extends AbstractDataSourceLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
 
-  return request;
-};
+  /**
+   * @inheritDoc
+   */
+  getImporter(options) {
+    var importer = new KMLImporter(/** @type {KMLParser} */ (this.getParser(options)));
+    importer.setTrustHTML(net.isTrustedUri(/** @type {string|undefined} */ (options['url'])));
 
+    // select the mappings we want to perform autodetection
+    importer.selectAutoMappings([
+      AltMapping.ID,
+      OrientationMapping.ID,
+      SemiMajorMapping.ID,
+      SemiMinorMapping.ID]);
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLLayerConfig.prototype.getSource = function(options) {
-  var source = new plugin.file.kml.KMLSource(undefined);
-  source.setFile(options['parserConfig'] ? options['parserConfig']['file'] : null);
-  return source;
-};
+    return importer;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLayer(source) {
+    return new KMLLayer({
+      source: source
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getParser(options) {
+    return new KMLParser(options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getRequest(options) {
+    var request = super.getRequest(options);
+
+    // requesting a Document in the response was slightly faster in testing, but only works for KML (not KMZ). if we run
+    // into related issues of parsing speed, we should try to determine the content type ahead of time and change this.
+    if (!userAgent.IE || userAgent.isVersionOrHigher(10)) {
+      request.setResponseType(ResponseType.ARRAY_BUFFER);
+    }
+
+    return request;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getSource(options) {
+    var source = new KMLSource(undefined);
+    source.setFile(options['parserConfig'] ? options['parserConfig']['file'] : null);
+    return source;
+  }
+}
+
+exports = KMLLayerConfig;

--- a/src/plugin/file/kml/kmlmenu.js
+++ b/src/plugin/file/kml/kmlmenu.js
@@ -1,20 +1,22 @@
-goog.provide('plugin.file.kml.menu');
+goog.module('plugin.file.kml.menu');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.Feature');
-goog.require('ol.geom.Polygon');
-goog.require('os.buffer');
-goog.require('os.ui.feature.featureInfoDirective');
-goog.require('os.ui.menu.layer');
-goog.require('plugin.file.kml.ui.KMLNetworkLinkNode');
-goog.require('plugin.file.kml.ui.KMLNode');
-goog.require('plugin.file.kml.ui.kmlTreeExportDirective');
+const asserts = goog.require('goog.asserts');
+
+const buffer = goog.require('os.buffer');
+const osFeature = goog.require('os.feature');
+const TriState = goog.require('os.structs.TriState');
+const launchMultiFeatureInfo = goog.require('os.ui.feature.launchMultiFeatureInfo');
+const layerMenu = goog.require('os.ui.menu.layer');
+const KMLNetworkLinkNode = goog.require('plugin.file.kml.ui.KMLNetworkLinkNode');
+const KMLNode = goog.require('plugin.file.kml.ui.KMLNode');
 
 
 /**
  * KML menu event types.
  * @enum {string}
  */
-plugin.file.kml.menu.EventType = {
+const EventType = {
   LOAD: 'kml:load',
   REFRESH: 'kml:refresh',
   FEATURE_INFO: 'kml:featureInfo',
@@ -25,132 +27,129 @@ plugin.file.kml.menu.EventType = {
   BUFFER: 'kml:buffer'
 };
 
-
 /**
  * Set up KML tree items in the layer menu.
  */
-plugin.file.kml.menu.treeSetup = function() {
-  var menu = os.ui.menu.layer.MENU;
-  if (menu && !menu.getRoot().find(plugin.file.kml.menu.EventType.GOTO)) {
+const treeSetup = function() {
+  var menu = layerMenu.MENU;
+  if (menu && !menu.getRoot().find(EventType.GOTO)) {
     var menuRoot = menu.getRoot();
-    var toolsGroup = menuRoot.find(os.ui.menu.layer.GroupLabel.TOOLS);
-    goog.asserts.assert(toolsGroup, 'Group should exist! Check spelling?');
+    var toolsGroup = menuRoot.find(layerMenu.GroupLabel.TOOLS);
+    asserts.assert(toolsGroup, 'Group should exist! Check spelling?');
 
     menuRoot.addChild({
       label: 'Load',
-      eventType: plugin.file.kml.menu.EventType.LOAD,
+      eventType: EventType.LOAD,
       tooltip: 'Load the network link',
       icons: ['<i class="fa fa-fw fa-cloud-download"></i>'],
-      beforeRender: plugin.file.kml.menu.visibleIfSupported_,
-      handler: plugin.file.kml.menu.onLayerEvent_,
-      sort: os.ui.menu.layer.GroupSort.LAYER++
+      beforeRender: visibleIfSupported_,
+      handler: onLayerEvent_,
+      sort: layerMenu.GroupSort.LAYER++
     });
 
     menuRoot.addChild({
       label: 'Refresh',
-      eventType: plugin.file.kml.menu.EventType.REFRESH,
+      eventType: EventType.REFRESH,
       tooltip: 'Refresh the network link',
       icons: ['<i class="fa fa-fw fa-refresh"></i>'],
-      beforeRender: plugin.file.kml.menu.visibleIfSupported_,
-      handler: plugin.file.kml.menu.onLayerEvent_,
-      sort: os.ui.menu.layer.GroupSort.LAYER++
+      beforeRender: visibleIfSupported_,
+      handler: onLayerEvent_,
+      sort: layerMenu.GroupSort.LAYER++
     });
 
     menuRoot.addChild({
       label: 'Feature Info',
-      eventType: plugin.file.kml.menu.EventType.FEATURE_INFO,
+      eventType: EventType.FEATURE_INFO,
       tooltip: 'Display detailed feature information',
       icons: ['<i class="fa fa-fw fa-info-circle"></i>'],
-      beforeRender: plugin.file.kml.menu.visibleIfSupported_,
-      handler: plugin.file.kml.menu.onLayerEvent_,
-      sort: os.ui.menu.layer.GroupSort.LAYER++
+      beforeRender: visibleIfSupported_,
+      handler: onLayerEvent_,
+      sort: layerMenu.GroupSort.LAYER++
     });
 
     menuRoot.addChild({
       label: 'Go To',
-      eventType: plugin.file.kml.menu.EventType.GOTO,
+      eventType: EventType.GOTO,
       tooltip: 'Repositions the map to display features at this level of the tree',
       icons: ['<i class="fa fa-fw fa-fighter-jet"></i>'],
-      beforeRender: plugin.file.kml.menu.visibleIfSupported_,
-      handler: plugin.file.kml.menu.onLayerEvent_,
-      sort: os.ui.menu.layer.GroupSort.LAYER++
+      beforeRender: visibleIfSupported_,
+      handler: onLayerEvent_,
+      sort: layerMenu.GroupSort.LAYER++
     });
 
     menuRoot.addChild({
       label: 'Select All',
-      eventType: plugin.file.kml.menu.EventType.SELECT,
+      eventType: EventType.SELECT,
       tooltip: 'Selects all features under the folder',
       icons: ['<i class="fa fa-fw fa-check-circle"></i>'],
-      beforeRender: plugin.file.kml.menu.visibleIfSupported_,
-      handler: plugin.file.kml.menu.onLayerEvent_,
-      sort: os.ui.menu.layer.GroupSort.LAYER++
+      beforeRender: visibleIfSupported_,
+      handler: onLayerEvent_,
+      sort: layerMenu.GroupSort.LAYER++
     });
 
     menuRoot.addChild({
       label: 'Deselect All',
-      eventType: plugin.file.kml.menu.EventType.DESELECT,
+      eventType: EventType.DESELECT,
       tooltip: 'Deselects all features under the folder',
       icons: ['<i class="fa fa-fw fa-times-circle"></i>'],
-      beforeRender: plugin.file.kml.menu.visibleIfSupported_,
-      handler: plugin.file.kml.menu.onLayerEvent_,
-      sort: os.ui.menu.layer.GroupSort.LAYER++
+      beforeRender: visibleIfSupported_,
+      handler: onLayerEvent_,
+      sort: layerMenu.GroupSort.LAYER++
     });
 
     menuRoot.addChild({
       label: 'Remove All',
-      eventType: plugin.file.kml.menu.EventType.REMOVE,
+      eventType: EventType.REMOVE,
       tooltip: 'Removes everything under the folder',
       icons: ['<i class="fa fa-fw fa-times"></i>'],
-      beforeRender: plugin.file.kml.menu.visibleIfSupported_,
-      handler: plugin.file.kml.menu.onLayerEvent_,
-      sort: os.ui.menu.layer.GroupSort.LAYER++
+      beforeRender: visibleIfSupported_,
+      handler: onLayerEvent_,
+      sort: layerMenu.GroupSort.LAYER++
     });
 
     toolsGroup.addChild({
       label: 'Create Buffer Region...',
-      eventType: plugin.file.kml.menu.EventType.BUFFER,
+      eventType: EventType.BUFFER,
       tooltip: 'Creates buffer regions around loaded data',
-      icons: ['<i class="fa fa-fw ' + os.buffer.ICON + '"></i>'],
-      beforeRender: plugin.file.kml.menu.visibleIfSupported_,
-      handler: plugin.file.kml.menu.onLayerEvent_
+      icons: ['<i class="fa fa-fw ' + buffer.ICON + '"></i>'],
+      beforeRender: visibleIfSupported_,
+      handler: onLayerEvent_
     });
   }
 };
 
-
 /**
  * Show a KML menu item if the context supports it.
  *
- * @param {os.ui.menu.layer.Context} context The menu context.
- * @private
+ * @param {layerMenu.Context} context The menu context.
  * @this {os.ui.menu.MenuItem}
  */
-plugin.file.kml.menu.visibleIfSupported_ = function(context) {
+const visibleIfSupported_ = function(context) {
   this.visible = false;
 
   if (this.eventType && context && context.length == 1) {
     var node = context[0];
-    if (node instanceof plugin.file.kml.ui.KMLNode) {
+    if (node instanceof KMLNode) {
       switch (this.eventType) {
-        case plugin.file.kml.menu.EventType.BUFFER:
+        case EventType.BUFFER:
           this.visible = node.hasFeatures();
           break;
-        case plugin.file.kml.menu.EventType.SELECT:
-        case plugin.file.kml.menu.EventType.DESELECT:
+        case EventType.SELECT:
+        case EventType.DESELECT:
           this.visible = node.isFolder() && node.hasFeatures();
           break;
-        case plugin.file.kml.menu.EventType.GOTO:
+        case EventType.GOTO:
           this.visible = !!node.getImage() || node.hasFeatures();
           break;
-        case plugin.file.kml.menu.EventType.LOAD:
-          this.visible = node instanceof plugin.file.kml.ui.KMLNetworkLinkNode &&
-              node.getState() === os.structs.TriState.OFF;
+        case EventType.LOAD:
+          this.visible = node instanceof KMLNetworkLinkNode &&
+              node.getState() === TriState.OFF;
           break;
-        case plugin.file.kml.menu.EventType.REFRESH:
-          this.visible = node instanceof plugin.file.kml.ui.KMLNetworkLinkNode &&
-              node.getState() !== os.structs.TriState.OFF && !node.isLoading();
+        case EventType.REFRESH:
+          this.visible = node instanceof KMLNetworkLinkNode &&
+              node.getState() !== TriState.OFF && !node.isLoading();
           break;
-        case plugin.file.kml.menu.EventType.FEATURE_INFO:
+        case EventType.FEATURE_INFO:
           this.visible = !!node.getFeature();
           break;
         default:
@@ -161,22 +160,20 @@ plugin.file.kml.menu.visibleIfSupported_ = function(context) {
   }
 };
 
-
 /**
  * Handle KML layer menu events.
  *
- * @param {!os.ui.menu.MenuEvent<os.ui.menu.layer.Context>} event The menu event.
- * @private
+ * @param {!os.ui.menu.MenuEvent<layerMenu.Context>} event The menu event.
  */
-plugin.file.kml.menu.onLayerEvent_ = function(event) {
+const onLayerEvent_ = function(event) {
   var context = event.getContext();
   if (context && context.length == 1) {
     var node = context[0];
-    if (node instanceof plugin.file.kml.ui.KMLNode) {
+    if (node instanceof KMLNode) {
       var source = node.getSource();
       if (source) {
         switch (event.type) {
-          case plugin.file.kml.menu.EventType.BUFFER:
+          case EventType.BUFFER:
             var features = node.getFeatures();
             if (features && features.length > 0) {
               var bufferTitle = node.getLabel() + ' Buffer';
@@ -184,37 +181,37 @@ plugin.file.kml.menu.onLayerEvent_ = function(event) {
                 'features': features,
                 'title': bufferTitle
               };
-              os.buffer.launchDialog(config);
+              buffer.launchDialog(config);
             }
             break;
-          case plugin.file.kml.menu.EventType.GOTO:
+          case EventType.GOTO:
             var features = node.getZoomFeatures();
             if (features) {
-              os.feature.flyTo(features);
+              osFeature.flyTo(features);
             }
             break;
-          case plugin.file.kml.menu.EventType.SELECT:
+          case EventType.SELECT:
             source.addToSelected(node.getFeatures());
             break;
-          case plugin.file.kml.menu.EventType.DESELECT:
+          case EventType.DESELECT:
             source.removeFromSelected(node.getFeatures());
             break;
-          case plugin.file.kml.menu.EventType.REMOVE:
+          case EventType.REMOVE:
             // don't put this on the stack because refreshing the layer will make commands invalid
             source.clearNode(node, true);
-            plugin.file.kml.ui.KMLNode.collapseEmpty(node);
+            KMLNode.collapseEmpty(node);
             break;
-          case plugin.file.kml.menu.EventType.LOAD:
-            /** @type {plugin.file.kml.ui.KMLNetworkLinkNode} */ (node).setState(os.structs.TriState.ON);
+          case EventType.LOAD:
+            /** @type {KMLNetworkLinkNode} */ (node).setState(TriState.ON);
             break;
-          case plugin.file.kml.menu.EventType.REFRESH:
-            /** @type {plugin.file.kml.ui.KMLNetworkLinkNode} */ (node).refresh();
+          case EventType.REFRESH:
+            /** @type {KMLNetworkLinkNode} */ (node).refresh();
             break;
-          case plugin.file.kml.menu.EventType.FEATURE_INFO:
+          case EventType.FEATURE_INFO:
             var title = source ? source.getTitle() : undefined;
             var feature = node.getFeature();
             if (feature) {
-              os.ui.feature.launchMultiFeatureInfo(feature, title);
+              launchMultiFeatureInfo(feature, title);
             }
             break;
           default:
@@ -223,4 +220,9 @@ plugin.file.kml.menu.onLayerEvent_ = function(event) {
       }
     }
   }
+};
+
+exports = {
+  EventType,
+  treeSetup
 };

--- a/src/plugin/file/kml/kmlnodelayerui.js
+++ b/src/plugin/file/kml/kmlnodelayerui.js
@@ -1,45 +1,61 @@
-goog.provide('plugin.file.kml.KMLNodeLayerUICtrl');
-goog.provide('plugin.file.kml.kmlNodeLayerUIDirective');
+goog.module('plugin.file.kml.KMLNodeLayerUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.action.EventType');
-goog.require('os.command.FeatureCenterShape');
-goog.require('os.command.FeatureColor');
-goog.require('os.command.FeatureIcon');
-goog.require('os.command.FeatureLabel');
-goog.require('os.command.FeatureLabelColor');
-goog.require('os.command.FeatureLabelSize');
-goog.require('os.command.FeatureLineDash');
-goog.require('os.command.FeatureOpacity');
-goog.require('os.command.FeatureShape');
-goog.require('os.command.FeatureShowLabel');
-goog.require('os.command.FeatureSize');
-goog.require('os.command.ParallelCommand');
-goog.require('os.command.SequenceCommand');
-goog.require('os.command.style');
-goog.require('os.data.ColumnDefinition');
-goog.require('os.geo');
-goog.require('os.ui.Module');
-goog.require('os.ui.layer.VectorLayerUICtrl');
 goog.require('os.ui.layer.iconStyleControlsDirective');
 goog.require('os.ui.layer.labelControlsDirective');
-goog.require('os.ui.layer.vectorLayerUIDirective');
 goog.require('os.ui.layer.vectorStyleControlsDirective');
-goog.require('os.ui.slick.column');
 goog.require('os.ui.uiSwitchDirective');
+
+const googArray = goog.require('goog.array');
+const olArray = goog.require('ol.array');
+const UrlTile = goog.require('ol.source.UrlTile');
+const {ROOT} = goog.require('os');
+const dispatcher = goog.require('os.Dispatcher');
+const EventType = goog.require('os.action.EventType');
+const osColor = goog.require('os.color');
+const CommandProcessor = goog.require('os.command.CommandProcessor');
+const FeatureCenterShape = goog.require('os.command.FeatureCenterShape');
+const FeatureColor = goog.require('os.command.FeatureColor');
+const FeatureIcon = goog.require('os.command.FeatureIcon');
+const FeatureLabel = goog.require('os.command.FeatureLabel');
+const FeatureLabelColor = goog.require('os.command.FeatureLabelColor');
+const FeatureLabelSize = goog.require('os.command.FeatureLabelSize');
+const FeatureLineDash = goog.require('os.command.FeatureLineDash');
+const FeatureOpacity = goog.require('os.command.FeatureOpacity');
+const FeatureShape = goog.require('os.command.FeatureShape');
+const FeatureShowLabel = goog.require('os.command.FeatureShowLabel');
+const FeatureSize = goog.require('os.command.FeatureSize');
+const ParallelCommand = goog.require('os.command.ParallelCommand');
+const SequenceCommand = goog.require('os.command.SequenceCommand');
+const style = goog.require('os.command.style');
+const ColumnDefinition = goog.require('os.data.ColumnDefinition');
+const osFeature = goog.require('os.feature');
+const DynamicFeature = goog.require('os.feature.DynamicFeature');
+const geo = goog.require('os.geo');
+const VectorSource = goog.require('os.source.Vector');
+const osStyle = goog.require('os.style');
+const StyleField = goog.require('os.style.StyleField');
+const StyleType = goog.require('os.style.StyleType');
+const label = goog.require('os.style.label');
+const FeatureEditCtrl = goog.require('os.ui.FeatureEditCtrl');
+const Module = goog.require('os.ui.Module');
+const kml = goog.require('os.ui.file.kml');
+const VectorLayerUICtrl = goog.require('os.ui.layer.VectorLayerUICtrl');
+const vectorLayerUIDirective = goog.require('os.ui.layer.vectorLayerUIDirective');
 
 
 /**
  * Supported shapes.
  * @type {Array}
  */
-plugin.file.kml.shapes = [
-  os.style.ShapeType.NONE,
-  os.style.ShapeType.POINT,
-  os.style.ShapeType.SQUARE,
-  os.style.ShapeType.TRIANGLE,
-  os.style.ShapeType.ICON,
-  os.style.ShapeType.ELLIPSE,
-  os.style.ShapeType.ELLIPSE_CENTER
+const supportedShapes = [
+  osStyle.ShapeType.NONE,
+  osStyle.ShapeType.POINT,
+  osStyle.ShapeType.SQUARE,
+  osStyle.ShapeType.TRIANGLE,
+  osStyle.ShapeType.ICON,
+  osStyle.ShapeType.ELLIPSE,
+  osStyle.ShapeType.ELLIPSE_CENTER
 ];
 
 
@@ -47,11 +63,11 @@ plugin.file.kml.shapes = [
  * Supported center shapes.
  * @type {Array}
  */
-plugin.file.kml.centerShapes = [
-  os.style.ShapeType.POINT,
-  os.style.ShapeType.SQUARE,
-  os.style.ShapeType.TRIANGLE,
-  os.style.ShapeType.ICON
+const supportedCenterShapes = [
+  osStyle.ShapeType.POINT,
+  osStyle.ShapeType.SQUARE,
+  osStyle.ShapeType.TRIANGLE,
+  osStyle.ShapeType.ICON
 ];
 
 
@@ -60,526 +76,723 @@ plugin.file.kml.centerShapes = [
  *
  * @return {angular.Directive}
  */
-plugin.file.kml.kmlNodeLayerUIDirective = function() {
-  var dir = os.ui.layer.vectorLayerUIDirective();
-  dir.templateUrl = os.ROOT + 'views/plugin/kml/kmlnodelayerui.html';
-  dir.controller = plugin.file.kml.KMLNodeLayerUICtrl;
+const directive = () => {
+  var dir = vectorLayerUIDirective();
+  dir.templateUrl = ROOT + 'views/plugin/kml/kmlnodelayerui.html';
+  dir.controller = Controller;
   return dir;
 };
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'kmlnodelayerui';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('kmlnodelayerui', [plugin.file.kml.kmlNodeLayerUIDirective]);
+Module.directive('kmlnodelayerui', [directive]);
 
 
 
 /**
  * Controller for the stream layer UI
- *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout
- * @constructor
- * @extends {os.ui.layer.VectorLayerUICtrl}
- * @ngInject
+ * @unrestricted
  */
-plugin.file.kml.KMLNodeLayerUICtrl = function($scope, $element, $timeout) {
-  plugin.file.kml.KMLNodeLayerUICtrl.base(this, 'constructor', $scope, $element, $timeout);
+class Controller extends VectorLayerUICtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @param {!angular.$timeout} $timeout
+   * @ngInject
+   */
+  constructor($scope, $element, $timeout) {
+    super($scope, $element, $timeout);
 
-  var defaultColumns = os.ui.FeatureEditCtrl.FIELDS.filter(function(field) {
-    return !os.feature.isInternalField(field);
-  }).map(function(col) {
-    return new os.data.ColumnDefinition(col);
-  });
+    var defaultColumns = FeatureEditCtrl.FIELDS.filter(function(field) {
+      return !osFeature.isInternalField(field);
+    }).map(function(col) {
+      return new ColumnDefinition(col);
+    });
+
+    /**
+     * Columns available for labels.
+     * @type {!Array<string>}
+     */
+    this['labelColumns'] = defaultColumns;
+
+    $scope.$on('opacity.slide', this.onOpacityValueChange.bind(this));
+    $scope.$on('opacity.slidestop', this.onOpacityChange.bind(this));
+    $scope.$on('fillOpacity.slide', this.onFillOpacityValueChange.bind(this));
+    $scope.$on('fillOpacity.slidestop', this.onFillOpacityChange.bind(this));
+
+    dispatcher.getInstance().listen(EventType.REFRESH, this.initUI, false, this);
+  }
 
   /**
-   * Columns available for labels.
-   * @type {!Array<string>}
+   * @inheritDoc
    */
-  this['labelColumns'] = defaultColumns;
-
-  $scope.$on('opacity.slide', this.onOpacityValueChange.bind(this));
-  $scope.$on('opacity.slidestop', this.onOpacityChange.bind(this));
-  $scope.$on('fillOpacity.slide', this.onFillOpacityValueChange.bind(this));
-  $scope.$on('fillOpacity.slidestop', this.onFillOpacityChange.bind(this));
-
-  os.dispatcher.listen(os.action.EventType.REFRESH, this.initUI, false, this);
-};
-goog.inherits(plugin.file.kml.KMLNodeLayerUICtrl, os.ui.layer.VectorLayerUICtrl);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.disposeInternal = function() {
-  os.dispatcher.unlisten(os.action.EventType.REFRESH, this.initUI, false, this);
-  plugin.file.kml.KMLNodeLayerUICtrl.base(this, 'disposeInternal');
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getProperties = function() {
-  return {}; // opacity set up in constructor
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.initUI = function() {
-  plugin.file.kml.KMLNodeLayerUICtrl.base(this, 'initUI');
-
-  if (this.scope && !this.isFeatureFillable()) {
-    delete this.scope['fillColor'];
-    delete this.scope['fillOpacity'];
+  disposeInternal() {
+    dispatcher.getInstance().unlisten(EventType.REFRESH, this.initUI, false, this);
+    super.disposeInternal();
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  getProperties() {
+    return {}; // opacity set up in constructor
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getColor = function() {
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+  /**
+   * @inheritDoc
+   */
+  initUI() {
+    super.initUI();
 
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var feature = items[i].getFeature();
-      if (feature) {
-        var config = /** @type {Object|undefined} */ (feature.get(os.style.StyleType.FEATURE));
-
-        if (config) {
-          if (Array.isArray(config)) {
-            config = config[0];
-          }
-          var color = /** @type {Array<number>|string|undefined} */ (os.style.getConfigColor(config)) ||
-            os.style.DEFAULT_LAYER_COLOR;
-          if (color) {
-            return os.color.toHexString(color);
-          }
-        }
-      }
+    if (this.scope && !this.isFeatureFillable()) {
+      delete this.scope['fillColor'];
+      delete this.scope['fillOpacity'];
     }
   }
 
-  return null;
-};
+  /**
+   * @inheritDoc
+   */
+  getColor() {
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
 
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var feature = items[i].getFeature();
+        if (feature) {
+          var config = /** @type {Object|undefined} */ (feature.get(StyleType.FEATURE));
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getFillColor = function() {
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var feature = items[i].getFeature();
-      if (feature) {
-        var config = /** @type {Object|undefined} */ (feature.get(os.style.StyleType.FEATURE));
-
-        if (config) {
-          if (Array.isArray(config)) {
-            config = config[0];
-          }
-
-          var color = os.style.getConfigColor(config, false, os.style.StyleField.FILL);
-          if (color) {
-            return os.color.toHexString(color);
-          }
-        }
-      }
-    }
-  }
-
-  return null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getFillOpacity = function() {
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  var opacity = os.style.DEFAULT_FILL_ALPHA;
-
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var feature = items[i].getFeature();
-      if (feature) {
-        var config = /** @type {Object|undefined} */ (feature.get(os.style.StyleType.FEATURE));
-
-        if (config) {
-          if (Array.isArray(config)) {
-            config = config[0];
-          }
-          var color = os.style.getConfigColor(config, true, os.style.StyleField.FILL);
-          if (color) {
-            opacity = color[3];
-          }
-        }
-      }
-    }
-  }
-
-  return opacity;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getSize = function() {
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  var size;
-
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var feature = items[i].getFeature();
-      if (feature) {
-        var config = /** @type {Object|undefined} */ (feature.get(os.style.StyleType.FEATURE));
-
-        if (config) {
-          if (Array.isArray(config)) {
-            config = config[0];
-          }
-          size = os.style.getConfigSize(config) || os.style.DEFAULT_FEATURE_SIZE;
-        }
-      }
-    }
-  }
-
-  return size || os.style.DEFAULT_FEATURE_SIZE;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getLineDash = function() {
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  var lineDash;
-
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var feature = items[i].getFeature();
-      if (feature) {
-        var config = /** @type {Object|undefined} */ (feature.get(os.style.StyleType.FEATURE));
-
-        if (config) {
-          if (Array.isArray(config)) {
-            config = config[0];
-          }
-          lineDash = os.style.getConfigLineDash(config);
-        }
-      }
-    }
-  }
-
-  return lineDash;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getIcon = function() {
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  var icon = null;
-
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var feature = items[i].getFeature();
-      if (feature) {
-        var config = /** @type {Object|undefined} */ (feature.get(os.style.StyleType.FEATURE));
-
-        if (config) {
-          if (Array.isArray(config)) {
-            config = config.length > 1 ? config[1] : config[0];
-          }
-          icon = os.style.getConfigIcon(config) || os.ui.file.kml.getDefaultIcon();
-        }
-      }
-    }
-  }
-
-  return icon;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getShape = function() {
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  var shape;
-
-  if (items && items.length > 0) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var feature = items[i].getFeature();
-      if (feature) {
-        shape = /** @type {string} */ (feature.get(os.style.StyleField.SHAPE));
-      }
-    }
-  }
-  this['shape'] = shape || os.style.ShapeType.POINT;
-  return this['shape'];
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getShapes = function() {
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  var shapes = plugin.file.kml.shapes;
-
-  if (items && items.length > 0) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var source = items[i].getSource();
-      if (source && source instanceof os.source.Vector) {
-        shapes = goog.array.filter(shapes, source.supportsShape, source);
-      }
-    }
-  }
-
-  return shapes;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getCenterShape = function() {
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  var shape;
-
-  if (items && items.length > 0) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var feature = items[i].getFeature();
-      if (feature) {
-        shape = /** @type {string} */ (feature.get(os.style.StyleField.CENTER_SHAPE));
-      }
-    }
-  }
-  this['centerShape'] = shape || os.style.ShapeType.POINT;
-  return this['centerShape'];
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getCenterShapes = function() {
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  var shapes = plugin.file.kml.centerShapes;
-
-  if (items && items.length > 0) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var source = items[i].getSource();
-      if (source && source instanceof os.source.Vector) {
-        shapes = goog.array.filter(shapes, source.supportsShape, source);
-      }
-    }
-  }
-
-  return shapes;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getOpacity = function() {
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  var opacity = os.style.DEFAULT_ALPHA;
-
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var feature = items[i].getFeature();
-      if (feature) {
-        var config = /** @type {Object|undefined} */ (feature.get(os.style.StyleType.FEATURE));
-
-        if (config) {
-          if (Array.isArray(config)) {
-            config = config[0];
-          }
-
-          var color = os.style.getConfigColor(config, true, os.style.StyleField.STROKE);
-          if (color) {
-            opacity = color[3];
-          }
-        }
-      }
-    }
-  }
-
-  return opacity;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getLabelSize = function() {
-  return Number(this.getFeatureValue(os.style.StyleField.LABEL_SIZE, os.style.label.DEFAULT_SIZE));
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getLabelColor = function() {
-  return this.getFeatureValue(os.style.StyleField.LABEL_COLOR, os.style.DEFAULT_LAYER_COLOR);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getColumns = function() {
-  var labelColumns = [];
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var source = items[i].getSource();
-      labelColumns = labelColumns.concat(source.getColumnsArray().filter(function(column) {
-        return !os.feature.isInternalField(column['field']);
-      }));
-    }
-  }
-
-  return labelColumns;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getColumn = function() {
-  var labelColumns = [];
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var feature = items[i].getFeature();
-      if (feature) {
-        var config = /** @type {Object|undefined} */ (feature.get(os.style.StyleType.FEATURE));
-        if (config) {
-          if (Array.isArray(config)) {
-            // locate the label config in the array
-            var labelsConfig = ol.array.find(config, os.style.isLabelConfig);
-            if (labelsConfig) {
-              labelColumns = labelsConfig[os.style.StyleField.LABELS];
+          if (config) {
+            if (Array.isArray(config)) {
+              config = config[0];
             }
-          } else if (config[os.style.StyleField.LABELS]) {
-            labelColumns = config[os.style.StyleField.LABELS];
+            var color = /** @type {Array<number>|string|undefined} */ (osStyle.getConfigColor(config)) ||
+              osStyle.DEFAULT_LAYER_COLOR;
+            if (color) {
+              return osColor.toHexString(color);
+            }
           }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getFillColor() {
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var feature = items[i].getFeature();
+        if (feature) {
+          var config = /** @type {Object|undefined} */ (feature.get(StyleType.FEATURE));
+
+          if (config) {
+            if (Array.isArray(config)) {
+              config = config[0];
+            }
+
+            var color = osStyle.getConfigColor(config, false, StyleField.FILL);
+            if (color) {
+              return osColor.toHexString(color);
+            }
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getFillOpacity() {
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    var opacity = osStyle.DEFAULT_FILL_ALPHA;
+
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var feature = items[i].getFeature();
+        if (feature) {
+          var config = /** @type {Object|undefined} */ (feature.get(StyleType.FEATURE));
+
+          if (config) {
+            if (Array.isArray(config)) {
+              config = config[0];
+            }
+            var color = osStyle.getConfigColor(config, true, StyleField.FILL);
+            if (color) {
+              opacity = color[3];
+            }
+          }
+        }
+      }
+    }
+
+    return opacity;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getSize() {
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    var size;
+
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var feature = items[i].getFeature();
+        if (feature) {
+          var config = /** @type {Object|undefined} */ (feature.get(StyleType.FEATURE));
+
+          if (config) {
+            if (Array.isArray(config)) {
+              config = config[0];
+            }
+            size = osStyle.getConfigSize(config) || osStyle.DEFAULT_FEATURE_SIZE;
+          }
+        }
+      }
+    }
+
+    return size || osStyle.DEFAULT_FEATURE_SIZE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLineDash() {
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    var lineDash;
+
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var feature = items[i].getFeature();
+        if (feature) {
+          var config = /** @type {Object|undefined} */ (feature.get(StyleType.FEATURE));
+
+          if (config) {
+            if (Array.isArray(config)) {
+              config = config[0];
+            }
+            lineDash = osStyle.getConfigLineDash(config);
+          }
+        }
+      }
+    }
+
+    return lineDash;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getIcon() {
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    var icon = null;
+
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var feature = items[i].getFeature();
+        if (feature) {
+          var config = /** @type {Object|undefined} */ (feature.get(StyleType.FEATURE));
+
+          if (config) {
+            if (Array.isArray(config)) {
+              config = config.length > 1 ? config[1] : config[0];
+            }
+            icon = osStyle.getConfigIcon(config) || kml.getDefaultIcon();
+          }
+        }
+      }
+    }
+
+    return icon;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getShape() {
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    var shape;
+
+    if (items && items.length > 0) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var feature = items[i].getFeature();
+        if (feature) {
+          shape = /** @type {string} */ (feature.get(StyleField.SHAPE));
+        }
+      }
+    }
+    this['shape'] = shape || osStyle.ShapeType.POINT;
+    return this['shape'];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getShapes() {
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    var shapes = supportedShapes;
+
+    if (items && items.length > 0) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var source = items[i].getSource();
+        if (source && source instanceof VectorSource) {
+          shapes = googArray.filter(shapes, source.supportsShape, source);
+        }
+      }
+    }
+
+    return shapes;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getCenterShape() {
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    var shape;
+
+    if (items && items.length > 0) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var feature = items[i].getFeature();
+        if (feature) {
+          shape = /** @type {string} */ (feature.get(StyleField.CENTER_SHAPE));
+        }
+      }
+    }
+    this['centerShape'] = shape || osStyle.ShapeType.POINT;
+    return this['centerShape'];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getCenterShapes() {
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    var shapes = supportedCenterShapes;
+
+    if (items && items.length > 0) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var source = items[i].getSource();
+        if (source && source instanceof VectorSource) {
+          shapes = googArray.filter(shapes, source.supportsShape, source);
+        }
+      }
+    }
+
+    return shapes;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getOpacity() {
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    var opacity = osStyle.DEFAULT_ALPHA;
+
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var feature = items[i].getFeature();
+        if (feature) {
+          var config = /** @type {Object|undefined} */ (feature.get(StyleType.FEATURE));
+
+          if (config) {
+            if (Array.isArray(config)) {
+              config = config[0];
+            }
+
+            var color = osStyle.getConfigColor(config, true, StyleField.STROKE);
+            if (color) {
+              opacity = color[3];
+            }
+          }
+        }
+      }
+    }
+
+    return opacity;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLabelSize() {
+    return Number(this.getFeatureValue(StyleField.LABEL_SIZE, label.DEFAULT_SIZE));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLabelColor() {
+    return this.getFeatureValue(StyleField.LABEL_COLOR, osStyle.DEFAULT_LAYER_COLOR);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getColumns() {
+    var labelColumns = [];
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var source = items[i].getSource();
+        labelColumns = labelColumns.concat(source.getColumnsArray().filter(function(column) {
+          return !osFeature.isInternalField(column['field']);
+        }));
+      }
+    }
+
+    return labelColumns;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getColumn() {
+    var labelColumns = [];
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var feature = items[i].getFeature();
+        if (feature) {
+          var config = /** @type {Object|undefined} */ (feature.get(StyleType.FEATURE));
+          if (config) {
+            if (Array.isArray(config)) {
+              // locate the label config in the array
+              var labelsConfig = olArray.find(config, osStyle.isLabelConfig);
+              if (labelsConfig) {
+                labelColumns = labelsConfig[StyleField.LABELS];
+              }
+            } else if (config[StyleField.LABELS]) {
+              labelColumns = config[StyleField.LABELS];
+            }
+          }
+        }
+      }
+    }
+
+    return labelColumns;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getShowLabel() {
+    return this.getFeatureValue(StyleField.SHOW_LABELS);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLockable() {
+    this['lock'] = false;
+    // Only display lock option if all sources are lockable
+    var lockable = true;
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var source = items[i].getSource();
+        if (source && source instanceof VectorSource && !source.isLockable()) {
+          lockable = false;
+          break;
+        } else {
+          this['lock'] = source.isLocked();
+        }
+      }
+    }
+    return lockable;
+  }
+
+  /**
+   * Handle changes to opacity while it changes via slide controls
+   *
+   * @param {?angular.Scope.Event} event
+   * @param {?} value
+   * @protected
+   */
+  onOpacityValueChange(event, value) {
+    event.stopPropagation();
+    this.scope['opacity'] = value;
+  }
+
+  /**
+   * Handle changes to fill opacity while it changes via slide controls
+   *
+   * @param {?angular.Scope.Event} event
+   * @param {?} value
+   * @protected
+   */
+  onFillOpacityValueChange(event, value) {
+    event.stopPropagation();
+    this.scope['fillOpacity'] = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  onLockChange() {
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var source = items[i].getSource();
+        if (source && source instanceof VectorSource && source.isLockable()) {
+          source.setLocked(this['lock']);
         }
       }
     }
   }
 
-  return labelColumns;
-};
+  /**
+   * @inheritDoc
+   */
+  onColorChange(event, value) {
+    if (!osColor.isColorString(value) && !Array.isArray(value)) {
+      return;
+    }
+    event.stopPropagation();
 
+    // Make sure the value includes the current opacity
+    var colorValue = osColor.toRgbArray(value);
+    colorValue[3] = this.scope['opacity'];
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getShowLabel = function() {
-  return this.getFeatureValue(os.style.StyleField.SHOW_LABELS);
-};
+    // Do we have fill color/opacity to consider?
+    if (this.scope['fillColor'] !== undefined && this.scope['fillOpacity'] !== undefined) {
+      // Determine if we are changing both stroke and fill entirely, or keeping opacities separate, or only affecting stroke
+      if (this.scope['color'] == this.scope['fillColor'] && this.scope['opacity'] == this.scope['fillOpacity']) {
+        this.scope['color'] = osColor.toHexString(colorValue);
+        this.scope['fillColor'] = osColor.toHexString(colorValue);
 
+        var fn =
+          /**
+           * @param {string} layerId
+           * @param {string} featureId
+           * @return {os.command.ICommand}
+           */
+          function(layerId, featureId) {
+            return new FeatureColor(layerId, featureId, colorValue);
+          };
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getLockable = function() {
-  this['lock'] = false;
-  // Only display lock option if all sources are lockable
-  var lockable = true;
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var source = items[i].getSource();
-      if (source && source instanceof os.source.Vector && !source.isLockable()) {
-        lockable = false;
-        break;
+        this.createFeatureCommand(fn);
+      } else if (this.scope['color'] == this.scope['fillColor']) {
+        this.scope['color'] = osColor.toHexString(colorValue);
+        this.scope['fillColor'] = osColor.toHexString(colorValue);
+
+        // We create two commands so that they retain the different opacities
+        var strokeColor = osColor.toRgbArray(this.scope['color']);
+        strokeColor[3] = this.scope['opacity'];
+        var fillColor = osColor.toRgbArray(this.scope['fillColor']);
+        fillColor[3] = this.scope['fillOpacity'];
+
+        var fn2 =
+          /**
+           * @param {string} layerId
+           * @param {string} featureId
+           * @return {os.command.ICommand}
+           */
+          function(layerId, featureId) {
+            var cmds = [];
+
+            cmds.push(new FeatureColor(
+                layerId, featureId, strokeColor, null, style.ColorChangeType.STROKE)
+            );
+            cmds.push(new FeatureColor(
+                layerId, featureId, fillColor, null, style.ColorChangeType.FILL)
+            );
+
+            var sequence = new SequenceCommand();
+            sequence.setCommands(cmds);
+            sequence.title = 'Change Color';
+
+            return sequence;
+          };
+
+        this.createFeatureCommand(fn2);
       } else {
-        this['lock'] = source.isLocked();
+        this.scope['color'] = osColor.toHexString(colorValue);
+        var fn3 =
+          /**
+           * @param {string} layerId
+           * @param {string} featureId
+           * @return {os.command.ICommand}
+           */
+          function(layerId, featureId) {
+            return new FeatureColor(layerId, featureId, colorValue, null,
+                style.ColorChangeType.STROKE);
+          };
+
+        this.createFeatureCommand(fn3);
       }
+    } else {
+      // We are not taking fill into consideration
+      var fn5 =
+        /**
+         * @param {string} layerId
+         * @param {string} featureId
+         * @return {os.command.ICommand}
+         */
+        function(layerId, featureId) {
+          return new FeatureColor(layerId, featureId, colorValue);
+        };
+
+      this.createFeatureCommand(fn5);
     }
   }
-  return lockable;
-};
 
+  /**
+   * @inheritDoc
+   */
+  onFillColorChange(event, value) {
+    if (!osColor.isColorString(value) && !Array.isArray(value)) {
+      return;
+    }
+    event.stopPropagation();
 
-/**
- * Handle changes to opacity while it changes via slide controls
- *
- * @param {?angular.Scope.Event} event
- * @param {?} value
- * @protected
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onOpacityValueChange = function(event, value) {
-  event.stopPropagation();
-  this.scope['opacity'] = value;
-};
+    // Make sure the value includes the current opacity
+    var colorValue = osColor.toRgbArray(value);
+    colorValue[3] = this.scope['fillOpacity'];
 
+    this.scope['fillColor'] = osStyle.toRgbaString(colorValue);
 
-/**
- * Handle changes to fill opacity while it changes via slide controls
- *
- * @param {?angular.Scope.Event} event
- * @param {?} value
- * @protected
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onFillOpacityValueChange = function(event, value) {
-  event.stopPropagation();
-  this.scope['fillOpacity'] = value;
-};
+    var fn =
+      /**
+       * @param {string} layerId
+       * @param {string} featureId
+       * @return {os.command.ICommand}
+       */
+      function(layerId, featureId) {
+        return new FeatureColor(layerId, featureId, colorValue, null, style.ColorChangeType.FILL);
+      };
 
+    this.createFeatureCommand(fn);
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onLockChange = function() {
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var source = items[i].getSource();
-      if (source && source instanceof os.source.Vector && source.isLockable()) {
-        source.setLocked(this['lock']);
-      }
+  /**
+   * @inheritDoc
+   */
+  onSizeChange(event, value) {
+    event.stopPropagation();
+
+    var fn =
+        /**
+         * @param {string} layerId
+         * @param {string} featureId
+         * @return {os.command.ICommand}
+         */
+        function(layerId, featureId) {
+          return new FeatureSize(layerId, featureId, value);
+        };
+
+    this.createFeatureCommand(fn);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  onLineDashChange(event, value) {
+    event.stopPropagation();
+
+    var fn =
+        /**
+         * @param {string} layerId
+         * @param {string} featureId
+         * @return {os.command.ICommand}
+         */
+        function(layerId, featureId) {
+          return new FeatureLineDash(layerId, featureId, value);
+        };
+
+    this.createFeatureCommand(fn);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  onIconChange(event, value) {
+    event.stopPropagation();
+
+    if (value) {
+      var fn =
+          /**
+           * @param {string} layerId
+           * @param {string} featureId
+           * @return {os.command.ICommand}
+           */
+          function(layerId, featureId) {
+            return new FeatureIcon(layerId, featureId, value);
+          };
+
+      this.createFeatureCommand(fn);
     }
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  onShapeChange(event, value) {
+    event.stopPropagation();
+    if (value) {
+      var fn =
+          /**
+           * @param {string} layerId
+           * @param {string} featureId
+           * @return {os.command.ICommand}
+           */
+          function(layerId, featureId) {
+            return new FeatureShape(layerId, featureId, value);
+          };
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onColorChange = function(event, value) {
-  if (!os.color.isColorString(value) && !Array.isArray(value)) {
-    return;
+      this.createFeatureCommand(fn);
+    }
   }
-  event.stopPropagation();
 
-  // Make sure the value includes the current opacity
-  var colorValue = os.color.toRgbArray(value);
-  colorValue[3] = this.scope['opacity'];
+  /**
+   * @inheritDoc
+   */
+  onCenterShapeChange(event, value) {
+    event.stopPropagation();
+    if (value) {
+      var fn =
+          /**
+           * @param {string} layerId
+           * @param {string} featureId
+           * @return {os.command.ICommand}
+           */
+          function(layerId, featureId) {
+            return new FeatureCenterShape(layerId, featureId, value);
+          };
 
-  // Do we have fill color/opacity to consider?
-  if (this.scope['fillColor'] !== undefined && this.scope['fillOpacity'] !== undefined) {
-    // Determine if we are changing both stroke and fill entirely, or keeping opacities separate, or only affecting stroke
-    if (this.scope['color'] == this.scope['fillColor'] && this.scope['opacity'] == this.scope['fillOpacity']) {
-      this.scope['color'] = os.color.toHexString(colorValue);
-      this.scope['fillColor'] = os.color.toHexString(colorValue);
+      this.createFeatureCommand(fn);
+    }
+  }
 
+  /**
+   * Handle changes to opacity while it changes via slide controls
+   *
+   * @param {?angular.Scope.Event} event
+   * @param {number} value
+   * @protected
+   */
+  onOpacityChange(event, value) {
+    event.stopPropagation();
+
+    if (value != null) {
       var fn =
         /**
          * @param {string} layerId
@@ -587,152 +800,43 @@ plugin.file.kml.KMLNodeLayerUICtrl.prototype.onColorChange = function(event, val
          * @return {os.command.ICommand}
          */
         function(layerId, featureId) {
-          return new os.command.FeatureColor(layerId, featureId, colorValue);
+          return new FeatureOpacity(layerId, featureId, value, null, style.ColorChangeType.STROKE);
         };
 
       this.createFeatureCommand(fn);
-    } else if (this.scope['color'] == this.scope['fillColor']) {
-      this.scope['color'] = os.color.toHexString(colorValue);
-      this.scope['fillColor'] = os.color.toHexString(colorValue);
-
-      // We create two commands so that they retain the different opacities
-      var strokeColor = os.color.toRgbArray(this.scope['color']);
-      strokeColor[3] = this.scope['opacity'];
-      var fillColor = os.color.toRgbArray(this.scope['fillColor']);
-      fillColor[3] = this.scope['fillOpacity'];
-
-      var fn2 =
-        /**
-         * @param {string} layerId
-         * @param {string} featureId
-         * @return {os.command.ICommand}
-         */
-        function(layerId, featureId) {
-          var cmds = [];
-
-          cmds.push(new os.command.FeatureColor(
-              layerId, featureId, strokeColor, null, os.command.style.ColorChangeType.STROKE)
-          );
-          cmds.push(new os.command.FeatureColor(
-              layerId, featureId, fillColor, null, os.command.style.ColorChangeType.FILL)
-          );
-
-          var sequence = new os.command.SequenceCommand();
-          sequence.setCommands(cmds);
-          sequence.title = 'Change Color';
-
-          return sequence;
-        };
-
-      this.createFeatureCommand(fn2);
-    } else {
-      this.scope['color'] = os.color.toHexString(colorValue);
-      var fn3 =
-        /**
-         * @param {string} layerId
-         * @param {string} featureId
-         * @return {os.command.ICommand}
-         */
-        function(layerId, featureId) {
-          return new os.command.FeatureColor(layerId, featureId, colorValue, null,
-              os.command.style.ColorChangeType.STROKE);
-        };
-
-      this.createFeatureCommand(fn3);
     }
-  } else {
-    // We are not taking fill into consideration
-    var fn5 =
-      /**
-       * @param {string} layerId
-       * @param {string} featureId
-       * @return {os.command.ICommand}
-       */
-      function(layerId, featureId) {
-        return new os.command.FeatureColor(layerId, featureId, colorValue);
-      };
-
-    this.createFeatureCommand(fn5);
   }
-};
 
+  /**
+   * Handle changes to fill opacity while it changes via slide controls
+   *
+   * @param {?angular.Scope.Event} event
+   * @param {number} value
+   * @protected
+   */
+  onFillOpacityChange(event, value) {
+    event.stopPropagation();
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onFillColorChange = function(event, value) {
-  if (!os.color.isColorString(value) && !Array.isArray(value)) {
-    return;
+    if (value != null) {
+      var fn =
+          /**
+           * @param {string} layerId
+           * @param {string} featureId
+           * @return {os.command.ICommand}
+           */
+          function(layerId, featureId) {
+            return new FeatureOpacity(layerId, featureId, value, null, style.ColorChangeType.FILL);
+          };
+
+      this.createFeatureCommand(fn);
+    }
   }
-  event.stopPropagation();
 
-  // Make sure the value includes the current opacity
-  var colorValue = os.color.toRgbArray(value);
-  colorValue[3] = this.scope['fillOpacity'];
-
-  this.scope['fillColor'] = os.style.toRgbaString(colorValue);
-
-  var fn =
-    /**
-     * @param {string} layerId
-     * @param {string} featureId
-     * @return {os.command.ICommand}
-     */
-    function(layerId, featureId) {
-      return new os.command.FeatureColor(layerId, featureId, colorValue, null, os.command.style.ColorChangeType.FILL);
-    };
-
-  this.createFeatureCommand(fn);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onSizeChange = function(event, value) {
-  event.stopPropagation();
-
-  var fn =
-      /**
-       * @param {string} layerId
-       * @param {string} featureId
-       * @return {os.command.ICommand}
-       */
-      function(layerId, featureId) {
-        return new os.command.FeatureSize(layerId, featureId, value);
-      };
-
-  this.createFeatureCommand(fn);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onLineDashChange = function(event, value) {
-  event.stopPropagation();
-
-  var fn =
-      /**
-       * @param {string} layerId
-       * @param {string} featureId
-       * @return {os.command.ICommand}
-       */
-      function(layerId, featureId) {
-        return new os.command.FeatureLineDash(layerId, featureId, value);
-      };
-
-  this.createFeatureCommand(fn);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onIconChange = function(event, value) {
-  event.stopPropagation();
-
-  if (value) {
+  /**
+   * @inheritDoc
+   */
+  updateLabelSize() {
+    var value = /** @type {number} */ (this.scope['labelSize']);
     var fn =
         /**
          * @param {string} layerId
@@ -740,93 +844,73 @@ plugin.file.kml.KMLNodeLayerUICtrl.prototype.onIconChange = function(event, valu
          * @return {os.command.ICommand}
          */
         function(layerId, featureId) {
-          return new os.command.FeatureIcon(layerId, featureId, value);
+          return new FeatureLabelSize(layerId, featureId, value);
         };
 
     this.createFeatureCommand(fn);
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  onLabelColorChange(event, value) {
+    event.stopPropagation();
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onShapeChange = function(event, value) {
-  event.stopPropagation();
-  if (value) {
-    var fn =
-        /**
-         * @param {string} layerId
-         * @param {string} featureId
-         * @return {os.command.ICommand}
-         */
-        function(layerId, featureId) {
-          return new os.command.FeatureShape(layerId, featureId, value);
-        };
+    if (value) {
+      var fn =
+          /**
+           * @param {string} layerId
+           * @param {string} featureId
+           * @return {os.command.ICommand}
+           */
+          function(layerId, featureId) {
+            return new FeatureLabelColor(layerId, featureId, value);
+          };
 
-    this.createFeatureCommand(fn);
+      this.createFeatureCommand(fn);
+    }
   }
-};
 
+  /**
+   * Set it to the current track color
+   *
+   * @inheritDoc
+   */
+  onLabelColorReset(event) {
+    event.stopPropagation();
+    this.scope['labelColor'] = this.getColor();
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onCenterShapeChange = function(event, value) {
-  event.stopPropagation();
-  if (value) {
-    var fn =
-        /**
-         * @param {string} layerId
-         * @param {string} featureId
-         * @return {os.command.ICommand}
-         */
-        function(layerId, featureId) {
-          return new os.command.FeatureCenterShape(layerId, featureId, value);
-        };
-
-    this.createFeatureCommand(fn);
+    // clear the label color config value
+    this.onLabelColorChange(event, this.scope['labelColor']);
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  onLabelColumnChange(event) {
+    event.stopPropagation();
 
-/**
- * Handle changes to opacity while it changes via slide controls
- *
- * @param {?angular.Scope.Event} event
- * @param {number} value
- * @protected
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onOpacityChange = function(event, value) {
-  event.stopPropagation();
-
-  if (value != null) {
-    var fn =
+    var items = /** @type {Array} */ (this.scope['items']);
+    if (items && items.length === 1) {
       /**
        * @param {string} layerId
        * @param {string} featureId
        * @return {os.command.ICommand}
        */
-      function(layerId, featureId) {
-        return new os.command.FeatureOpacity(layerId, featureId, value, null, os.command.style.ColorChangeType.STROKE);
-      };
+      var fn = function(layerId, featureId) {
+        return new FeatureLabel(layerId, featureId, this.scope['labels']);
+      }.bind(this);
 
-    this.createFeatureCommand(fn);
+      this.createFeatureCommand(fn);
+    }
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  onShowLabelsChange(event, value) {
+    event.stopPropagation();
 
-/**
- * Handle changes to fill opacity while it changes via slide controls
- *
- * @param {?angular.Scope.Event} event
- * @param {number} value
- * @protected
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onFillOpacityChange = function(event, value) {
-  event.stopPropagation();
-
-  if (value != null) {
     var fn =
         /**
          * @param {string} layerId
@@ -834,310 +918,209 @@ plugin.file.kml.KMLNodeLayerUICtrl.prototype.onFillOpacityChange = function(even
          * @return {os.command.ICommand}
          */
         function(layerId, featureId) {
-          return new os.command.FeatureOpacity(layerId, featureId, value, null, os.command.style.ColorChangeType.FILL);
+          return new FeatureShowLabel(layerId, featureId, value);
         };
 
     this.createFeatureCommand(fn);
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  updateRefresh() {
+    this['showRefresh'] = false;
+    this['refresh'] = null;
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.updateLabelSize = function() {
-  var value = /** @type {number} */ (this.scope['labelSize']);
-  var fn =
-      /**
-       * @param {string} layerId
-       * @param {string} featureId
-       * @return {os.command.ICommand}
-       */
-      function(layerId, featureId) {
-        return new os.command.FeatureLabelSize(layerId, featureId, value);
-      };
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    if (items && items.length > 0) {
+      var refreshInterval;
 
-  this.createFeatureCommand(fn);
-};
+      // only show refresh options if all sources support it
+      this['showRefresh'] = googArray.every(items, function(item) {
+        var source = item.getSource();
+        if (source && (source instanceof VectorSource || source instanceof UrlTile &&
+            source.isRefreshEnabled())) {
+          if (refreshInterval == null) {
+            // init the control to the refresh interval of the first item
+            refreshInterval = source.getRefreshInterval();
+          }
 
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onLabelColorChange = function(event, value) {
-  event.stopPropagation();
-
-  if (value) {
-    var fn =
-        /**
-         * @param {string} layerId
-         * @param {string} featureId
-         * @return {os.command.ICommand}
-         */
-        function(layerId, featureId) {
-          return new os.command.FeatureLabelColor(layerId, featureId, value);
-        };
-
-    this.createFeatureCommand(fn);
-  }
-};
-
-
-/**
- * Set it to the current track color
- *
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onLabelColorReset = function(event) {
-  event.stopPropagation();
-  this.scope['labelColor'] = this.getColor();
-
-  // clear the label color config value
-  this.onLabelColorChange(event, this.scope['labelColor']);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onLabelColumnChange = function(event) {
-  event.stopPropagation();
-
-  var items = /** @type {Array} */ (this.scope['items']);
-  if (items && items.length === 1) {
-    /**
-     * @param {string} layerId
-     * @param {string} featureId
-     * @return {os.command.ICommand}
-     */
-    var fn = function(layerId, featureId) {
-      return new os.command.FeatureLabel(layerId, featureId, this.scope['labels']);
-    }.bind(this);
-
-    this.createFeatureCommand(fn);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.onShowLabelsChange = function(event, value) {
-  event.stopPropagation();
-
-  var fn =
-      /**
-       * @param {string} layerId
-       * @param {string} featureId
-       * @return {os.command.ICommand}
-       */
-      function(layerId, featureId) {
-        return new os.command.FeatureShowLabel(layerId, featureId, value);
-      };
-
-  this.createFeatureCommand(fn);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.updateRefresh = function() {
-  this['showRefresh'] = false;
-  this['refresh'] = null;
-
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  if (items && items.length > 0) {
-    var refreshInterval;
-
-    // only show refresh options if all sources support it
-    this['showRefresh'] = goog.array.every(items, function(item) {
-      var source = item.getSource();
-      if (source && (source instanceof os.source.Vector || source instanceof ol.source.UrlTile &&
-          source.isRefreshEnabled())) {
-        if (refreshInterval == null) {
-          // init the control to the refresh interval of the first item
-          refreshInterval = source.getRefreshInterval();
+          return true;
         }
 
-        return true;
-      }
-
-      return false;
-    });
-
-    if (refreshInterval != null) {
-      // find the refresh interval by interval
-      this['refresh'] = ol.array.find(this['refreshOptions'], function(option) {
-        return option.interval == refreshInterval;
+        return false;
       });
-    }
-  }
-};
 
-
-/**
- * Gets a value from the feature
- *
- * @param {string} field The field to retrieve
- * @param {?=} opt_default
- * @return {?}
- * @protected
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getFeatureValue = function(field, opt_default) {
-  var defaultVal = opt_default !== undefined ? opt_default : 1;
-
-  var features = this.getFeatures();
-  for (var i = 0, n = features.length; i < n; i++) {
-    var val = features[i].get(field);
-    if (val) {
-      return val;
-    }
-  }
-
-  return defaultVal;
-};
-
-
-/**
- * Get the layer nodes from the list of UI items.
- *
- * @return {!Array<!ol.Feature>}
- * @protected
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getFeatures = function() {
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  var features = [];
-
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      var feature = items[i].getFeature();
-      if (feature) {
-        features = features.concat(feature);
+      if (refreshInterval != null) {
+        // find the refresh interval by interval
+        this['refresh'] = olArray.find(this['refreshOptions'], function(option) {
+          return option.interval == refreshInterval;
+        });
       }
     }
   }
 
-  return features;
-};
+  /**
+   * Gets a value from the feature
+   *
+   * @param {string} field The field to retrieve
+   * @param {?=} opt_default
+   * @return {?}
+   * @protected
+   */
+  getFeatureValue(field, opt_default) {
+    var defaultVal = opt_default !== undefined ? opt_default : 1;
 
+    var features = this.getFeatures();
+    for (var i = 0, n = features.length; i < n; i++) {
+      var val = features[i].get(field);
+      if (val) {
+        return val;
+      }
+    }
 
-/**
- * Creates a command to run on each feature
- *
- * @param {function(string, string):os.command.ICommand} commandFunction
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.createFeatureCommand = function(commandFunction) {
-  var cmds = [];
+    return defaultVal;
+  }
 
-  var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
-  if (items) {
-    for (var i = 0; i < items.length; i++) {
-      var feature = items[i].getFeature();
-      var source = items[i].getSource();
-      if (feature && source) {
-        var featureId = feature.getId();
-        var layerId = source.getId();
-        if (featureId != null && layerId != null) {
-          featureId = String(featureId);
-          layerId = String(layerId);
-          var cmd = commandFunction(layerId, featureId);
-          if (cmd) { // if we have a feature and get a command, add it
-            cmds.push(cmd);
+  /**
+   * Get the layer nodes from the list of UI items.
+   *
+   * @return {!Array<!ol.Feature>}
+   * @protected
+   */
+  getFeatures() {
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    var features = [];
+
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        var feature = items[i].getFeature();
+        if (feature) {
+          features = features.concat(feature);
+        }
+      }
+    }
+
+    return features;
+  }
+
+  /**
+   * Creates a command to run on each feature
+   *
+   * @param {function(string, string):os.command.ICommand} commandFunction
+   */
+  createFeatureCommand(commandFunction) {
+    var cmds = [];
+
+    var items = /** @type {Array<!plugin.file.kml.ui.KMLNode>} */ (this.scope['items']);
+    if (items) {
+      for (var i = 0; i < items.length; i++) {
+        var feature = items[i].getFeature();
+        var source = items[i].getSource();
+        if (feature && source) {
+          var featureId = feature.getId();
+          var layerId = source.getId();
+          if (featureId != null && layerId != null) {
+            featureId = String(featureId);
+            layerId = String(layerId);
+            var cmd = commandFunction(layerId, featureId);
+            if (cmd) { // if we have a feature and get a command, add it
+              cmds.push(cmd);
+            }
           }
         }
       }
     }
+
+    var cmd = null;
+    if (cmds.length > 1) {
+      cmd = new ParallelCommand();
+      cmd.setCommands(cmds);
+      cmd.title = cmds[0].title + ' (' + cmds.length + ' features)';
+    } else if (cmds.length > 0) {
+      cmd = cmds[0];
+    }
+
+    if (cmd) {
+      CommandProcessor.getInstance().addCommand(cmd);
+    }
   }
 
-  var cmd = null;
-  if (cmds.length > 1) {
-    cmd = new os.command.ParallelCommand();
-    cmd.setCommands(cmds);
-    cmd.title = cmds[0].title + ' (' + cmds.length + ' features)';
-  } else if (cmds.length > 0) {
-    cmd = cmds[0];
+  /**
+   * If the feature is dynamic, which means it is a time based track
+   *
+   * @return {boolean}
+   * @export
+   */
+  isFeatureDynamic() {
+    var features = this.getFeatures();
+    var feature = features.length > 0 ? features[0] : null;
+    return feature instanceof DynamicFeature;
   }
 
-  if (cmd) {
-    os.command.CommandProcessor.getInstance().addCommand(cmd);
-  }
-};
+  /**
+   * If the feature is fillable, which means it should show fill controls
+   *
+   * @return {boolean}
+   * @export
+   */
+  isFeatureFillable() {
+    var features = this.getFeatures();
+    var feature = features.length > 0 ? features[0] : null;
+    if (feature) {
+      let hasPolyGeom = false;
 
+      osFeature.forEachGeometry(feature, (geom) => {
+        hasPolyGeom = geo.isGeometryPolygonal(geom, true) || hasPolyGeom;
+      });
 
-/**
- * If the feature is dynamic, which means it is a time based track
- *
- * @return {boolean}
- * @export
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.isFeatureDynamic = function() {
-  var features = this.getFeatures();
-  var feature = features.length > 0 ? features[0] : null;
-  return feature instanceof os.feature.DynamicFeature;
-};
+      return hasPolyGeom;
+    }
 
-
-/**
- * If the feature is fillable, which means it should show fill controls
- *
- * @return {boolean}
- * @export
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.isFeatureFillable = function() {
-  var features = this.getFeatures();
-  var feature = features.length > 0 ? features[0] : null;
-  if (feature) {
-    let hasPolyGeom = false;
-
-    os.feature.forEachGeometry(feature, (geom) => {
-      hasPolyGeom = os.geo.isGeometryPolygonal(geom, true) || hasPolyGeom;
-    });
-
-    return hasPolyGeom;
+    return false;
   }
 
-  return false;
-};
+  /**
+   * Leave the rotation choices to the Place Add/Edit dialog since it is more involved
+   *
+   * @inheritDoc
+   */
+  showRotationOption() {
+    return false;
+  }
 
+  /**
+   * Hide the ellipse options (ellipsoids/ground ref), also lob isn't supported at this time
+   *
+   * @inheritDoc
+   */
+  getShapeUIInternal() {
+    return undefined;
+  }
 
-/**
- * Leave the rotation choices to the Place Add/Edit dialog since it is more involved
- *
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.showRotationOption = function() {
-  return false;
-};
+  /**
+   * If the icon picker should be displayed.
+   *
+   * @return {boolean}
+   * @export
+   */
+  showIcon() {
+    return osStyle.ICON_REGEXP.test(this['shape']);
+  }
 
+  /**
+   * If the icon picker should be displayed.
+   *
+   * @return {boolean}
+   * @export
+   */
+  showCenterIcon() {
+    return !!osStyle.CENTER_LOOKUP[this['shape']] && osStyle.ICON_REGEXP.test(this['centerShape']);
+  }
+}
 
-/**
- * Hide the ellipse options (ellipsoids/ground ref), also lob isn't supported at this time
- *
- * @inheritDoc
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.getShapeUIInternal = function() {
-  return undefined;
-};
-
-
-/**
- * If the icon picker should be displayed.
- *
- * @return {boolean}
- * @export
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.showIcon = function() {
-  return os.style.ICON_REGEXP.test(this['shape']);
-};
-
-
-/**
- * If the icon picker should be displayed.
- *
- * @return {boolean}
- * @export
- */
-plugin.file.kml.KMLNodeLayerUICtrl.prototype.showCenterIcon = function() {
-  return !!os.style.CENTER_LOOKUP[this['shape']] && os.style.ICON_REGEXP.test(this['centerShape']);
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/file/kml/kmlparser.js
+++ b/src/plugin/file/kml/kmlparser.js
@@ -1,239 +1,1796 @@
-goog.provide('plugin.file.kml.KMLParser');
+goog.module('plugin.file.kml.KMLParser');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Uri');
-goog.require('goog.asserts');
-goog.require('goog.async.ConditionalDelay');
-goog.require('goog.dom');
-goog.require('goog.dom.NodeType');
-goog.require('goog.dom.xml');
-goog.require('goog.log');
-goog.require('goog.log.Logger');
-goog.require('goog.object');
-goog.require('ol.Feature');
-goog.require('ol.format.Feature');
-goog.require('ol.format.XSD');
-goog.require('ol.geom.LineString');
-goog.require('ol.geom.flat.inflate');
-goog.require('ol.layer.Image');
-goog.require('ol.xml');
-goog.require('os.annotation');
-goog.require('os.data.ColumnDefinition');
-goog.require('os.file.mime.text');
-goog.require('os.file.mime.zip');
-goog.require('os.layer.Image');
-goog.require('os.net.Request');
-goog.require('os.object');
-goog.require('os.parse.AsyncZipParser');
-goog.require('os.parse.IParser');
-goog.require('os.source.ImageStatic');
-goog.require('os.track');
-goog.require('os.ui.file.kml');
-goog.require('os.xml');
-goog.require('plugin.file.kml');
-goog.require('plugin.file.kml.KMLField');
-goog.require('plugin.file.kml.model');
-goog.require('plugin.file.kml.tour.FlyTo');
-goog.require('plugin.file.kml.tour.Tour');
-goog.require('plugin.file.kml.tour.TourControl');
-goog.require('plugin.file.kml.tour.Wait');
-goog.require('plugin.file.kml.tour.parseTour');
-goog.require('plugin.file.kml.ui.KMLNetworkLinkNode');
-goog.require('plugin.file.kml.ui.KMLNode');
-goog.require('plugin.file.kml.ui.KMLTourNode');
+const Uri = goog.require('goog.Uri');
+const asserts = goog.require('goog.asserts');
+const ConditionalDelay = goog.require('goog.async.ConditionalDelay');
+const dom = goog.require('goog.dom');
+const NodeType = goog.require('goog.dom.NodeType');
+const googDomXml = goog.require('goog.dom.xml');
+const GoogFileReader = goog.require('goog.fs.FileReader');
+const log = goog.require('goog.log');
+const EventType = goog.require('goog.net.EventType');
+const googObject = goog.require('goog.object');
+const googString = goog.require('goog.string');
+const ol = goog.require('ol');
+const Feature = goog.require('ol.Feature');
+const XSD = goog.require('ol.format.XSD');
+const GeometryLayout = goog.require('ol.geom.GeometryLayout');
+const GeometryType = goog.require('ol.geom.GeometryType');
+const LineString = goog.require('ol.geom.LineString');
+const MultiLineString = goog.require('ol.geom.MultiLineString');
+const inflate = goog.require('ol.geom.flat.inflate');
+const olProj = goog.require('ol.proj');
+const olXml = goog.require('ol.xml');
+const Fields = goog.require('os.Fields');
+const MapContainer = goog.require('os.MapContainer');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const AlertManager = goog.require('os.alert.AlertManager');
+const annotation = goog.require('os.annotation');
+const arraybuf = goog.require('os.arraybuf');
+const ColumnDefinition = goog.require('os.data.ColumnDefinition');
+const RecordField = goog.require('os.data.RecordField');
+const osFileMimeText = goog.require('os.file.mime.text');
+const mimeZip = goog.require('os.file.mime.zip');
+const Image = goog.require('os.layer.Image');
+const osMap = goog.require('os.map');
+const net = goog.require('os.net');
+const Request = goog.require('os.net.Request');
+const osObject = goog.require('os.object');
+const AsyncZipParser = goog.require('os.parse.AsyncZipParser');
+const osProj = goog.require('os.proj');
+const ImageStatic = goog.require('os.source.ImageStatic');
+const TriState = goog.require('os.structs.TriState');
+const osStyle = goog.require('os.style');
+const StyleField = goog.require('os.style.StyleField');
+const StyleType = goog.require('os.style.StyleType');
+const track = goog.require('os.track');
+const ui = goog.require('os.ui');
+const osUiFileKml = goog.require('os.ui.file.kml');
+const xml = goog.require('os.xml');
+const kml = goog.require('plugin.file.kml');
+const KMLField = goog.require('plugin.file.kml.KMLField');
+const model = goog.require('plugin.file.kml.model');
+const parseTour = goog.require('plugin.file.kml.tour.parseTour');
+const KMLNetworkLinkNode = goog.require('plugin.file.kml.ui.KMLNetworkLinkNode');
+const KMLNode = goog.require('plugin.file.kml.ui.KMLNode');
+const KMLTourNode = goog.require('plugin.file.kml.ui.KMLTourNode');
+
+const Logger = goog.requireType('goog.log.Logger');
+const IParser = goog.requireType('os.parse.IParser');
 
 
 /**
  * @typedef {{
  *   children: !(Array|NodeList),
  *   index: number,
- *   node: plugin.file.kml.ui.KMLNode
+ *   node: KMLNode
  * }}
  */
-plugin.file.kml.KMLParserStackObj;
+kml.KMLParserStackObj;
 
 
 
 /**
  * Parses a KML source
  *
- * @param {Object.<string, *>} options Layer configuration options.
- * @extends {os.parse.AsyncZipParser}
- * @implements {os.parse.IParser.<plugin.file.kml.ui.KMLNode>}
+ * @implements {IParser.<KMLNode>}
  * @template T
- * @constructor
  */
-plugin.file.kml.KMLParser = function(options) {
-  plugin.file.kml.KMLParser.base(this, 'constructor');
+class KMLParser extends AsyncZipParser {
+  /**
+   * Constructor.
+   * @param {Object.<string, *>} options Layer configuration options.
+   */
+  constructor(options) {
+    super();
 
-  // load default KML styles
-  plugin.file.kml.createStyleDefaults();
+    // load default KML styles
+    kml.createStyleDefaults();
+
+    /**
+     * The source document
+     * @type {Document}
+     * @private
+     */
+    this.document_ = null;
+
+    /**
+     * Parser identifier
+     * @type {string}
+     * @private
+     */
+    this.id_ = googString.getRandomString();
+
+    /**
+     * The logger
+     * @type {Logger}
+     * @private
+     */
+    this.log_ = logger;
+
+    /**
+     * If the parse should merge into an existing tree
+     * @type {boolean}
+     * @private
+     */
+    this.merging_ = false;
+
+    /**
+     * The root KML tree node
+     * @type {KMLNode}
+     * @private
+     */
+    this.rootNode_ = null;
+
+    /**
+     * Columns detected in the KML
+     * @type {Array<!ColumnDefinition>}
+     * @private
+     */
+    this.columns_ = null;
+
+    /**
+     * Map used to detect KML Placemark columns
+     * @type {Object<string, boolean>}
+     * @private
+     */
+    this.columnMap_ = null;
+
+    /**
+     * The parsing stack
+     * @type {!Array.<!kml.KMLParserStackObj>}
+     * @private
+     */
+    this.stack_ = [];
+
+    /**
+     * The KML style config map
+     * @type {!Object<string, Object<string, *>>}
+     * @private
+     */
+    this.styleMap_ = {};
+
+    /**
+     * The KML balloon style config map.
+     * @type {!Object<string, !Object<string, *>>}
+     * @private
+     */
+    this.balloonStyleMap = {};
+
+    /**
+     * The KML style config map for highlight styles from StyleMap tags
+     * @type {!Object<string, !Object<string, *>>}
+     * @private
+     */
+    this.highlightStyleMap_ = {};
+
+    /**
+     * The number of unnamed nodes parsed from the document - used for providing unique names
+     * @type {number}
+     * @private
+     */
+    this.unnamedCount_ = 0;
+
+    /**
+     * The settings from the network link control for the minRefreshPeriod
+     * 0 means to use link refresh defined by the requestor
+     * @type {number}
+     * @private
+     */
+    this.minRefreshPeriod_ = 0;
+
+    /**
+     * Map of asset file names to data URIs
+     * @type {Object<string, string>}
+     * @private
+     */
+    this.assetMap_ = {};
+
+    /**
+     * Map of URLs to external style sheets
+     * @type {Object<string, boolean|Request>}
+     * @private
+     */
+    this.extStyles_ = {};
+
+    /**
+     * The number of kmz image entries to process
+     * @type {number}
+     * @private
+     */
+    this.kmzImagesRemaining_ = 0;
+
+    /**
+     * @type {Object<string, !zip.Entry>} entries
+     * @private
+     */
+    this.kmlEntries_ = {};
+
+    /**
+     * @type {Array<string>}
+     * @private
+     */
+    this.kmlThings_ = KMLParser.KML_THINGS.slice();
+
+    /**
+     * @type {RegExp}
+     * @private
+     */
+    this.kmlThingRegex_ = this.getKmlThingRegex();
+
+    /**
+     * Indicates if the kmz has a collada model to parse.
+     * @type {boolean}
+     * @private
+     */
+    this.hasModel_ = false;
+
+    /**
+     * @type {Object<string, {parent: ?string, parsers: Object<string, Object<string, ol.XmlParser>>}>}
+     * @private
+     */
+    this.parsersByPlacemarkTag_ = {
+      'Placemark': {
+        parent: null,
+        parsers: kml.OL_PLACEMARK_PARSERS()
+      }
+    };
+  }
 
   /**
-   * The source document
-   * @type {Document}
-   * @private
+   * @inheritDoc
    */
-  this.document_ = null;
+  disposeInternal() {
+    this.cleanup();
+    this.clearAssets();
+    super.disposeInternal();
+  }
 
   /**
-   * Parser identifier
-   * @type {string}
-   * @private
+   * @inheritDoc
    */
-  this.id_ = goog.string.getRandomString();
+  cleanup() {
+    // FIXME: we should be clearing assets here, but they won't be available at load time
+    // this.clearAssets();
+
+    this.document_ = null;
+    this.merging_ = false;
+    this.rootNode_ = null;
+    this.columns_ = null;
+    this.columnMap_ = null;
+    this.stack_.length = 0;
+    this.styleMap_ = {};
+    this.balloonStyleMap = {};
+    this.unnamedCount_ = 0;
+    this.minRefreshPeriod_ = 0;
+  }
 
   /**
-   * The logger
-   * @type {goog.log.Logger}
-   * @private
+   * Cleans up any KMZ assets. This should be done before parsing again or when the layer is removed.
    */
-  this.log_ = plugin.file.kml.KMLParser.LOGGER_;
+  clearAssets() {
+    this.assetMap_ = {};
+  }
 
   /**
-   * If the parse should merge into an existing tree
-   * @type {boolean}
-   * @private
+   * Get the last parsed root KML tree node. This reference will be lost on cleanup, so it must be retrieved when parsing
+   * completes.
+   *
+   * @return {KMLNode}
    */
-  this.merging_ = false;
+  getRootNode() {
+    return this.rootNode_;
+  }
 
   /**
-   * The root KML tree node
-   * @type {plugin.file.kml.ui.KMLNode}
-   * @private
+   * Get the minimum refresh period (from the network link control)
+   *
+   * @return {number}
    */
-  this.rootNode_ = null;
+  getMinRefreshPeriod() {
+    return this.minRefreshPeriod_;
+  }
 
   /**
-   * Columns detected in the KML
-   * @type {Array<!os.data.ColumnDefinition>}
-   * @private
+   * Set the root KML tree node. Use this to merge the parse result into an existing tree.
+   *
+   * @param {KMLNode} rootNode
    */
-  this.columns_ = null;
+  setRootNode(rootNode) {
+    this.rootNode_ = rootNode;
+    this.merging_ = !!rootNode;
+  }
 
   /**
-   * Map used to detect KML Placemark columns
-   * @type {Object<string, boolean>}
-   * @private
+   * Get columns detected in the KML.
+   *
+   * @return {Array<!ColumnDefinition>}
    */
-  this.columnMap_ = null;
+  getColumns() {
+    if (!this.columns_ && this.columnMap_) {
+      // translate the column map into slickgrid columns
+      this.columns_ = [];
 
-  /**
-   * The parsing stack
-   * @type {!Array.<!plugin.file.kml.KMLParserStackObj>}
-   * @private
-   */
-  this.stack_ = [];
+      for (var column in this.columnMap_) {
+        if (column === RecordField.TIME) {
+          // display the recordTime field as TIME
+          this.columns_.push(new ColumnDefinition(Fields.TIME, RecordField.TIME));
+        } else if (!KMLParser.SKIPPED_COLUMNS_.test(column)) {
+          this.columns_.push(new ColumnDefinition(column));
+        }
+      }
 
-  /**
-   * The KML style config map
-   * @type {!Object<string, Object<string, *>>}
-   * @private
-   */
-  this.styleMap_ = {};
-
-  /**
-   * The KML balloon style config map.
-   * @type {!Object<string, !Object<string, *>>}
-   * @private
-   */
-  this.balloonStyleMap = {};
-
-  /**
-   * The KML style config map for highlight styles from StyleMap tags
-   * @type {!Object<string, !Object<string, *>>}
-   * @private
-   */
-  this.highlightStyleMap_ = {};
-
-  /**
-   * The number of unnamed nodes parsed from the document - used for providing unique names
-   * @type {number}
-   * @private
-   */
-  this.unnamedCount_ = 0;
-
-  /**
-   * The settings from the network link control for the minRefreshPeriod
-   * 0 means to use link refresh defined by the requestor
-   * @type {number}
-   * @private
-   */
-  this.minRefreshPeriod_ = 0;
-
-  /**
-   * Map of asset file names to data URIs
-   * @type {Object<string, string>}
-   * @private
-   */
-  this.assetMap_ = {};
-
-  /**
-   * Map of URLs to external style sheets
-   * @type {Object<string, boolean|os.net.Request>}
-   * @private
-   */
-  this.extStyles_ = {};
-
-  /**
-   * The number of kmz image entries to process
-   * @type {number}
-   * @private
-   */
-  this.kmzImagesRemaining_ = 0;
-
-  /**
-   * @type {Object<string, !zip.Entry>} entries
-   * @private
-   */
-  this.kmlEntries_ = {};
-
-  /**
-   * @type {Array<string>}
-   * @private
-   */
-  this.kmlThings_ = plugin.file.kml.KMLParser.KML_THINGS.slice();
-
-  /**
-   * @type {RegExp}
-   * @private
-   */
-  this.kmlThingRegex_ = this.getKmlThingRegex();
-
-  /**
-   * Indicates if the kmz has a collada model to parse.
-   * @type {boolean}
-   * @private
-   */
-  this.hasModel_ = false;
-
-  /**
-   * @type {Object<string, {parent: ?string, parsers: Object<string, Object<string, ol.XmlParser>>}>}
-   * @private
-   */
-  this.parsersByPlacemarkTag_ = {
-    'Placemark': {
-      parent: null,
-      parsers: plugin.file.kml.OL_PLACEMARK_PARSERS()
+      this.columnMap_ = null;
     }
-  };
-};
-goog.inherits(plugin.file.kml.KMLParser, os.parse.AsyncZipParser);
+
+    return this.columns_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  hasNext() {
+    return this.stack_.length > 0;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setSource(source) {
+    this.cleanup();
+
+    if (olXml.isDocument(source)) {
+      this.document_ = /** @type {Document} */ (source);
+    } else if (typeof source === 'string') {
+      this.document_ = xml.loadXml(source);
+    } else if (source instanceof ArrayBuffer) {
+      if (mimeZip.isZip(source)) {
+        this.clearAssets();
+        this.createZipReader(source);
+        return;
+      } else {
+        var s = osFileMimeText.getText(source);
+        if (s) {
+          this.document_ = googDomXml.loadXml(s);
+        } else {
+          log.error(this.log_, 'Source buffer does not appear to be text');
+          this.onError();
+        }
+      }
+    } else if (source instanceof Blob) {
+      GoogFileReader.readAsArrayBuffer(source).addCallback(this.setSource, this);
+      return;
+    }
+
+    if (this.document_) {
+      var rootEl = dom.getFirstElementChild(this.document_);
+      if (rootEl && rootEl.localName.toLowerCase() !== 'kml') {
+        // Sometimes people are dumb and create documents without a root <kml> tag.
+        // This is technically invalid KML and even invalid XML.  Because Google Earth
+        // accepts this crap, add a special case to put the proper root tag.
+        var newRoot = xml.createElement('kml', this.document_);
+
+        // add the Document element to the KML element
+        newRoot.appendChild(rootEl);
+
+        // add the new KML element to the document
+        this.document_.appendChild(newRoot);
+
+        // and update the root element
+        rootEl = newRoot;
+      }
+
+      if (rootEl) {
+        if (!this.loadExternalStyles()) {
+          this.begin();
+        }
+      } else {
+        log.error(this.log_, 'No KML content to parse!');
+        this.onError();
+      }
+    } else {
+      log.error(this.log_, 'Content must be a valid KML document!');
+      this.onError();
+    }
+  }
+
+  /**
+   * @protected
+   * @return {boolean} Whether or not external styles are loading
+   */
+  loadExternalStyles() {
+    var styles = this.document_.querySelectorAll('styleUrl');
+    var extStylesFound = false;
+
+    for (var i = 0, n = styles.length; i < n; i++) {
+      var style = olXml.getAllTextContent(styles[i], true).trim();
+      if (style) {
+        // remove the fragment, if url is incorrectly formatted, kml is bad and this url should be skipped
+        var url = style.replace(/#.*/, '');
+        url = encodeURI(url) === url ? url : undefined;
+        if (url) {
+          extStylesFound = true;
+          dom.setTextContent(styles[i], '#' + style.replace('#', '_'));
+
+          if (!(url in this.extStyles_)) {
+            if (url in this.kmlEntries_) {
+              var entry = this.kmlEntries_[url];
+              entry.getData(new zip.BlobWriter(), this.processZIPEntry_.bind(this, entry.filename));
+              this.extStyles_[url] = true;
+            } else {
+              var req = new Request(url);
+              req.listen(EventType.SUCCESS, this.onExtStyleLoad, false, this);
+              req.listen(EventType.ERROR, this.onExtStyleLoad, false, this);
+              this.extStyles_[url] = req;
+              req.load();
+            }
+          }
+        }
+      }
+    }
+
+    return extStylesFound;
+  }
+
+  /**
+   * @param {goog.events.Event} evt
+   * @protected
+   */
+  onExtStyleLoad(evt) {
+    var req = /** @type {Request} */ (evt.target);
+    var url = req.getUri().toString();
+    var safeUrl = this.extStyles_[url] ? url : decodeURI(url);
+    delete this.extStyles_[safeUrl];
+
+    var resp = /** @type {string} */ (req.getResponse());
+    req.dispose();
+
+    if (evt.type === EventType.SUCCESS) {
+      this.handleExternalStylesheet_(resp, url);
+    } else {
+      this.continueStyles_();
+    }
+  }
+
+  /**
+   * @param {!string} content
+   * @param {!string} url
+   * @private
+   */
+  handleExternalStylesheet_(content, url) {
+    try {
+      var doc = googDomXml.loadXml(content);
+      var appendTo = this.document_.querySelector('Document') || dom.getFirstElementChild(this.document_);
+
+      var styles = doc.querySelectorAll('Style');
+      for (var i = 0, n = styles.length; i < n; i++) {
+        var style = styles[i];
+
+        // "namespace" the style with the URL
+        style.setAttribute('id', url + '_' + style.getAttribute('id'));
+
+        // append it to the main document
+        appendTo.appendChild(style);
+      }
+
+      var styleMaps = doc.querySelectorAll('StyleMap');
+      for (var i = 0, n = styleMaps.length; i < n; i++) {
+        var styleMap = styleMaps[i];
+
+        // "namespace" the style with the URL
+        styleMap.setAttribute('id', url + '_' + styleMap.getAttribute('id'));
+
+        var styleUrls = Array.prototype.slice.call(styleMap.querySelectorAll('styleUrl'));
+        styleUrls.forEach(function(styleUrl) {
+          var current = styleUrl.textContent.replace(/^#/, '');
+          styleUrl.textContent = '#' + url + '_' + current;
+        });
+
+        // append it to the main document
+        appendTo.appendChild(styleMap);
+      }
+    } catch (e) {
+      log.error(this.log_, 'Could not parse KML stylesheet ' + url);
+    }
+
+    this.continueStyles_();
+  }
+
+  /**
+   * Keep waiting for styles or begin if they are done
+   *
+   * @private
+   */
+  continueStyles_() {
+    // if we still have any outstanding style requests, keep waiting
+    for (var key in this.extStyles_) {
+      return;
+    }
+
+    // otherwise start parsing the main document
+    this.begin();
+  }
+
+  /**
+   * @protected
+   */
+  begin() {
+    var rootEl = dom.getFirstElementChild(this.document_);
+    var rootChildren = dom.getChildren(rootEl);
+
+    if (rootChildren && rootChildren.length > 0) {
+      // start parsing at the first child of the kml tag
+      this.stack_.push(/** @type {kml.KMLParserStackObj} */ ({
+        children: [rootEl],
+        index: 0,
+        node: null
+      }));
+
+      this.onReady();
+
+      // read NetworkLinkControl
+      for (var i = 0; i < rootChildren.length; i++) {
+        var child = rootChildren[i];
+        if (child.localName == 'NetworkLinkControl' && child.querySelector('minRefreshPeriod')) {
+          this.minRefreshPeriod_ = parseInt(child.querySelector('minRefreshPeriod').textContent, 10) * 1000;
+        }
+      }
+    } else {
+      log.error(this.log_, 'Empty KML tree!');
+      this.onError();
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handleZipReaderError() {
+    super.handleZipReaderError();
+    this.onError();
+  }
+
+  /**
+   * HACK ALERT! zip.js has a zip.TextWriter() class that directly turns the zip entry into the string we want.
+   * Unfortunately, it doesn't work in FF24 for some reason, but luckily, the BlobWriter does. Here, we read
+   * the zip as a Blob, then feed it to a FileReader in the next callback in order to extract the text.
+   *
+   * @inheritDoc
+   */
+  handleZipEntries(entries) {
+    var mainEntry = null;
+    var firstEntry = null;
+    var mainKml = /(doc|index)\.kml$/i;
+    var anyKml = /\.kml$/i;
+    var collada = /\.dae$/i;
+    var img = /\.(png|jpg|jpeg|gif|bmp|do)$/i;
+
+    for (var i = 0, n = entries.length; i < n; i++) {
+      // if we have multiple entries, try to find one titled either doc.kml or index.kml as these
+      // are generally the most important ones
+      var entry = entries[i];
+      if (!mainEntry && mainKml.test(entry.filename)) {
+        mainEntry = entry;
+      } else if (anyKml.test(entry.filename)) {
+        if (!firstEntry) {
+          firstEntry = entry;
+        }
+
+        this.kmlEntries_[entry.filename] = entry;
+      } else if (img.test(entry.filename)) {
+        var result = img.exec(entry.filename);
+        img.lastIndex = 0;
+
+        this.kmzImagesRemaining_++;
+
+        entry.getData(new zip.Data64URIWriter('image/' + result[1]), this.processZipAsset_.bind(this, entry.filename));
+      } else if (collada.test(entry.filename)) {
+        this.hasModel_ = true;
+        this.kmzImagesRemaining_++;
+        entry.getData(new zip.TextWriter(), this.processZipAsset_.bind(this, entry.filename));
+      } else {
+        this.kmzImagesRemaining_++;
+        this.processUnknownZipAsset_(entry);
+      }
+    }
+
+    mainEntry = mainEntry || firstEntry;
+
+
+    // before processing the main KML, try to delay until all images have been added to our asset map
+    // move on if it takes longer than 20 seconds
+    if (mainEntry) {
+      var delay = new ConditionalDelay(this.imagesRemaining_.bind(this));
+      delay.onSuccess = this.processMainEntry_.bind(this, mainEntry, true);
+      delay.onFailure = this.processMainEntry_.bind(this, mainEntry, false);
+      delay.start(200, 20000);
+    } else {
+      log.error(this.log_, 'No KML found in the ZIP!');
+      this.onError();
+    }
+  }
+
+  /**
+   * Parse the main kml file
+   *
+   * @param {zip.Entry} mainEntry
+   * @param {boolean} success True if all entries/images were processed
+   * @private
+   */
+  processMainEntry_(mainEntry, success) {
+    if (!success) {
+      log.error(this.log_, 'Failed to process KMZ images in a timely manner - skipping ' +
+          this.kmzImagesRemaining_ + ' images.');
+    }
+    mainEntry.getData(new zip.BlobWriter(), this.processZIPEntry_.bind(this, mainEntry.filename));
+  }
+
+  /**
+   * True if we have processed all images
+   *
+   * @return {boolean} True if not all images have been processes
+   * @private
+   */
+  imagesRemaining_() {
+    return this.kmzImagesRemaining_ <= 0;
+  }
+
+  /**
+   * Handler for processing unknown assets within the ZIP file
+   * @param {!zip.Entry} entry
+   * @private
+   */
+  processUnknownZipAsset_(entry) {
+    entry.getData(new zip.ArrayBufferWriter(), (data) => {
+      const type = arraybuf.getMimeType(/** @type {ArrayBuffer} */ (data));
+      if (type && type.substr(0, 5) === 'image') {
+        entry.getData(new zip.Data64URIWriter(type), this.processZipAsset_.bind(this, entry.filename));
+      } else {
+        // eh whatever just skip this
+        this.kmzImagesRemaining_--;
+      }
+    });
+  }
+
+  /**
+   * Handler for processing assets within the ZIP file. This includes images and collada model files.
+   * @param {*} filename
+   * @param {*} uri
+   * @private
+   */
+  processZipAsset_(filename, uri) {
+    if (typeof filename === 'string' && typeof uri === 'string') {
+      this.assetMap_[filename] = uri;
+      this.kmzImagesRemaining_--;
+    } else {
+      log.error(this.log_, 'There was a problem unzipping the KMZ!');
+      this.onError();
+    }
+  }
+
+  /**
+   * @param {string} filename
+   * @param {*} content
+   * @private
+   */
+  processZIPEntry_(filename, content) {
+    if (content && content instanceof Blob) {
+      var reader = new FileReader();
+      reader.onload = this.handleZIPText_.bind(this, filename);
+      reader.readAsText(content);
+    } else {
+      log.error(this.log_, 'There was a problem unzipping the KMZ!');
+      this.onError();
+    }
+  }
+
+  /**
+   * @param {string} filename
+   * @param {Event} event
+   * @private
+   */
+  handleZIPText_(filename, event) {
+    var content = event.target.result;
+
+    if (content && typeof content === 'string') {
+      if (!this.document_) {
+        this.setSource(content);
+      } else {
+        delete this.extStyles_[filename];
+        this.handleExternalStylesheet_(content, filename);
+      }
+    } else {
+      log.error(this.log_, 'There was a problem reading the ZIP content!');
+      this.onError();
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  parseNext() {
+    asserts.assert(this.stack_.length > 0, 'Stack should not be empty');
+    asserts.assert(this.stack_[this.stack_.length - 1] != null, 'Top of stack should be an object');
+
+    var stackObj = null;
+    var node = null;
+    var top = this.stack_[this.stack_.length - 1];
+    var parentNode = top.node;
+    var children = top.children;
+    var currentEl = children[top.index];
+
+    if (!currentEl) {
+      var parentLabel = parentNode ? parentNode.getLabel() : 'Unknown';
+      var msg = `Encountered null child under node ${parentLabel} - skipping.`;
+      log.warning(this.log_, msg);
+      return null;
+    }
+
+    // Clever hack alert!
+    // Since we parse KMZs, the readURI function needs to know if a URL is in the asset map before it tries to resolve
+    // it against the node's baseURI. The only thing that is passed to that function is the node, so we'll just tack it on
+    currentEl.assetMap = this.assetMap_;
+
+    var localName = currentEl.localName;
+    try {
+      if (localName === 'Document' || localName === 'Folder' || localName === 'kml') {
+        node = this.createTreeNode_(currentEl, parentNode);
+
+        if (node) {
+          if (this.merging_) {
+            // if this is a merge, initially mark all child nodes for removal. merged children will be unmarked, and
+            // remaining children should be removed since they weren't found in the new KML
+            this.markAllChildren_(node);
+          }
+
+          var stackChildren = dom.getChildren(currentEl);
+          if (stackChildren && stackChildren.length > 0) {
+            // only continue down this path if the element has children to parse
+            stackObj = /** @type {kml.KMLParserStackObj} */ ({
+              children: stackChildren,
+              index: 0,
+              node: node
+            });
+          }
+
+          if (localName === 'Document') {
+            // parse schema nodes
+            this.parseSchema_(currentEl);
+          }
+        }
+      } else if (this.kmlThingRegex_ && this.kmlThingRegex_.test(localName) && localName != 'NetworkLinkControl') {
+        node = this.createTreeNode_(currentEl, parentNode);
+      }
+    } catch (e) {
+      // something failed so we don't want to continue parsing this DOM path
+      stackObj = null;
+      node = null;
+
+      log.error(this.log_, 'Failed parsing node type: ' + localName, e);
+    }
+
+    ++top.index;
+    if (top.index >= children.length) {
+      if (this.merging_ && parentNode) {
+        // remove any children that weren't found in the new KML
+        this.removeMarkedChildren_(parentNode);
+      }
+
+      // no more children to parse, so pop the current item off the stack
+      this.stack_.pop();
+    }
+
+    if (stackObj) {
+      // current element is a container, so parse its children next
+      this.stack_.push(stackObj);
+      this.extractStyles_(currentEl);
+    }
+
+    if (!this.hasNext()) {
+      this.closeZipReaders();
+    }
+
+    return node;
+  }
+
+  /**
+   * Parses sample data from a KML.
+   *
+   * @return {!Array<!Feature>}
+   */
+  parsePreview() {
+    var features = [];
+    while (this.hasNext() && features.length < 50) {
+      var node = this.parseNext();
+      if (node) {
+        var feature = node.getFeature();
+        if (feature) {
+          features.push(feature);
+        }
+      }
+    }
+
+    return features;
+  }
+
+  /**
+   * Marks the node's children for removal.
+   *
+   * @param {!KMLNode} node The KML node
+   * @private
+   */
+  markAllChildren_(node) {
+    var children = node.getChildren();
+    if (children) {
+      for (var i = 0, n = children.length; i < n; i++) {
+        /** @type {KMLNode} */ (children[i]).marked = true;
+      }
+    }
+  }
+
+  /**
+   * Removes all marked children from a node.
+   *
+   * @param {!KMLNode} node The KML node
+   * @private
+   */
+  removeMarkedChildren_(node) {
+    var children = node.getChildren();
+    if (children) {
+      var i = children.length;
+      while (i--) {
+        var child = /** @type {KMLNode} */ (children[i]);
+        if (child.marked) {
+          node.removeChildAt(i);
+          child.dispose();
+        }
+      }
+    }
+  }
+
+  /**
+   * Creates a tree node from an XML element
+   *
+   * @param {Element} el The XML element
+   * @param {KMLNode=} opt_parent The parent tree node
+   * @return {kml.ui.KMLNode} The tree node
+   * @private
+   */
+  createTreeNode_(el, opt_parent) {
+    var node = this.examineElement_(el);
+    if (node) {
+      if (!node.getLabel()) {
+        // use the id if one is available, otherwise create a default name based on the element type
+        var id = el.id || el.getAttribute('id');
+        node.setLabel(id || this.getDefaultName_(el.localName));
+      }
+
+      if (opt_parent != null) {
+        // if the child already exists, the new node will be merged and the original node returned
+        node = /** @type {KMLNode} */ (opt_parent.addChild(node));
+      } else if (this.rootNode_ === null) {
+        this.rootNode_ = node;
+      } else if (this.rootNode_.getLabel() != node.getLabel()) {
+        // the root node name changed, so start with a fresh tree. if this rains on anyone's parade we can probably
+        // just rename the existing root node but we're assuming this means the KML has changed significantly
+        this.rootNode_.dispose();
+        this.rootNode_ = node;
+      } else {
+        // keep the old root node
+        node = this.rootNode_;
+      }
+    }
+
+    return node;
+  }
+
+  /**
+   * Examine styles that are unsupported in OpenLayers KML styles.
+   *
+   * @param {Node} node Node.
+   * @private
+   */
+  examineStyles_(node) {
+    var n;
+    for (n = node.firstElementChild; n; n = n.nextElementSibling) {
+      if (n.localName == 'BalloonStyle') {
+        var properties = olXml.pushParseAndPop({}, kml.BALLOON_PROPERTY_PARSERS, n, []);
+        if (properties) {
+          var id = node.id || node.getAttribute('id');
+          this.balloonStyleMap[id] = properties;
+        }
+      }
+    }
+  }
+
+  /**
+   * Read the KML balloon style.
+   *
+   * @param {Element} el The XML element
+   * @param {Feature} feature The feature
+   * @private
+   *
+   * @suppress {accessControls} To allow direct access to feature metadata.
+   */
+  readBalloonStyle_(el, feature) {
+    if (feature.get(annotation.OPTIONS_FIELD)) {
+      // the feature is an Open Sphere annotation, so ignore the balloon style. it's there for display in other
+      // applications, like Google Earth.
+      return;
+    }
+
+    var style;
+    var balloonEl = el.querySelector('BalloonStyle');
+    if (balloonEl) {
+      // the placemark has an internal balloon style
+      style = olXml.pushParseAndPop({}, kml.BALLOON_PROPERTY_PARSERS, balloonEl, []);
+    } else {
+      // look for a balloon style referenced by styleUrl
+      var styleUrl = /** @type {string} */ (feature.get('styleUrl'));
+      var styleId = this.getStyleId(decodeURIComponent(styleUrl));
+      style = styleId in this.balloonStyleMap ? this.balloonStyleMap[styleId] : null;
+    }
+
+    if (style) {
+      var text = style['text'];
+      var pattern = /[$]\[(.*?)\]/g;
+      var regex = new RegExp(pattern);
+
+      text = text.replace(regex, function(match, key) {
+        if (key in feature.values_) {
+          return feature.get(key);
+        } else {
+          return '';
+        }
+      });
+
+      text = ui.sanitize(text);
+
+      feature.set(KMLField.BALLOON_TEXT, text);
+    }
+  }
+
+  /**
+   * Creates a tree node from an XML element
+   *
+   * @param {Element} el The XML element
+   * @return {KMLNode} The tree node
+   * @private
+   */
+  examineElement_(el) {
+    var node = null;
+    if (el.localName === 'NetworkLink') {
+      node = this.readNetworkLink_(el);
+    } else if (el.localName === 'GroundOverlay') {
+      node = this.readGroundOverlay_(el);
+    } else if (el.localName === 'ScreenOverlay') {
+      node = this.readScreenOverlay_(el);
+    } else if (el.localName === 'Tour') {
+      var tour = parseTour(el);
+      if (tour) {
+        node = new KMLTourNode(tour);
+      }
+    } else if (this.kmlThingRegex_ && this.kmlThingRegex_.test(el.localName) && el.localName != 'NetworkLinkControl') {
+      var feature = this.readPlacemark_(el);
+      if (feature) {
+        node = new KMLNode();
+        node.setFeature(feature);
+        node.layerUI = 'kmlnodelayerui';
+      }
+    } else {
+      node = new KMLNode();
+    }
+
+    if (node) {
+      this.updateNode_(el, node, KMLParser.BASE_ELEMENT_PARSERS_);
+    }
+
+    return node;
+  }
+
+  /**
+   * Executes a set of parsers to modify a tree node from an element.
+   *
+   * @param {Element} el The XML element
+   * @param {KMLNode} node The KML tree node
+   * @param {Object.<string, kml.KMLElementParser>} parsers The parsers to use
+   * @private
+   */
+  updateNode_(el, node, parsers) {
+    var n;
+    for (n = dom.getFirstElementChild(el); n !== null; n = n.nextElementSibling) {
+      var parser = parsers[n.localName];
+      if (parser !== undefined) {
+        parser.call(this, node, n);
+      }
+    }
+  }
+
+  /**
+   * Get a default name for a KML tree node
+   *
+   * @param {string} localName The element name
+   * @return {string}
+   * @private
+   */
+  getDefaultName_(localName) {
+    this.unnamedCount_++;
+
+    if (localName == 'kml') {
+      // this is the root node, so make it obvious
+      return 'kmlroot';
+    }
+
+    return 'Unnamed ' + this.unnamedCount_ + ' [' + localName + ']';
+  }
+
+  /**
+   * Parses a KML NetworkLink element into a tree node
+   *
+   * @param {Element} el The XML element
+   * @return {KMLNetworkLinkNode} The network link node, or null if unable to parse
+   * @private
+   */
+  readNetworkLink_(el) {
+    var node = null;
+    var linkObj = olXml.pushParseAndPop({}, kml.OL_NETWORK_LINK_PARSERS(), el, []);
+    if (linkObj && linkObj['href']) {
+      node = new KMLNetworkLinkNode(linkObj['href']);
+
+      // default provided by KML spec
+      var refreshMode = linkObj['refreshMode'];
+      if (refreshMode && googObject.containsValue(osUiFileKml.RefreshMode, refreshMode)) {
+        node.setRefreshMode(refreshMode);
+
+        switch (refreshMode) {
+          case osUiFileKml.RefreshMode.CHANGE:
+            // this is the default, so nothing to do unless we start parsing viewRefreshMode
+            break;
+          case osUiFileKml.RefreshMode.EXPIRE:
+            // the network link should refresh based on HTTP headers or the NetworkLinkControl tag in the fetched KML,
+            // so nothing else to do here
+            break;
+          case osUiFileKml.RefreshMode.INTERVAL:
+            var interval = /** @type {number} */ (linkObj['refreshInterval']);
+            if (typeof interval === 'number' && !isNaN(interval)) {
+              node.setRefreshInterval(interval * 1000);
+            }
+            break;
+          default:
+            break;
+        }
+      }
+
+      var viewRefreshMode = linkObj['viewRefreshMode'];
+      if (viewRefreshMode && googObject.containsValue(osUiFileKml.ViewRefreshMode, viewRefreshMode)) {
+        node.setViewRefreshMode(viewRefreshMode);
+
+        switch (viewRefreshMode) {
+          case osUiFileKml.ViewRefreshMode.NEVER:
+            // do nothing
+            break;
+          case osUiFileKml.ViewRefreshMode.REQUEST:
+            // the node handles this case by automatically populating the current view BBOX when the user manually
+            // refreshes the layer
+            break;
+          case osUiFileKml.ViewRefreshMode.STOP:
+          case osUiFileKml.ViewRefreshMode.REGION:
+            // TODO: Region support. For now I'm going to treat it like onStop, but regions are a more
+            // complicated construct for determining view refreshes that we don't support yet.
+
+            // there should be a second parameter defining a time delay after changes for these cases
+            var time = /** @type {number} */ (linkObj['viewRefreshTime']);
+            if (typeof time === 'number' && !isNaN(time)) {
+              node.setViewRefreshTimer(time * 1000);
+            }
+            break;
+          default:
+            break;
+        }
+      }
+    }
+
+    return node;
+  }
+
+  /**
+   * Parses a KML Placemark element into a map feature
+   *
+   * @param {Element} el The XML element
+   * @return {os.feature.DynamicFeature|Feature|undefined} The map feature
+   * @private
+   *
+   * I don't care what you think, compiler.
+   * @suppress {accessControls}
+   */
+  readPlacemark_(el) {
+    asserts.assert(el.nodeType == NodeType.ELEMENT, 'el.nodeType should be ELEMENT');
+    asserts.assert(el.localName in this.parsersByPlacemarkTag_,
+        'localName should be Placemark or be defined by Schema tags');
+
+    var set = this.parsersByPlacemarkTag_[el.localName];
+    var object = {'geometry': null};
+
+    // This is slightly odd in that it allows parent parsers to override values set by
+    // child parsers (generally the opposite of what you expect from inheritence), however,
+    // use of Schema tags is silly if you are just using them for key/value pairs (that's what
+    // ExtendedData is for) and anything more complicated isn't going to be handled by this
+    // parser anyway.
+    while (set) {
+      object = olXml.pushParseAndPop(object, set.parsers, el, []);
+      set = set.parent ? this.parsersByPlacemarkTag_[set.parent] : null;
+    }
+
+    if (!object) {
+      return null;
+    }
+
+    if (this.hasModel_) {
+      model.parseModel(el, object);
+    }
+
+    // set geometry fields on the object
+    var geometry = /** @type {ol.geom.Geometry|undefined} */ (object['geometry']);
+    delete object['geometry'];
+
+    if (geometry) {
+      // grab the lon/lat coordinate before we potentially convert it to god knows what
+      if (geometry.getType() == GeometryType.POINT) {
+        var coord = /** @type {!ol.geom.Point} */ (geometry).getFirstCoordinate();
+        if (coord.length > 1) {
+          object[Fields.LAT] = object[Fields.LAT] || coord[1];
+          object[Fields.LON] = object[Fields.LON] || coord[0];
+
+          if ((coord.length > 2) && (coord[2] != 0)) {
+            object[Fields.GEOM_ALT] = object[Fields.GEOM_ALT] || coord[2];
+          }
+        }
+      }
+
+      // convert to application projection
+      geometry.osTransform();
+    }
+
+    // make sure parsed styles don't appear as a source column
+    if (object['Style']) {
+      object[kml.STYLE_KEY] = object['Style'];
+      delete object['Style'];
+    }
+
+    var feature;
+    if ((geometry instanceof LineString || geometry instanceof MultiLineString) &&
+        geometry.getLayout() === GeometryLayout.XYZM) {
+      // Openlayers parses KML tracks into a LineString/MultiLineString with the XYZM layout (lon, lat, alt, time). if one
+      // of these is encountered, create a track so it can be animated on the timeline.
+
+      if (geometry instanceof MultiLineString && geometry.get('interpolate')) {
+        // if a multi track should be interpolated, join it into a single line. the track updates will handle the
+        // interpolation between known positions.
+        var flatCoordinates = geometry.getFlatCoordinates();
+        var coordinates = inflate.coordinates(flatCoordinates, 0, flatCoordinates.length, 4);
+        geometry = new LineString(coordinates);
+      }
+
+      feature = track.createTrack(/** @type {!track.CreateOptions} */ ({
+        geometry: geometry,
+        name: /** @type {string|undefined} */ (object['name'])
+      }));
+    } else {
+      feature = new Feature(geometry);
+    }
+
+    if (feature) {
+      this.setFeatureId_(feature);
+
+      // parse any fields that are known to contain JSON data into objects
+      for (var i = 0, ii = kml.JsonField.length; i < ii; i++) {
+        var field = kml.JsonField[i];
+
+        if (object[field] && typeof object[field] === 'string') {
+          object[field] = JSON.parse(object[field]);
+        }
+      }
+
+      feature.setProperties(object);
+
+      // create/modify the set of columns detected in the file. for now, just keep a basic set to keep this as low
+      // overhead as possible.
+      if (!this.columnMap_) {
+        this.columnMap_ = [];
+      }
+
+      for (var key in object) {
+        this.columnMap_[key] = true;
+      }
+
+      this.applyStyles_(el, feature);
+    }
+
+    return feature;
+  }
+
+  /**
+   * Parses a KML GroundOverlay element into a map layer.
+   *
+   * @param {Element} el The XML element.
+   * @return {KMLNode} A KML node for the overlay, or null if one couldn't be created.
+   * @private
+   */
+  readGroundOverlay_(el) {
+    asserts.assert(el.nodeType == NodeType.ELEMENT, 'el.nodeType should be ELEMENT');
+    asserts.assert(el.localName == 'GroundOverlay', 'localName should be GroundOverlay');
+
+    var obj = olXml.pushParseAndPop({}, kml.GROUND_OVERLAY_PARSERS, el, []);
+    if (obj) {
+      if (obj['extent'] && obj['Icon'] && obj['Icon']['href']) {
+        var icon = /** @type {string} */ (obj['Icon']['href']);
+        if (this.assetMap_[icon]) {
+          icon = this.assetMap_[icon]; // handle images included in a kmz
+        }
+
+        var extent = olProj.transformExtent(/** @type {ol.Extent} */ (obj['extent']), osProj.EPSG4326,
+            osMap.PROJECTION);
+
+        var feature = new Feature();
+        this.setFeatureId_(feature);
+
+        if (obj[RecordField.TIME]) {
+          feature.set(RecordField.TIME, obj[RecordField.TIME], true);
+        }
+
+        var image = new Image({
+          source: new ImageStatic({
+            crossOrigin: net.getCrossOrigin(icon),
+            url: icon,
+            imageExtent: extent,
+            projection: osMap.PROJECTION
+          }, -(obj['rotation'] || 0))
+        });
+        image.setId(/** @type {string} */ (feature.getId()));
+
+        var node = new KMLNode();
+        node.setFeature(feature);
+        node.setImage(image);
+
+        return node;
+      } else if (obj['error']) {
+        var msg = obj['error'].toString();
+        log.warning(logger, msg);
+        AlertManager.getInstance().sendAlert(msg, AlertEventSeverity.WARNING);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Parses a KML ScreenOverlay element into a legend style window.
+   *
+   * @param {Element} el The XML element.
+   * @return {KMLNode} A KML node for the overlay, or null if one couldn't be created.
+   * @private
+   */
+  readScreenOverlay_(el) {
+    asserts.assert(el.nodeType == NodeType.ELEMENT, 'el.nodeType should be ELEMENT');
+    asserts.assert(el.localName == 'ScreenOverlay', 'localName should be ScreenOverlay');
+
+    var obj = olXml.pushParseAndPop({}, kml.SCREEN_OVERLAY_PARSERS, el, []);
+    if (obj && obj['name'] && obj['Icon'] && obj['Icon']['href']) {
+      var name = /** @type {string} */ (obj['name']);
+
+      var icon = /** @type {string} */ (obj['Icon']['href']);
+      if (this.assetMap_[icon]) {
+        icon = this.assetMap_[icon]; // handle images included in a kmz
+      }
+
+      var screenXY = this.parseScreenXY_(obj['screenXY']);
+      var size = this.parseSizeXY_(obj['size']);
+      if (screenXY && size) {
+        var feature = new Feature();
+        this.setFeatureId_(feature);
+
+        if (obj[RecordField.TIME]) {
+          feature.set(RecordField.TIME, obj[RecordField.TIME], true);
+        }
+
+        var overlayOptions = /** @type {!osx.window.ScreenOverlayOptions} */ ({
+          id: feature.getId(),
+          name: this.rootNode_.getLabel() + ' - ' + name,
+          image: icon,
+          size: size,
+          xy: screenXY,
+          showHide: true
+        });
+
+        var node = new KMLNode();
+        node.setFeature(feature);
+        node.setOverlayOptions(overlayOptions);
+
+        return node;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Parse XY attributes from a screenXY element and return an object with more useful location coordinates
+   *
+   * @param {Object} obj The XY options.
+   * @return {Array<string|number>} An array with x/y values representing location in pixels.
+   * @private
+   */
+  parseScreenXY_(obj) {
+    if (obj && obj['x'] != null && obj['y'] != null) {
+      var xvalue = /** @type {number} */ (obj['x']);
+      var yvalue = /** @type {number} */ (obj['y']);
+      var xunits = /** @type {string} */ (obj['xunits']);
+      var yunits = /** @type {string} */ (obj['yunits']);
+
+      var xy = [0, 0];
+      var mapSize = MapContainer.getInstance().getMap().getSize();
+
+      if (xunits == 'fraction') {
+        if (xvalue == 0.5) {
+          xy[0] = 'center';
+        } else {
+          xy[0] = mapSize[0] * xvalue;
+        }
+      } else {
+        xy[0] = xvalue;
+      }
+
+      if (yunits == 'fraction') {
+        if (yvalue == 0.5) {
+          xy[1] = 'center';
+        } else {
+          xy[1] = mapSize[1] - (mapSize[1] * yvalue);
+        }
+      } else {
+        xy[1] = yvalue;
+      }
+
+      return xy;
+    }
+
+    return null;
+  }
+
+  /**
+   * Parse XY attributes from a size element and return an object with more sizing for our overlay
+   *
+   * @param {Object} obj The XY options.
+   * @return {Array<string|number>} An array with x/y values representing size in pixels.
+   * @private
+   */
+  parseSizeXY_(obj) {
+    if (obj && obj['x'] != null && obj['y'] != null) {
+      var xvalue = /** @type {number} */ (obj['x']);
+      var yvalue = /** @type {number} */ (obj['y']);
+      var xunits = /** @type {string} */ (obj['xunits']);
+      var yunits = /** @type {string} */ (obj['yunits']);
+
+      var xy = [0, 0];
+      var mapSize = MapContainer.getInstance().getMap().getSize();
+
+      if (xunits == 'fraction') {
+        // -1 = use native, 0 = maintain aspect, n = relative to screen size
+        if (xvalue == -1 || xvalue == 0) {
+          // TODO: no easy way of knowing what size the image is... don't set a size
+        } else {
+          xy[0] = mapSize[0] * xvalue;
+        }
+      } else {
+        xy[0] = xvalue;
+      }
+
+      if (yunits == 'fraction') {
+        // -1 = use native, 0 = maintain aspect, n = relative to screen size
+        if (yvalue == -1 || yvalue == 0) {
+          // TODO: no easy way of knowing what size the image is... don't set a size
+        } else {
+          xy[1] = mapSize[1] * yvalue;
+        }
+      } else {
+        xy[1] = yvalue;
+      }
+
+      return xy;
+    }
+
+    return null;
+  }
+
+  /**
+   * @param {Element} el The XML element
+   * @param {Feature} feature The feature
+   * @private
+   */
+  applyStyles_(el, feature) {
+    var styles = [];
+    var highlightStyle = null;
+
+    // style from style url
+    var styleUrl = /** @type {string} */ (feature.get('styleUrl'));
+    if (styleUrl) {
+      var styleId = this.getStyleId(decodeURIComponent(styleUrl));
+      styles.push(styleId in this.styleMap_ ? this.styleMap_[styleId] : null);
+      highlightStyle = styleId in this.highlightStyleMap_ ? this.highlightStyleMap_[styleId] : null;
+    }
+
+    this.readBalloonStyle_(el, feature);
+
+
+    // local style
+    var style = /** @type {Object} */ (feature.get(kml.STYLE_KEY));
+    if (style) {
+      this.updateStyleConfig_(style);
+      styles.push(style);
+    }
+
+    // inherited styles
+    var p = el.parentNode;
+    while (p) {
+      if (p.kmlStyle) {
+        styles.unshift(p.kmlStyle);
+      }
+
+      p = p.parentNode;
+    }
+
+    // default style
+    styles.unshift(kml.DEFAULT_STYLE);
+
+    // reduce style sets to single set
+    var mergedStyle = styles.reduce(KMLParser.reduceStyles_, null);
+    if (mergedStyle) {
+      var existingStyle = /** @type {Array<!Object>|Object|undefined} */ (feature.get(StyleType.FEATURE));
+      if (existingStyle) {
+        // if the feature already has a style config, merge in the KML style
+        if (Array.isArray(existingStyle)) {
+          for (var i = 0; i < existingStyle.length; i++) {
+            osObject.merge(mergedStyle, existingStyle[i]);
+          }
+        } else {
+          osObject.merge(mergedStyle, existingStyle);
+        }
+      } else {
+        // set the style config for the feature
+        feature.set(StyleType.FEATURE, mergedStyle, true);
+      }
+
+      if (highlightStyle) {
+        feature.set(StyleType.CUSTOM_HIGHLIGHT, highlightStyle, true);
+      }
+
+      // set the feature shape if it wasn't defined in the file and an icon style is present
+      if (!feature.get(StyleField.SHAPE) && osStyle.isIconConfig(mergedStyle)) {
+        feature.set(StyleField.SHAPE, osStyle.ShapeType.ICON);
+      }
+
+      // set the feature shape if it wasn't defined in the file and an icon style is present
+      if (!feature.get(StyleField.CENTER_SHAPE) && osStyle.isIconConfig(mergedStyle)) {
+        feature.set(StyleField.CENTER_SHAPE, osStyle.ShapeType.ICON);
+      }
+
+      // apply the feature style
+      osStyle.setFeatureStyle(feature);
+    }
+
+    var description = /** @type {string} */ (feature.get('description'));
+    if (description) {
+      // support KMZ assets in the description
+      for (var key in this.assetMap_) {
+        // replace naive URLs
+        var pattern = 'src=["\']' + key.replace(/(.)/g, '[$1]') + '["\']';
+        var regex = new RegExp(pattern);
+        description = description.replace(regex, 'src="' + this.assetMap_[key] + '"');
+
+        // Replace href's
+        pattern = 'href=["\']' + key.replace(/(.)/g, '[$1]') + '["\']';
+        regex = new RegExp(pattern);
+        description = description.replace(regex, 'href="' + this.assetMap_[key] + '"');
+
+        // replace properly encoded URLs
+        var encodedKey = new Uri(key).toString();
+        pattern = 'src=["\']' + encodedKey.replace(/(.)/g, '[$1]') + '["\']';
+        regex = new RegExp(pattern);
+        description = description.replace(regex, 'src="' + this.assetMap_[key] + '"');
+
+        // Replace href's for encoded URLs
+        pattern = 'href=["\']' + encodedKey.replace(/(.)/g, '[$1]') + '["\']';
+        regex = new RegExp(pattern);
+        description = description.replace(regex, 'href="' + this.assetMap_[key] + '"');
+      }
+
+      feature.set('description', description);
+    }
+  }
+
+  /**
+   * Extracts all immediate styles from the provided element.
+   *
+   * @param {Element} el The XML element
+   * @private
+   */
+  extractStyles_(el) {
+    // grab only immediate children. styles are inherited from ancestors only.
+    var styleEls = xml.getChildrenByTagName(el, 'Style');
+    for (var i = 0, n = styleEls.length; i < n; i++) {
+      var style = styleEls[i];
+
+      this.examineStyles_(style);
+
+      var styleConfig = kml.readStyle(style, this.stack_);
+      this.updateStyleConfig_(styleConfig);
+      var id = style.id || style.getAttribute('id');
+      if (!id) {
+        // styles without an ID are merely the base styles for the container
+        //
+        // Clever hack alert!
+        // The "stack" in this class is not really a stack. Therefore, we are
+        // going to store the KML styles on the element itself
+        el.kmlStyle = styleConfig;
+        continue;
+      }
+
+      if (id in this.styleMap_) {
+        var newId = id + '-' + googString.getRandomString();
+        var styleUrls = Array.prototype.slice.call(el.querySelectorAll('styleUrl'));
+        styleUrls.forEach(function(styleUrl) {
+          if (styleUrl.textContent.replace(/^#/, '') == id) {
+            styleUrl.textContent = '#' + newId;
+          }
+        });
+
+        id = newId;
+      }
+
+      this.styleMap_[id] = styleConfig;
+    }
+
+    // handle StyleMap elements
+    styleEls = xml.getChildrenByTagName(el, 'StyleMap');
+    for (i = 0, n = styleEls.length; i < n; i++) {
+      style = styleEls[i];
+      id = style.id || style.getAttribute('id');
+
+      if (!id) {
+        log.error(logger, 'StyleMap tags must have an "id" attribute');
+        continue;
+      }
+
+      var pairs = xml.getChildrenByTagName(style, 'Pair');
+      for (var j = 0, m = pairs.length; j < m; j++) {
+        var key = xml.getChildValue(pairs[j], 'key');
+        var url = xml.getChildValue(pairs[j], 'styleUrl');
+
+        if (key && url) {
+          key = key.trim();
+          var assignMap = key === 'normal' ? this.styleMap_ : this.highlightStyleMap_;
+          url = url.trim().replace(/^#/, '');
+
+          if (url in this.styleMap_) {
+            assignMap[id] = this.styleMap_[url];
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Gets all the schema tags and adds ol XML parsers for each one
+   *
+   * @param {Element} el The XML element
+   * @private
+   */
+  parseSchema_(el) {
+    var schemas = xml.getChildrenByTagName(el, 'Schema');
+    for (var i = 0, n = schemas.length; i < n; i++) {
+      var name = schemas[i].name || schemas[i].getAttribute('name');
+      if (!name) {
+        continue;
+      }
+
+      if (this.kmlThings_.indexOf(name) === -1) {
+        this.kmlThings_.push(name);
+      }
+
+      var fields = xml.getChildrenByTagName(schemas[i], 'SimpleField');
+
+      /**
+       * @type {Object<string, ol.XmlParser>}
+       */
+      var parsers = {};
+      var fieldCount = 0;
+      for (var j = 0, m = fields.length; j < m; j++) {
+        var reader = null;
+        var type = fields[j].type || fields[j].getAttribute('type');
+        type = type.toLowerCase();
+
+        switch (type) {
+          case 'bool':
+            reader = XSD.readBoolean;
+            break;
+          case 'int':
+          case 'short':
+          case 'float':
+          case 'double':
+            reader = XSD.readDecimal;
+            break;
+          case 'uint':
+          case 'ushort':
+            reader = XSD.readNonNegativeInteger;
+            break;
+          default:
+            // all other types are strings
+            reader = XSD.readString;
+            break;
+        }
+
+        var field = fields[j].name || fields[j].getAttribute('name');
+        if (field && reader) {
+          parsers[field] = olXml.makeObjectPropertySetter(reader);
+          fieldCount++;
+        }
+      }
+
+      if (fieldCount) {
+        this.parsersByPlacemarkTag_[name] = {
+          parent: /** @type {string} */ (schemas[i].getAttribute('parent')),
+          parsers: olXml.makeStructureNS(kml.OL_NAMESPACE_URIS(), parsers)
+        };
+      }
+    }
+
+    this.kmlThingRegex_ = this.getKmlThingRegex();
+  }
+
+  /**
+   * Creates the regex from the current set of KML things.
+   *
+   * @return {RegExp} The KML regex.
+   */
+  getKmlThingRegex() {
+    return new RegExp('^(' + this.kmlThings_.join('|') + ')$');
+  }
+
+  /**
+   * @param {Object} config
+   * @private
+   */
+  updateStyleConfig_(config) {
+    if (config) {
+      // attempt to convert local KMZ asset URIs to the proper data URIs
+      if (config['image'] && config['image']['src']) {
+        try {
+          var src = decodeURIComponent(config['image']['src']);
+
+          if (src && src in this.assetMap_) {
+            config['image']['src'] = this.assetMap_[src];
+          }
+        } catch (e) {
+          // ain't no thang
+        }
+      }
+    }
+  }
+
+  /**
+   * Parse the StyleUrl into the correct id format.
+   *
+   * @param {string} id The StyleUrl.
+   * @return {string} The Parsed Style id.
+   */
+  getStyleId(id) {
+    var x = id.indexOf('#');
+
+    if (x > -1) {
+      id = id.substring(x + 1);
+    }
+    return id;
+  }
+
+  /**
+   * Set the ID on a KML feature.
+   *
+   * @param {!Feature} feature The feature.
+   * @private
+   */
+  setFeatureId_(feature) {
+    // files containing duplicate network links will create features with duplicate id's. this allows us to merge
+    // features on refresh, while still creating an id that's unique from other network links (which will use a
+    // different parser)
+    var baseId = ol.getUid(feature);
+    var id = this.id_ + '#' + baseId;
+    feature.setId(id);
+
+    if (feature.get(Fields.ID) == null) {
+      feature.set(Fields.ID, baseId, true);
+    }
+  }
+
+  /**
+   * @param {?Object} merged The merged style config
+   * @param {Array<Object>} config The current config
+   * @return {Object}
+   * @private
+   */
+  static reduceStyles_(merged, config) {
+    merged = merged || {};
+    osStyle.mergeConfig(config, merged);
+    return merged;
+  }
+
+  /**
+   * Set the KML tree node name.
+   *
+   * @param {KMLNode} node The KML tree node
+   * @param {Element} el The name element
+   * @private
+   */
+  static setNodeLabel_(node, el) {
+    asserts.assert(el.localName == 'name', 'localName should be name');
+
+    // default to null and a default label will be created later
+    node.setLabel(olXml.getAllTextContent(el, true).trim() || null);
+  }
+
+  /**
+   * Set the KML tree node name.
+   *
+   * @param {KMLNode} node The KML tree node
+   * @param {Element} el The name element
+   * @private
+   */
+  static setNodeCollapsed_(node, el) {
+    asserts.assert(el.localName == 'open', 'localName should be open');
+
+    // default to collapsed, so only expand if the text is '1'.
+    node.collapsed = olXml.getAllTextContent(el, true).trim() !== '1';
+  }
+
+  /**
+   * Set the KML tree node visibility state.
+   *
+   * @param {KMLNode} node The KML tree node
+   * @param {Element} el The name element
+   * @private
+   */
+  static setNodeVisibility_(node, el) {
+    asserts.assert(el.localName == 'visibility', 'localName should be visibility');
+
+    var content = olXml.getAllTextContent(el, true).trim();
+    if (content) {
+      // this only handles turning the node off so we can honor our node defaults. this is specifically for network links,
+      // which we always default to being turned off.
+      var visibility = XSD.readBooleanString(content);
+      if (!visibility) {
+        node.setState(TriState.OFF);
+      }
+    }
+
+    var feature = node.getFeature();
+    if (feature) {
+      // remove the visibility property so it doesn't show up in the list tool
+      feature.set('visibility', undefined);
+    }
+  }
+}
 
 
 /**
  * @type {Array<string>}
  * @const
  */
-plugin.file.kml.KMLParser.KML_THINGS = ['NetworkLink', 'Placemark', 'GroundOverlay', 'ScreenOverlay', 'Tour'];
+KMLParser.KML_THINGS = ['NetworkLink', 'Placemark', 'GroundOverlay', 'ScreenOverlay', 'Tour'];
 
 
 /**
  * Logger
- * @type {goog.log.Logger}
- * @private
- * @const
+ * @type {Logger}
  */
-plugin.file.kml.KMLParser.LOGGER_ = goog.log.getLogger('plugin.file.kml.KMLParser');
+const logger = log.getLogger('plugin.file.kml.KMLParser');
 
 
 /**
@@ -242,1608 +1799,23 @@ plugin.file.kml.KMLParser.LOGGER_ = goog.log.getLogger('plugin.file.kml.KMLParse
  * @private
  * @const
  */
-plugin.file.kml.KMLParser.SKIPPED_COLUMNS_ = /^(geometry|recordtime|time|styleurl|_kmlStyle)$/i;
+KMLParser.SKIPPED_COLUMNS_ = /^(geometry|recordtime|time|styleurl|_kmlStyle)$/i;
 
 
 /**
- * @inheritDoc
+ * @typedef {function(KMLNode, Element)}
  */
-plugin.file.kml.KMLParser.prototype.disposeInternal = function() {
-  this.cleanup();
-  this.clearAssets();
-  plugin.file.kml.KMLParser.base(this, 'disposeInternal');
-};
+kml.KMLElementParser;
 
 
 /**
- * @inheritDoc
- */
-plugin.file.kml.KMLParser.prototype.cleanup = function() {
-  // FIXME: we should be clearing assets here, but they won't be available at load time
-  // this.clearAssets();
-
-  this.document_ = null;
-  this.merging_ = false;
-  this.rootNode_ = null;
-  this.columns_ = null;
-  this.columnMap_ = null;
-  this.stack_.length = 0;
-  this.styleMap_ = {};
-  this.balloonStyleMap = {};
-  this.unnamedCount_ = 0;
-  this.minRefreshPeriod_ = 0;
-};
-
-
-/**
- * Cleans up any KMZ assets. This should be done before parsing again or when the layer is removed.
- */
-plugin.file.kml.KMLParser.prototype.clearAssets = function() {
-  this.assetMap_ = {};
-};
-
-
-/**
- * Get the last parsed root KML tree node. This reference will be lost on cleanup, so it must be retrieved when parsing
- * completes.
- *
- * @return {plugin.file.kml.ui.KMLNode}
- */
-plugin.file.kml.KMLParser.prototype.getRootNode = function() {
-  return this.rootNode_;
-};
-
-
-/**
- * Get the minimum refresh period (from the network link control)
- *
- * @return {number}
- */
-plugin.file.kml.KMLParser.prototype.getMinRefreshPeriod = function() {
-  return this.minRefreshPeriod_;
-};
-
-
-/**
- * Set the root KML tree node. Use this to merge the parse result into an existing tree.
- *
- * @param {plugin.file.kml.ui.KMLNode} rootNode
- */
-plugin.file.kml.KMLParser.prototype.setRootNode = function(rootNode) {
-  this.rootNode_ = rootNode;
-  this.merging_ = !!rootNode;
-};
-
-
-/**
- * Get columns detected in the KML.
- *
- * @return {Array<!os.data.ColumnDefinition>}
- */
-plugin.file.kml.KMLParser.prototype.getColumns = function() {
-  if (!this.columns_ && this.columnMap_) {
-    // translate the column map into slickgrid columns
-    this.columns_ = [];
-
-    for (var column in this.columnMap_) {
-      if (column === os.data.RecordField.TIME) {
-        // display the recordTime field as TIME
-        this.columns_.push(new os.data.ColumnDefinition(os.Fields.TIME, os.data.RecordField.TIME));
-      } else if (!plugin.file.kml.KMLParser.SKIPPED_COLUMNS_.test(column)) {
-        this.columns_.push(new os.data.ColumnDefinition(column));
-      }
-    }
-
-    this.columnMap_ = null;
-  }
-
-  return this.columns_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLParser.prototype.hasNext = function() {
-  return this.stack_.length > 0;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLParser.prototype.setSource = function(source) {
-  this.cleanup();
-
-  if (ol.xml.isDocument(source)) {
-    this.document_ = /** @type {Document} */ (source);
-  } else if (typeof source === 'string') {
-    this.document_ = os.xml.loadXml(source);
-  } else if (source instanceof ArrayBuffer) {
-    if (os.file.mime.zip.isZip(source)) {
-      this.clearAssets();
-      this.createZipReader(source);
-      return;
-    } else {
-      var s = os.file.mime.text.getText(source);
-      if (s) {
-        this.document_ = goog.dom.xml.loadXml(s);
-      } else {
-        goog.log.error(this.log_, 'Source buffer does not appear to be text');
-        this.onError();
-      }
-    }
-  } else if (source instanceof Blob) {
-    goog.fs.FileReader.readAsArrayBuffer(source).addCallback(this.setSource, this);
-    return;
-  }
-
-  if (this.document_) {
-    var rootEl = goog.dom.getFirstElementChild(this.document_);
-    if (rootEl && rootEl.localName.toLowerCase() !== 'kml') {
-      // Sometimes people are dumb and create documents without a root <kml> tag.
-      // This is technically invalid KML and even invalid XML.  Because Google Earth
-      // accepts this crap, add a special case to put the proper root tag.
-      var newRoot = os.xml.createElement('kml', this.document_);
-
-      // add the Document element to the KML element
-      newRoot.appendChild(rootEl);
-
-      // add the new KML element to the document
-      this.document_.appendChild(newRoot);
-
-      // and update the root element
-      rootEl = newRoot;
-    }
-
-    if (rootEl) {
-      if (!this.loadExternalStyles()) {
-        this.begin();
-      }
-    } else {
-      goog.log.error(this.log_, 'No KML content to parse!');
-      this.onError();
-    }
-  } else {
-    goog.log.error(this.log_, 'Content must be a valid KML document!');
-    this.onError();
-  }
-};
-
-
-/**
- * @protected
- * @return {boolean} Whether or not external styles are loading
- */
-plugin.file.kml.KMLParser.prototype.loadExternalStyles = function() {
-  var styles = this.document_.querySelectorAll('styleUrl');
-  var extStylesFound = false;
-
-  for (var i = 0, n = styles.length; i < n; i++) {
-    var style = ol.xml.getAllTextContent(styles[i], true).trim();
-    if (style) {
-      // remove the fragment, if url is incorrectly formatted, kml is bad and this url should be skipped
-      var url = style.replace(/#.*/, '');
-      url = encodeURI(url) === url ? url : undefined;
-      if (url) {
-        extStylesFound = true;
-        goog.dom.setTextContent(styles[i], '#' + style.replace('#', '_'));
-
-        if (!(url in this.extStyles_)) {
-          if (url in this.kmlEntries_) {
-            var entry = this.kmlEntries_[url];
-            entry.getData(new zip.BlobWriter(), this.processZIPEntry_.bind(this, entry.filename));
-            this.extStyles_[url] = true;
-          } else {
-            var req = new os.net.Request(url);
-            req.listen(goog.net.EventType.SUCCESS, this.onExtStyleLoad, false, this);
-            req.listen(goog.net.EventType.ERROR, this.onExtStyleLoad, false, this);
-            this.extStyles_[url] = req;
-            req.load();
-          }
-        }
-      }
-    }
-  }
-
-  return extStylesFound;
-};
-
-
-/**
- * @param {goog.events.Event} evt
- * @protected
- */
-plugin.file.kml.KMLParser.prototype.onExtStyleLoad = function(evt) {
-  var req = /** @type {os.net.Request} */ (evt.target);
-  var url = req.getUri().toString();
-  var safeUrl = this.extStyles_[url] ? url : decodeURI(url);
-  delete this.extStyles_[safeUrl];
-
-  var resp = /** @type {string} */ (req.getResponse());
-  req.dispose();
-
-  if (evt.type === goog.net.EventType.SUCCESS) {
-    this.handleExternalStylesheet_(resp, url);
-  } else {
-    this.continueStyles_();
-  }
-};
-
-
-/**
- * @param {!string} content
- * @param {!string} url
- * @private
- */
-plugin.file.kml.KMLParser.prototype.handleExternalStylesheet_ = function(content, url) {
-  try {
-    var doc = goog.dom.xml.loadXml(content);
-    var appendTo = this.document_.querySelector('Document') || goog.dom.getFirstElementChild(this.document_);
-
-    var styles = doc.querySelectorAll('Style');
-    for (var i = 0, n = styles.length; i < n; i++) {
-      var style = styles[i];
-
-      // "namespace" the style with the URL
-      style.setAttribute('id', url + '_' + style.getAttribute('id'));
-
-      // append it to the main document
-      appendTo.appendChild(style);
-    }
-
-    var styleMaps = doc.querySelectorAll('StyleMap');
-    for (var i = 0, n = styleMaps.length; i < n; i++) {
-      var styleMap = styleMaps[i];
-
-      // "namespace" the style with the URL
-      styleMap.setAttribute('id', url + '_' + styleMap.getAttribute('id'));
-
-      var styleUrls = Array.prototype.slice.call(styleMap.querySelectorAll('styleUrl'));
-      styleUrls.forEach(function(styleUrl) {
-        var current = styleUrl.textContent.replace(/^#/, '');
-        styleUrl.textContent = '#' + url + '_' + current;
-      });
-
-      // append it to the main document
-      appendTo.appendChild(styleMap);
-    }
-  } catch (e) {
-    goog.log.error(this.log_, 'Could not parse KML stylesheet ' + url);
-  }
-
-  this.continueStyles_();
-};
-
-
-/**
- * Keep waiting for styles or begin if they are done
- *
- * @private
- */
-plugin.file.kml.KMLParser.prototype.continueStyles_ = function() {
-  // if we still have any outstanding style requests, keep waiting
-  for (var key in this.extStyles_) {
-    return;
-  }
-
-  // otherwise start parsing the main document
-  this.begin();
-};
-
-
-/**
- * @protected
- */
-plugin.file.kml.KMLParser.prototype.begin = function() {
-  var rootEl = goog.dom.getFirstElementChild(this.document_);
-  var rootChildren = goog.dom.getChildren(rootEl);
-
-  if (rootChildren && rootChildren.length > 0) {
-    // start parsing at the first child of the kml tag
-    this.stack_.push(/** @type {plugin.file.kml.KMLParserStackObj} */ ({
-      children: [rootEl],
-      index: 0,
-      node: null
-    }));
-
-    this.onReady();
-
-    // read NetworkLinkControl
-    for (var i = 0; i < rootChildren.length; i++) {
-      var child = rootChildren[i];
-      if (child.localName == 'NetworkLinkControl' && child.querySelector('minRefreshPeriod')) {
-        this.minRefreshPeriod_ = parseInt(child.querySelector('minRefreshPeriod').textContent, 10) * 1000;
-      }
-    }
-  } else {
-    goog.log.error(this.log_, 'Empty KML tree!');
-    this.onError();
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLParser.prototype.handleZipReaderError = function() {
-  plugin.file.kml.KMLParser.base(this, 'handleZipReaderError');
-  this.onError();
-};
-
-
-/**
- * HACK ALERT! zip.js has a zip.TextWriter() class that directly turns the zip entry into the string we want.
- * Unfortunately, it doesn't work in FF24 for some reason, but luckily, the BlobWriter does. Here, we read
- * the zip as a Blob, then feed it to a FileReader in the next callback in order to extract the text.
- *
- * @inheritDoc
- */
-plugin.file.kml.KMLParser.prototype.handleZipEntries = function(entries) {
-  var mainEntry = null;
-  var firstEntry = null;
-  var mainKml = /(doc|index)\.kml$/i;
-  var anyKml = /\.kml$/i;
-  var collada = /\.dae$/i;
-  var img = /\.(png|jpg|jpeg|gif|bmp|do)$/i;
-
-  for (var i = 0, n = entries.length; i < n; i++) {
-    // if we have multiple entries, try to find one titled either doc.kml or index.kml as these
-    // are generally the most important ones
-    var entry = entries[i];
-    if (!mainEntry && mainKml.test(entry.filename)) {
-      mainEntry = entry;
-    } else if (anyKml.test(entry.filename)) {
-      if (!firstEntry) {
-        firstEntry = entry;
-      }
-
-      this.kmlEntries_[entry.filename] = entry;
-    } else if (img.test(entry.filename)) {
-      var result = img.exec(entry.filename);
-      img.lastIndex = 0;
-
-      this.kmzImagesRemaining_++;
-
-      entry.getData(new zip.Data64URIWriter('image/' + result[1]), this.processZipAsset_.bind(this, entry.filename));
-    } else if (collada.test(entry.filename)) {
-      this.hasModel_ = true;
-      this.kmzImagesRemaining_++;
-      entry.getData(new zip.TextWriter(), this.processZipAsset_.bind(this, entry.filename));
-    } else {
-      this.kmzImagesRemaining_++;
-      this.processUnknownZipAsset_(entry);
-    }
-  }
-
-  mainEntry = mainEntry || firstEntry;
-
-
-  // before processing the main KML, try to delay until all images have been added to our asset map
-  // move on if it takes longer than 20 seconds
-  if (mainEntry) {
-    var delay = new goog.async.ConditionalDelay(this.imagesRemaining_.bind(this));
-    delay.onSuccess = this.processMainEntry_.bind(this, mainEntry, true);
-    delay.onFailure = this.processMainEntry_.bind(this, mainEntry, false);
-    delay.start(200, 20000);
-  } else {
-    goog.log.error(this.log_, 'No KML found in the ZIP!');
-    this.onError();
-  }
-};
-
-
-/**
- * Parse the main kml file
- *
- * @param {zip.Entry} mainEntry
- * @param {boolean} success True if all entries/images were processed
- * @private
- */
-plugin.file.kml.KMLParser.prototype.processMainEntry_ = function(mainEntry, success) {
-  if (!success) {
-    goog.log.error(this.log_, 'Failed to process KMZ images in a timely manner - skipping ' +
-        this.kmzImagesRemaining_ + ' images.');
-  }
-  mainEntry.getData(new zip.BlobWriter(), this.processZIPEntry_.bind(this, mainEntry.filename));
-};
-
-
-/**
- * True if we have processed all images
- *
- * @return {boolean} True if not all images have been processes
- * @private
- */
-plugin.file.kml.KMLParser.prototype.imagesRemaining_ = function() {
-  return this.kmzImagesRemaining_ <= 0;
-};
-
-/**
- * Handler for processing unknown assets within the ZIP file
- * @param {!zip.Entry} entry
- * @private
- */
-plugin.file.kml.KMLParser.prototype.processUnknownZipAsset_ = function(entry) {
-  entry.getData(new zip.ArrayBufferWriter(), (data) => {
-    const type = os.arraybuf.getMimeType(/** @type {ArrayBuffer} */ (data));
-    if (type && type.substr(0, 5) === 'image') {
-      entry.getData(new zip.Data64URIWriter(type), this.processZipAsset_.bind(this, entry.filename));
-    } else {
-      // eh whatever just skip this
-      this.kmzImagesRemaining_--;
-    }
-  });
-};
-
-
-/**
- * Handler for processing assets within the ZIP file. This includes images and collada model files.
- * @param {*} filename
- * @param {*} uri
- * @private
- */
-plugin.file.kml.KMLParser.prototype.processZipAsset_ = function(filename, uri) {
-  if (typeof filename === 'string' && typeof uri === 'string') {
-    this.assetMap_[filename] = uri;
-    this.kmzImagesRemaining_--;
-  } else {
-    goog.log.error(this.log_, 'There was a problem unzipping the KMZ!');
-    this.onError();
-  }
-};
-
-
-/**
- * @param {string} filename
- * @param {*} content
- * @private
- */
-plugin.file.kml.KMLParser.prototype.processZIPEntry_ = function(filename, content) {
-  if (content && content instanceof Blob) {
-    var reader = new FileReader();
-    reader.onload = this.handleZIPText_.bind(this, filename);
-    reader.readAsText(content);
-  } else {
-    goog.log.error(this.log_, 'There was a problem unzipping the KMZ!');
-    this.onError();
-  }
-};
-
-
-/**
- * @param {string} filename
- * @param {Event} event
- * @private
- */
-plugin.file.kml.KMLParser.prototype.handleZIPText_ = function(filename, event) {
-  var content = event.target.result;
-
-  if (content && typeof content === 'string') {
-    if (!this.document_) {
-      this.setSource(content);
-    } else {
-      delete this.extStyles_[filename];
-      this.handleExternalStylesheet_(content, filename);
-    }
-  } else {
-    goog.log.error(this.log_, 'There was a problem reading the ZIP content!');
-    this.onError();
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLParser.prototype.parseNext = function() {
-  goog.asserts.assert(this.stack_.length > 0, 'Stack should not be empty');
-  goog.asserts.assert(this.stack_[this.stack_.length - 1] != null, 'Top of stack should be an object');
-
-  var stackObj = null;
-  var node = null;
-  var top = this.stack_[this.stack_.length - 1];
-  var parentNode = top.node;
-  var children = top.children;
-  var currentEl = children[top.index];
-
-  if (!currentEl) {
-    var msg = 'Encountered null child under node ' + (parentNode ? parentNode.getLabel() : 'Unknown') + ' - skipping.';
-    goog.log.warning(this.log_, msg);
-    return null;
-  }
-
-  // Clever hack alert!
-  // Since we parse KMZs, the readURI function needs to know if a URL is in the asset map before it tries to resolve
-  // it against the node's baseURI. The only thing that is passed to that function is the node, so we'll just tack it on
-  currentEl.assetMap = this.assetMap_;
-
-  var localName = currentEl.localName;
-  try {
-    if (localName === 'Document' || localName === 'Folder' || localName === 'kml') {
-      node = this.createTreeNode_(currentEl, parentNode);
-
-      if (node) {
-        if (this.merging_) {
-          // if this is a merge, initially mark all child nodes for removal. merged children will be unmarked, and
-          // remaining children should be removed since they weren't found in the new KML
-          this.markAllChildren_(node);
-        }
-
-        var stackChildren = goog.dom.getChildren(currentEl);
-        if (stackChildren && stackChildren.length > 0) {
-          // only continue down this path if the element has children to parse
-          stackObj = /** @type {plugin.file.kml.KMLParserStackObj} */ ({
-            children: stackChildren,
-            index: 0,
-            node: node
-          });
-        }
-
-        if (localName === 'Document') {
-          // parse schema nodes
-          this.parseSchema_(currentEl);
-        }
-      }
-    } else if (this.kmlThingRegex_ && this.kmlThingRegex_.test(localName) && localName != 'NetworkLinkControl') {
-      node = this.createTreeNode_(currentEl, parentNode);
-    }
-  } catch (e) {
-    // something failed so we don't want to continue parsing this DOM path
-    stackObj = null;
-    node = null;
-
-    goog.log.error(this.log_, 'Failed parsing node type: ' + localName, e);
-  }
-
-  ++top.index;
-  if (top.index >= children.length) {
-    if (this.merging_ && parentNode) {
-      // remove any children that weren't found in the new KML
-      this.removeMarkedChildren_(parentNode);
-    }
-
-    // no more children to parse, so pop the current item off the stack
-    this.stack_.pop();
-  }
-
-  if (stackObj) {
-    // current element is a container, so parse its children next
-    this.stack_.push(stackObj);
-    this.extractStyles_(currentEl);
-  }
-
-  if (!this.hasNext()) {
-    this.closeZipReaders();
-  }
-
-  return node;
-};
-
-
-/**
- * Parses sample data from a KML.
- *
- * @return {!Array<!ol.Feature>}
- */
-plugin.file.kml.KMLParser.prototype.parsePreview = function() {
-  var features = [];
-  while (this.hasNext() && features.length < 50) {
-    var node = this.parseNext();
-    if (node) {
-      var feature = node.getFeature();
-      if (feature) {
-        features.push(feature);
-      }
-    }
-  }
-
-  return features;
-};
-
-
-/**
- * Marks the node's children for removal.
- *
- * @param {!plugin.file.kml.ui.KMLNode} node The KML node
- * @private
- */
-plugin.file.kml.KMLParser.prototype.markAllChildren_ = function(node) {
-  var children = node.getChildren();
-  if (children) {
-    for (var i = 0, n = children.length; i < n; i++) {
-      /** @type {plugin.file.kml.ui.KMLNode} */ (children[i]).marked = true;
-    }
-  }
-};
-
-
-/**
- * Removes all marked children from a node.
- *
- * @param {!plugin.file.kml.ui.KMLNode} node The KML node
- * @private
- */
-plugin.file.kml.KMLParser.prototype.removeMarkedChildren_ = function(node) {
-  var children = node.getChildren();
-  if (children) {
-    var i = children.length;
-    while (i--) {
-      var child = /** @type {plugin.file.kml.ui.KMLNode} */ (children[i]);
-      if (child.marked) {
-        node.removeChildAt(i);
-        child.dispose();
-      }
-    }
-  }
-};
-
-
-/**
- * Creates a tree node from an XML element
- *
- * @param {Element} el The XML element
- * @param {plugin.file.kml.ui.KMLNode=} opt_parent The parent tree node
- * @return {plugin.file.kml.ui.KMLNode} The tree node
- * @private
- */
-plugin.file.kml.KMLParser.prototype.createTreeNode_ = function(el, opt_parent) {
-  var node = this.examineElement_(el);
-  if (node) {
-    if (!node.getLabel()) {
-      // use the id if one is available, otherwise create a default name based on the element type
-      var id = el.id || el.getAttribute('id');
-      node.setLabel(id || this.getDefaultName_(el.localName));
-    }
-
-    if (opt_parent != null) {
-      // if the child already exists, the new node will be merged and the original node returned
-      node = /** @type {plugin.file.kml.ui.KMLNode} */ (opt_parent.addChild(node));
-    } else if (this.rootNode_ === null) {
-      this.rootNode_ = node;
-    } else if (this.rootNode_.getLabel() != node.getLabel()) {
-      // the root node name changed, so start with a fresh tree. if this rains on anyone's parade we can probably
-      // just rename the existing root node but we're assuming this means the KML has changed significantly
-      this.rootNode_.dispose();
-      this.rootNode_ = node;
-    } else {
-      // keep the old root node
-      node = this.rootNode_;
-    }
-  }
-
-  return node;
-};
-
-
-/**
- * Examine styles that are unsupported in OpenLayers KML styles.
- *
- * @param {Node} node Node.
- * @private
- */
-plugin.file.kml.KMLParser.prototype.examineStyles_ = function(node) {
-  var n;
-  for (n = node.firstElementChild; n; n = n.nextElementSibling) {
-    if (n.localName == 'BalloonStyle') {
-      var properties = ol.xml.pushParseAndPop({}, plugin.file.kml.BALLOON_PROPERTY_PARSERS, n, []);
-      if (properties) {
-        var id = node.id || node.getAttribute('id');
-        this.balloonStyleMap[id] = properties;
-      }
-    }
-  }
-};
-
-
-/**
- * Read the KML balloon style.
- *
- * @param {Element} el The XML element
- * @param {ol.Feature} feature The feature
- * @private
- *
- * @suppress {accessControls} To allow direct access to feature metadata.
- */
-plugin.file.kml.KMLParser.prototype.readBalloonStyle_ = function(el, feature) {
-  if (feature.get(os.annotation.OPTIONS_FIELD)) {
-    // the feature is an Open Sphere annotation, so ignore the balloon style. it's there for display in other
-    // applications, like Google Earth.
-    return;
-  }
-
-  var style;
-  var balloonEl = el.querySelector('BalloonStyle');
-  if (balloonEl) {
-    // the placemark has an internal balloon style
-    style = ol.xml.pushParseAndPop({}, plugin.file.kml.BALLOON_PROPERTY_PARSERS, balloonEl, []);
-  } else {
-    // look for a balloon style referenced by styleUrl
-    var styleUrl = /** @type {string} */ (feature.get('styleUrl'));
-    var styleId = this.getStyleId(decodeURIComponent(styleUrl));
-    style = styleId in this.balloonStyleMap ? this.balloonStyleMap[styleId] : null;
-  }
-
-  if (style) {
-    var text = style['text'];
-    var pattern = /[$]\[(.*?)\]/g;
-    var regex = new RegExp(pattern);
-
-    text = text.replace(regex, function(match, key) {
-      if (key in feature.values_) {
-        return feature.get(key);
-      } else {
-        return '';
-      }
-    });
-
-    text = os.ui.sanitize(text);
-
-    feature.set(plugin.file.kml.KMLField.BALLOON_TEXT, text);
-  }
-};
-
-
-/**
- * Creates a tree node from an XML element
- *
- * @param {Element} el The XML element
- * @return {plugin.file.kml.ui.KMLNode} The tree node
- * @private
- */
-plugin.file.kml.KMLParser.prototype.examineElement_ = function(el) {
-  var node = null;
-  if (el.localName === 'NetworkLink') {
-    node = this.readNetworkLink_(el);
-  } else if (el.localName === 'GroundOverlay') {
-    node = this.readGroundOverlay_(el);
-  } else if (el.localName === 'ScreenOverlay') {
-    node = this.readScreenOverlay_(el);
-  } else if (el.localName === 'Tour') {
-    var tour = plugin.file.kml.tour.parseTour(el);
-    if (tour) {
-      node = new plugin.file.kml.ui.KMLTourNode(tour);
-    }
-  } else if (this.kmlThingRegex_ && this.kmlThingRegex_.test(el.localName) && el.localName != 'NetworkLinkControl') {
-    var feature = this.readPlacemark_(el);
-    if (feature) {
-      node = new plugin.file.kml.ui.KMLNode();
-      node.setFeature(feature);
-      node.layerUI = 'kmlnodelayerui';
-    }
-  } else {
-    node = new plugin.file.kml.ui.KMLNode();
-  }
-
-  if (node) {
-    this.updateNode_(el, node, plugin.file.kml.KMLParser.BASE_ELEMENT_PARSERS_);
-  }
-
-  return node;
-};
-
-
-/**
- * Executes a set of parsers to modify a tree node from an element.
- *
- * @param {Element} el The XML element
- * @param {plugin.file.kml.ui.KMLNode} node The KML tree node
- * @param {Object.<string, plugin.file.kml.KMLElementParser>} parsers The parsers to use
- * @private
- */
-plugin.file.kml.KMLParser.prototype.updateNode_ = function(el, node, parsers) {
-  var n;
-  for (n = goog.dom.getFirstElementChild(el); n !== null; n = n.nextElementSibling) {
-    var parser = parsers[n.localName];
-    if (parser !== undefined) {
-      parser.call(this, node, n);
-    }
-  }
-};
-
-
-/**
- * Get a default name for a KML tree node
- *
- * @param {string} localName The element name
- * @return {string}
- * @private
- */
-plugin.file.kml.KMLParser.prototype.getDefaultName_ = function(localName) {
-  this.unnamedCount_++;
-
-  if (localName == 'kml') {
-    // this is the root node, so make it obvious
-    return 'kmlroot';
-  }
-
-  return 'Unnamed ' + this.unnamedCount_ + ' [' + localName + ']';
-};
-
-
-/**
- * Parses a KML NetworkLink element into a tree node
- *
- * @param {Element} el The XML element
- * @return {plugin.file.kml.ui.KMLNetworkLinkNode} The network link node, or null if unable to parse
- * @private
- */
-plugin.file.kml.KMLParser.prototype.readNetworkLink_ = function(el) {
-  var node = null;
-  var linkObj = ol.xml.pushParseAndPop({}, plugin.file.kml.OL_NETWORK_LINK_PARSERS(), el, []);
-  if (linkObj && linkObj['href']) {
-    node = new plugin.file.kml.ui.KMLNetworkLinkNode(linkObj['href']);
-
-    // default provided by KML spec
-    var refreshMode = linkObj['refreshMode'];
-    if (refreshMode && goog.object.containsValue(os.ui.file.kml.RefreshMode, refreshMode)) {
-      node.setRefreshMode(refreshMode);
-
-      switch (refreshMode) {
-        case os.ui.file.kml.RefreshMode.CHANGE:
-          // this is the default, so nothing to do unless we start parsing viewRefreshMode
-          break;
-        case os.ui.file.kml.RefreshMode.EXPIRE:
-          // the network link should refresh based on HTTP headers or the NetworkLinkControl tag in the fetched KML,
-          // so nothing else to do here
-          break;
-        case os.ui.file.kml.RefreshMode.INTERVAL:
-          var interval = /** @type {number} */ (linkObj['refreshInterval']);
-          if (typeof interval === 'number' && !isNaN(interval)) {
-            node.setRefreshInterval(interval * 1000);
-          }
-          break;
-        default:
-          break;
-      }
-    }
-
-    var viewRefreshMode = linkObj['viewRefreshMode'];
-    if (viewRefreshMode && goog.object.containsValue(os.ui.file.kml.ViewRefreshMode, viewRefreshMode)) {
-      node.setViewRefreshMode(viewRefreshMode);
-
-      switch (viewRefreshMode) {
-        case os.ui.file.kml.ViewRefreshMode.NEVER:
-          // do nothing
-          break;
-        case os.ui.file.kml.ViewRefreshMode.REQUEST:
-          // the node handles this case by automatically populating the current view BBOX when the user manually
-          // refreshes the layer
-          break;
-        case os.ui.file.kml.ViewRefreshMode.STOP:
-        case os.ui.file.kml.ViewRefreshMode.REGION:
-          // TODO: Region support. For now I'm going to treat it like onStop, but regions are a more
-          // complicated construct for determining view refreshes that we don't support yet.
-
-          // there should be a second parameter defining a time delay after changes for these cases
-          var time = /** @type {number} */ (linkObj['viewRefreshTime']);
-          if (typeof time === 'number' && !isNaN(time)) {
-            node.setViewRefreshTimer(time * 1000);
-          }
-          break;
-        default:
-          break;
-      }
-    }
-  }
-
-  return node;
-};
-
-
-/**
- * Parses a KML Placemark element into a map feature
- *
- * @param {Element} el The XML element
- * @return {os.feature.DynamicFeature|ol.Feature|undefined} The map feature
- * @private
- *
- * I don't care what you think, compiler.
- * @suppress {accessControls}
- */
-plugin.file.kml.KMLParser.prototype.readPlacemark_ = function(el) {
-  goog.asserts.assert(el.nodeType == goog.dom.NodeType.ELEMENT, 'el.nodeType should be ELEMENT');
-  goog.asserts.assert(el.localName in this.parsersByPlacemarkTag_,
-      'localName should be Placemark or be defined by Schema tags');
-
-  var set = this.parsersByPlacemarkTag_[el.localName];
-  var object = {'geometry': null};
-
-  // This is slightly odd in that it allows parent parsers to override values set by
-  // child parsers (generally the opposite of what you expect from inheritence), however,
-  // use of Schema tags is silly if you are just using them for key/value pairs (that's what
-  // ExtendedData is for) and anything more complicated isn't going to be handled by this
-  // parser anyway.
-  while (set) {
-    object = ol.xml.pushParseAndPop(object, set.parsers, el, []);
-    set = set.parent ? this.parsersByPlacemarkTag_[set.parent] : null;
-  }
-
-  if (!object) {
-    return null;
-  }
-
-  if (this.hasModel_) {
-    plugin.file.kml.model.parseModel(el, object);
-  }
-
-  // set geometry fields on the object
-  var geometry = /** @type {ol.geom.Geometry|undefined} */ (object['geometry']);
-  delete object['geometry'];
-
-  if (geometry) {
-    // grab the lon/lat coordinate before we potentially convert it to god knows what
-    if (geometry.getType() == ol.geom.GeometryType.POINT) {
-      var coord = /** @type {!ol.geom.Point} */ (geometry).getFirstCoordinate();
-      if (coord.length > 1) {
-        object[os.Fields.LAT] = object[os.Fields.LAT] || coord[1];
-        object[os.Fields.LON] = object[os.Fields.LON] || coord[0];
-
-        if ((coord.length > 2) && (coord[2] != 0)) {
-          object[os.Fields.GEOM_ALT] = object[os.Fields.GEOM_ALT] || coord[2];
-        }
-      }
-    }
-
-    // convert to application projection
-    geometry.osTransform();
-  }
-
-  // make sure parsed styles don't appear as a source column
-  if (object['Style']) {
-    object[plugin.file.kml.STYLE_KEY] = object['Style'];
-    delete object['Style'];
-  }
-
-  var feature;
-  if ((geometry instanceof ol.geom.LineString || geometry instanceof ol.geom.MultiLineString) &&
-      geometry.getLayout() === ol.geom.GeometryLayout.XYZM) {
-    // Openlayers parses KML tracks into a LineString/MultiLineString with the XYZM layout (lon, lat, alt, time). if one
-    // of these is encountered, create a track so it can be animated on the timeline.
-
-    if (geometry instanceof ol.geom.MultiLineString && geometry.get('interpolate')) {
-      // if a multi track should be interpolated, join it into a single line. the track updates will handle the
-      // interpolation between known positions.
-      var flatCoordinates = geometry.getFlatCoordinates();
-      var coordinates = ol.geom.flat.inflate.coordinates(flatCoordinates, 0, flatCoordinates.length, 4);
-      geometry = new ol.geom.LineString(coordinates);
-    }
-
-    feature = os.track.createTrack(/** @type {!os.track.CreateOptions} */ ({
-      geometry: geometry,
-      name: /** @type {string|undefined} */ (object['name'])
-    }));
-  } else {
-    feature = new ol.Feature(geometry);
-  }
-
-  if (feature) {
-    this.setFeatureId_(feature);
-
-    // parse any fields that are known to contain JSON data into objects
-    for (var i = 0, ii = plugin.file.kml.JsonField.length; i < ii; i++) {
-      var field = plugin.file.kml.JsonField[i];
-
-      if (object[field] && typeof object[field] === 'string') {
-        object[field] = JSON.parse(object[field]);
-      }
-    }
-
-    feature.setProperties(object);
-
-    // create/modify the set of columns detected in the file. for now, just keep a basic set to keep this as low
-    // overhead as possible.
-    if (!this.columnMap_) {
-      this.columnMap_ = [];
-    }
-
-    for (var key in object) {
-      this.columnMap_[key] = true;
-    }
-
-    this.applyStyles_(el, feature);
-  }
-
-  return feature;
-};
-
-
-/**
- * Parses a KML GroundOverlay element into a map layer.
- *
- * @param {Element} el The XML element.
- * @return {plugin.file.kml.ui.KMLNode} A KML node for the overlay, or null if one couldn't be created.
- * @private
- */
-plugin.file.kml.KMLParser.prototype.readGroundOverlay_ = function(el) {
-  goog.asserts.assert(el.nodeType == goog.dom.NodeType.ELEMENT, 'el.nodeType should be ELEMENT');
-  goog.asserts.assert(el.localName == 'GroundOverlay', 'localName should be GroundOverlay');
-
-  var obj = ol.xml.pushParseAndPop({}, plugin.file.kml.GROUND_OVERLAY_PARSERS, el, []);
-  if (obj) {
-    if (obj['extent'] && obj['Icon'] && obj['Icon']['href']) {
-      var icon = /** @type {string} */ (obj['Icon']['href']);
-      if (this.assetMap_[icon]) {
-        icon = this.assetMap_[icon]; // handle images included in a kmz
-      }
-
-      var extent = ol.proj.transformExtent(/** @type {ol.Extent} */ (obj['extent']), os.proj.EPSG4326,
-          os.map.PROJECTION);
-
-      var feature = new ol.Feature();
-      this.setFeatureId_(feature);
-
-      if (obj[os.data.RecordField.TIME]) {
-        feature.set(os.data.RecordField.TIME, obj[os.data.RecordField.TIME], true);
-      }
-
-      var image = new os.layer.Image({
-        source: new os.source.ImageStatic({
-          crossOrigin: os.net.getCrossOrigin(icon),
-          url: icon,
-          imageExtent: extent,
-          projection: os.map.PROJECTION
-        }, -(obj['rotation'] || 0))
-      });
-      image.setId(/** @type {string} */ (feature.getId()));
-
-      var node = new plugin.file.kml.ui.KMLNode();
-      node.setFeature(feature);
-      node.setImage(image);
-
-      return node;
-    } else if (obj['error']) {
-      var msg = obj['error'].toString();
-      goog.log.warning(plugin.file.kml.KMLParser.LOGGER_, msg);
-      os.alertManager.sendAlert(msg, os.alert.AlertEventSeverity.WARNING);
-    }
-  }
-
-  return null;
-};
-
-
-/**
- * Parses a KML ScreenOverlay element into a legend style window.
- *
- * @param {Element} el The XML element.
- * @return {plugin.file.kml.ui.KMLNode} A KML node for the overlay, or null if one couldn't be created.
- * @private
- */
-plugin.file.kml.KMLParser.prototype.readScreenOverlay_ = function(el) {
-  goog.asserts.assert(el.nodeType == goog.dom.NodeType.ELEMENT, 'el.nodeType should be ELEMENT');
-  goog.asserts.assert(el.localName == 'ScreenOverlay', 'localName should be ScreenOverlay');
-
-  var obj = ol.xml.pushParseAndPop({}, plugin.file.kml.SCREEN_OVERLAY_PARSERS, el, []);
-  if (obj && obj['name'] && obj['Icon'] && obj['Icon']['href']) {
-    var name = /** @type {string} */ (obj['name']);
-
-    var icon = /** @type {string} */ (obj['Icon']['href']);
-    if (this.assetMap_[icon]) {
-      icon = this.assetMap_[icon]; // handle images included in a kmz
-    }
-
-    var screenXY = this.parseScreenXY_(obj['screenXY']);
-    var size = this.parseSizeXY_(obj['size']);
-    if (screenXY && size) {
-      var feature = new ol.Feature();
-      this.setFeatureId_(feature);
-
-      if (obj[os.data.RecordField.TIME]) {
-        feature.set(os.data.RecordField.TIME, obj[os.data.RecordField.TIME], true);
-      }
-
-      var overlayOptions = /** @type {!osx.window.ScreenOverlayOptions} */ ({
-        id: feature.getId(),
-        name: this.rootNode_.getLabel() + ' - ' + name,
-        image: icon,
-        size: size,
-        xy: screenXY,
-        showHide: true
-      });
-
-      var node = new plugin.file.kml.ui.KMLNode();
-      node.setFeature(feature);
-      node.setOverlayOptions(overlayOptions);
-
-      return node;
-    }
-  }
-
-  return null;
-};
-
-
-/**
- * Parse XY attributes from a screenXY element and return an object with more useful location coordinates
- *
- * @param {Object} obj The XY options.
- * @return {Array<string|number>} An array with x/y values representing location in pixels.
- * @private
- */
-plugin.file.kml.KMLParser.prototype.parseScreenXY_ = function(obj) {
-  if (obj && obj['x'] != null && obj['y'] != null) {
-    var xvalue = /** @type {number} */ (obj['x']);
-    var yvalue = /** @type {number} */ (obj['y']);
-    var xunits = /** @type {string} */ (obj['xunits']);
-    var yunits = /** @type {string} */ (obj['yunits']);
-
-    var xy = [0, 0];
-    var mapSize = os.MapContainer.getInstance().getMap().getSize();
-
-    if (xunits == 'fraction') {
-      if (xvalue == 0.5) {
-        xy[0] = 'center';
-      } else {
-        xy[0] = mapSize[0] * xvalue;
-      }
-    } else {
-      xy[0] = xvalue;
-    }
-
-    if (yunits == 'fraction') {
-      if (yvalue == 0.5) {
-        xy[1] = 'center';
-      } else {
-        xy[1] = mapSize[1] - (mapSize[1] * yvalue);
-      }
-    } else {
-      xy[1] = yvalue;
-    }
-
-    return xy;
-  }
-
-  return null;
-};
-
-
-/**
- * Parse XY attributes from a size element and return an object with more sizing for our overlay
- *
- * @param {Object} obj The XY options.
- * @return {Array<string|number>} An array with x/y values representing size in pixels.
- * @private
- */
-plugin.file.kml.KMLParser.prototype.parseSizeXY_ = function(obj) {
-  if (obj && obj['x'] != null && obj['y'] != null) {
-    var xvalue = /** @type {number} */ (obj['x']);
-    var yvalue = /** @type {number} */ (obj['y']);
-    var xunits = /** @type {string} */ (obj['xunits']);
-    var yunits = /** @type {string} */ (obj['yunits']);
-
-    var xy = [0, 0];
-    var mapSize = os.MapContainer.getInstance().getMap().getSize();
-
-    if (xunits == 'fraction') {
-      // -1 = use native, 0 = maintain aspect, n = relative to screen size
-      if (xvalue == -1 || xvalue == 0) {
-        // TODO: no easy way of knowing what size the image is... don't set a size
-      } else {
-        xy[0] = mapSize[0] * xvalue;
-      }
-    } else {
-      xy[0] = xvalue;
-    }
-
-    if (yunits == 'fraction') {
-      // -1 = use native, 0 = maintain aspect, n = relative to screen size
-      if (yvalue == -1 || yvalue == 0) {
-        // TODO: no easy way of knowing what size the image is... don't set a size
-      } else {
-        xy[1] = mapSize[1] * yvalue;
-      }
-    } else {
-      xy[1] = yvalue;
-    }
-
-    return xy;
-  }
-
-  return null;
-};
-
-
-/**
- * @param {?Object} merged The merged style config
- * @param {Array<Object>} config The current config
- * @return {Object}
- * @private
- */
-plugin.file.kml.KMLParser.reduceStyles_ = function(merged, config) {
-  merged = merged || {};
-  os.style.mergeConfig(config, merged);
-  return merged;
-};
-
-
-/**
- * @param {Element} el The XML element
- * @param {ol.Feature} feature The feature
- * @private
- */
-plugin.file.kml.KMLParser.prototype.applyStyles_ = function(el, feature) {
-  var styles = [];
-  var highlightStyle = null;
-
-  // style from style url
-  var styleUrl = /** @type {string} */ (feature.get('styleUrl'));
-  if (styleUrl) {
-    var styleId = this.getStyleId(decodeURIComponent(styleUrl));
-    styles.push(styleId in this.styleMap_ ? this.styleMap_[styleId] : null);
-    highlightStyle = styleId in this.highlightStyleMap_ ? this.highlightStyleMap_[styleId] : null;
-  }
-
-  this.readBalloonStyle_(el, feature);
-
-
-  // local style
-  var style = /** @type {Object} */ (feature.get(plugin.file.kml.STYLE_KEY));
-  if (style) {
-    this.updateStyleConfig_(style);
-    styles.push(style);
-  }
-
-  // inherited styles
-  var p = el.parentNode;
-  while (p) {
-    if (p.kmlStyle) {
-      styles.unshift(p.kmlStyle);
-    }
-
-    p = p.parentNode;
-  }
-
-  // default style
-  styles.unshift(plugin.file.kml.DEFAULT_STYLE);
-
-  // reduce style sets to single set
-  var mergedStyle = styles.reduce(plugin.file.kml.KMLParser.reduceStyles_, null);
-  if (mergedStyle) {
-    var existingStyle = /** @type {Array<!Object>|Object|undefined} */ (feature.get(os.style.StyleType.FEATURE));
-    if (existingStyle) {
-      // if the feature already has a style config, merge in the KML style
-      if (Array.isArray(existingStyle)) {
-        for (var i = 0; i < existingStyle.length; i++) {
-          os.object.merge(mergedStyle, existingStyle[i]);
-        }
-      } else {
-        os.object.merge(mergedStyle, existingStyle);
-      }
-    } else {
-      // set the style config for the feature
-      feature.set(os.style.StyleType.FEATURE, mergedStyle, true);
-    }
-
-    if (highlightStyle) {
-      feature.set(os.style.StyleType.CUSTOM_HIGHLIGHT, highlightStyle, true);
-    }
-
-    // set the feature shape if it wasn't defined in the file and an icon style is present
-    if (!feature.get(os.style.StyleField.SHAPE) && os.style.isIconConfig(mergedStyle)) {
-      feature.set(os.style.StyleField.SHAPE, os.style.ShapeType.ICON);
-    }
-
-    // set the feature shape if it wasn't defined in the file and an icon style is present
-    if (!feature.get(os.style.StyleField.CENTER_SHAPE) && os.style.isIconConfig(mergedStyle)) {
-      feature.set(os.style.StyleField.CENTER_SHAPE, os.style.ShapeType.ICON);
-    }
-
-    // apply the feature style
-    os.style.setFeatureStyle(feature);
-  }
-
-  var description = /** @type {string} */ (feature.get('description'));
-  if (description) {
-    // support KMZ assets in the description
-    for (var key in this.assetMap_) {
-      // replace naive URLs
-      var pattern = 'src=["\']' + key.replace(/(.)/g, '[$1]') + '["\']';
-      var regex = new RegExp(pattern);
-      description = description.replace(regex, 'src="' + this.assetMap_[key] + '"');
-
-      // Replace href's
-      pattern = 'href=["\']' + key.replace(/(.)/g, '[$1]') + '["\']';
-      regex = new RegExp(pattern);
-      description = description.replace(regex, 'href="' + this.assetMap_[key] + '"');
-
-      // replace properly encoded URLs
-      var encodedKey = new goog.Uri(key).toString();
-      pattern = 'src=["\']' + encodedKey.replace(/(.)/g, '[$1]') + '["\']';
-      regex = new RegExp(pattern);
-      description = description.replace(regex, 'src="' + this.assetMap_[key] + '"');
-
-      // Replace href's for encoded URLs
-      pattern = 'href=["\']' + encodedKey.replace(/(.)/g, '[$1]') + '["\']';
-      regex = new RegExp(pattern);
-      description = description.replace(regex, 'href="' + this.assetMap_[key] + '"');
-    }
-
-    feature.set('description', description);
-  }
-};
-
-
-/**
- * Extracts all immediate styles from the provided element.
- *
- * @param {Element} el The XML element
- * @private
- */
-plugin.file.kml.KMLParser.prototype.extractStyles_ = function(el) {
-  // grab only immediate children. styles are inherited from ancestors only.
-  var styleEls = os.xml.getChildrenByTagName(el, 'Style');
-  for (var i = 0, n = styleEls.length; i < n; i++) {
-    var style = styleEls[i];
-
-    this.examineStyles_(style);
-
-    var styleConfig = plugin.file.kml.readStyle(style, this.stack_);
-    this.updateStyleConfig_(styleConfig);
-    var id = style.id || style.getAttribute('id');
-    if (!id) {
-      // styles without an ID are merely the base styles for the container
-      //
-      // Clever hack alert!
-      // The "stack" in this class is not really a stack. Therefore, we are
-      // going to store the KML styles on the element itself
-      el.kmlStyle = styleConfig;
-      continue;
-    }
-
-    if (id in this.styleMap_) {
-      var newId = id + '-' + goog.string.getRandomString();
-      var styleUrls = Array.prototype.slice.call(el.querySelectorAll('styleUrl'));
-      styleUrls.forEach(function(styleUrl) {
-        if (styleUrl.textContent.replace(/^#/, '') == id) {
-          styleUrl.textContent = '#' + newId;
-        }
-      });
-
-      id = newId;
-    }
-
-    this.styleMap_[id] = styleConfig;
-  }
-
-  // handle StyleMap elements
-  styleEls = os.xml.getChildrenByTagName(el, 'StyleMap');
-  for (i = 0, n = styleEls.length; i < n; i++) {
-    style = styleEls[i];
-    id = style.id || style.getAttribute('id');
-
-    if (!id) {
-      goog.log.error(plugin.file.kml.KMLParser.LOGGER_, 'StyleMap tags must have an "id" attribute');
-      continue;
-    }
-
-    var pairs = os.xml.getChildrenByTagName(style, 'Pair');
-    for (var j = 0, m = pairs.length; j < m; j++) {
-      var key = os.xml.getChildValue(pairs[j], 'key');
-      var url = os.xml.getChildValue(pairs[j], 'styleUrl');
-
-      if (key && url) {
-        key = key.trim();
-        var assignMap = key === 'normal' ? this.styleMap_ : this.highlightStyleMap_;
-        url = url.trim().replace(/^#/, '');
-
-        if (url in this.styleMap_) {
-          assignMap[id] = this.styleMap_[url];
-        }
-      }
-    }
-  }
-};
-
-
-/**
- * Gets all the schema tags and adds ol XML parsers for each one
- *
- * @param {Element} el The XML element
- * @private
- */
-plugin.file.kml.KMLParser.prototype.parseSchema_ = function(el) {
-  var schemas = os.xml.getChildrenByTagName(el, 'Schema');
-  for (var i = 0, n = schemas.length; i < n; i++) {
-    var name = schemas[i].name || schemas[i].getAttribute('name');
-    if (!name) {
-      continue;
-    }
-
-    if (this.kmlThings_.indexOf(name) === -1) {
-      this.kmlThings_.push(name);
-    }
-
-    var fields = os.xml.getChildrenByTagName(schemas[i], 'SimpleField');
-
-    /**
-     * @type {Object<string, ol.XmlParser>}
-     */
-    var parsers = {};
-    var fieldCount = 0;
-    for (var j = 0, m = fields.length; j < m; j++) {
-      var reader = null;
-      var type = fields[j].type || fields[j].getAttribute('type');
-      type = type.toLowerCase();
-
-      switch (type) {
-        case 'bool':
-          reader = ol.format.XSD.readBoolean;
-          break;
-        case 'int':
-        case 'short':
-        case 'float':
-        case 'double':
-          reader = ol.format.XSD.readDecimal;
-          break;
-        case 'uint':
-        case 'ushort':
-          reader = ol.format.XSD.readNonNegativeInteger;
-          break;
-        default:
-          // all other types are strings
-          reader = ol.format.XSD.readString;
-          break;
-      }
-
-      var field = fields[j].name || fields[j].getAttribute('name');
-      if (field && reader) {
-        parsers[field] = ol.xml.makeObjectPropertySetter(reader);
-        fieldCount++;
-      }
-    }
-
-    if (fieldCount) {
-      this.parsersByPlacemarkTag_[name] = {
-        parent: /** @type {string} */ (schemas[i].getAttribute('parent')),
-        parsers: ol.xml.makeStructureNS(plugin.file.kml.OL_NAMESPACE_URIS(), parsers)
-      };
-    }
-  }
-
-  this.kmlThingRegex_ = this.getKmlThingRegex();
-};
-
-
-/**
- * Creates the regex from the current set of KML things.
- *
- * @return {RegExp} The KML regex.
- */
-plugin.file.kml.KMLParser.prototype.getKmlThingRegex = function() {
-  return new RegExp('^(' + this.kmlThings_.join('|') + ')$');
-};
-
-
-/**
- * @param {Object} config
- * @private
- */
-plugin.file.kml.KMLParser.prototype.updateStyleConfig_ = function(config) {
-  if (config) {
-    // attempt to convert local KMZ asset URIs to the proper data URIs
-    if (config['image'] && config['image']['src']) {
-      try {
-        var src = decodeURIComponent(config['image']['src']);
-
-        if (src && src in this.assetMap_) {
-          config['image']['src'] = this.assetMap_[src];
-        }
-      } catch (e) {
-        // ain't no thang
-      }
-    }
-  }
-};
-
-
-/**
- * Parse the StyleUrl into the correct id format.
- *
- * @param {string} id The StyleUrl.
- * @return {string} The Parsed Style id.
- */
-plugin.file.kml.KMLParser.prototype.getStyleId = function(id) {
-  var x = id.indexOf('#');
-
-  if (x > -1) {
-    id = id.substring(x + 1);
-  }
-  return id;
-};
-
-
-/**
- * Set the ID on a KML feature.
- *
- * @param {!ol.Feature} feature The feature.
- * @private
- */
-plugin.file.kml.KMLParser.prototype.setFeatureId_ = function(feature) {
-  // files containing duplicate network links will create features with duplicate id's. this allows us to merge
-  // features on refresh, while still creating an id that's unique from other network links (which will use a
-  // different parser)
-  var baseId = ol.getUid(feature);
-  var id = this.id_ + '#' + baseId;
-  feature.setId(id);
-
-  if (feature.get(os.Fields.ID) == null) {
-    feature.set(os.Fields.ID, baseId, true);
-  }
-};
-
-
-/**
- * Set the KML tree node name.
- *
- * @param {plugin.file.kml.ui.KMLNode} node The KML tree node
- * @param {Element} el The name element
- * @private
- */
-plugin.file.kml.KMLParser.setNodeLabel_ = function(node, el) {
-  goog.asserts.assert(el.localName == 'name', 'localName should be name');
-
-  // default to null and a default label will be created later
-  node.setLabel(ol.xml.getAllTextContent(el, true).trim() || null);
-};
-
-
-/**
- * Set the KML tree node name.
- *
- * @param {plugin.file.kml.ui.KMLNode} node The KML tree node
- * @param {Element} el The name element
- * @private
- */
-plugin.file.kml.KMLParser.setNodeCollapsed_ = function(node, el) {
-  goog.asserts.assert(el.localName == 'open', 'localName should be open');
-
-  // default to collapsed, so only expand if the text is '1'.
-  node.collapsed = ol.xml.getAllTextContent(el, true).trim() !== '1';
-};
-
-
-/**
- * Set the KML tree node visibility state.
- *
- * @param {plugin.file.kml.ui.KMLNode} node The KML tree node
- * @param {Element} el The name element
- * @private
- */
-plugin.file.kml.KMLParser.setNodeVisibility_ = function(node, el) {
-  goog.asserts.assert(el.localName == 'visibility', 'localName should be visibility');
-
-  var content = ol.xml.getAllTextContent(el, true).trim();
-  if (content) {
-    // this only handles turning the node off so we can honor our node defaults. this is specifically for network links,
-    // which we always default to being turned off.
-    var visibility = ol.format.XSD.readBooleanString(content);
-    if (!visibility) {
-      node.setState(os.structs.TriState.OFF);
-    }
-  }
-
-  var feature = node.getFeature();
-  if (feature) {
-    // remove the visibility property so it doesn't show up in the list tool
-    feature.set('visibility', undefined);
-  }
-};
-
-
-/**
- * @typedef {function(plugin.file.kml.ui.KMLNode, Element)}
- */
-plugin.file.kml.KMLElementParser;
-
-
-/**
- * @type {Object.<string, plugin.file.kml.KMLElementParser>}
+ * @type {Object.<string, kml.KMLElementParser>}
  * @private
  * @const
  */
-plugin.file.kml.KMLParser.BASE_ELEMENT_PARSERS_ = {
-  'name': plugin.file.kml.KMLParser.setNodeLabel_,
-  'open': plugin.file.kml.KMLParser.setNodeCollapsed_,
-  'visibility': plugin.file.kml.KMLParser.setNodeVisibility_
+KMLParser.BASE_ELEMENT_PARSERS_ = {
+  'name': KMLParser.setNodeLabel_,
+  'open': KMLParser.setNodeCollapsed_,
+  'visibility': KMLParser.setNodeVisibility_
 };
+exports = KMLParser;

--- a/src/plugin/file/kml/kmlplugin.js
+++ b/src/plugin/file/kml/kmlplugin.js
@@ -1,100 +1,107 @@
-goog.provide('plugin.file.kml.KMLPlugin');
+goog.module('plugin.file.kml.KMLPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.DataManager');
-goog.require('os.data.ProviderEntry');
-goog.require('os.fn');
-goog.require('os.layer.config.LayerConfigManager');
-goog.require('os.net.Request');
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.ui.im.ImportManager');
-goog.require('plugin.file.kml.KMLDescriptor');
-goog.require('plugin.file.kml.KMLExporter');
-goog.require('plugin.file.kml.KMLFeatureParser');
-goog.require('plugin.file.kml.KMLLayerConfig');
-goog.require('plugin.file.kml.KMLParser');
-goog.require('plugin.file.kml.KMLProvider');
-goog.require('plugin.file.kml.menu');
-goog.require('plugin.file.kml.mime');
-goog.require('plugin.file.kml.ui.KMLImportUI');
-goog.require('plugin.file.kml.ui.placemarkEditDirective');
+const Settings = goog.require('os.config.Settings');
+
+const DataManager = goog.require('os.data.DataManager');
+const ProviderEntry = goog.require('os.data.ProviderEntry');
+const fn = goog.require('os.fn');
+const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
+const Request = goog.require('os.net.Request');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const exportManager = goog.require('os.ui.exportManager');
+const kml = goog.require('os.ui.file.kml');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const KMLDescriptor = goog.require('plugin.file.kml.KMLDescriptor');
+const KMLExporter = goog.require('plugin.file.kml.KMLExporter');
+const KMLFeatureParser = goog.require('plugin.file.kml.KMLFeatureParser');
+const KMLLayerConfig = goog.require('plugin.file.kml.KMLLayerConfig');
+const KMLParser = goog.require('plugin.file.kml.KMLParser');
+const KMLProvider = goog.require('plugin.file.kml.KMLProvider');
+const menu = goog.require('plugin.file.kml.menu');
+const mime = goog.require('plugin.file.kml.mime');
+const KMLImportUI = goog.require('plugin.file.kml.ui.KMLImportUI');
 
 
 /**
  * Provides KML support
- *
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.file.kml.KMLPlugin = function() {
-  plugin.file.kml.KMLPlugin.base(this, 'constructor');
-  this.id = plugin.file.kml.KMLPlugin.ID;
-};
-goog.inherits(plugin.file.kml.KMLPlugin, os.plugin.AbstractPlugin);
+class KMLPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = KMLPlugin.ID;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    var dm = DataManager.getInstance();
+
+    // register kml provider type
+    dm.registerProviderType(new ProviderEntry(
+        KMLPlugin.ID,
+        KMLProvider,
+        KMLPlugin.TYPE,
+        KMLPlugin.TYPE));
+
+    // register the kml descriptor type
+    dm.registerDescriptorType(this.id, KMLDescriptor);
+
+    // register the kml layer config
+    var lcm = LayerConfigManager.getInstance();
+    lcm.registerLayerConfig(this.id, KMLLayerConfig);
+
+    // register the kml import ui
+    var im = ImportManager.getInstance();
+    im.registerImportDetails('KML/KMZ', true);
+    im.registerImportUI(mime.TYPE, new KMLImportUI());
+    im.registerImportUI(mime.KMZ_TYPE, new KMLImportUI());
+    im.registerParser(this.id, KMLParser);
+    im.registerParser('kmlfeature', KMLFeatureParser);
+
+    // register the kml exporter
+    exportManager.registerExportMethod(new KMLExporter());
+
+    // set up actions
+    menu.treeSetup();
+
+    // try to load the first google earth icon; if it fails, set the mirror and flag
+    return new Request(kml.GOOGLE_EARTH_ICON_SET[0].path).getPromise()
+        .then(fn.noop, () => {
+          const settings = Settings.getInstance();
+          const mirror = /** @type {string|null} */ (settings.get(KMLPlugin.ICON_MIRROR));
+          if (mirror) {
+            kml.mirror = mirror;
+          }
+          kml.isGoogleMapsAccessible = false;
+        });
+  }
+}
 
 
 /**
  * @type {string}
  * @const
  */
-plugin.file.kml.KMLPlugin.ID = 'kml';
+KMLPlugin.ID = 'kml';
 
 
 /**
  * @type {string}
  * @const
  */
-plugin.file.kml.KMLPlugin.TYPE = 'KML Layers';
+KMLPlugin.TYPE = 'KML Layers';
 
 
 /**
  * @type {string}
  * @const
  */
-plugin.file.kml.KMLPlugin.ICON_MIRROR = 'plugin.file.kml.icon.mirror';
+KMLPlugin.ICON_MIRROR = 'plugin.file.kml.icon.mirror';
 
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLPlugin.prototype.init = function() {
-  var dm = os.dataManager;
-
-  // register kml provider type
-  dm.registerProviderType(new os.data.ProviderEntry(
-      plugin.file.kml.KMLPlugin.ID,
-      plugin.file.kml.KMLProvider,
-      plugin.file.kml.KMLPlugin.TYPE,
-      plugin.file.kml.KMLPlugin.TYPE));
-
-  // register the kml descriptor type
-  dm.registerDescriptorType(this.id, plugin.file.kml.KMLDescriptor);
-
-  // register the kml layer config
-  var lcm = os.layer.config.LayerConfigManager.getInstance();
-  lcm.registerLayerConfig(this.id, plugin.file.kml.KMLLayerConfig);
-
-  // register the kml import ui
-  var im = os.ui.im.ImportManager.getInstance();
-  im.registerImportDetails('KML/KMZ', true);
-  im.registerImportUI(plugin.file.kml.mime.TYPE, new plugin.file.kml.ui.KMLImportUI());
-  im.registerImportUI(plugin.file.kml.mime.KMZ_TYPE, new plugin.file.kml.ui.KMLImportUI());
-  im.registerParser(this.id, plugin.file.kml.KMLParser);
-  im.registerParser('kmlfeature', plugin.file.kml.KMLFeatureParser);
-
-  // register the kml exporter
-  os.ui.exportManager.registerExportMethod(new plugin.file.kml.KMLExporter());
-
-  // set up actions
-  plugin.file.kml.menu.treeSetup();
-
-  // try to load the first google earth icon; if it fails, set the mirror and flag
-  return new os.net.Request(os.ui.file.kml.GOOGLE_EARTH_ICON_SET[0].path).getPromise()
-      .then(os.fn.noop, () => {
-        const settings = os.config.Settings.getInstance();
-        const mirror = /** @type {string|null} */ (settings.get(plugin.file.kml.KMLPlugin.ICON_MIRROR));
-        if (mirror) {
-          os.ui.file.kml.mirror = mirror;
-        }
-        os.ui.file.kml.isGoogleMapsAccessible = false;
-      });
-};
+exports = KMLPlugin;

--- a/src/plugin/file/kml/kmlprovider.js
+++ b/src/plugin/file/kml/kmlprovider.js
@@ -23,32 +23,8 @@ class KMLProvider extends FileProvider {
     this.setId('kml');
     this.setLabel('KML Files');
   }
-
-  /**
-   * Get the global instance.
-   * @return {!KMLProvider}
-   */
-  static getInstance() {
-    if (!instance) {
-      instance = new KMLProvider();
-    }
-
-    return instance;
-  }
-
-  /**
-   * Set the global instance.
-   * @param {KMLProvider} value
-   */
-  static setInstance(value) {
-    instance = value;
-  }
 }
+goog.addSingletonGetter(KMLProvider);
 
-/**
- * Global instance.
- * @type {KMLProvider|undefined}
- */
-let instance;
 
 exports = KMLProvider;

--- a/src/plugin/file/kml/kmlprovider.js
+++ b/src/plugin/file/kml/kmlprovider.js
@@ -1,26 +1,54 @@
-goog.provide('plugin.file.kml.KMLProvider');
-goog.require('os.data.FileProvider');
+goog.module('plugin.file.kml.KMLProvider');
+goog.module.declareLegacyNamespace();
 
+const FileProvider = goog.require('os.data.FileProvider');
 
 
 /**
  * KML file provider
- *
- * @extends {os.data.FileProvider}
- * @constructor
  */
-plugin.file.kml.KMLProvider = function() {
-  plugin.file.kml.KMLProvider.base(this, 'constructor');
-};
-goog.inherits(plugin.file.kml.KMLProvider, os.data.FileProvider);
-goog.addSingletonGetter(plugin.file.kml.KMLProvider);
+class KMLProvider extends FileProvider {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
 
+  /**
+   * @inheritDoc
+   */
+  configure(config) {
+    super.configure(config);
+    this.setId('kml');
+    this.setLabel('KML Files');
+  }
+
+  /**
+   * Get the global instance.
+   * @return {!KMLProvider}
+   */
+  static getInstance() {
+    if (!instance) {
+      instance = new KMLProvider();
+    }
+
+    return instance;
+  }
+
+  /**
+   * Set the global instance.
+   * @param {KMLProvider} value
+   */
+  static setInstance(value) {
+    instance = value;
+  }
+}
 
 /**
- * @inheritDoc
+ * Global instance.
+ * @type {KMLProvider|undefined}
  */
-plugin.file.kml.KMLProvider.prototype.configure = function(config) {
-  plugin.file.kml.KMLProvider.base(this, 'configure', config);
-  this.setId('kml');
-  this.setLabel('KML Files');
-};
+let instance;
+
+exports = KMLProvider;

--- a/src/plugin/file/kml/kmlsource.js
+++ b/src/plugin/file/kml/kmlsource.js
@@ -1,875 +1,847 @@
-goog.provide('plugin.file.kml.KMLSource');
-goog.require('goog.Timer');
-goog.require('goog.async.Delay');
-goog.require('goog.log');
-goog.require('goog.log.Logger');
-goog.require('goog.object');
-goog.require('ol.array');
-goog.require('os.events.PropertyChangeEvent');
-goog.require('os.layer.AnimationOverlay');
-goog.require('os.layer.Image');
-goog.require('os.object');
-goog.require('os.source.PropertyChange');
-goog.require('os.source.Request');
-goog.require('os.structs.TriState');
-goog.require('os.ui.FeatureEditCtrl');
-goog.require('os.ui.slick.column');
-goog.require('plugin.file.kml.KMLImporter');
-goog.require('plugin.file.kml.KMLParser');
-goog.require('plugin.file.kml.KMLSourceEvent');
+goog.module('plugin.file.kml.KMLSource');
+goog.module.declareLegacyNamespace();
 
+const Timer = goog.require('goog.Timer');
+const Delay = goog.require('goog.async.Delay');
+const dispose = goog.require('goog.dispose');
+const log = goog.require('goog.log');
+const olArray = goog.require('ol.array');
+const dispatcher = goog.require('os.Dispatcher');
+const MapContainer = goog.require('os.MapContainer');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const AlertManager = goog.require('os.alert.AlertManager');
+const PropertyChangeEvent = goog.require('os.events.PropertyChangeEvent');
+const osObject = goog.require('os.object');
+const source = goog.require('os.source');
+const PropertyChange = goog.require('os.source.PropertyChange');
+const RequestSource = goog.require('os.source.Request');
+const TriState = goog.require('os.structs.TriState');
+const FeatureEditCtrl = goog.require('os.ui.FeatureEditCtrl');
+const UIEventType = goog.require('os.ui.events.UIEventType');
+const column = goog.require('os.ui.slick.column');
+const osWindow = goog.require('os.ui.window');
+const KMLImporter = goog.require('plugin.file.kml.KMLImporter');
+const KMLParser = goog.require('plugin.file.kml.KMLParser');
+const KMLSourceEvent = goog.require('plugin.file.kml.KMLSourceEvent');
 
+const KMLNode = goog.require('plugin.file.kml.ui.KMLNode');
 
-/**
- * @param {olx.source.VectorOptions=} opt_options OpenLayers vector source options.
- * @extends {os.source.Request}
- * @constructor
- */
-plugin.file.kml.KMLSource = function(opt_options) {
-  plugin.file.kml.KMLSource.base(this, 'constructor', opt_options);
-  this.log = plugin.file.kml.KMLSource.LOGGER_;
-
-  /**
-   * Minimum time for how often the source will automatically refresh itself.
-   * @type {number}
-   * @protected
-   */
-  this.minRefreshPeriod = 0;
-
-  // KML features are more likely to vary which columns are available, so test more of them when auto detecting columns
-  this.columnAutoDetectLimit = 100;
-
-  /**
-   * The root KML node
-   * @type {plugin.file.kml.ui.KMLNode}
-   * @protected
-   */
-  this.rootNode = null;
-
-  /**
-   * A map of feature id's to KML tree node
-   * @type {!Object<string, (!plugin.file.kml.ui.KMLNode|undefined)>}
-   * @private
-   */
-  this.nodeMap_ = {};
-
-  /**
-   * If node visibility should be updated when a feature is removed
-   * @type {boolean}
-   * @private
-   */
-  this.disposeOnRemove_ = true;
-
-  /**
-   * Timer for updating all the visibility from the tree at once
-   * @type {goog.async.Delay}
-   * @private
-   */
-  this.updateFromNodesTimer_ = new goog.async.Delay(this.updateVisibilityFromNodes, 50, this);
-
-  /**
-   * Whether or not we have gotten an update from the tree at least once
-   * @type {boolean}
-   * @private
-   */
-  this.treeInit_ = false;
-
-  /**
-   * The initial file, set by the layer config when constructing a new KML layer.
-   * @type {?os.file.File}
-   * @protected
-   */
-  this.file = null;
-
-  /**
-   * GroundOverlay data associated with this layer
-   * @type {Array<os.layer.Image>}
-   * @protected
-   */
-  this.images = [];
-
-  /**
-   * ScreenOverlay data asscociated with this layer
-   * @type {Array<string>}
-   * @protected
-   */
-  this.overlays = [];
-
-  os.dispatcher.listen(os.ui.events.UIEventType.TOGGLE_UI, this.onToggleUI_, false, this);
-};
-goog.inherits(plugin.file.kml.KMLSource, os.source.Request);
+const Logger = goog.requireType('goog.log.Logger');
+const Image = goog.requireType('os.layer.Image');
 
 
 /**
- * Logger
- * @type {goog.log.Logger}
- * @private
- * @const
  */
-plugin.file.kml.KMLSource.LOGGER_ = goog.log.getLogger('plugin.file.kml.KMLSource');
+class KMLSource extends RequestSource {
+  /**
+   * Constructor.
+   * @param {olx.source.VectorOptions=} opt_options OpenLayers vector source options.
+   */
+  constructor(opt_options) {
+    super(opt_options);
+    this.log = logger;
 
+    /**
+     * Minimum time for how often the source will automatically refresh itself.
+     * @type {number}
+     * @protected
+     */
+    this.minRefreshPeriod = 0;
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.disposeInternal = function() {
-  plugin.file.kml.KMLSource.base(this, 'disposeInternal');
+    // KML features are more likely to vary which columns are available, so test more of them when auto detecting columns
+    this.columnAutoDetectLimit = 100;
 
-  os.dispatcher.unlisten(os.ui.events.UIEventType.TOGGLE_UI, this.onToggleUI_, false, this);
+    /**
+     * The root KML node
+     * @type {plugin.file.kml.ui.KMLNode}
+     * @protected
+     */
+    this.rootNode = null;
 
-  this.clearImages(true);
-  this.clearOverlays(true);
+    /**
+     * A map of feature id's to KML tree node
+     * @type {!Object<string, (!plugin.file.kml.ui.KMLNode|undefined)>}
+     * @private
+     */
+    this.nodeMap_ = {};
 
-  this.nodeMap_ = {};
-  this.setRootNode(null);
-};
+    /**
+     * If node visibility should be updated when a feature is removed
+     * @type {boolean}
+     * @private
+     */
+    this.disposeOnRemove_ = true;
 
+    /**
+     * Timer for updating all the visibility from the tree at once
+     * @type {Delay}
+     * @private
+     */
+    this.updateFromNodesTimer_ = new Delay(this.updateVisibilityFromNodes, 50, this);
 
-/**
- * Listen for screen overlays being toggled off via the X button on the GUI
- *
- * @param {os.ui.events.UIEvent} event The event
- * @private
- */
-plugin.file.kml.KMLSource.prototype.onToggleUI_ = function(event) {
-  if (this.nodeMap_[event.id]) {
-    this.nodeMap_[event.id].setState(os.structs.TriState.OFF);
-  }
-};
+    /**
+     * Whether or not we have gotten an update from the tree at least once
+     * @type {boolean}
+     * @private
+     */
+    this.treeInit_ = false;
 
+    /**
+     * The initial file, set by the layer config when constructing a new KML layer.
+     * @type {?os.file.File}
+     * @protected
+     */
+    this.file = null;
 
-/**
- * Get a new importer. This is used by network link nodes so they have their own importer.
- *
- * @return {plugin.file.kml.KMLImporter}
- */
-plugin.file.kml.KMLSource.prototype.createImporter = function() {
-  return new plugin.file.kml.KMLImporter(new plugin.file.kml.KMLParser({}));
-};
+    /**
+     * GroundOverlay data associated with this layer
+     * @type {Array<Image>}
+     * @protected
+     */
+    this.images = [];
 
+    /**
+     * ScreenOverlay data asscociated with this layer
+     * @type {Array<string>}
+     * @protected
+     */
+    this.overlays = [];
 
-/**
- * Get the KML tree node for a feature.
- *
- * @param {ol.Feature} feature The feature.
- * @return {plugin.file.kml.ui.KMLNode} The KML node, or null if not found.
- */
-plugin.file.kml.KMLSource.prototype.getFeatureNode = function(feature) {
-  if (feature) {
-    var id = /** @type {string} */ (feature.getId());
-    var node = this.nodeMap_[id] || null;
-
-    if (node && node.getFeature() === feature) {
-      return node;
-    }
+    dispatcher.getInstance().listen(UIEventType.TOGGLE_UI, this.onToggleUI_, false, this);
   }
 
-  return null;
-};
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
 
+    dispatcher.getInstance().unlisten(UIEventType.TOGGLE_UI, this.onToggleUI_, false, this);
 
-/**
- * Get the root KML tree node
- *
- * @return {plugin.file.kml.ui.KMLNode}
- */
-plugin.file.kml.KMLSource.prototype.getRootNode = function() {
-  return this.rootNode;
-};
+    this.clearImages(true);
+    this.clearOverlays(true);
 
-
-/**
- * Set the root KML tree node
- *
- * @param {plugin.file.kml.ui.KMLNode} node
- */
-plugin.file.kml.KMLSource.prototype.setRootNode = function(node) {
-  if (this.rootNode && this.rootNode !== node) {
-    // the root may not change after a merge parse, so only dispose if it has changed
-    this.rootNode.dispose();
-  }
-
-  this.rootNode = node;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.setEnabledInternal = function(value) {
-  if (!value) {
-    // when the layer is disabled, drop reference to the root node to save memory
+    this.nodeMap_ = {};
     this.setRootNode(null);
   }
 
-  plugin.file.kml.KMLSource.base(this, 'setEnabledInternal', value);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.addFeature = function(feature) {
-  plugin.file.kml.KMLSource.base(this, 'addFeature', feature);
-
-  if (!this.getVisible()) {
-    this.hideFeatures([feature]);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.addFeatures = function(features) {
-  plugin.file.kml.KMLSource.base(this, 'addFeatures', features);
-
-  if (!this.getVisible()) {
-    this.hideFeatures(features);
-  }
-};
-
-
-/**
- * Keep track of kml image layers and add then to the map
- *
- * @param {Array<os.layer.Image>} images
- * @suppress {checkTypes}
- */
-plugin.file.kml.KMLSource.prototype.addImages = function(images) {
-  for (var i = 0; i < images.length; i++) {
-    os.MapContainer.getInstance().addLayer(images[i]);
-    this.images.push(images[i]);
-  }
-};
-
-
-/**
- * Keep track of kml screen overlays and add then to the map
- *
- * @param {Array<string>} overlays
- * @suppress {checkTypes}
- */
-plugin.file.kml.KMLSource.prototype.addOverlays = function(overlays) {
-  for (var i = 0; i < overlays.length; i++) {
-    this.overlays.push(overlays[i]);
-  }
-};
-
-
-/**
- * Removes image layers in the passed array.
- *
- * @param {Array<os.layer.Image>} images
- * @param {boolean} removeNode Don't remove the node if it's only a refresh
- * @suppress {checkTypes}
- */
-plugin.file.kml.KMLSource.prototype.removeImages = function(images, removeNode) {
-  for (var i = 0; i < images.length; i++) {
-    var image = images[i];
-    os.MapContainer.getInstance().removeLayer(image);
-    ol.array.remove(this.images, image);
-
-    if (removeNode) {
-      this.removeNode(/** @type {string} */ (image.getId()));
+  /**
+   * Listen for screen overlays being toggled off via the X button on the GUI
+   *
+   * @param {os.ui.events.UIEvent} event The event
+   * @private
+   */
+  onToggleUI_(event) {
+    if (this.nodeMap_[event.id]) {
+      this.nodeMap_[event.id].setState(TriState.OFF);
     }
   }
 
-  // clear image highlight in case the image was removed from the layers tree
-  this.setHighlightedItems(null);
-};
-
-
-/**
- * Removes all overlays in the passed array.
- *
- * @param {Array<string>} overlays
- * @param {boolean} removeNode Don't remove the node if it's only a refresh
- * @suppress {checkTypes}
- */
-plugin.file.kml.KMLSource.prototype.removeOverlays = function(overlays, removeNode) {
-  for (var i = 0; i < overlays.length; i++) {
-    var overlay = overlays[i];
-    var id = os.ui.window.getById(overlay);
-    ol.array.remove(this.overlays, overlay);
-
-    if (removeNode) {
-      os.ui.window.close(id);
-      this.removeNode(overlay);
-    }
-  }
-};
-
-
-/**
- * Clears the whole images array. Faster than removeOverlays due to no calls to ol.array.remove.
- *
- * @param {boolean} removeNode Whether to remove nodes (false for refresh)
- * @suppress {checkTypes}
- */
-plugin.file.kml.KMLSource.prototype.clearImages = function(removeNode) {
-  for (var i = 0; i < this.images.length; i++) {
-    var image = this.images[i];
-    os.MapContainer.getInstance().removeLayer(image);
-
-    if (removeNode) {
-      this.removeNode(/** @type {string} */ (image.getId()));
-    }
+  /**
+   * Get a new importer. This is used by network link nodes so they have their own importer.
+   *
+   * @return {KMLImporter}
+   */
+  createImporter() {
+    return new KMLImporter(new KMLParser({}));
   }
 
-  this.images = [];
+  /**
+   * Get the KML tree node for a feature.
+   *
+   * @param {ol.Feature} feature The feature.
+   * @return {plugin.file.kml.ui.KMLNode} The KML node, or null if not found.
+   */
+  getFeatureNode(feature) {
+    if (feature) {
+      var id = /** @type {string} */ (feature.getId());
+      var node = this.nodeMap_[id] || null;
 
-  // clear image highlight in case the image was removed from the layers tree
-  this.setHighlightedItems(null);
-};
-
-
-/**
- * Clears the whole overlays array. Faster than removeOverlays due to no calls to ol.array.remove.
- *
- * @param {boolean} removeNode Whether to remove nodes (false for refresh)
- * @suppress {checkTypes}
- */
-plugin.file.kml.KMLSource.prototype.clearOverlays = function(removeNode) {
-  for (var i = 0; i < this.overlays.length; i++) {
-    var overlay = this.overlays[i];
-    var id = os.ui.window.getById(overlay);
-
-    if (removeNode) {
-      os.ui.window.close(id);
-      this.removeNode(overlay);
-    }
-  }
-
-  this.overlays = [];
-};
-
-
-/**
- * Adds KML nodes to the source. Any features referenced by the nodes will also be added.
- *
- * @param {!Array<plugin.file.kml.ui.KMLNode>} nodes The KML nodes to add
- * @param {boolean=} opt_recurse If children should be added recursively
- */
-plugin.file.kml.KMLSource.prototype.addNodes = function(nodes, opt_recurse) {
-  var features = [];
-  var images = [];
-  var overlays = [];
-  for (var i = 0, n = nodes.length; i < n; i++) {
-    var node = nodes[i];
-    if (node instanceof plugin.file.kml.ui.KMLNode) {
-      node.setSource(this);
-      var id;
-
-      var feature = node.getFeature();
-      if (feature) {
-        // always replace the node in the map in case it changed. the old node will be disposed by the parser.
-        id = /** @type {string} */ (node.getId());
-        this.nodeMap_[id] = node;
-
-        features.push(feature);
+      if (node && node.getFeature() === feature) {
+        return node;
       }
-
-      var image = node.getImage();
-      if (image) {
-        // always replace the node in the map in case it changed. the old node will be disposed by the parser.
-        id = /** @type {string} */ (node.getId());
-        this.nodeMap_[id] = node;
-
-        images.push(image);
-      }
-
-      var overlay = node.getOverlayId();
-      if (overlay) {
-        id = /** @type {string} */ (node.getId());
-        this.nodeMap_[id] = node;
-        overlays.push(overlay);
-      }
-
-      node.loadAnnotation();
     }
 
-    if (opt_recurse) {
-      var children = /** @type {Array<plugin.file.kml.ui.KMLNode>} */ (node.getChildren());
-      if (children && children.length > 0) {
-        this.addNodes(children, true);
+    return null;
+  }
+
+  /**
+   * Get the root KML tree node
+   *
+   * @return {plugin.file.kml.ui.KMLNode}
+   */
+  getRootNode() {
+    return this.rootNode;
+  }
+
+  /**
+   * Set the root KML tree node
+   *
+   * @param {plugin.file.kml.ui.KMLNode} node
+   */
+  setRootNode(node) {
+    if (this.rootNode && this.rootNode !== node) {
+      // the root may not change after a merge parse, so only dispose if it has changed
+      this.rootNode.dispose();
+    }
+
+    this.rootNode = node;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setEnabledInternal(value) {
+    if (!value) {
+      // when the layer is disabled, drop reference to the root node to save memory
+      this.setRootNode(null);
+    }
+
+    super.setEnabledInternal(value);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  addFeature(feature) {
+    super.addFeature(feature);
+
+    if (!this.getVisible()) {
+      this.hideFeatures([feature]);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  addFeatures(features) {
+    super.addFeatures(features);
+
+    if (!this.getVisible()) {
+      this.hideFeatures(features);
+    }
+  }
+
+  /**
+   * Keep track of kml image layers and add then to the map
+   *
+   * @param {Array<Image>} images
+   * @suppress {checkTypes}
+   */
+  addImages(images) {
+    for (var i = 0; i < images.length; i++) {
+      MapContainer.getInstance().addLayer(images[i]);
+      this.images.push(images[i]);
+    }
+  }
+
+  /**
+   * Keep track of kml screen overlays and add then to the map
+   *
+   * @param {Array<string>} overlays
+   * @suppress {checkTypes}
+   */
+  addOverlays(overlays) {
+    for (var i = 0; i < overlays.length; i++) {
+      this.overlays.push(overlays[i]);
+    }
+  }
+
+  /**
+   * Removes image layers in the passed array.
+   *
+   * @param {Array<Image>} images
+   * @param {boolean} removeNode Don't remove the node if it's only a refresh
+   * @suppress {checkTypes}
+   */
+  removeImages(images, removeNode) {
+    for (var i = 0; i < images.length; i++) {
+      var image = images[i];
+      MapContainer.getInstance().removeLayer(image);
+      olArray.remove(this.images, image);
+
+      if (removeNode) {
+        this.removeNode(/** @type {string} */ (image.getId()));
+      }
+    }
+
+    // clear image highlight in case the image was removed from the layers tree
+    this.setHighlightedItems(null);
+  }
+
+  /**
+   * Removes all overlays in the passed array.
+   *
+   * @param {Array<string>} overlays
+   * @param {boolean} removeNode Don't remove the node if it's only a refresh
+   * @suppress {checkTypes}
+   */
+  removeOverlays(overlays, removeNode) {
+    for (var i = 0; i < overlays.length; i++) {
+      var overlay = overlays[i];
+      var id = osWindow.getById(overlay);
+      olArray.remove(this.overlays, overlay);
+
+      if (removeNode) {
+        osWindow.close(id);
+        this.removeNode(overlay);
       }
     }
   }
 
-  if (features.length > 0) {
-    this.addFeatures(features);
-  }
+  /**
+   * Clears the whole images array. Faster than removeOverlays due to no calls to olArray.remove.
+   *
+   * @param {boolean} removeNode Whether to remove nodes (false for refresh)
+   * @suppress {checkTypes}
+   */
+  clearImages(removeNode) {
+    for (var i = 0; i < this.images.length; i++) {
+      var image = this.images[i];
+      MapContainer.getInstance().removeLayer(image);
 
-  if (images.length > 0) {
-    this.addImages(images);
-  }
-
-  if (overlays.length > 0) {
-    this.addOverlays(overlays);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.onImportProgress = function(opt_event) {
-  this.clearQueue();
-
-  // KML parsing is about 30% faster in FF if this is done in one shot in the complete handler, instead of here. the
-  // slowdown is caused by the renderer and parser competing for resources, since FF has a much slower canvas renderer.
-  // moving this to the complete handler will prevent any features from displaying until the parser is done, instead of
-  // displaying them piecemeal and providing the user with some feedback.
-  if (this.importer) {
-    // request source importer expects features, but this one returns KML nodes
-    this.addNodes(/** @type {!Array<plugin.file.kml.ui.KMLNode>} */ (this.importer.getData()));
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.onImportComplete = function(opt_event) {
-  this.setRootNode(this.importer.getRootNode());
-  this.setMinRefreshPeriod(this.importer.getMinRefreshPeriod());
-
-  if (!this.externalColumns) {
-    var columns = this.importer.getColumns();
-    if (columns) {
-      // set columns on the source. {@link setColumns} may create new columns, so wait until after the call to sort and
-      // dispatch the column event
-      this.suppressEvents();
-      this.setColumns(columns);
-      this.enableEvents();
-
-      this.dispatchEvent(new os.events.PropertyChangeEvent(os.source.PropertyChange.COLUMNS, this.columns));
-    }
-  } else if (this.columns) {
-    // initialize column sort/widths if they have not yet been adjusted by the user
-    if (!this.columns.some(os.ui.slick.column.isUserModified)) {
-      this.columns.sort(os.ui.slick.column.autoSizeAndSortColumns);
+      if (removeNode) {
+        this.removeNode(/** @type {string} */ (image.getId()));
+      }
     }
 
-    this.dispatchEvent(new os.events.PropertyChangeEvent(os.source.PropertyChange.COLUMNS, this.columns));
+    this.images = [];
+
+    // clear image highlight in case the image was removed from the layers tree
+    this.setHighlightedItems(null);
   }
 
-  this.updateVisibilityFromNodes();
+  /**
+   * Clears the whole overlays array. Faster than removeOverlays due to no calls to olArray.remove.
+   *
+   * @param {boolean} removeNode Whether to remove nodes (false for refresh)
+   * @suppress {checkTypes}
+   */
+  clearOverlays(removeNode) {
+    for (var i = 0; i < this.overlays.length; i++) {
+      var overlay = this.overlays[i];
+      var id = osWindow.getById(overlay);
 
-  plugin.file.kml.KMLSource.base(this, 'onImportComplete', opt_event);
-};
+      if (removeNode) {
+        osWindow.close(id);
+        this.removeNode(overlay);
+      }
+    }
 
+    this.overlays = [];
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.clearQueue = function() {
-  for (var key in this.nodeMap_) {
-    var node = this.nodeMap_[key];
-    if (node && node.isDisposed()) {
-      this.nodeMap_[key] = undefined;
+  /**
+   * Adds KML nodes to the source. Any features referenced by the nodes will also be added.
+   *
+   * @param {!Array<plugin.file.kml.ui.KMLNode>} nodes The KML nodes to add
+   * @param {boolean=} opt_recurse If children should be added recursively
+   */
+  addNodes(nodes, opt_recurse) {
+    var features = [];
+    var images = [];
+    var overlays = [];
+    for (var i = 0, n = nodes.length; i < n; i++) {
+      var node = nodes[i];
+      if (node instanceof KMLNode) {
+        node.setSource(this);
+        var id;
+
+        var feature = node.getFeature();
+        if (feature) {
+          // always replace the node in the map in case it changed. the old node will be disposed by the parser.
+          id = /** @type {string} */ (node.getId());
+          this.nodeMap_[id] = node;
+
+          features.push(feature);
+        }
+
+        var image = node.getImage();
+        if (image) {
+          // always replace the node in the map in case it changed. the old node will be disposed by the parser.
+          id = /** @type {string} */ (node.getId());
+          this.nodeMap_[id] = node;
+
+          images.push(image);
+        }
+
+        var overlay = node.getOverlayId();
+        if (overlay) {
+          id = /** @type {string} */ (node.getId());
+          this.nodeMap_[id] = node;
+          overlays.push(overlay);
+        }
+
+        node.loadAnnotation();
+      }
+
+      if (opt_recurse) {
+        var children = /** @type {Array<plugin.file.kml.ui.KMLNode>} */ (node.getChildren());
+        if (children && children.length > 0) {
+          this.addNodes(children, true);
+        }
+      }
+    }
+
+    if (features.length > 0) {
+      this.addFeatures(features);
+    }
+
+    if (images.length > 0) {
+      this.addImages(images);
+    }
+
+    if (overlays.length > 0) {
+      this.addOverlays(overlays);
     }
   }
 
-  this.nodeMap_ = os.object.prune(this.nodeMap_);
+  /**
+   * @inheritDoc
+   */
+  onImportProgress(opt_event) {
+    this.clearQueue();
 
-  plugin.file.kml.KMLSource.base(this, 'clearQueue');
-};
+    // KML parsing is about 30% faster in FF if this is done in one shot in the complete handler, instead of here. the
+    // slowdown is caused by the renderer and parser competing for resources, since FF has a much slower canvas renderer.
+    // moving this to the complete handler will prevent any features from displaying until the parser is done, instead of
+    // displaying them piecemeal and providing the user with some feedback.
+    if (this.importer) {
+      // request source importer expects features, but this one returns KML nodes
+      this.addNodes(/** @type {!Array<plugin.file.kml.ui.KMLNode>} */ (this.importer.getData()));
+    }
+  }
 
+  /**
+   * @inheritDoc
+   */
+  onImportComplete(opt_event) {
+    this.setRootNode(this.importer.getRootNode());
+    this.setMinRefreshPeriod(this.importer.getMinRefreshPeriod());
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.removeFeature = function(feature) {
-  this.removeNode(/** @type {string} */ (feature.getId()));
+    if (!this.externalColumns) {
+      var columns = this.importer.getColumns();
+      if (columns) {
+        // set columns on the source. {@link setColumns} may create new columns, so wait until after the call to sort and
+        // dispatch the column event
+        this.suppressEvents();
+        this.setColumns(columns);
+        this.enableEvents();
 
-  // clear feature highlight in case the feature was removed from the layers tree
-  this.setHighlightedItems(null);
+        this.dispatchEvent(new PropertyChangeEvent(PropertyChange.COLUMNS, this.columns));
+      }
+    } else if (this.columns) {
+      // initialize column sort/widths if they have not yet been adjusted by the user
+      if (!this.columns.some(column.isUserModified)) {
+        this.columns.sort(column.autoSizeAndSortColumns);
+      }
 
-  plugin.file.kml.KMLSource.base(this, 'removeFeature', feature);
-};
+      this.dispatchEvent(new PropertyChangeEvent(PropertyChange.COLUMNS, this.columns));
+    }
 
+    this.updateVisibilityFromNodes();
 
-/**
- * Remove the node based on the mapped ID
- *
- * @param {string} id
- */
-plugin.file.kml.KMLSource.prototype.removeNode = function(id) {
-  if (this.disposeOnRemove_) {
-    var node = this.nodeMap_[id];
-    if (node) {
-      this.nodeMap_[id] = undefined;
+    super.onImportComplete(opt_event);
+  }
 
-      if (!node.isDisposed()) {
-        if (node.getId() == id) {
-          // dispose first to remove listeners
-          node.dispose();
+  /**
+   * @inheritDoc
+   */
+  clearQueue() {
+    for (var key in this.nodeMap_) {
+      var node = this.nodeMap_[key];
+      if (node && node.isDisposed()) {
+        this.nodeMap_[key] = undefined;
+      }
+    }
 
-          // then unlink from the parent
-          var parent = node.getParent();
-          if (parent) {
-            parent.removeChild(node);
+    this.nodeMap_ = osObject.prune(this.nodeMap_);
+
+    super.clearQueue();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  removeFeature(feature) {
+    this.removeNode(/** @type {string} */ (feature.getId()));
+
+    // clear feature highlight in case the feature was removed from the layers tree
+    this.setHighlightedItems(null);
+
+    super.removeFeature(feature);
+  }
+
+  /**
+   * Remove the node based on the mapped ID
+   *
+   * @param {string} id
+   */
+  removeNode(id) {
+    if (this.disposeOnRemove_) {
+      var node = this.nodeMap_[id];
+      if (node) {
+        this.nodeMap_[id] = undefined;
+
+        if (!node.isDisposed()) {
+          if (node.getId() == id) {
+            // dispose first to remove listeners
+            node.dispose();
+
+            // then unlink from the parent
+            var parent = node.getParent();
+            if (parent) {
+              parent.removeChild(node);
+            }
+          } else {
+            // the node's ID changed as a result of a merge, so update the reference in the map
+            this.nodeMap_[node.getId()] = node;
           }
-        } else {
-          // the node's ID changed as a result of a merge, so update the reference in the map
-          this.nodeMap_[node.getId()] = node;
         }
       }
     }
   }
-};
 
+  /**
+   * Clears all descendant features of a tree node, disposing of the nodes unless indicated otherwise. Disable node
+   * disposal when refreshing a node (like network links) to allow merging the tree.
+   *
+   * @param {!plugin.file.kml.ui.KMLNode} node The root node.
+   * @param {boolean=} opt_dispose If feature nodes should be disposed on removal; defaults to false.
+   */
+  clearNode(node, opt_dispose) {
+    this.disposeOnRemove_ = opt_dispose !== undefined ? opt_dispose : false;
 
-/**
- * Clears all descendant features of a tree node, disposing of the nodes unless indicated otherwise. Disable node
- * disposal when refreshing a node (like network links) to allow merging the tree.
- *
- * @param {!plugin.file.kml.ui.KMLNode} node The root node.
- * @param {boolean=} opt_dispose If feature nodes should be disposed on removal; defaults to false.
- */
-plugin.file.kml.KMLSource.prototype.clearNode = function(node, opt_dispose) {
-  this.disposeOnRemove_ = opt_dispose !== undefined ? opt_dispose : false;
+    // handle the process queue in case we're removing features lingering inside of it
+    this.processNow();
 
-  // handle the process queue in case we're removing features lingering inside of it
-  this.processNow();
-
-  var features = node.getFeatures(true);
-  if (features && features.length > 0) {
-    this.removeFeatures(features);
-  }
-
-  var images = node.getImages(true);
-  if (images && images.length > 0) {
-    this.removeImages(images, true);
-  }
-
-  var overlays = node.getOverlays(true);
-  if (overlays && overlays.length > 0) {
-    this.removeOverlays(overlays, true);
-  }
-
-  node.clearAnnotations();
-
-  // handle the unprocess queue immediately in case a network link is being refreshed
-  this.unprocessNow();
-
-  this.disposeOnRemove_ = true;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.processImmediate = function(feature) {
-  os.ui.FeatureEditCtrl.updateFeatureStyle(feature);
-  os.ui.FeatureEditCtrl.restoreFeatureLabels(feature);
-
-  plugin.file.kml.KMLSource.base(this, 'processImmediate', feature);
-
-  if (this.animationOverlay) {
-    var node = this.getFeatureNode(feature);
-    if (node) {
-      node.setAnimationState(false);
+    var features = node.getFeatures(true);
+    if (features && features.length > 0) {
+      this.removeFeatures(features);
     }
+
+    var images = node.getImages(true);
+    if (images && images.length > 0) {
+      this.removeImages(images, true);
+    }
+
+    var overlays = node.getOverlays(true);
+    if (overlays && overlays.length > 0) {
+      this.removeOverlays(overlays, true);
+    }
+
+    node.clearAnnotations();
+
+    // handle the unprocess queue immediately in case a network link is being refreshed
+    this.unprocessNow();
+
+    this.disposeOnRemove_ = true;
   }
 
-  this.scheduleUpdateFromNodes();
-};
+  /**
+   * @inheritDoc
+   */
+  processImmediate(feature) {
+    FeatureEditCtrl.updateFeatureStyle(feature);
+    FeatureEditCtrl.restoreFeatureLabels(feature);
 
+    super.processImmediate(feature);
 
-/**
- * Schedules a visibility update from the tree
- */
-plugin.file.kml.KMLSource.prototype.scheduleUpdateFromNodes = function() {
-  this.updateFromNodesTimer_.start();
-};
-
-
-/**
- * @protected
- */
-plugin.file.kml.KMLSource.prototype.updateVisibilityFromNodes = function() {
-  var features = this.getFeatures();
-  var toShow = [];
-  var toHide = [];
-  var node;
-
-  for (var i = 0, n = features.length; i < n; i++) {
-    var feature = features[i];
-    var id = /** @type {string} */ (feature.getId());
-    node = this.nodeMap_[id];
-
-    if (node) {
-      if (node.getState() == os.structs.TriState.ON) {
-        toShow.push(feature);
-      } else if (node.getState() == os.structs.TriState.OFF) {
-        toHide.push(feature);
+    if (this.animationOverlay) {
+      var node = this.getFeatureNode(feature);
+      if (node) {
+        node.setAnimationState(false);
       }
-    } else {
-      goog.log.warning(this.log, 'Feature [' + id + '] is not in the KML tree!');
     }
+
+    this.scheduleUpdateFromNodes();
   }
 
-  if (toShow.length) {
-    this.showFeatures(toShow);
+  /**
+   * Schedules a visibility update from the tree
+   */
+  scheduleUpdateFromNodes() {
+    this.updateFromNodesTimer_.start();
   }
 
-  if (toHide.length) {
-    this.hideFeatures(toHide);
-    this.removeFromSelected(toHide);
-  }
+  /**
+   * @protected
+   */
+  updateVisibilityFromNodes() {
+    var features = this.getFeatures();
+    var toShow = [];
+    var toHide = [];
+    var node;
 
-  this.treeInit_ = true;
-};
-
-
-/**
- * Sets the initial file on the source.
- *
- * @param {?os.file.File} file
- */
-plugin.file.kml.KMLSource.prototype.setFile = function(file) {
-  this.file = file;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.updateFeaturesVisibility = function(features, visible) {
-  plugin.file.kml.KMLSource.base(this, 'updateFeaturesVisibility', features, visible);
-
-  if (this.treeInit_) {
     for (var i = 0, n = features.length; i < n; i++) {
       var feature = features[i];
       var id = /** @type {string} */ (feature.getId());
-      if (id in this.nodeMap_) {
-        this.nodeMap_[id].setStateOnly(visible ? os.structs.TriState.ON : os.structs.TriState.OFF);
+      node = this.nodeMap_[id];
+
+      if (node) {
+        if (node.getState() == TriState.ON) {
+          toShow.push(feature);
+        } else if (node.getState() == TriState.OFF) {
+          toHide.push(feature);
+        }
       } else {
-        goog.log.warning(this.log, 'Show/hide feature [' + id + '] is not in the KML tree!');
-      }
-    }
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.clear = function() {
-  plugin.file.kml.KMLSource.base(this, 'clear');
-
-  // Drop everything, clear the root node, then dispose of it. The KML will be parsed again on refresh.
-  this.clearImages(true);
-  this.clearOverlays(true);
-  this.nodeMap_ = {};
-
-  this.setRootNode(null);
-  goog.dispose(this.rootNode);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.refresh = function() {
-  // clean up 'non-features'
-  this.clearImages(false);
-  this.clearOverlays(false);
-  this.nodeMap_ = os.object.prune(this.nodeMap_);
-
-  if (this.file) {
-    // this block handles the case of the file being initially available from an import process and without it
-    // the request source naively requests the file again (which is a waste and slow)
-    this.doImport(this.file.getContent());
-    this.file = null;
-  } else {
-    plugin.file.kml.KMLSource.base(this, 'refresh');
-  }
-
-  this.dispatchEvent(plugin.file.kml.KMLSourceEvent.REFRESH);
-};
-
-
-/**
- * KML sources are not lockable.
- *
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.isLockable = function() {
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.setRefreshInterval = function(value) {
-  var minRefresh = this.minRefreshPeriod / 1000;
-  if (this.refreshInterval != value || this.refreshInterval < minRefresh) {
-    this.refreshInterval = value;
-
-    if (this.refreshTimer) {
-      this.refreshTimer.unlisten(goog.Timer.TICK, this.onRefreshTimer, false, this);
-      if (!this.refreshTimer.hasListener()) {
-        // nobody's listening, so stop it
-        this.refreshTimer.stop();
+        log.warning(this.log, 'Feature [' + id + '] is not in the KML tree!');
       }
     }
 
-    this.refreshTimer = null;
+    if (toShow.length) {
+      this.showFeatures(toShow);
+    }
 
-    if (this.refreshInterval > 0) {
-      var interval = Math.max(value, minRefresh);
-      if (interval != value) {
-        var msg = 'The selected refresh period is lower than the minimum (' + minRefresh + ' seconds) allowed by ' +
-            'the KML. The minimum will be used instead.';
-        os.alertManager.sendAlert(msg, os.alert.AlertEventSeverity.WARNING);
+    if (toHide.length) {
+      this.hideFeatures(toHide);
+      this.removeFromSelected(toHide);
+    }
+
+    this.treeInit_ = true;
+  }
+
+  /**
+   * Sets the initial file on the source.
+   *
+   * @param {?os.file.File} file
+   */
+  setFile(file) {
+    this.file = file;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  updateFeaturesVisibility(features, visible) {
+    super.updateFeaturesVisibility(features, visible);
+
+    if (this.treeInit_) {
+      for (var i = 0, n = features.length; i < n; i++) {
+        var feature = features[i];
+        var id = /** @type {string} */ (feature.getId());
+        if (id in this.nodeMap_) {
+          this.nodeMap_[id].setStateOnly(visible ? TriState.ON : TriState.OFF);
+        } else {
+          log.warning(this.log, 'Show/hide feature [' + id + '] is not in the KML tree!');
+        }
+      }
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  clear() {
+    super.clear();
+
+    // Drop everything, clear the root node, then dispose of it. The KML will be parsed again on refresh.
+    this.clearImages(true);
+    this.clearOverlays(true);
+    this.nodeMap_ = {};
+
+    this.setRootNode(null);
+    dispose(this.rootNode);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  refresh() {
+    // clean up 'non-features'
+    this.clearImages(false);
+    this.clearOverlays(false);
+    this.nodeMap_ = osObject.prune(this.nodeMap_);
+
+    if (this.file) {
+      // this block handles the case of the file being initially available from an import process and without it
+      // the request source naively requests the file again (which is a waste and slow)
+      this.doImport(this.file.getContent());
+      this.file = null;
+    } else {
+      super.refresh();
+    }
+
+    this.dispatchEvent(KMLSourceEvent.REFRESH);
+  }
+
+  /**
+   * KML sources are not lockable.
+   *
+   * @inheritDoc
+   */
+  isLockable() {
+    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setRefreshInterval(value) {
+    var minRefresh = this.minRefreshPeriod / 1000;
+    if (this.refreshInterval != value || this.refreshInterval < minRefresh) {
+      this.refreshInterval = value;
+
+      if (this.refreshTimer) {
+        this.refreshTimer.unlisten(Timer.TICK, this.onRefreshTimer, false, this);
+        if (!this.refreshTimer.hasListener()) {
+          // nobody's listening, so stop it
+          this.refreshTimer.stop();
+        }
       }
 
-      this.refreshTimer = os.source.RefreshTimers[interval];
+      this.refreshTimer = null;
 
-      if (!this.refreshTimer) {
-        // didn't find one for that time, so make a new one and save it off
-        this.refreshTimer = new goog.Timer(1000 * interval);
-        os.source.RefreshTimers[interval] = this.refreshTimer;
+      if (this.refreshInterval > 0) {
+        var interval = Math.max(value, minRefresh);
+        if (interval != value) {
+          var msg = 'The selected refresh period is lower than the minimum (' + minRefresh + ' seconds) allowed by ' +
+              'the KML. The minimum will be used instead.';
+          AlertManager.getInstance().sendAlert(msg, AlertEventSeverity.WARNING);
+        }
+
+        this.refreshTimer = source.RefreshTimers[interval];
+
+        if (!this.refreshTimer) {
+          // didn't find one for that time, so make a new one and save it off
+          this.refreshTimer = new Timer(1000 * interval);
+          source.RefreshTimers[interval] = this.refreshTimer;
+        }
+
+        this.refreshTimer.listen(Timer.TICK, this.onRefreshTimer, false, this);
+        this.refreshTimer.start();
       }
 
-      this.refreshTimer.listen(goog.Timer.TICK, this.onRefreshTimer, false, this);
-      this.refreshTimer.start();
-    }
-
-    this.dispatchEvent(new os.events.PropertyChangeEvent(os.source.PropertyChange.REFRESH_INTERVAL));
-  }
-};
-
-
-/**
- * Get the minimum automatic refresh period for the source.
- *
- * @return {number}
- */
-plugin.file.kml.KMLSource.prototype.getMinRefreshPeriod = function() {
-  return this.minRefreshPeriod;
-};
-
-
-/**
- * Set the minimum automatic refresh period for the source.
- *
- * @param {number} value
- */
-plugin.file.kml.KMLSource.prototype.setMinRefreshPeriod = function(value) {
-  if (this.minRefreshPeriod != value) {
-    this.minRefreshPeriod = Math.max(value, 0);
-    if (this.refreshInterval < this.minRefreshPeriod / 1000) {
-      this.setRefreshInterval(this.refreshInterval);
+      this.dispatchEvent(new PropertyChangeEvent(PropertyChange.REFRESH_INTERVAL));
     }
   }
-};
 
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.isTimeEditEnabled = function() {
-  return true;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.persist = function(opt_to) {
-  var options = plugin.file.kml.KMLSource.base(this, 'persist', opt_to);
-  options['minRefreshPeriod'] = this.minRefreshPeriod;
-  return options;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLSource.prototype.restore = function(config) {
-  plugin.file.kml.KMLSource.base(this, 'restore', config);
-
-  if (config['minRefreshPeriod']) {
-    this.setMinRefreshPeriod(config['minRefreshPeriod']);
+  /**
+   * Get the minimum automatic refresh period for the source.
+   *
+   * @return {number}
+   */
+  getMinRefreshPeriod() {
+    return this.minRefreshPeriod;
   }
-};
 
-
-/**
- * Creates a basic feature overlay used to animate features on the map.
- *
- * @protected
- * @override
- */
-plugin.file.kml.KMLSource.prototype.createAnimationOverlay = function() {
-  plugin.file.kml.KMLSource.base(this, 'createAnimationOverlay');
-
-  // hide all features
-  var features = this.getFeatures();
-  for (var i = 0, n = features.length; i < n; i++) {
-    var node = this.getFeatureNode(features[i]);
-    if (node) {
-      node.setAnimationState(false);
+  /**
+   * Set the minimum automatic refresh period for the source.
+   *
+   * @param {number} value
+   */
+  setMinRefreshPeriod(value) {
+    if (this.minRefreshPeriod != value) {
+      this.minRefreshPeriod = Math.max(value, 0);
+      if (this.refreshInterval < this.minRefreshPeriod / 1000) {
+        this.setRefreshInterval(this.refreshInterval);
+      }
     }
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  isTimeEditEnabled() {
+    return true;
+  }
 
-/**
- * Updates features displayed by the animation overlay if it exists.
- *
- * @protected
- * @override
- */
-plugin.file.kml.KMLSource.prototype.updateAnimationOverlay = function() {
-  if (this.animationOverlay) {
-    // hide features from the previous animation frame
-    var overlayFeatures = this.animationOverlay.getFeatures();
-    for (var i = 0, n = overlayFeatures.length; i < n; i++) {
-      var node = this.getFeatureNode(overlayFeatures[i]);
+  /**
+   * @inheritDoc
+   */
+  persist(opt_to) {
+    var options = super.persist(opt_to);
+    options['minRefreshPeriod'] = this.minRefreshPeriod;
+    return options;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  restore(config) {
+    super.restore(config);
+
+    if (config['minRefreshPeriod']) {
+      this.setMinRefreshPeriod(config['minRefreshPeriod']);
+    }
+  }
+
+  /**
+   * Creates a basic feature overlay used to animate features on the map.
+   *
+   * @protected
+   * @override
+   */
+  createAnimationOverlay() {
+    super.createAnimationOverlay();
+
+    // hide all features
+    var features = this.getFeatures();
+    for (var i = 0, n = features.length; i < n; i++) {
+      var node = this.getFeatureNode(features[i]);
       if (node) {
         node.setAnimationState(false);
       }
     }
   }
 
-  plugin.file.kml.KMLSource.base(this, 'updateAnimationOverlay');
+  /**
+   * Updates features displayed by the animation overlay if it exists.
+   *
+   * @protected
+   * @override
+   */
+  updateAnimationOverlay() {
+    if (this.animationOverlay) {
+      // hide features from the previous animation frame
+      var overlayFeatures = this.animationOverlay.getFeatures();
+      for (var i = 0, n = overlayFeatures.length; i < n; i++) {
+        var node = this.getFeatureNode(overlayFeatures[i]);
+        if (node) {
+          node.setAnimationState(false);
+        }
+      }
+    }
 
-  if (this.animationOverlay) {
-    // show features in the current animation frame
-    var overlayFeatures = this.animationOverlay.getFeatures();
-    for (var i = 0, n = overlayFeatures.length; i < n; i++) {
-      var node = this.getFeatureNode(overlayFeatures[i]);
+    super.updateAnimationOverlay();
+
+    if (this.animationOverlay) {
+      // show features in the current animation frame
+      var overlayFeatures = this.animationOverlay.getFeatures();
+      for (var i = 0, n = overlayFeatures.length; i < n; i++) {
+        var node = this.getFeatureNode(overlayFeatures[i]);
+        if (node) {
+          node.setAnimationState(true);
+        }
+      }
+    }
+  }
+
+  /**
+   * Disposes of the animation overlay and cached features.
+   *
+   * @protected
+   * @override
+   */
+  disposeAnimationOverlay() {
+    super.disposeAnimationOverlay();
+
+    // show all features
+    var features = this.getFeatures();
+    for (var i = 0, n = features.length; i < n; i++) {
+      var node = this.getFeatureNode(features[i]);
       if (node) {
         node.setAnimationState(true);
       }
     }
   }
-};
-
+}
 
 /**
- * Disposes of the animation overlay and cached features.
- *
- * @protected
- * @override
+ * Logger
+ * @type {Logger}
  */
-plugin.file.kml.KMLSource.prototype.disposeAnimationOverlay = function() {
-  plugin.file.kml.KMLSource.base(this, 'disposeAnimationOverlay');
+const logger = log.getLogger('plugin.file.kml.KMLSource');
 
-  // show all features
-  var features = this.getFeatures();
-  for (var i = 0, n = features.length; i < n; i++) {
-    var node = this.getFeatureNode(features[i]);
-    if (node) {
-      node.setAnimationState(true);
-    }
-  }
-};
 
+exports = KMLSource;

--- a/src/plugin/file/kml/kmlsourceevent.js
+++ b/src/plugin/file/kml/kmlsourceevent.js
@@ -1,10 +1,11 @@
-goog.provide('plugin.file.kml.KMLSourceEvent');
+goog.module('plugin.file.kml.KMLSourceEvent');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * KML source event types
  * @enum {string}
  */
-plugin.file.kml.KMLSourceEvent = {
+exports = {
   REFRESH: 'kmlSource:refresh'
 };

--- a/src/plugin/file/kml/kmltreeexporter.js
+++ b/src/plugin/file/kml/kmltreeexporter.js
@@ -1,393 +1,379 @@
-goog.provide('plugin.file.kml.KMLTreeExporter');
+goog.module('plugin.file.kml.KMLTreeExporter');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.object');
-goog.require('goog.string');
-goog.require('ol.geom.GeometryCollection');
-goog.require('ol.xml');
-goog.require('os.data.RecordField');
-goog.require('os.feature');
-goog.require('os.source');
-goog.require('os.style');
-goog.require('os.ui.file.kml');
-goog.require('os.ui.file.kml.AbstractKMLExporter');
-goog.require('os.xml');
-goog.require('plugin.file.kml');
-goog.require('plugin.file.kml.export');
+const log = goog.require('goog.log');
 
+const googObject = goog.require('goog.object');
+const googString = goog.require('goog.string');
+const ol = goog.require('ol');
+const GeometryCollection = goog.require('ol.geom.GeometryCollection');
+const Point = goog.require('ol.geom.Point');
+const RecordField = goog.require('os.data.RecordField');
+const osFeature = goog.require('os.feature');
+const osSource = goog.require('os.source');
+const TriState = goog.require('os.structs.TriState');
+const osStyle = goog.require('os.style');
+const osUiFileKml = goog.require('os.ui.file.kml');
+const AbstractKMLExporter = goog.require('os.ui.file.kml.AbstractKMLExporter');
+const xml = goog.require('os.xml');
+const pluginFileKmlExport = goog.require('plugin.file.kml.export');
+
+const kml = goog.requireType('plugin.file.kml');
 
 
 /**
  * KML tree exporter
  *
- * @extends {os.ui.file.kml.AbstractKMLExporter<!plugin.file.kml.ui.KMLNode>}
- * @constructor
+ * @extends {AbstractKMLExporter<!kml.ui.KMLNode>}
  */
-plugin.file.kml.KMLTreeExporter = function() {
-  plugin.file.kml.KMLTreeExporter.base(this, 'constructor');
-  this.setUseItemColor(true);
-  this.setUseItemIcon(true);
-  this.log = plugin.file.kml.KMLTreeExporter.LOGGER_;
+class KMLTreeExporter extends AbstractKMLExporter {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.setUseItemColor(true);
+    this.setUseItemIcon(true);
+    this.log = logger;
+
+    /**
+     * Map of folders in the KML by id.
+     * @type {!Object<string, !Element>}
+     * @private
+     */
+    this.folders_ = {};
+  }
 
   /**
-   * Map of folders in the KML by id.
-   * @type {!Object<string, !Element>}
-   * @private
+   * @inheritDoc
    */
-  this.folders_ = {};
-};
-goog.inherits(plugin.file.kml.KMLTreeExporter, os.ui.file.kml.AbstractKMLExporter);
+  reset() {
+    super.reset();
+
+    this.folders_ = {};
+  }
+
+  /**
+   * @inheritDoc
+   */
+  supportsMultiple() {
+    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  createLabel(item) {
+    return item.getLabel();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getChildren(item) {
+    return item.getChildren();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getColor(item) {
+    var featureColor = osFeature.getColor(item.getFeature());
+    if (!featureColor || (typeof featureColor != 'string' && !Array.isArray(featureColor))) {
+      featureColor = osStyle.DEFAULT_LAYER_COLOR;
+    }
+
+    return osStyle.toAbgrString(featureColor);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getFill(item) {
+    const feature = item.getFeature();
+    const style = feature.getStyle();
+    const styles = Array.isArray(style) ? style : [style];
+    return styles.some(osStyle.hasNonZeroFillOpacity);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getStroke(item) {
+    const feature = item.getFeature();
+    const style = feature.getStyle();
+    const styles = Array.isArray(style) ? style : [style];
+    return styles.some(osStyle.hasNonZeroStrokeOpacity);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getFillColor(item) {
+    var featureColor = osFeature.getFillColor(item.getFeature());
+    return featureColor ? osStyle.toAbgrString(featureColor) : null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getStrokeColor(item) {
+    var featureColor = osFeature.getStrokeColor(item.getFeature());
+    return featureColor ? osStyle.toAbgrString(featureColor) : null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getStrokeWidth(item) {
+    return osFeature.getStrokeWidth(item.getFeature());
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getElementType(item) {
+    return item.isFolder() ? osUiFileKml.ElementType.FOLDER : osUiFileKml.ElementType.PLACEMARK;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getField(item, field) {
+    return osFeature.getField(item.getFeature(), field);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getFields(item) {
+    if (!this.fields) {
+      // if fields aren't defined, try to read them from source columns
+      var source = item.getSource();
+      if (source) {
+        this.fields = osSource.getExportFields(source, true);
+      }
+    }
+
+    return this.fields;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getIcon(item) {
+    var icon = super.getIcon(item);
+
+    var feature = item.getFeature();
+    if (feature) {
+      icon = /** @type {osUiFileKml.Icon} */ (googObject.clone(icon));
+
+      var config = /** @type {Array<Object>|Object|undefined} */ (feature.get(osStyle.StyleType.FEATURE));
+
+      // may be an array of configs - use the first one (feature style)
+      if (Array.isArray(config)) {
+        config = feature instanceof osFeature.DynamicFeature ? config[1] : config[0];
+      }
+
+      if (config && config['image']) {
+        var image = config['image'];
+        if (image['src']) {
+          icon.href = image['src'];
+          icon.options = image['options'];
+        }
+
+        var size = osStyle.getConfigSize(image);
+        if (size) {
+          var scale = icon.scale || 1;
+          icon.scale = scale * osStyle.sizeToScale(size);
+        }
+      }
+    }
+
+    return icon;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getId(item) {
+    return String(ol.getUid(item));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getParent(item) {
+    // initialize the parent to the root kml:Document
+    var parent = this.kmlDoc;
+    if (parent) {
+      var parentNode = /** @type {kml.ui.KMLNode} */ (item.getParent());
+      if (parentNode) {
+        var parentId = parentNode.getId();
+        if (this.folders_[parentId]) {
+          parent = this.folders_[parentId];
+        } else if (!this.isRootItem(item)) {
+          // only create a parent folder if the item isn't one of the root items set on the exporter
+          var prevParent = this.getParent(parentNode);
+          if (prevParent) {
+            // create a new folder for the node
+            var folder = xml.appendElementNS('Folder', this.kmlNS, prevParent);
+            xml.appendElementNS('name', this.kmlNS, folder, this.createLabel(parentNode));
+
+            var open = parentNode.collapsed ? 0 : 1;
+            xml.appendElementNS('open', this.kmlNS, folder, open);
+
+            // update the parent
+            parent = this.folders_[parentId] = folder;
+          }
+        }
+      }
+    }
+
+    return parent;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getProperties(item) {
+    var properties;
+
+    var feature = item.getFeature();
+    if (feature) {
+      properties = feature.getProperties();
+
+      var keys = googObject.getKeys(properties);
+      for (var i = 0, n = keys.length; i < n; i++) {
+        var key = keys[i];
+        if (googString.startsWith(key, '_') || osFeature.isInternalField(key)) {
+          delete properties[key];
+        }
+      }
+    }
+
+    return properties || null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getStyleType(item) {
+    return osUiFileKml.StyleType.ICON;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getTime(item) {
+    var feature = item.getFeature();
+    if (feature) {
+      return (
+        /** @type {os.time.ITime|undefined} */ (feature.get(RecordField.TIME)) || null
+      );
+    }
+
+    return null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getUI() {
+    return '';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  isItemVisible(item) {
+    return item.getState() != TriState.OFF;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  processFolder(element, item) {
+    // add the folder to the map so children won't create a new one
+    this.folders_[item.getId()] = element;
+
+    var open = item.collapsed ? 0 : 1;
+    xml.appendElementNS('open', this.kmlNS, element, open);
+
+    super.processFolder(element, item);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  supportsLabelExport() {
+    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getGeometry(item) {
+    var geometry;
+
+    var feature = item ? item.getFeature() : null;
+    if (feature) {
+      var geomAltitudeMode;
+      var featAltitudeMode = feature.get(RecordField.ALTITUDE_MODE);
+
+      geometry = feature.getGeometry();
+      if (geometry) {
+        geometry = geometry.clone().toLonLat();
+        geomAltitudeMode = geometry.get(RecordField.ALTITUDE_MODE);
+      }
+
+      if (this.exportEllipses) {
+        var ellipse = osFeature.createEllipse(feature);
+        if (ellipse && !(ellipse instanceof Point)) {
+          if (this.useCenterPoint && geometry instanceof Point) {
+            geometry = new GeometryCollection([ellipse, geometry]);
+          } else {
+            geometry = ellipse;
+          }
+        }
+      }
+
+      if (geometry) {
+        geometry.set(RecordField.ALTITUDE_MODE, geomAltitudeMode || featAltitudeMode);
+      }
+    }
+
+    return geometry;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getBalloonOptions(item) {
+    return pluginFileKmlExport.getBalloonOptions(item ? item.getFeature() : null);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getRotationColumn(item) {
+    return pluginFileKmlExport.getRotationColumn(item ? item.getFeature() : null);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLineDash(item) {
+    return pluginFileKmlExport.getLineDash(item ? item.getFeature() : null);
+  }
+}
 
 
 /**
  * Logger
  * @type {goog.log.Logger}
- * @private
- * @const
  */
-plugin.file.kml.KMLTreeExporter.LOGGER_ = goog.log.getLogger('plugin.file.kml.KMLTreeExporter');
+const logger = log.getLogger('plugin.file.kml.KMLTreeExporter');
 
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.reset = function() {
-  plugin.file.kml.KMLTreeExporter.base(this, 'reset');
-
-  this.folders_ = {};
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.supportsMultiple = function() {
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.createLabel = function(item) {
-  return item.getLabel();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getChildren = function(item) {
-  return item.getChildren();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getColor = function(item) {
-  var featureColor = os.feature.getColor(item.getFeature());
-  if (!featureColor || (typeof featureColor != 'string' && !Array.isArray(featureColor))) {
-    featureColor = os.style.DEFAULT_LAYER_COLOR;
-  }
-
-  return os.style.toAbgrString(featureColor);
-};
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getFill = function(item) {
-  const feature = item.getFeature();
-  const style = feature.getStyle();
-  const styles = Array.isArray(style) ? style : [style];
-  return styles.some(os.style.hasNonZeroFillOpacity);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getStroke = function(item) {
-  const feature = item.getFeature();
-  const style = feature.getStyle();
-  const styles = Array.isArray(style) ? style : [style];
-  return styles.some(os.style.hasNonZeroStrokeOpacity);
-};
-
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getFillColor = function(item) {
-  var featureColor = os.feature.getFillColor(item.getFeature());
-  return featureColor ? os.style.toAbgrString(featureColor) : null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getStrokeColor = function(item) {
-  var featureColor = os.feature.getStrokeColor(item.getFeature());
-  return featureColor ? os.style.toAbgrString(featureColor) : null;
-};
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getStrokeWidth = function(item) {
-  return os.feature.getStrokeWidth(item.getFeature());
-};
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getElementType = function(item) {
-  return item.isFolder() ? os.ui.file.kml.ElementType.FOLDER : os.ui.file.kml.ElementType.PLACEMARK;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getField = function(item, field) {
-  return os.feature.getField(item.getFeature(), field);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getFields = function(item) {
-  if (!this.fields) {
-    // if fields aren't defined, try to read them from source columns
-    var source = item.getSource();
-    if (source) {
-      this.fields = os.source.getExportFields(source, true);
-    }
-  }
-
-  return this.fields;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getIcon = function(item) {
-  var icon = plugin.file.kml.KMLTreeExporter.base(this, 'getIcon', item);
-
-  var feature = item.getFeature();
-  if (feature) {
-    icon = /** @type {os.ui.file.kml.Icon} */ (goog.object.clone(icon));
-
-    var config = /** @type {Array<Object>|Object|undefined} */ (feature.get(os.style.StyleType.FEATURE));
-
-    // may be an array of configs - use the first one (feature style)
-    if (Array.isArray(config)) {
-      config = feature instanceof os.feature.DynamicFeature ? config[1] : config[0];
-    }
-
-    if (config && config['image']) {
-      var image = config['image'];
-      if (image['src']) {
-        icon.href = image['src'];
-        icon.options = image['options'];
-      }
-
-      var size = os.style.getConfigSize(image);
-      if (size) {
-        var scale = icon.scale || 1;
-        icon.scale = scale * os.style.sizeToScale(size);
-      }
-    }
-  }
-
-  return icon;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getId = function(item) {
-  return String(ol.getUid(item));
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getParent = function(item) {
-  // initialize the parent to the root kml:Document
-  var parent = this.kmlDoc;
-  if (parent) {
-    var parentNode = /** @type {plugin.file.kml.ui.KMLNode} */ (item.getParent());
-    if (parentNode) {
-      var parentId = parentNode.getId();
-      if (this.folders_[parentId]) {
-        parent = this.folders_[parentId];
-      } else if (!this.isRootItem(item)) {
-        // only create a parent folder if the item isn't one of the root items set on the exporter
-        var prevParent = this.getParent(parentNode);
-        if (prevParent) {
-          // create a new folder for the node
-          var folder = os.xml.appendElementNS('Folder', this.kmlNS, prevParent);
-          os.xml.appendElementNS('name', this.kmlNS, folder, this.createLabel(parentNode));
-
-          var open = parentNode.collapsed ? 0 : 1;
-          os.xml.appendElementNS('open', this.kmlNS, folder, open);
-
-          // update the parent
-          parent = this.folders_[parentId] = folder;
-        }
-      }
-    }
-  }
-
-  return parent;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getProperties = function(item) {
-  var properties;
-
-  var feature = item.getFeature();
-  if (feature) {
-    properties = feature.getProperties();
-
-    var keys = goog.object.getKeys(properties);
-    for (var i = 0, n = keys.length; i < n; i++) {
-      var key = keys[i];
-      if (goog.string.startsWith(key, '_') || os.feature.isInternalField(key)) {
-        delete properties[key];
-      }
-    }
-  }
-
-  return properties || null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getStyleType = function(item) {
-  return os.ui.file.kml.StyleType.ICON;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getTime = function(item) {
-  var feature = item.getFeature();
-  if (feature) {
-    return /** @type {os.time.ITime|undefined} */ (feature.get(os.data.RecordField.TIME)) || null;
-  }
-
-  return null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getUI = function() {
-  return '';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.isItemVisible = function(item) {
-  return item.getState() != os.structs.TriState.OFF;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.processFolder = function(element, item) {
-  // add the folder to the map so children won't create a new one
-  this.folders_[item.getId()] = element;
-
-  var open = item.collapsed ? 0 : 1;
-  os.xml.appendElementNS('open', this.kmlNS, element, open);
-
-  plugin.file.kml.KMLTreeExporter.base(this, 'processFolder', element, item);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.supportsLabelExport = function() {
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getGeometry = function(item) {
-  var geometry;
-
-  var feature = item ? item.getFeature() : null;
-  if (feature) {
-    var geomAltitudeMode;
-    var featAltitudeMode = feature.get(os.data.RecordField.ALTITUDE_MODE);
-
-    geometry = feature.getGeometry();
-    if (geometry) {
-      geometry = geometry.clone().toLonLat();
-      geomAltitudeMode = geometry.get(os.data.RecordField.ALTITUDE_MODE);
-    }
-
-    if (this.exportEllipses) {
-      var ellipse = os.feature.createEllipse(feature);
-      if (ellipse && !(ellipse instanceof ol.geom.Point)) {
-        if (this.useCenterPoint && geometry instanceof ol.geom.Point) {
-          geometry = new ol.geom.GeometryCollection([ellipse, geometry]);
-        } else {
-          geometry = ellipse;
-        }
-      }
-    }
-
-    if (geometry) {
-      geometry.set(os.data.RecordField.ALTITUDE_MODE, geomAltitudeMode || featAltitudeMode);
-    }
-  }
-
-  return geometry;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getBalloonOptions = function(item) {
-  return plugin.file.kml.export.getBalloonOptions(item ? item.getFeature() : null);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getRotationColumn = function(item) {
-  return plugin.file.kml.export.getRotationColumn(item ? item.getFeature() : null);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.KMLTreeExporter.prototype.getLineDash = function(item) {
-  return plugin.file.kml.export.getLineDash(item ? item.getFeature() : null);
-};
+exports = KMLTreeExporter;

--- a/src/plugin/file/kml/mime.js
+++ b/src/plugin/file/kml/mime.js
@@ -1,23 +1,24 @@
-goog.provide('plugin.file.kml.mime');
+goog.module('plugin.file.kml.mime');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Promise');
-goog.require('os.file.mime.xml');
-goog.require('os.file.mime.zip');
+const Promise = goog.require('goog.Promise');
+const mime = goog.require('os.file.mime');
+const xml = goog.require('os.file.mime.xml');
+const mimeZip = goog.require('os.file.mime.zip');
+
 
 /**
- * @const
  * @type {string}
  */
-plugin.file.kml.mime.TYPE = 'application/vnd.google-earth.kml+xml';
-
+const TYPE = 'application/vnd.google-earth.kml+xml';
 
 /**
  * @param {ArrayBuffer} buffer
  * @param {os.file.File=} opt_file
  * @param {*=} opt_context
- * @return {!goog.Promise<*|undefined>}
+ * @return {!Promise<*|undefined>}
  */
-plugin.file.kml.detect = function(buffer, opt_file, opt_context) {
+const detect = function(buffer, opt_file, opt_context) {
   var retVal;
   if (opt_context && (
     (/^(document|folder|kml)$/i.test(opt_context.rootTag)) ||
@@ -25,22 +26,17 @@ plugin.file.kml.detect = function(buffer, opt_file, opt_context) {
     retVal = opt_context;
   }
 
-  return goog.Promise.resolve(retVal);
+  return Promise.resolve(retVal);
 };
 
 
-os.file.mime.register(
-    plugin.file.kml.mime.TYPE,
-    plugin.file.kml.detect,
-    0, os.file.mime.xml.TYPE);
+mime.register(TYPE, detect, 0, xml.TYPE);
 
 
 /**
- * @const
  * @type {string}
  */
-plugin.file.kml.mime.KMZ_TYPE = 'application/vnd.google-earth.kmz';
-
+const KMZ_TYPE = 'application/vnd.google-earth.kmz';
 
 /**
  * Determine if this file is a KMZ file.  Currently, the logic is:
@@ -50,16 +46,16 @@ plugin.file.kml.mime.KMZ_TYPE = 'application/vnd.google-earth.kmz';
  * @param {ArrayBuffer} buffer
  * @param {os.file.File=} opt_file
  * @param {*=} opt_context
- * @return {!goog.Promise<*|undefined>}
+ * @return {!Promise<*|undefined>}
  */
-plugin.file.kml.detectKmz = function(buffer, opt_file, opt_context) {
+const detectKmz = function(buffer, opt_file, opt_context) {
   var retVal;
   var kmzRegex = /\.kmz$/i;
   var kmlRegex = /\.kml$/i;
 
   if (opt_file && (
     kmzRegex.test(opt_file.getFileName()) ||
-    plugin.file.kml.mime.TYPE == opt_file.getContentType()
+    TYPE == opt_file.getContentType()
   )) {
     if (opt_context && Array.isArray(opt_context)) {
       var entries = /** @type {!Array<!zip.Entry>} */ (opt_context);
@@ -72,11 +68,13 @@ plugin.file.kml.detectKmz = function(buffer, opt_file, opt_context) {
     }
   }
 
-  return /** @type {!goog.Promise<*|undefined>} */ (goog.Promise.resolve(retVal));
+  return /** @type {!Promise<*|undefined>} */ (Promise.resolve(retVal));
 };
 
 
-os.file.mime.register(
-    plugin.file.kml.mime.KMZ_TYPE,
-    plugin.file.kml.detectKmz,
-    0, os.file.mime.zip.TYPE);
+mime.register(KMZ_TYPE, detectKmz, 0, mimeZip.TYPE);
+
+exports = {
+  TYPE,
+  KMZ_TYPE
+};

--- a/src/plugin/file/kml/tour/abstracttourprimitive.js
+++ b/src/plugin/file/kml/tour/abstracttourprimitive.js
@@ -1,39 +1,44 @@
-goog.provide('plugin.file.kml.tour.AbstractTourPrimitive');
+goog.module('plugin.file.kml.tour.AbstractTourPrimitive');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.fn');
+const fn = goog.require('os.fn');
 
 
 /**
  * Abstract KML tour primitive.
  *
  * @abstract
- * @constructor
  */
-plugin.file.kml.tour.AbstractTourPrimitive = function() {
+class AbstractTourPrimitive {
   /**
-   * If the tour primitive executes asynchronously.
-   * @type {boolean}
+   * Constructor.
    */
-  this.isAsync = false;
-};
+  constructor() {
+    /**
+     * If the tour primitive executes asynchronously.
+     * @type {boolean}
+     */
+    this.isAsync = false;
+  }
 
-
-/**
- * Execute the tour instruction.
- *
- * @abstract
- * @return {!goog.Promise} A promise that resolves when execution completes.
- */
-plugin.file.kml.tour.AbstractTourPrimitive.prototype.execute = function() {};
+  /**
+   * Execute the tour instruction.
+   *
+   * @abstract
+   * @return {!goog.Promise} A promise that resolves when execution completes.
+   */
+  execute() {}
+}
 
 
 /**
  * Pause tour instruction execution.
  */
-plugin.file.kml.tour.AbstractTourPrimitive.prototype.pause = os.fn.noop;
+AbstractTourPrimitive.prototype.pause = fn.noop;
 
 
 /**
  * Reset the tour primitive.
  */
-plugin.file.kml.tour.AbstractTourPrimitive.prototype.reset = os.fn.noop;
+AbstractTourPrimitive.prototype.reset = fn.noop;
+exports = AbstractTourPrimitive;

--- a/src/plugin/file/kml/tour/eventtype.js
+++ b/src/plugin/file/kml/tour/eventtype.js
@@ -1,0 +1,11 @@
+goog.module('plugin.file.kml.tour.EventType');
+goog.module.declareLegacyNamespace();
+
+
+/**
+ * Tour event types.
+ * @enum {string}
+ */
+exports = {
+  PLAYING: 'playing'
+};

--- a/src/plugin/file/kml/tour/tour.js
+++ b/src/plugin/file/kml/tour/tour.js
@@ -1,236 +1,222 @@
-goog.provide('plugin.file.kml.tour.EventType');
-goog.provide('plugin.file.kml.tour.Tour');
+goog.module('plugin.file.kml.tour.Tour');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.async.nextTick');
-goog.require('goog.events.EventTarget');
-
-
-/**
- * Tour event types.
- * @enum {string}
- */
-plugin.file.kml.tour.EventType = {
-  PLAYING: 'playing'
-};
+const nextTick = goog.require('goog.async.nextTick');
+const EventTarget = goog.require('goog.events.EventTarget');
+const EventType = goog.require('plugin.file.kml.tour.EventType');
 
 
 /**
  * Represents a KML tour, from a `gx:Tour` (KML 2.2) or `Tour` (KML 2.3) element.
- *
- * @param {string=} opt_name The name of the tour.
- * @param {string=} opt_description The tour description.
- * @param {Array<!plugin.file.kml.tour.AbstractTourPrimitive>=} opt_playlist The tour playlist.
- * @extends {goog.events.EventTarget}
- * @constructor
+ * @unrestricted
  */
-plugin.file.kml.tour.Tour = function(opt_name, opt_description, opt_playlist) {
-  plugin.file.kml.tour.Tour.base(this, 'constructor');
-
+class Tour extends EventTarget {
   /**
-   * The name of the tour.
-   * @type {string}
+   * Constructor.
+   * @param {string=} opt_name The name of the tour.
+   * @param {string=} opt_description The tour description.
+   * @param {Array<!plugin.file.kml.tour.AbstractTourPrimitive>=} opt_playlist The tour playlist.
    */
-  this['name'] = opt_name || 'Unnamed Tour';
+  constructor(opt_name, opt_description, opt_playlist) {
+    super();
 
-  /**
-   * The tour description.
-   * @type {string}
-   */
-  this['description'] = opt_description || '';
+    /**
+     * The name of the tour.
+     * @type {string}
+     */
+    this['name'] = opt_name || 'Unnamed Tour';
 
-  /**
-   * If the tour should be repeated when it completes.
-   * @type {boolean}
-   */
-  this['repeat'] = false;
+    /**
+     * The tour description.
+     * @type {string}
+     */
+    this['description'] = opt_description || '';
 
-  /**
-   * If the tour is currently playing.
-   * @type {boolean}
-   */
-  this['playing'] = false;
+    /**
+     * If the tour should be repeated when it completes.
+     * @type {boolean}
+     */
+    this['repeat'] = false;
 
-  /**
-   * The tour playlist.
-   * @type {!Array<!plugin.file.kml.tour.AbstractTourPrimitive>}
-   * @private
-   */
-  this.playlist_ = opt_playlist || [];
+    /**
+     * If the tour is currently playing.
+     * @type {boolean}
+     */
+    this['playing'] = false;
 
-  /**
-   * Index of the next tour primitive to execute.
-   * @type {number}
-   * @private
-   */
-  this.playlistIndex_ = 0;
+    /**
+     * The tour playlist.
+     * @type {!Array<!plugin.file.kml.tour.AbstractTourPrimitive>}
+     * @private
+     */
+    this.playlist_ = opt_playlist || [];
 
-  /**
-   * Promise for the currently executing tour primitive.
-   * @type {goog.Promise|undefined}
-   * @private
-   */
-  this.currentPromise_ = undefined;
-};
-goog.inherits(plugin.file.kml.tour.Tour, goog.events.EventTarget);
+    /**
+     * Index of the next tour primitive to execute.
+     * @type {number}
+     * @private
+     */
+    this.playlistIndex_ = 0;
 
-
-/**
- * Get the tour playlist.
- *
- * @return {!Array<!plugin.file.kml.tour.AbstractTourPrimitive>}
- */
-plugin.file.kml.tour.Tour.prototype.getPlaylist = function() {
-  return this.playlist_;
-};
-
-
-/**
- * Set the tour playlist.
- *
- * @param {!Array<!plugin.file.kml.tour.AbstractTourPrimitive>} value The tour playlist.
- */
-plugin.file.kml.tour.Tour.prototype.setPlaylist = function(value) {
-  this.playlist_ = value;
-  this.reset();
-};
-
-
-/**
- * Add a tour primitive to the playlist.
- *
- * @param {!plugin.file.kml.tour.AbstractTourPrimitive} value The tour playlist.
- */
-plugin.file.kml.tour.Tour.prototype.addToPlaylist = function(value) {
-  this.playlist_.push(value);
-  this.reset();
-};
-
-
-/**
- * Set if the tour is playing.
- *
- * @param {boolean} value If the tour is playing.
- */
-plugin.file.kml.tour.Tour.prototype.setPlaying = function(value) {
-  if (this['playing'] !== value) {
-    this['playing'] = value;
-    this.dispatchEvent(plugin.file.kml.tour.EventType.PLAYING);
+    /**
+     * Promise for the currently executing tour primitive.
+     * @type {goog.Promise|undefined}
+     * @private
+     */
+    this.currentPromise_ = undefined;
   }
-};
 
+  /**
+   * Get the tour playlist.
+   *
+   * @return {!Array<!plugin.file.kml.tour.AbstractTourPrimitive>}
+   */
+  getPlaylist() {
+    return this.playlist_;
+  }
 
-/**
- * Play the tour.
- */
-plugin.file.kml.tour.Tour.prototype.play = function() {
-  if (this['playing']) {
-    // if the tour is started while it is playing, reset it to the beginning
+  /**
+   * Set the tour playlist.
+   *
+   * @param {!Array<!plugin.file.kml.tour.AbstractTourPrimitive>} value The tour playlist.
+   */
+  setPlaylist(value) {
+    this.playlist_ = value;
     this.reset();
+  }
 
-    // wait until the stack clears (so the active promise can be cancelled), then play the tour
-    goog.async.nextTick(this.play, this);
-  } else {
-    this.setPlaying(true);
+  /**
+   * Add a tour primitive to the playlist.
+   *
+   * @param {!plugin.file.kml.tour.AbstractTourPrimitive} value The tour playlist.
+   */
+  addToPlaylist(value) {
+    this.playlist_.push(value);
+    this.reset();
+  }
 
-    // execute any asynchronous tour primitives
-    for (var i = 0; i < this.playlistIndex_; i++) {
-      var item = this.playlist_[i];
-      if (item && item.isAsync) {
-        item.execute();
+  /**
+   * Set if the tour is playing.
+   *
+   * @param {boolean} value If the tour is playing.
+   */
+  setPlaying(value) {
+    if (this['playing'] !== value) {
+      this['playing'] = value;
+      this.dispatchEvent(EventType.PLAYING);
+    }
+  }
+
+  /**
+   * Play the tour.
+   */
+  play() {
+    if (this['playing']) {
+      // if the tour is started while it is playing, reset it to the beginning
+      this.reset();
+
+      // wait until the stack clears (so the active promise can be cancelled), then play the tour
+      nextTick(this.play, this);
+    } else {
+      this.setPlaying(true);
+
+      // execute any asynchronous tour primitives
+      for (var i = 0; i < this.playlistIndex_; i++) {
+        var item = this.playlist_[i];
+        if (item && item.isAsync) {
+          item.execute();
+        }
+      }
+
+      // execute the next primitive
+      this.playNext_();
+    }
+  }
+
+  /**
+   * Pause the tour.
+   */
+  pause() {
+    this.setPlaying(false);
+
+    if (this.currentPromise_) {
+      this.currentPromise_.cancel();
+      this.currentPromise_ = undefined;
+    }
+
+    this.playlist_.forEach(function(p) {
+      p.pause();
+    });
+  }
+
+  /**
+   * Reset the tour.
+   */
+  reset() {
+    // reset the tour to start from the beginning
+    this.playlistIndex_ = 0;
+    this.setPlaying(false);
+
+    if (this.currentPromise_) {
+      this.currentPromise_.cancel();
+      this.currentPromise_ = undefined;
+    }
+
+    this.playlist_.forEach(function(p) {
+      p.reset();
+    });
+  }
+
+  /**
+   * Play the next primitive in the tour.
+   *
+   * @private
+   */
+  playNext_() {
+    if (this['playing']) {
+      var current = this.playlist_[this.playlistIndex_];
+      if (current) {
+        // execute the next playlist item
+        this.currentPromise_ = current.execute().then(this.onExecuteResolved_, this.onExecuteRejected_, this);
+      } else {
+        // should have been a playlist item, so reset the tour
+        this.reset();
+      }
+    }
+  }
+
+  /**
+   * Handle successful resolution of a playlist item.
+   */
+  onExecuteResolved_() {
+    this.currentPromise_ = undefined;
+    this.playlistIndex_++;
+
+    if (this.playlistIndex_ > this.playlist_.length) {
+      if (this['repeat']) {
+        // start from the beginning if repeat is enabled
+        this.playlistIndex_ = 0;
+      } else {
+        // otherwise reset the tour to the beginning
+        this.reset();
       }
     }
 
-    // execute the next primitive
-    this.playNext_();
-  }
-};
-
-
-/**
- * Pause the tour.
- */
-plugin.file.kml.tour.Tour.prototype.pause = function() {
-  this.setPlaying(false);
-
-  if (this.currentPromise_) {
-    this.currentPromise_.cancel();
-    this.currentPromise_ = undefined;
+    // let the stack clear before running the next item in the tour
+    nextTick(this.playNext_, this);
   }
 
-  this.playlist_.forEach(function(p) {
-    p.pause();
-  });
-};
-
-
-/**
- * Reset the tour.
- */
-plugin.file.kml.tour.Tour.prototype.reset = function() {
-  // reset the tour to start from the beginning
-  this.playlistIndex_ = 0;
-  this.setPlaying(false);
-
-  if (this.currentPromise_) {
-    this.currentPromise_.cancel();
-    this.currentPromise_ = undefined;
-  }
-
-  this.playlist_.forEach(function(p) {
-    p.reset();
-  });
-};
-
-
-/**
- * Play the next primitive in the tour.
- *
- * @private
- */
-plugin.file.kml.tour.Tour.prototype.playNext_ = function() {
-  if (this['playing']) {
-    var current = this.playlist_[this.playlistIndex_];
-    if (current) {
-      // execute the next playlist item
-      this.currentPromise_ = current.execute().then(this.onExecuteResolved_, this.onExecuteRejected_, this);
-    } else {
-      // should have been a playlist item, so reset the tour
+  /**
+   * Handle rejection of a playlist item.
+   *
+   * @param {*} opt_reason The rejection reason.
+   */
+  onExecuteRejected_(opt_reason) {
+    // if a promise is rejected while playing, reset the tour
+    if (this['playing']) {
       this.reset();
     }
   }
-};
+}
 
-
-/**
- * Handle successful resolution of a playlist item.
- */
-plugin.file.kml.tour.Tour.prototype.onExecuteResolved_ = function() {
-  this.currentPromise_ = undefined;
-  this.playlistIndex_++;
-
-  if (this.playlistIndex_ > this.playlist_.length) {
-    if (this['repeat']) {
-      // start from the beginning if repeat is enabled
-      this.playlistIndex_ = 0;
-    } else {
-      // otherwise reset the tour to the beginning
-      this.reset();
-    }
-  }
-
-  // let the stack clear before running the next item in the tour
-  goog.async.nextTick(this.playNext_, this);
-};
-
-
-/**
- * Handle rejection of a playlist item.
- *
- * @param {*} opt_reason The rejection reason.
- */
-plugin.file.kml.tour.Tour.prototype.onExecuteRejected_ = function(opt_reason) {
-  // if a promise is rejected while playing, reset the tour
-  if (this['playing']) {
-    this.reset();
-  }
-};
+exports = Tour;

--- a/src/plugin/file/kml/tour/tour.js
+++ b/src/plugin/file/kml/tour/tour.js
@@ -5,6 +5,9 @@ const nextTick = goog.require('goog.async.nextTick');
 const EventTarget = goog.require('goog.events.EventTarget');
 const EventType = goog.require('plugin.file.kml.tour.EventType');
 
+const Promise = goog.requireType('goog.Promise');
+const AbstractTourPrimitive = goog.requireType('plugin.file.kml.tour.AbstractTourPrimitive');
+
 
 /**
  * Represents a KML tour, from a `gx:Tour` (KML 2.2) or `Tour` (KML 2.3) element.
@@ -15,7 +18,7 @@ class Tour extends EventTarget {
    * Constructor.
    * @param {string=} opt_name The name of the tour.
    * @param {string=} opt_description The tour description.
-   * @param {Array<!plugin.file.kml.tour.AbstractTourPrimitive>=} opt_playlist The tour playlist.
+   * @param {Array<!AbstractTourPrimitive>=} opt_playlist The tour playlist.
    */
   constructor(opt_name, opt_description, opt_playlist) {
     super();
@@ -46,7 +49,7 @@ class Tour extends EventTarget {
 
     /**
      * The tour playlist.
-     * @type {!Array<!plugin.file.kml.tour.AbstractTourPrimitive>}
+     * @type {!Array<!AbstractTourPrimitive>}
      * @private
      */
     this.playlist_ = opt_playlist || [];
@@ -60,7 +63,7 @@ class Tour extends EventTarget {
 
     /**
      * Promise for the currently executing tour primitive.
-     * @type {goog.Promise|undefined}
+     * @type {Promise|undefined}
      * @private
      */
     this.currentPromise_ = undefined;
@@ -69,7 +72,7 @@ class Tour extends EventTarget {
   /**
    * Get the tour playlist.
    *
-   * @return {!Array<!plugin.file.kml.tour.AbstractTourPrimitive>}
+   * @return {!Array<!AbstractTourPrimitive>}
    */
   getPlaylist() {
     return this.playlist_;
@@ -78,7 +81,7 @@ class Tour extends EventTarget {
   /**
    * Set the tour playlist.
    *
-   * @param {!Array<!plugin.file.kml.tour.AbstractTourPrimitive>} value The tour playlist.
+   * @param {!Array<!AbstractTourPrimitive>} value The tour playlist.
    */
   setPlaylist(value) {
     this.playlist_ = value;
@@ -88,7 +91,7 @@ class Tour extends EventTarget {
   /**
    * Add a tour primitive to the playlist.
    *
-   * @param {!plugin.file.kml.tour.AbstractTourPrimitive} value The tour playlist.
+   * @param {!AbstractTourPrimitive} value The tour playlist.
    */
   addToPlaylist(value) {
     this.playlist_.push(value);

--- a/src/plugin/file/kml/tour/tourcontrol.js
+++ b/src/plugin/file/kml/tour/tourcontrol.js
@@ -1,59 +1,61 @@
-goog.provide('plugin.file.kml.tour.TourControl');
+goog.module('plugin.file.kml.tour.TourControl');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Promise');
-goog.require('goog.async.nextTick');
-goog.require('plugin.file.kml.tour.AbstractTourPrimitive');
+const Promise = goog.require('goog.Promise');
+const nextTick = goog.require('goog.async.nextTick');
+const AbstractTourPrimitive = goog.require('plugin.file.kml.tour.AbstractTourPrimitive');
 
 
 /**
  * Enables the tour to be paused until a user takes action to continue the tour.
- *
- * @param {!plugin.file.kml.tour.Tour} tour The tour object.
- * @extends {plugin.file.kml.tour.AbstractTourPrimitive}
- * @constructor
  */
-plugin.file.kml.tour.TourControl = function(tour) {
-  plugin.file.kml.tour.TourControl.base(this, 'constructor');
+class TourControl extends AbstractTourPrimitive {
+  /**
+   * Constructor.
+   * @param {!plugin.file.kml.tour.Tour} tour The tour object.
+   */
+  constructor(tour) {
+    super();
+
+    /**
+     * The tour object.
+     * @type {!plugin.file.kml.tour.Tour}
+     * @private
+     */
+    this.tour_ = tour;
+
+    /**
+     * If the tour has been paused by this control.
+     * @type {boolean}
+     * @private
+     */
+    this.paused_ = false;
+  }
 
   /**
-   * The tour object.
-   * @type {!plugin.file.kml.tour.Tour}
-   * @private
+   * @inheritDoc
    */
-  this.tour_ = tour;
+  execute() {
+    return new Promise((resolve, reject) => {
+      // let the tour pick up the promise before pausing
+      nextTick(() => {
+        // pause the tour once, until reset
+        if (!this.paused_) {
+          this.paused_ = true;
+          this.tour_.pause();
+        }
+
+        resolve();
+      });
+    });
+  }
 
   /**
-   * If the tour has been paused by this control.
-   * @type {boolean}
-   * @private
+   * @inheritDoc
    */
-  this.paused_ = false;
-};
-goog.inherits(plugin.file.kml.tour.TourControl, plugin.file.kml.tour.AbstractTourPrimitive);
+  reset() {
+    this.paused_ = false;
+  }
+}
 
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.tour.TourControl.prototype.execute = function() {
-  return new goog.Promise(function(resolve, reject) {
-    // let the tour pick up the promise before pausing
-    goog.async.nextTick(function() {
-      // pause the tour once, until reset
-      if (!this.paused_) {
-        this.paused_ = true;
-        this.tour_.pause();
-      }
-
-      resolve();
-    }, this);
-  }, this);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.tour.TourControl.prototype.reset = function() {
-  this.paused_ = false;
-};
+exports = TourControl;

--- a/src/plugin/file/kml/tour/tourparser.js
+++ b/src/plugin/file/kml/tour/tourparser.js
@@ -2,41 +2,40 @@
  * @fileoverview KML Tour parser.
  * @suppress {accessControls}
  */
-goog.provide('plugin.file.kml.tour.parseTour');
+goog.module('plugin.file.kml.tour.parseTour');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.format.KML');
-goog.require('ol.format.XSD');
-goog.require('ol.xml');
-goog.require('os.map.FlightMode');
-goog.require('plugin.file.kml.tour.FlyTo');
-goog.require('plugin.file.kml.tour.SoundCue');
-goog.require('plugin.file.kml.tour.Tour');
-goog.require('plugin.file.kml.tour.TourControl');
-goog.require('plugin.file.kml.tour.Wait');
+const KML = goog.require('ol.format.KML');
+const XSD = goog.require('ol.format.XSD');
+const xml = goog.require('ol.xml');
+const FlightMode = goog.require('os.map.FlightMode');
+const FlyTo = goog.require('plugin.file.kml.tour.FlyTo');
+const SoundCue = goog.require('plugin.file.kml.tour.SoundCue');
+const Tour = goog.require('plugin.file.kml.tour.Tour');
+const TourControl = goog.require('plugin.file.kml.tour.TourControl');
+const Wait = goog.require('plugin.file.kml.tour.Wait');
 
 
 /**
  * Parses a KML Tour element into a tour object.
  *
  * @param {Element} el The XML element.
- * @return {plugin.file.kml.tour.Tour|undefined} The tour.
+ * @return {Tour|undefined} The tour.
  */
-plugin.file.kml.tour.parseTour = function(el) {
+const parseTour = (el) => {
   if (!el || el.localName !== 'Tour') {
     return undefined;
   }
 
-  return ol.xml.pushParseAndPop(new plugin.file.kml.tour.Tour(), plugin.file.kml.tour.TOUR_PARSERS_, el, []);
+  return xml.pushParseAndPop(new Tour(), TOUR_PARSERS, el, []);
 };
 
 
 /**
  * Support both KML 2.3 and `gx:` tour elements.
  * @type {Array<string>}
- * @private
- * @const
  */
-plugin.file.kml.tour.NAMESPACE_URIS_ = ol.format.KML.NAMESPACE_URIS_.concat(ol.format.KML.GX_NAMESPACE_URIS_);
+const tourNamespaceUris = KML.NAMESPACE_URIS_.concat(KML.GX_NAMESPACE_URIS_);
 
 
 /**
@@ -44,13 +43,12 @@ plugin.file.kml.tour.NAMESPACE_URIS_ = ol.format.KML.NAMESPACE_URIS_.concat(ol.f
  *
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @private
  */
-plugin.file.kml.tour.parsePlaylist_ = function(node, objectStack) {
-  var playlist = ol.xml.pushParseAndPop([], plugin.file.kml.tour.PLAYLIST_PARSERS_, node, objectStack);
+const parsePlaylist = function(node, objectStack) {
+  var playlist = xml.pushParseAndPop([], PLAYLIST_PARSERS, node, objectStack);
   if (playlist) {
     var tour = objectStack[objectStack.length - 1];
-    if (tour instanceof plugin.file.kml.tour.Tour) {
+    if (tour instanceof Tour) {
       tour.setPlaylist(playlist);
     }
   }
@@ -62,12 +60,11 @@ plugin.file.kml.tour.parsePlaylist_ = function(node, objectStack) {
  *
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {plugin.file.kml.tour.FlyTo|undefined}
- * @private
+ * @return {FlyTo|undefined}
  */
-plugin.file.kml.tour.parseFlyTo_ = function(node, objectStack) {
+const parseFlyTo = function(node, objectStack) {
   var flyTo;
-  var flyToProps = ol.xml.pushParseAndPop({}, plugin.file.kml.tour.FLYTO_PARSERS_, node, objectStack);
+  var flyToProps = xml.pushParseAndPop({}, FLYTO_PARSERS, node, objectStack);
   if (flyToProps) {
     var viewProps = /** @type {Object|undefined} */ (flyToProps['Camera']);
     if (!viewProps) {
@@ -78,7 +75,7 @@ plugin.file.kml.tour.parseFlyTo_ = function(node, objectStack) {
     var duration = /** @type {number} */ (flyToProps['duration'] || 0) * 1000;
 
     // only 'smooth' and 'bounce' are allowed values, default to 'bounce'
-    var flightMode = flyToProps['flyToMode'] === 'smooth' ? os.map.FlightMode.SMOOTH : os.map.FlightMode.BOUNCE;
+    var flightMode = flyToProps['flyToMode'] === 'smooth' ? FlightMode.SMOOTH : FlightMode.BOUNCE;
 
     // if center isn't defined, the flight should still adjust heading, pitch, etc
     var center;
@@ -107,7 +104,7 @@ plugin.file.kml.tour.parseFlyTo_ = function(node, objectStack) {
       positionCamera: !!flyToProps['Camera']
     });
 
-    flyTo = new plugin.file.kml.tour.FlyTo(options);
+    flyTo = new FlyTo(options);
   }
 
   return flyTo;
@@ -120,10 +117,9 @@ plugin.file.kml.tour.parseFlyTo_ = function(node, objectStack) {
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined}
- * @private
  */
-plugin.file.kml.tour.parseCamera_ = function(node, objectStack) {
-  return ol.xml.pushParseAndPop({}, plugin.file.kml.tour.CAMERA_PARSERS_, node, objectStack);
+const parseCamera = function(node, objectStack) {
+  return xml.pushParseAndPop({}, CAMERA_PARSERS, node, objectStack);
 };
 
 
@@ -133,10 +129,9 @@ plugin.file.kml.tour.parseCamera_ = function(node, objectStack) {
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined}
- * @private
  */
-plugin.file.kml.tour.parseLookAt_ = function(node, objectStack) {
-  return ol.xml.pushParseAndPop({}, plugin.file.kml.tour.LOOKAT_PARSERS_, node, objectStack);
+const parseLookAt = function(node, objectStack) {
+  return xml.pushParseAndPop({}, LOOKAT_PARSERS, node, objectStack);
 };
 
 
@@ -145,16 +140,15 @@ plugin.file.kml.tour.parseLookAt_ = function(node, objectStack) {
  *
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {plugin.file.kml.tour.SoundCue|undefined}
- * @private
+ * @return {SoundCue|undefined}
  */
-plugin.file.kml.tour.parseSoundCue_ = function(node, objectStack) {
+const parseSoundCue = function(node, objectStack) {
   var soundCue;
-  var soundCueOptions = ol.xml.pushParseAndPop({}, plugin.file.kml.tour.SOUNDCUE_PARSERS_, node, objectStack);
+  var soundCueOptions = xml.pushParseAndPop({}, SOUNDCUE_PARSERS, node, objectStack);
   if (soundCueOptions['href']) {
     var href = /** @type {string} */ (soundCueOptions['href']);
     var delayedStart = /** @type {number|undefined} */ (soundCueOptions['delayedStart'] || 0) * 1000;
-    soundCue = new plugin.file.kml.tour.SoundCue(href, delayedStart);
+    soundCue = new SoundCue(href, delayedStart);
   }
   return soundCue;
 };
@@ -165,14 +159,13 @@ plugin.file.kml.tour.parseSoundCue_ = function(node, objectStack) {
  *
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {plugin.file.kml.tour.TourControl|undefined}
- * @private
+ * @return {TourControl|undefined}
  */
-plugin.file.kml.tour.parseTourControl_ = function(node, objectStack) {
+const parseTourControl = function(node, objectStack) {
   var tourControl;
   var tour = objectStack.length > 1 ? objectStack[objectStack.length - 2] : undefined;
-  if (tour instanceof plugin.file.kml.tour.Tour) {
-    tourControl = new plugin.file.kml.tour.TourControl(tour);
+  if (tour instanceof Tour) {
+    tourControl = new TourControl(tour);
   }
   return tourControl;
 };
@@ -183,118 +176,105 @@ plugin.file.kml.tour.parseTourControl_ = function(node, objectStack) {
  *
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {plugin.file.kml.tour.Wait|undefined}
- * @private
+ * @return {Wait|undefined}
  */
-plugin.file.kml.tour.parseWait_ = function(node, objectStack) {
-  var waitOptions = ol.xml.pushParseAndPop({}, plugin.file.kml.tour.WAIT_PARSERS_, node, objectStack);
+const parseWait = function(node, objectStack) {
+  var waitOptions = xml.pushParseAndPop({}, WAIT_PARSERS, node, objectStack);
 
   // KML duration is in seconds, so convert to milliseconds
   var duration = (waitOptions.duration || 0) * 1000;
-  return new plugin.file.kml.tour.Wait(duration);
+  return new Wait(duration);
 };
 
 
 /**
  * Parsers for a KML Tour element.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @private
- * @const
  */
-plugin.file.kml.tour.TOUR_PARSERS_ = ol.xml.makeStructureNS(
-    plugin.file.kml.tour.NAMESPACE_URIS_, {
-      'Playlist': plugin.file.kml.tour.parsePlaylist_,
-      'description': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString),
-      'name': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString)
+const TOUR_PARSERS = xml.makeStructureNS(
+    tourNamespaceUris, {
+      'Playlist': parsePlaylist,
+      'description': xml.makeObjectPropertySetter(XSD.readString),
+      'name': xml.makeObjectPropertySetter(XSD.readString)
     });
 
 
 /**
  * Parsers for a KML Playlist element.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @private
- * @const
  */
-plugin.file.kml.tour.PLAYLIST_PARSERS_ = ol.xml.makeStructureNS(
-    plugin.file.kml.tour.NAMESPACE_URIS_, {
-      'FlyTo': ol.xml.makeArrayPusher(plugin.file.kml.tour.parseFlyTo_),
-      'SoundCue': ol.xml.makeArrayPusher(plugin.file.kml.tour.parseSoundCue_),
-      'TourControl': ol.xml.makeArrayPusher(plugin.file.kml.tour.parseTourControl_),
-      'Wait': ol.xml.makeArrayPusher(plugin.file.kml.tour.parseWait_)
+const PLAYLIST_PARSERS = xml.makeStructureNS(
+    tourNamespaceUris, {
+      'FlyTo': xml.makeArrayPusher(parseFlyTo),
+      'SoundCue': xml.makeArrayPusher(parseSoundCue),
+      'TourControl': xml.makeArrayPusher(parseTourControl),
+      'Wait': xml.makeArrayPusher(parseWait)
     });
 
 
 /**
  * Parsers for a KML FlyTo element.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @private
- * @const
  */
-plugin.file.kml.tour.FLYTO_PARSERS_ = ol.xml.makeStructureNS(
-    plugin.file.kml.tour.NAMESPACE_URIS_, {
-      'duration': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'flyToMode': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString),
-      'Camera': ol.xml.makeObjectPropertySetter(plugin.file.kml.tour.parseCamera_),
-      'LookAt': ol.xml.makeObjectPropertySetter(plugin.file.kml.tour.parseLookAt_)
+const FLYTO_PARSERS = xml.makeStructureNS(
+    tourNamespaceUris, {
+      'duration': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'flyToMode': xml.makeObjectPropertySetter(XSD.readString),
+      'Camera': xml.makeObjectPropertySetter(parseCamera),
+      'LookAt': xml.makeObjectPropertySetter(parseLookAt)
     });
 
 
 /**
  * Parsers for a KML Camera element.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @private
- * @const
  */
-plugin.file.kml.tour.CAMERA_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.KML.NAMESPACE_URIS_, {
-      'longitude': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'latitude': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'altitude': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'heading': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'tilt': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'roll': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'altitudeMode': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString)
+const CAMERA_PARSERS = xml.makeStructureNS(
+    KML.NAMESPACE_URIS_, {
+      'longitude': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'latitude': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'altitude': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'heading': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'tilt': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'roll': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'altitudeMode': xml.makeObjectPropertySetter(XSD.readString)
     });
 
 
 /**
  * Parsers for a KML Camera element.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @private
- * @const
  */
-plugin.file.kml.tour.LOOKAT_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.KML.NAMESPACE_URIS_, {
-      'longitude': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'latitude': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'altitude': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'heading': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'tilt': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'range': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal),
-      'altitudeMode': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString)
+const LOOKAT_PARSERS = xml.makeStructureNS(
+    KML.NAMESPACE_URIS_, {
+      'longitude': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'latitude': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'altitude': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'heading': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'tilt': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'range': xml.makeObjectPropertySetter(XSD.readDecimal),
+      'altitudeMode': xml.makeObjectPropertySetter(XSD.readString)
     });
 
 
 /**
  * Parsers for a KML SoundCue element.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @private
- * @const
  */
-plugin.file.kml.tour.SOUNDCUE_PARSERS_ = ol.xml.makeStructureNS(
-    plugin.file.kml.tour.NAMESPACE_URIS_, {
-      'href': ol.xml.makeObjectPropertySetter(ol.format.XSD.readString),
-      'delayedStart': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal)
+const SOUNDCUE_PARSERS = xml.makeStructureNS(
+    tourNamespaceUris, {
+      'href': xml.makeObjectPropertySetter(XSD.readString),
+      'delayedStart': xml.makeObjectPropertySetter(XSD.readDecimal)
     });
 
 
 /**
  * Parsers for a KML Wait element.
  * @type {Object<string, Object<string, ol.XmlParser>>}
- * @private
- * @const
  */
-plugin.file.kml.tour.WAIT_PARSERS_ = ol.xml.makeStructureNS(
-    plugin.file.kml.tour.NAMESPACE_URIS_, {
-      'duration': ol.xml.makeObjectPropertySetter(ol.format.XSD.readDecimal)
+const WAIT_PARSERS = xml.makeStructureNS(
+    tourNamespaceUris, {
+      'duration': xml.makeObjectPropertySetter(XSD.readDecimal)
     });
+
+exports = parseTour;

--- a/src/plugin/file/kml/tour/toursoundcue.js
+++ b/src/plugin/file/kml/tour/toursoundcue.js
@@ -1,122 +1,119 @@
-goog.provide('plugin.file.kml.tour.SoundCue');
+goog.module('plugin.file.kml.tour.SoundCue');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Promise');
-goog.require('os.audio.AudioManager');
-goog.require('os.audio.AudioSetting');
-goog.require('os.fn');
-goog.require('plugin.file.kml.tour.Wait');
+const AudioManager = goog.require('os.audio.AudioManager');
+const AudioSetting = goog.require('os.audio.AudioSetting');
+const Settings = goog.require('os.config.Settings');
+const Wait = goog.require('plugin.file.kml.tour.Wait');
 
 
 /**
  * Plays an audio file during the tour.
- *
- * @param {string} href The URL to the audio file.
- * @param {number=} opt_delayedStart Delay before playing the file.
- * @extends {plugin.file.kml.tour.Wait}
- * @constructor
  */
-plugin.file.kml.tour.SoundCue = function(href, opt_delayedStart) {
-  plugin.file.kml.tour.SoundCue.base(this, 'constructor', opt_delayedStart || 0);
-  this.isAsync = true;
-
+class SoundCue extends Wait {
   /**
-   * The audio element.
-   * @type {HTMLAudioElement|undefined}
-   * @private
+   * Constructor.
+   * @param {string} href The URL to the audio file.
+   * @param {number=} opt_delayedStart Delay before playing the file.
    */
-  this.audio_ = undefined;
+  constructor(href, opt_delayedStart) {
+    super(opt_delayedStart || 0);
+    this.isAsync = true;
 
-  /**
-   * URL for the audio file.
-   * @type {string}
-   * @private
-   */
-  this.href_ = href;
-};
-goog.inherits(plugin.file.kml.tour.SoundCue, plugin.file.kml.tour.Wait);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.tour.SoundCue.prototype.executeWait = function(opt_resolve, opt_reject) {
-  if (this.audio_) {
-    // audio was already created, so resume playback
-    this.playAudio_();
-  } else {
-    // audio not created yet, wait for the delayed start
-    plugin.file.kml.tour.SoundCue.base(this, 'executeWait', opt_resolve, opt_reject); // .then(os.fn.noop, os.fn.noop);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.tour.SoundCue.prototype.onWaitComplete = function(opt_resolve, opt_reject) {
-  plugin.file.kml.tour.SoundCue.base(this, 'onWaitComplete', opt_resolve, opt_reject);
-
-  // delayed start is complete, start audio playback
-  this.playAudio_();
-};
-
-
-/**
- * Play the audio file.
- *
- * @private
- */
-plugin.file.kml.tour.SoundCue.prototype.playAudio_ = function() {
-  if (!this.audio_) {
-    this.audio_ = /** @type {!HTMLAudioElement} */ (document.createElement('audio'));
-    this.audio_.src = this.href_;
-
-    // respect the global volume mute setting
-    this.updateMute_();
-    os.settings.listen(os.audio.AudioSetting.MUTE, this.updateMute_, false, this);
-  }
-
-  this.audio_.play();
-};
-
-
-/**
- * Handle changes to the global mute setting.
- *
- * @private
- */
-plugin.file.kml.tour.SoundCue.prototype.updateMute_ = function() {
-  if (this.audio_) {
-    var am = os.audio.AudioManager.getInstance();
-    this.audio_.muted = am.getMute();
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.tour.SoundCue.prototype.pause = function() {
-  plugin.file.kml.tour.SoundCue.base(this, 'pause');
-
-  // pause the audio clip, but keep it around in case the tour starts again
-  if (this.audio_) {
-    this.audio_.pause();
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.tour.SoundCue.prototype.reset = function() {
-  plugin.file.kml.tour.SoundCue.base(this, 'reset');
-
-  // stop playback and drop the audio reference
-  if (this.audio_) {
-    os.settings.unlisten(os.audio.AudioSetting.MUTE, this.updateMute_, false, this);
-
-    this.audio_.pause();
+    /**
+     * The audio element.
+     * @type {HTMLAudioElement|undefined}
+     * @private
+     */
     this.audio_ = undefined;
+
+    /**
+     * URL for the audio file.
+     * @type {string}
+     * @private
+     */
+    this.href_ = href;
   }
-};
+
+  /**
+   * @inheritDoc
+   */
+  executeWait(opt_resolve, opt_reject) {
+    if (this.audio_) {
+      // audio was already created, so resume playback
+      this.playAudio_();
+    } else {
+      // audio not created yet, wait for the delayed start
+      super.executeWait(opt_resolve, opt_reject); // .then(os.fn.noop, os.fn.noop);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  onWaitComplete(opt_resolve, opt_reject) {
+    super.onWaitComplete(opt_resolve, opt_reject);
+
+    // delayed start is complete, start audio playback
+    this.playAudio_();
+  }
+
+  /**
+   * Play the audio file.
+   *
+   * @private
+   */
+  playAudio_() {
+    if (!this.audio_) {
+      this.audio_ = /** @type {!HTMLAudioElement} */ (document.createElement('audio'));
+      this.audio_.src = this.href_;
+
+      // respect the global volume mute setting
+      this.updateMute_();
+      Settings.getInstance().listen(AudioSetting.MUTE, this.updateMute_, false, this);
+    }
+
+    this.audio_.play();
+  }
+
+  /**
+   * Handle changes to the global mute setting.
+   *
+   * @private
+   */
+  updateMute_() {
+    if (this.audio_) {
+      var am = AudioManager.getInstance();
+      this.audio_.muted = am.getMute();
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  pause() {
+    super.pause();
+
+    // pause the audio clip, but keep it around in case the tour starts again
+    if (this.audio_) {
+      this.audio_.pause();
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  reset() {
+    super.reset();
+
+    // stop playback and drop the audio reference
+    if (this.audio_) {
+      Settings.getInstance().unlisten(AudioSetting.MUTE, this.updateMute_, false, this);
+
+      this.audio_.pause();
+      this.audio_ = undefined;
+    }
+  }
+}
+
+exports = SoundCue;

--- a/src/plugin/file/kml/tour/tourwait.js
+++ b/src/plugin/file/kml/tour/tourwait.js
@@ -1,152 +1,149 @@
-goog.provide('plugin.file.kml.tour.Wait');
+goog.module('plugin.file.kml.tour.Wait');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Promise');
-goog.require('plugin.file.kml.tour.AbstractTourPrimitive');
+const Promise = goog.require('goog.Promise');
+const AbstractTourPrimitive = goog.require('plugin.file.kml.tour.AbstractTourPrimitive');
 
 
 /**
  * Holds the camera still for a specified amount of time.
- *
- * @param {number} duration How long to wait, in milliseconds.
- * @extends {plugin.file.kml.tour.AbstractTourPrimitive}
- * @constructor
  */
-plugin.file.kml.tour.Wait = function(duration) {
-  plugin.file.kml.tour.Wait.base(this, 'constructor');
-
+class Wait extends AbstractTourPrimitive {
   /**
-   * The wait duration, in milliseconds.
-   * @type {number}
-   * @private
+   * Constructor.
+   * @param {number} duration How long to wait, in milliseconds.
    */
-  this.duration_ = Math.max(duration, 0);
+  constructor(duration) {
+    super();
 
-  /**
-   * Remaining duration on the wait.
-   * @type {number|undefined}
-   * @private
-   */
-  this.remaining_ = undefined;
+    /**
+     * The wait duration, in milliseconds.
+     * @type {number}
+     * @private
+     */
+    this.duration_ = Math.max(duration, 0);
 
-  /**
-   * The last time the wait was started.
-   * @type {number}
-   * @private
-   */
-  this.start_ = 0;
+    /**
+     * Remaining duration on the wait.
+     * @type {number|undefined}
+     * @private
+     */
+    this.remaining_ = undefined;
 
-  /**
-   * The active timeout id.
-   * @type {number|undefined}
-   * @private
-   */
-  this.timeoutId_ = undefined;
-};
-goog.inherits(plugin.file.kml.tour.Wait, plugin.file.kml.tour.AbstractTourPrimitive);
+    /**
+     * The last time the wait was started.
+     * @type {number}
+     * @private
+     */
+    this.start_ = 0;
 
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.tour.Wait.prototype.execute = function() {
-  if (this.isAsync) {
-    // asynchronous primitives should run the timeout routine but resolve immediately
-    this.executeWait();
-    return goog.Promise.resolve();
-  } else {
-    // synchronous primitives should resolve the promise after the timeout completes
-    return new goog.Promise(this.executeWait, this);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.tour.Wait.prototype.pause = function() {
-  if (this.timeoutId_ !== undefined) {
-    // cancel the timeout
-    clearTimeout(this.timeoutId_);
+    /**
+     * The active timeout id.
+     * @type {number|undefined}
+     * @private
+     */
     this.timeoutId_ = undefined;
+  }
 
-    // save how much time is remaining to wait for the next execute call
-    var elapsed = Date.now() - this.start_;
+  /**
+   * @inheritDoc
+   */
+  execute() {
+    if (this.isAsync) {
+      // asynchronous primitives should run the timeout routine but resolve immediately
+      this.executeWait();
+      return Promise.resolve();
+    } else {
+      // synchronous primitives should resolve the promise after the timeout completes
+      return new Promise(this.executeWait, this);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  pause() {
+    if (this.timeoutId_ !== undefined) {
+      // cancel the timeout
+      clearTimeout(this.timeoutId_);
+      this.timeoutId_ = undefined;
+
+      // save how much time is remaining to wait for the next execute call
+      var elapsed = Date.now() - this.start_;
+      var interval = this.getInterval();
+      this.remaining_ = Math.max(interval - elapsed, 0);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  reset() {
+    // cancel the timeout (no-op if already completed)
+    if (this.timeoutId_ !== undefined) {
+      clearTimeout(this.timeoutId_);
+      this.timeoutId_ = undefined;
+    }
+
+    // reset the wait status
+    this.remaining_ = undefined;
+    this.start_ = 0;
+  }
+
+  /**
+   * Get the remaining time on the wait operation.
+   *
+   * @return {number} The remaining wait interval, in milliseconds.
+   * @protected
+   */
+  getInterval() {
+    return this.remaining_ !== undefined ? this.remaining_ : this.duration_;
+  }
+
+  /**
+   * Handle wait completion.
+   *
+   * @param {function()=} opt_resolve The promise resolve function to call when done.
+   * @param {function()=} opt_reject The promise reject function to call on failure.
+   * @protected
+   */
+  executeWait(opt_resolve, opt_reject) {
     var interval = this.getInterval();
-    this.remaining_ = Math.max(interval - elapsed, 0);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.tour.Wait.prototype.reset = function() {
-  // cancel the timeout (no-op if already completed)
-  if (this.timeoutId_ !== undefined) {
-    clearTimeout(this.timeoutId_);
-    this.timeoutId_ = undefined;
+    if (interval > 0) {
+      // start the timeout
+      this.timeoutId_ = setTimeout(this.onWaitComplete.bind(this, opt_resolve, opt_reject), interval);
+      this.start_ = Date.now();
+    } else {
+      // timeout duration 0 or already completed
+      this.onWaitComplete(opt_resolve, opt_reject);
+    }
   }
 
-  // reset the wait status
-  this.remaining_ = undefined;
-  this.start_ = 0;
-};
-
-
-/**
- * Get the remaining time on the wait operation.
- *
- * @return {number} The remaining wait interval, in milliseconds.
- * @protected
- */
-plugin.file.kml.tour.Wait.prototype.getInterval = function() {
-  return this.remaining_ !== undefined ? this.remaining_ : this.duration_;
-};
-
-
-/**
- * Handle wait completion.
- *
- * @param {function()=} opt_resolve The promise resolve function to call when done.
- * @param {function()=} opt_reject The promise reject function to call on failure.
- * @protected
- */
-plugin.file.kml.tour.Wait.prototype.executeWait = function(opt_resolve, opt_reject) {
-  var interval = this.getInterval();
-  if (interval > 0) {
-    // start the timeout
-    this.timeoutId_ = setTimeout(this.onWaitComplete.bind(this, opt_resolve, opt_reject), interval);
-    this.start_ = Date.now();
-  } else {
-    // timeout duration 0 or already completed
-    this.onWaitComplete(opt_resolve, opt_reject);
+  /**
+   * If the wait is currently active.
+   *
+   * @return {boolean}
+   * @protected
+   */
+  isWaitActive() {
+    return this.timeoutId_ !== undefined;
   }
-};
 
+  /**
+   * Handle wait completion.
+   *
+   * @param {function()=} opt_resolve The promise resolve function to call when done.
+   * @param {function()=} opt_reject The promise reject function to call on failure.
+   * @protected
+   */
+  onWaitComplete(opt_resolve, opt_reject) {
+    // reset everything and resolve the promise
+    this.reset();
 
-/**
- * If the wait is currently active.
- *
- * @return {boolean}
- * @protected
- */
-plugin.file.kml.tour.Wait.prototype.isWaitActive = function() {
-  return this.timeoutId_ !== undefined;
-};
-
-
-/**
- * Handle wait completion.
- *
- * @param {function()=} opt_resolve The promise resolve function to call when done.
- * @param {function()=} opt_reject The promise reject function to call on failure.
- * @protected
- */
-plugin.file.kml.tour.Wait.prototype.onWaitComplete = function(opt_resolve, opt_reject) {
-  // reset everything and resolve the promise
-  this.reset();
-
-  if (opt_resolve) {
-    opt_resolve();
+    if (opt_resolve) {
+      opt_resolve();
+    }
   }
-};
+}
+
+exports = Wait;

--- a/src/plugin/file/kml/ui/geometryicons.js
+++ b/src/plugin/file/kml/ui/geometryicons.js
@@ -1,12 +1,12 @@
-goog.provide('plugin.file.kml.ui.GeometryIcons');
-goog.provide('plugin.file.kml.ui.NetworkLinkIcons');
+goog.module('plugin.file.kml.ui.GeometryIcons');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * KML geometry icons. This is intentionally not an enum so the keys map to {@link ol.geom.GeometryType} values.
  * @type {Object.<string, string>}
  */
-plugin.file.kml.ui.GeometryIcons = {
+exports = {
   'Circle': '<i class="fa fa-circle-o fa-fw compact" title="Circle Geometry"></i>',
   'GeometryCollection': '<i class="fa fa-picture-o fa-fw compact" title="Geometry Collection"></i>',
   'LineString': '<i class="fa fa-share-alt fa-fw compact" title="Line String Geometry"></i>',
@@ -16,16 +16,4 @@ plugin.file.kml.ui.GeometryIcons = {
   'MultiPolygon': '<i class="fa fa-bullseye fa-fw compact" title="Multi Polygon Geometry"></i>',
   'Point': '<i class="fa fa-circle fa-fw compact" title="Point Geometry"></i>',
   'Polygon': '<i class="fa fa-star-o fa-fw compact" title="Polygon Geometry"></i>'
-};
-
-
-/**
- * KML network link icons.
- * @enum {string}
- */
-plugin.file.kml.ui.NetworkLinkIcons = {
-  ACTIVE: '<i class="fa fa-link fa-fw compact text-success" title="KML network link"></i>',
-  ERROR: '<i class="fa fa-unlink fa-fw compact text-danger" title="Unable to load network link"></i>',
-  INACTIVE: '<i class="fa fa-link fa-fw compact" title="KML network link - enable to load"></i>',
-  LOADING: '<i class="fa fa-link fa-fw compact text-warning" title="Loading network link..."></i>'
 };

--- a/src/plugin/file/kml/ui/kmlexportui.js
+++ b/src/plugin/file/kml/ui/kmlexportui.js
@@ -1,11 +1,13 @@
-goog.provide('plugin.file.kml.ui.KMLExportCtrl');
-goog.provide('plugin.file.kml.ui.kmlExportDirective');
+goog.module('plugin.file.kml.ui.KMLExportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os');
-goog.require('os.ui.Module');
-goog.require('os.ui.file.kml');
-goog.require('os.ui.icon.IconPickerCtrl');
 goog.require('os.ui.icon.iconPickerDirective');
+
+const {ROOT} = goog.require('os');
+const Module = goog.require('os.ui.Module');
+const kml = goog.require('os.ui.file.kml');
+
+const AbstractKMLExporter = goog.requireType('os.ui.file.kml.AbstractKMLExporter');
 
 
 /**
@@ -13,134 +15,148 @@ goog.require('os.ui.icon.iconPickerDirective');
  *
  * @return {angular.Directive}
  */
-plugin.file.kml.ui.kmlExportDirective = function() {
-  return {
-    restrict: 'E',
-    scope: {
-      'exporter': '=',
-      'simple': '=?'
-    },
-    templateUrl: os.ROOT + 'views/plugin/kml/kmlexport.html',
-    controller: plugin.file.kml.ui.KMLExportCtrl,
-    controllerAs: 'kmlexport'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+
+  scope: {
+    'exporter': '=',
+    'simple': '=?'
+  },
+
+  templateUrl: ROOT + 'views/plugin/kml/kmlexport.html',
+  controller: Controller,
+  controllerAs: 'kmlexport'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'kmlexport';
 
 
 /**
  * Add the directive to the module.
  */
-os.ui.Module.directive('kmlexport', [plugin.file.kml.ui.kmlExportDirective]);
+Module.directive('kmlexport', [directive]);
 
 
 
 /**
  * Controller function for the kmlexport directive
- *
- * @param {!angular.Scope} $scope
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.file.kml.ui.KMLExportCtrl = function($scope) {
+class Controller {
   /**
-   * @type {?angular.Scope}
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @ngInject
+   */
+  constructor($scope) {
+    /**
+     * @type {?angular.Scope}
+     * @private
+     */
+    this.scope_ = $scope;
+
+    /**
+     * @type {AbstractKMLExporter}
+     * @private
+     */
+    this.exporter_ = /** @type {AbstractKMLExporter} */ ($scope['exporter']);
+
+    /**
+     * @type {!osx.icon.Icon}
+     */
+    this['icon'] = /** @type {!osx.icon.Icon} */ ({// kml.Icon to osx.icon.Icon
+      path: this.exporter_.getDefaultIcon() ? this.exporter_.getDefaultIcon().href : kml.getDefaultIcon().path,
+      options: this.exporter_.getDefaultIcon() ?
+        this.exporter_.getDefaultIcon().options : kml.getDefaultIcon().options
+    });
+
+    /**
+     * @type {boolean}
+     */
+    this['useItemColor'] = this.exporter_.getUseItemColor();
+
+    /**
+     * @type {boolean}
+     */
+    this['useItemIcon'] = this.exporter_.getUseItemIcon();
+
+    /**
+     * @type {boolean}
+     */
+    this['compress'] = this.exporter_.getCompress();
+
+    /**
+     * @type {boolean}
+     */
+    this['exportEllipses'] = this.exporter_.getExportEllipses();
+
+    /**
+     * @type {boolean}
+     */
+    this['useCenterPoint'] = this.exporter_.getUseCenterPoint();
+
+    /**
+     * Icons available to the icon picker.
+     * @type {!Array<!osx.icon.Icon>}
+     */
+    this['iconSet'] = kml.GOOGLE_EARTH_ICON_SET;
+
+    /**
+     * Function to translate image sources from the icon set.
+     * @type {function(string):string}
+     */
+    this['iconSrc'] = kml.replaceGoogleUri;
+
+    $scope.$watch('kmlexport.icon.path', this.updateExporter_.bind(this));
+    $scope.$watch('kmlexport.useItemColor', this.updateExporter_.bind(this));
+    $scope.$watch('kmlexport.useItemIcon', this.updateExporter_.bind(this));
+    $scope.$watch('kmlexport.compress', this.updateExporter_.bind(this));
+    $scope.$watch('kmlexport.exportEllipses', this.updateExporter_.bind(this));
+    $scope.$watch('kmlexport.useCenterPoint', this.updateExporter_.bind(this));
+    $scope.$on('$destroy', this.destroy_.bind(this));
+
+    this.updateExporter_();
+  }
+
+  /**
+   * Clean up.
+   *
    * @private
    */
-  this.scope_ = $scope;
+  destroy_() {
+    this.scope_ = null;
+    this.exporter_ = null;
+  }
 
   /**
-   * @type {os.ui.file.kml.AbstractKMLExporter}
+   * Updates the KML exporter with the current UI configuration.
+   *
    * @private
    */
-  this.exporter_ = /** @type {os.ui.file.kml.AbstractKMLExporter} */ ($scope['exporter']);
-
-  /**
-   * @type {!osx.icon.Icon}
-   */
-  this['icon'] = /** @type {!osx.icon.Icon} */ ({// os.ui.file.kml.Icon to osx.icon.Icon
-    path: this.exporter_.getDefaultIcon() ? this.exporter_.getDefaultIcon().href : os.ui.file.kml.getDefaultIcon().path,
-    options: this.exporter_.getDefaultIcon() ?
-      this.exporter_.getDefaultIcon().options : os.ui.file.kml.getDefaultIcon().options
-  });
-
-  /**
-   * @type {boolean}
-   */
-  this['useItemColor'] = this.exporter_.getUseItemColor();
-
-  /**
-   * @type {boolean}
-   */
-  this['useItemIcon'] = this.exporter_.getUseItemIcon();
-
-  /**
-   * @type {boolean}
-   */
-  this['compress'] = this.exporter_.getCompress();
-
-  /**
-   * @type {boolean}
-   */
-  this['exportEllipses'] = this.exporter_.getExportEllipses();
-
-  /**
-   * @type {boolean}
-   */
-  this['useCenterPoint'] = this.exporter_.getUseCenterPoint();
-
-  /**
-   * Icons available to the icon picker.
-   * @type {!Array<!osx.icon.Icon>}
-   */
-  this['iconSet'] = os.ui.file.kml.GOOGLE_EARTH_ICON_SET;
-
-  /**
-   * Function to translate image sources from the icon set.
-   * @type {function(string):string}
-   */
-  this['iconSrc'] = os.ui.file.kml.replaceGoogleUri;
-
-  $scope.$watch('kmlexport.icon.path', this.updateExporter_.bind(this));
-  $scope.$watch('kmlexport.useItemColor', this.updateExporter_.bind(this));
-  $scope.$watch('kmlexport.useItemIcon', this.updateExporter_.bind(this));
-  $scope.$watch('kmlexport.compress', this.updateExporter_.bind(this));
-  $scope.$watch('kmlexport.exportEllipses', this.updateExporter_.bind(this));
-  $scope.$watch('kmlexport.useCenterPoint', this.updateExporter_.bind(this));
-  $scope.$on('$destroy', this.destroy_.bind(this));
-
-  this.updateExporter_();
-};
-
-
-/**
- * Clean up.
- *
- * @private
- */
-plugin.file.kml.ui.KMLExportCtrl.prototype.destroy_ = function() {
-  this.scope_ = null;
-  this.exporter_ = null;
-};
-
-
-/**
- * Updates the KML exporter with the current UI configuration.
- *
- * @private
- */
-plugin.file.kml.ui.KMLExportCtrl.prototype.updateExporter_ = function() {
-  if (this.exporter_ && this.scope_) {
-    this.exporter_.setUseItemColor(this['useItemColor']);
-    this.exporter_.setUseItemIcon(this['useItemIcon']);
-    this.exporter_.setCompress(this['compress']);
-    this.exporter_.setExportEllipses(this['exportEllipses']);
-    this.exporter_.setUseCenterPoint(this['useCenterPoint']);
-    if (this['icon']) {
-      var kmlIcon = {// osx.icon.Icon to os.ui.file.kml.Icon
-        'href': os.ui.file.kml.exportableIconUri(this['icon']['path']),
-        'options': this['icon']['options']
-      };
-      this.exporter_.setIcon(kmlIcon);
+  updateExporter_() {
+    if (this.exporter_ && this.scope_) {
+      this.exporter_.setUseItemColor(this['useItemColor']);
+      this.exporter_.setUseItemIcon(this['useItemIcon']);
+      this.exporter_.setCompress(this['compress']);
+      this.exporter_.setExportEllipses(this['exportEllipses']);
+      this.exporter_.setUseCenterPoint(this['useCenterPoint']);
+      if (this['icon']) {
+        var kmlIcon = {// osx.icon.Icon to kml.Icon
+          'href': kml.exportableIconUri(this['icon']['path']),
+          'options': this['icon']['options']
+        };
+        this.exporter_.setIcon(kmlIcon);
+      }
     }
   }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/file/kml/ui/kmlimport.js
+++ b/src/plugin/file/kml/ui/kmlimport.js
@@ -1,11 +1,12 @@
-goog.provide('plugin.file.kml.ui.KMLImportCtrl');
-goog.provide('plugin.file.kml.ui.kmlImportDirective');
+goog.module('plugin.file.kml.ui.KMLImport');
+goog.module.declareLegacyNamespace();
 
-goog.require('os');
-goog.require('os.ui.Module');
-goog.require('os.ui.file.ui.AbstractFileImportCtrl');
-goog.require('plugin.file.kml.KMLDescriptor');
-goog.require('plugin.file.kml.KMLProvider');
+const {ROOT} = goog.require('os');
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const Module = goog.require('os.ui.Module');
+const AbstractFileImportCtrl = goog.require('os.ui.file.ui.AbstractFileImportCtrl');
+const KMLDescriptor = goog.require('plugin.file.kml.KMLDescriptor');
+const KMLProvider = goog.require('plugin.file.kml.KMLProvider');
 
 
 /**
@@ -13,61 +14,74 @@ goog.require('plugin.file.kml.KMLProvider');
  *
  * @return {angular.Directive}
  */
-plugin.file.kml.ui.kmlImportDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    scope: true,
-    templateUrl: os.ROOT + 'views/file/genericfileimport.html',
-    controller: plugin.file.kml.ui.KMLImportCtrl,
-    controllerAs: 'ctrl'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  scope: true,
+  templateUrl: ROOT + 'views/file/genericfileimport.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'kmlimport';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('kmlimport', [plugin.file.kml.ui.kmlImportDirective]);
+Module.directive('kmlimport', [directive]);
 
 
 
 /**
  * Controller for the KML import dialog
  *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @extends {os.ui.file.ui.AbstractFileImportCtrl<!os.parse.FileParserConfig,!plugin.file.kml.KMLDescriptor>}
- * @constructor
- * @ngInject
+ * @extends {AbstractFileImportCtrl<!os.parse.FileParserConfig,!KMLDescriptor>}
+ * @unrestricted
  */
-plugin.file.kml.ui.KMLImportCtrl = function($scope, $element) {
-  plugin.file.kml.ui.KMLImportCtrl.base(this, 'constructor', $scope, $element);
-};
-goog.inherits(plugin.file.kml.ui.KMLImportCtrl, os.ui.file.ui.AbstractFileImportCtrl);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLImportCtrl.prototype.createDescriptor = function() {
-  var descriptor = null;
-  if (this.config['descriptor']) {
-    // existing descriptor, update it
-    descriptor = /** @type {!plugin.file.kml.KMLDescriptor} */ (this.config['descriptor']);
-    descriptor.updateFromConfig(this.config);
-  } else {
-    // this is a new import
-    descriptor = plugin.file.kml.KMLDescriptor.createFromConfig(this.config);
+class Controller extends AbstractFileImportCtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    super($scope, $element);
   }
 
-  return descriptor;
-};
+  /**
+   * @inheritDoc
+   */
+  createDescriptor() {
+    var descriptor = null;
+    if (this.config['descriptor']) {
+      // existing descriptor, update it
+      descriptor = /** @type {!KMLDescriptor} */ (this.config['descriptor']);
+      descriptor.updateFromConfig(this.config);
+    } else {
+      // this is a new import
+      descriptor = new KMLDescriptor();
+      FileDescriptor.createFromConfig(descriptor, KMLProvider.getInstance(), this.config);
+    }
 
+    return descriptor;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLImportCtrl.prototype.getProvider = function() {
-  return plugin.file.kml.KMLProvider.getInstance();
+  /**
+   * @inheritDoc
+   */
+  getProvider() {
+    return KMLProvider.getInstance();
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/file/kml/ui/kmlimportui.js
+++ b/src/plugin/file/kml/ui/kmlimportui.js
@@ -1,86 +1,91 @@
-goog.provide('plugin.file.kml.ui.KMLImportUI');
+goog.module('plugin.file.kml.ui.KMLImportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.DataManager');
-goog.require('os.parse.FileParserConfig');
-goog.require('os.ui.im.FileImportUI');
-goog.require('os.ui.window');
-goog.require('plugin.file.kml.KMLDescriptor');
-goog.require('plugin.file.kml.KMLProvider');
-goog.require('plugin.file.kml.ui.kmlImportDirective');
-
-
-
-/**
- * @extends {os.ui.im.FileImportUI}
- * @constructor
- */
-plugin.file.kml.ui.KMLImportUI = function() {
-  plugin.file.kml.ui.KMLImportUI.base(this, 'constructor');
-};
-goog.inherits(plugin.file.kml.ui.KMLImportUI, os.ui.im.FileImportUI);
+const DataManager = goog.require('os.data.DataManager');
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const FileParserConfig = goog.require('os.parse.FileParserConfig');
+const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const osWindow = goog.require('os.ui.window');
+const KMLDescriptor = goog.require('plugin.file.kml.KMLDescriptor');
+const KMLProvider = goog.require('plugin.file.kml.KMLProvider');
+const {directiveTag: importEl} = goog.require('plugin.file.kml.ui.KMLImport');
 
 
 /**
- * @inheritDoc
  */
-plugin.file.kml.ui.KMLImportUI.prototype.getTitle = function() {
-  return 'KML';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLImportUI.prototype.launchUI = function(file, opt_config) {
-  plugin.file.kml.ui.KMLImportUI.base(this, 'launchUI', file, opt_config);
-
-  var config = new os.parse.FileParserConfig();
-
-  // if an existing config was provided, merge it in
-  if (opt_config) {
-    this.mergeConfig(opt_config, config);
+class KMLImportUI extends FileImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
 
-  config['file'] = file;
-  config['title'] = file.getFileName();
-
-  if (opt_config && opt_config['defaultImport']) {
-    this.handleDefaultImport(file, config);
-    return;
+  /**
+   * @inheritDoc
+   */
+  getTitle() {
+    return 'KML';
   }
 
-  var scopeOptions = {
-    'config': config
-  };
-  var windowOptions = {
-    'label': 'Import KML',
-    'icon': 'fa fa-file-text',
-    'x': 'center',
-    'y': 'center',
-    'width': 400,
-    'min-width': 400,
-    'max-width': 800,
-    'height': 'auto',
-    'modal': true,
-    'show-close': true
-  };
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    super.launchUI(file, opt_config);
 
-  var template = '<kmlimport></kmlimport>';
-  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
-};
+    var config = new FileParserConfig();
 
+    // if an existing config was provided, merge it in
+    if (opt_config) {
+      this.mergeConfig(opt_config, config);
+    }
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLImportUI.prototype.handleDefaultImport = function(file, config) {
-  config = this.getDefaultConfig(file, config);
+    config['file'] = file;
+    config['title'] = file.getFileName();
 
-  // create the descriptor and add it
-  if (config) {
-    const descriptor = plugin.file.kml.KMLDescriptor.createFromConfig(config);
-    plugin.file.kml.KMLProvider.getInstance().addDescriptor(descriptor);
-    os.data.DataManager.getInstance().addDescriptor(descriptor);
-    descriptor.setActive(true);
+    if (opt_config && opt_config['defaultImport']) {
+      this.handleDefaultImport(file, config);
+      return;
+    }
+
+    var scopeOptions = {
+      'config': config
+    };
+    var windowOptions = {
+      'label': 'Import KML',
+      'icon': 'fa fa-file-text',
+      'x': 'center',
+      'y': 'center',
+      'width': 400,
+      'min-width': 400,
+      'max-width': 800,
+      'height': 'auto',
+      'modal': true,
+      'show-close': true
+    };
+
+    var template = `<${importEl}></${importEl}>`;
+    osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
   }
-};
+
+  /**
+   * @inheritDoc
+   */
+  handleDefaultImport(file, config) {
+    config = this.getDefaultConfig(file, config);
+
+    // create the descriptor and add it
+    if (config) {
+      const provider = KMLProvider.getInstance();
+      const descriptor = new KMLDescriptor();
+      FileDescriptor.createFromConfig(descriptor, provider, config);
+
+      provider.addDescriptor(descriptor);
+      DataManager.getInstance().addDescriptor(descriptor);
+      descriptor.setActive(true);
+    }
+  }
+}
+
+exports = KMLImportUI;

--- a/src/plugin/file/kml/ui/kmlnetworklinknode.js
+++ b/src/plugin/file/kml/ui/kmlnetworklinknode.js
@@ -1,602 +1,582 @@
-goog.provide('plugin.file.kml.ui.KMLNetworkLinkNode');
+goog.module('plugin.file.kml.ui.KMLNetworkLinkNode');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Uri');
-goog.require('goog.async.Delay');
-goog.require('goog.log');
-goog.require('goog.log.Logger');
-goog.require('goog.net.EventType');
-goog.require('goog.net.XhrIo.ResponseType');
-goog.require('goog.userAgent');
-goog.require('ol.events');
-goog.require('os.alert.AlertEventSeverity');
-goog.require('os.alert.AlertManager');
-goog.require('os.events.PropertyChangeEvent');
-goog.require('os.net');
-goog.require('os.net.Request');
-goog.require('os.structs.TriState');
-goog.require('os.ui.file.kml');
-goog.require('plugin.file.kml.KMLImporter');
-goog.require('plugin.file.kml.KMLSourceEvent');
-goog.require('plugin.file.kml.ui.KMLNode');
-goog.require('plugin.file.kml.ui.NetworkLinkIcons');
+const Delay = goog.require('goog.async.Delay');
+const dispose = goog.require('goog.dispose');
+const log = goog.require('goog.log');
+const EventType = goog.require('goog.net.EventType');
+const ResponseType = goog.require('goog.net.XhrIo.ResponseType');
+const userAgent = goog.require('goog.userAgent');
+const events = goog.require('ol.events');
+const MapContainer = goog.require('os.MapContainer');
+const MapEvent = goog.require('os.MapEvent');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const AlertManager = goog.require('os.alert.AlertManager');
+const osEventsEventType = goog.require('os.events.EventType');
+const PropertyChangeEvent = goog.require('os.events.PropertyChangeEvent');
+const net = goog.require('os.net');
+const Request = goog.require('os.net.Request');
+const TriState = goog.require('os.structs.TriState');
+const osThreadEventType = goog.require('os.thread.EventType');
+const time = goog.require('os.time');
+const kml = goog.require('os.ui.file.kml');
+const KMLSourceEvent = goog.require('plugin.file.kml.KMLSourceEvent');
+const KMLNode = goog.require('plugin.file.kml.ui.KMLNode');
+const NetworkLinkIcons = goog.require('plugin.file.kml.ui.NetworkLinkIcons');
 
+const Logger = goog.requireType('goog.log.Logger');
+const KMLImporter = goog.requireType('plugin.file.kml.KMLImporter');
 
 
 /**
  * Tree node for KML network links
- *
- * @param {string} uri The network link URI
- * @extends {plugin.file.kml.ui.KMLNode}
- * @constructor
  */
-plugin.file.kml.ui.KMLNetworkLinkNode = function(uri) {
-  plugin.file.kml.ui.KMLNetworkLinkNode.base(this, 'constructor');
-  this.checkboxTooltip = 'Enable/disable the network link';
-
-  // Don't bubble child state up to the network link, or disabling children will unload the link.
-  this.setBubbleState(false);
-
-  // Network links should default to being turned off.
-  this.setState(os.structs.TriState.OFF);
-
+class KMLNetworkLinkNode extends KMLNode {
   /**
-   * @type {goog.log.Logger}
-   * @protected
+   * Constructor.
+   * @param {string} uri The network link URI
    */
-  this.log = plugin.file.kml.ui.KMLNetworkLinkNode.LOGGER_;
+  constructor(uri) {
+    super();
+    this.checkboxTooltip = 'Enable/disable the network link';
 
-  /**
-   * @type {number}
-   * @private
-   */
-  this.durationStart_ = 0;
+    // Don't bubble child state up to the network link, or disabling children will unload the link.
+    this.setBubbleState(false);
 
-  /**
-   * The icon displayed on the node UI
-   * @type {!plugin.file.kml.ui.NetworkLinkIcons}
-   * @private
-   */
-  this.icon_ = plugin.file.kml.ui.NetworkLinkIcons.INACTIVE;
+    // Network links should default to being turned off.
+    this.setState(TriState.OFF);
 
-  /**
-   * The network link importer
-   * @type {plugin.file.kml.KMLImporter}
-   * @private
-   */
-  this.importer_ = null;
+    /**
+     * @type {Logger}
+     * @protected
+     */
+    this.log = logger;
 
-  /**
-   * The network link request
-   * @type {os.net.Request}
-   * @private
-   */
-  this.request_ = null;
+    /**
+     * @type {number}
+     * @private
+     */
+    this.durationStart_ = 0;
 
-  /**
-   * How often the network link will refresh in milliseconds. Default value (4 seconds) provided by the KML spec.
-   * @type {number}
-   * @private
-   */
-  this.refreshInterval_ = 4000;
+    /**
+     * The icon displayed on the node UI
+     * @type {!NetworkLinkIcons}
+     * @private
+     */
+    this.icon_ = NetworkLinkIcons.INACTIVE;
 
-  /**
-   * The minimum network link refresh in milliseconds - defined by the NetworkLinkControl
-   * @type {number}
-   * @private
-   */
-  this.minRefreshPeriod_ = 0;
+    /**
+     * The network link importer
+     * @type {KMLImporter}
+     * @private
+     */
+    this.importer_ = null;
 
-  /**
-   * The refresh mode for the network link
-   * @type {os.ui.file.kml.RefreshMode}
-   * @private
-   */
-  this.refreshMode_ = os.ui.file.kml.RefreshMode.CHANGE;
+    /**
+     * The network link request
+     * @type {Request}
+     * @private
+     */
+    this.request_ = null;
 
-  /**
-   * The network link refresh timer
-   * @type {goog.async.Delay}
-   * @private
-   */
-  this.refreshTimer_ = null;
+    /**
+     * How often the network link will refresh in milliseconds. Default value (4 seconds) provided by the KML spec.
+     * @type {number}
+     * @private
+     */
+    this.refreshInterval_ = 4000;
 
-  /**
-   * How often the network link will refresh in milliseconds.
-   * @type {number}
-   * @private
-   */
-  this.viewRefreshInterval_ = 4000;
+    /**
+     * The minimum network link refresh in milliseconds - defined by the NetworkLinkControl
+     * @type {number}
+     * @private
+     */
+    this.minRefreshPeriod_ = 0;
 
-  /**
-   * The view refresh mode for the network link.
-   * @type {os.ui.file.kml.ViewRefreshMode}
-   * @private
-   */
-  this.viewRefreshMode_ = os.ui.file.kml.ViewRefreshMode.NEVER;
+    /**
+     * The refresh mode for the network link
+     * @type {kml.RefreshMode}
+     * @private
+     */
+    this.refreshMode_ = kml.RefreshMode.CHANGE;
 
-  /**
-   * The view refresh timer.
-   * @type {goog.async.Delay}
-   * @private
-   */
-  this.viewRefreshTimer_ = null;
+    /**
+     * The network link refresh timer
+     * @type {Delay}
+     * @private
+     */
+    this.refreshTimer_ = null;
 
-  /**
-   * The network link URI
-   * @type {string}
-   * @private
-   */
-  this.uri_ = uri;
+    /**
+     * How often the network link will refresh in milliseconds.
+     * @type {number}
+     * @private
+     */
+    this.viewRefreshInterval_ = 4000;
 
-  this.updateRefreshTimer_();
-};
-goog.inherits(plugin.file.kml.ui.KMLNetworkLinkNode, plugin.file.kml.ui.KMLNode);
+    /**
+     * The view refresh mode for the network link.
+     * @type {kml.ViewRefreshMode}
+     * @private
+     */
+    this.viewRefreshMode_ = kml.ViewRefreshMode.NEVER;
 
-
-/**
- * Logger
- * @type {goog.log.Logger}
- * @private
- * @const
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.LOGGER_ = goog.log.getLogger('plugin.file.kml.ui.KMLNetworkLinkNode');
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.disposeInternal = function() {
-  plugin.file.kml.ui.KMLNetworkLinkNode.base(this, 'disposeInternal');
-
-  os.MapContainer.getInstance().unlisten(os.MapEvent.VIEW_CHANGE, this.onViewChange_, false, this);
-  goog.dispose(this.importer_);
-  goog.dispose(this.request_);
-  goog.dispose(this.refreshTimer_);
-  goog.dispose(this.viewRefreshTimer_);
-};
-
-
-/**
- * Clear the network link's features from the source.
- *
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.clear_ = function() {
-  if (this.source) {
-    this.source.clearNode(this);
-    this.setChildren(null);
-  }
-};
-
-
-/**
- * Gets a string representing the duration from the last time durationStart_ was set. Resets durationStart_ for
- * subsequent calls in the same request sequence.
- *
- * @return {string}
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.durationString_ = function() {
-  var now = Date.now();
-  var duration = new Date(now - this.durationStart_);
-  var durationString = ' in ' + os.time.formatDate(duration, 'mm:ss.SSS');
-  this.durationStart_ = now;
-
-  return durationString;
-};
-
-
-/**
- * Displays an error message and disables the node.
- *
- * @param {string} msg The error message
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.handleError_ = function(msg) {
-  var errorMsg = 'Unable to load KML network link "' + this.getLabel() + '"' + this.urlLogString_() + ': ' + msg;
-  goog.log.error(this.log, errorMsg);
-  os.alert.AlertManager.getInstance().sendAlert(errorMsg, os.alert.AlertEventSeverity.ERROR);
-  this.setState(os.structs.TriState.OFF);
-  this.setIcon_(plugin.file.kml.ui.NetworkLinkIcons.ERROR);
-  this.setLoading(false);
-};
-
-
-/**
- * Gets a string representing the URL for the source request.
- *
- * @return {string}
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.urlLogString_ = function() {
-  return ' (' + this.uri_ + ')';
-};
-
-
-/**
- * Get the refresh interval for the network link.
- *
- * @return {number}
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.getRefreshInterval = function() {
-  return this.refreshMode_ == os.ui.file.kml.RefreshMode.INTERVAL ? this.refreshInterval_ : 0;
-};
-
-
-/**
- * Set the refresh interval for the network link. If {@link refreshMode} is set to
- * {@link os.ui.file.kml.RefreshMode.INTERVAL}, the network link will be refreshed after the provided amount of time.
- * The timer will not be started until data import has completed.
- *
- * @param {number} value The refresh interval in milliseconds, or zero to prevent automatic refresh
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.setRefreshInterval = function(value) {
-  // value should always be positive - negative values will prevent refresh
-  this.refreshInterval_ = Math.max(value, this.minRefreshPeriod_);
-  this.updateRefreshTimer_();
-};
-
-
-/**
- * Set the minimum refresh interval for the network link.
- *
- * @param {number} value The minimum refresh interval in milliseconds, or zero to prevent automatic refresh
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.setMinRefreshPeriod = function(value) {
-  // value should always be positive - negative values will prevent refresh
-  this.minRefreshPeriod_ = Math.max(value, 0);
-  this.setRefreshInterval(this.refreshInterval_); // update the refresh interval, if needed
-};
-
-
-/**
- * Get the refresh mode for the network link.
- *
- * @return {os.ui.file.kml.RefreshMode}
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.getRefreshMode = function() {
-  return this.refreshMode_;
-};
-
-
-/**
- * Set the refresh mode for the network link.
- *
- * @param {os.ui.file.kml.RefreshMode} value
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.setRefreshMode = function(value) {
-  this.refreshMode_ = value;
-  this.updateRefreshTimer_();
-};
-
-
-/**
- * Updates the refresh timer based on the current refresh mode/interval.
- *
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.updateRefreshTimer_ = function() {
-  var active = false;
-  if (this.refreshTimer_) {
-    active = this.refreshTimer_.isActive();
-    this.refreshTimer_.dispose();
-  }
-
-  this.refreshTimer_ = new goog.async.Delay(this.onRefreshTimer_, this.getRefreshInterval(), this);
-  if (active) {
-    this.refreshTimer_.start();
-  }
-};
-
-
-/**
- * Get the view refresh mode.
- *
- * @return {os.ui.file.kml.ViewRefreshMode}
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.getViewRefreshMode = function() {
-  return this.viewRefreshMode_;
-};
-
-
-/**
- * Set the view refresh mode.
- *
- * @param {os.ui.file.kml.ViewRefreshMode} value
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.setViewRefreshMode = function(value) {
-  this.viewRefreshMode_ = value;
-};
-
-
-/**
- * Set the view refresh interval for the network link. If {@link viewRefreshMode} is set to
- * {@link os.ui.file.kml.ViewRefreshMode.STOP}, the link refreshes this many milliseconds after the camera stops moving.
- *
- * @param {number} value The refresh timer in seconds, or zero to prevent automatic refresh
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.setViewRefreshTimer = function(value) {
-  // value should always be positive - negative values will prevent refresh
-  this.viewRefreshInterval_ = Math.max(value, 0);
-  this.updateViewRefreshTimer_();
-};
-
-
-/**
- * Updates the view refresh timer.
- *
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.updateViewRefreshTimer_ = function() {
-  goog.dispose(this.viewRefreshTimer_);
-
-  if (this.viewRefreshInterval_) {
-    os.MapContainer.getInstance().listen(os.MapEvent.VIEW_CHANGE, this.onViewChange_, false, this);
-    this.viewRefreshTimer_ = new goog.async.Delay(this.onRefreshTimer_, this.viewRefreshInterval_, this);
-  } else {
-    os.MapContainer.getInstance().unlisten(os.MapEvent.VIEW_CHANGE, this.onViewChange_, false, this);
+    /**
+     * The view refresh timer.
+     * @type {Delay}
+     * @private
+     */
     this.viewRefreshTimer_ = null;
+
+    /**
+     * The network link URI
+     * @type {string}
+     * @private
+     */
+    this.uri_ = uri;
+
+    this.updateRefreshTimer_();
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
 
-/**
- * Handles changes to the view.
- *
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.onViewChange_ = function() {
-  if (this.viewRefreshTimer_ && this.getState() != os.structs.TriState.OFF) {
-    if (this.isLoading() && this.request_) {
-      // cancel the pending request
-      this.request_.abort();
+    MapContainer.getInstance().unlisten(MapEvent.VIEW_CHANGE, this.onViewChange_, false, this);
+    dispose(this.importer_);
+    dispose(this.request_);
+    dispose(this.refreshTimer_);
+    dispose(this.viewRefreshTimer_);
+  }
+
+  /**
+   * Clear the network link's features from the source.
+   *
+   * @private
+   */
+  clear_() {
+    if (this.source) {
+      this.source.clearNode(this);
+      this.setChildren(null);
+    }
+  }
+
+  /**
+   * Gets a string representing the duration from the last time durationStart_ was set. Resets durationStart_ for
+   * subsequent calls in the same request sequence.
+   *
+   * @return {string}
+   * @private
+   */
+  durationString_() {
+    var now = Date.now();
+    var duration = new Date(now - this.durationStart_);
+    var durationString = ' in ' + time.formatDate(duration, 'mm:ss.SSS');
+    this.durationStart_ = now;
+
+    return durationString;
+  }
+
+  /**
+   * Displays an error message and disables the node.
+   *
+   * @param {string} msg The error message
+   * @private
+   */
+  handleError_(msg) {
+    var errorMsg = 'Unable to load KML network link "' + this.getLabel() + '"' + this.urlLogString_() + ': ' + msg;
+    log.error(this.log, errorMsg);
+    AlertManager.getInstance().sendAlert(errorMsg, AlertEventSeverity.ERROR);
+    this.setState(TriState.OFF);
+    this.setIcon_(NetworkLinkIcons.ERROR);
+    this.setLoading(false);
+  }
+
+  /**
+   * Gets a string representing the URL for the source request.
+   *
+   * @return {string}
+   * @private
+   */
+  urlLogString_() {
+    return ' (' + this.uri_ + ')';
+  }
+
+  /**
+   * Get the refresh interval for the network link.
+   *
+   * @return {number}
+   */
+  getRefreshInterval() {
+    return this.refreshMode_ == kml.RefreshMode.INTERVAL ? this.refreshInterval_ : 0;
+  }
+
+  /**
+   * Set the refresh interval for the network link. If {@link refreshMode} is set to
+   * {@link kml.RefreshMode.INTERVAL}, the network link will be refreshed after the provided amount of time.
+   * The timer will not be started until data import has completed.
+   *
+   * @param {number} value The refresh interval in milliseconds, or zero to prevent automatic refresh
+   */
+  setRefreshInterval(value) {
+    // value should always be positive - negative values will prevent refresh
+    this.refreshInterval_ = Math.max(value, this.minRefreshPeriod_);
+    this.updateRefreshTimer_();
+  }
+
+  /**
+   * Set the minimum refresh interval for the network link.
+   *
+   * @param {number} value The minimum refresh interval in milliseconds, or zero to prevent automatic refresh
+   */
+  setMinRefreshPeriod(value) {
+    // value should always be positive - negative values will prevent refresh
+    this.minRefreshPeriod_ = Math.max(value, 0);
+    this.setRefreshInterval(this.refreshInterval_); // update the refresh interval, if needed
+  }
+
+  /**
+   * Get the refresh mode for the network link.
+   *
+   * @return {kml.RefreshMode}
+   */
+  getRefreshMode() {
+    return this.refreshMode_;
+  }
+
+  /**
+   * Set the refresh mode for the network link.
+   *
+   * @param {kml.RefreshMode} value
+   */
+  setRefreshMode(value) {
+    this.refreshMode_ = value;
+    this.updateRefreshTimer_();
+  }
+
+  /**
+   * Updates the refresh timer based on the current refresh mode/interval.
+   *
+   * @private
+   */
+  updateRefreshTimer_() {
+    var active = false;
+    if (this.refreshTimer_) {
+      active = this.refreshTimer_.isActive();
+      this.refreshTimer_.dispose();
     }
 
-    this.viewRefreshTimer_.start();
-  }
-};
-
-
-/**
- * Manually trigger a network link refresh.
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.refresh = function() {
-  if (this.refreshTimer_) {
-    this.refreshTimer_.fire();
-  } else {
-    this.onRefreshTimer_();
-  }
-};
-
-
-/**
- * Handle the refresh timer firing.
- *
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.onRefreshTimer_ = function() {
-  if (!this.request_) {
-    this.request_ = new os.net.Request(this.uri_);
-
-    // requesting a Document in the response was slightly faster in testing, but only works for KML (not KMZ). if we run
-    // into related issues of parsing speed, we should try to determine the content type ahead of time and change this.
-    if (!goog.userAgent.IE || goog.userAgent.isVersionOrHigher(10)) {
-      this.request_.setResponseType(goog.net.XhrIo.ResponseType.ARRAY_BUFFER);
+    this.refreshTimer_ = new Delay(this.onRefreshTimer_, this.getRefreshInterval(), this);
+    if (active) {
+      this.refreshTimer_.start();
     }
-
-    this.request_.listen(goog.net.EventType.SUCCESS, this.onRequestComplete_, false, this);
-    this.request_.listen(goog.net.EventType.ERROR, this.onRequestError_, false, this);
   }
 
-  if (this.source) {
-    // clear previous features loaded by the network link.
-    // TODO it would be better to gracefully replace features instead of clearing everything prior to loading the
-    //      request. this causes all features to be wiped from the application on every refresh which could be annoying
-    //      to the user.
-    this.source.clearNode(this);
+  /**
+   * Get the view refresh mode.
+   *
+   * @return {kml.ViewRefreshMode}
+   */
+  getViewRefreshMode() {
+    return this.viewRefreshMode_;
+  }
 
-    this.setLoading(true);
-    this.setIcon_(plugin.file.kml.ui.NetworkLinkIcons.LOADING);
+  /**
+   * Set the view refresh mode.
+   *
+   * @param {kml.ViewRefreshMode} value
+   */
+  setViewRefreshMode(value) {
+    this.viewRefreshMode_ = value;
+  }
 
-    if (this.viewRefreshMode_ !== os.ui.file.kml.ViewRefreshMode.NEVER) {
-      // include the BBOX as part of the request URL, the {extent} tag is handled by the variable replacer
-      var uri = this.request_.getUri();
-      uri.setParameterValue('BBOX', '{extent:west},{extent:south},{extent:east},{extent:north}');
+  /**
+   * Set the view refresh interval for the network link. If {@link viewRefreshMode} is set to
+   * {@link kml.ViewRefreshMode.STOP}, the link refreshes this many milliseconds after the camera stops moving.
+   *
+   * @param {number} value The refresh timer in seconds, or zero to prevent automatic refresh
+   */
+  setViewRefreshTimer(value) {
+    // value should always be positive - negative values will prevent refresh
+    this.viewRefreshInterval_ = Math.max(value, 0);
+    this.updateViewRefreshTimer_();
+  }
+
+  /**
+   * Updates the view refresh timer.
+   *
+   * @private
+   */
+  updateViewRefreshTimer_() {
+    dispose(this.viewRefreshTimer_);
+
+    if (this.viewRefreshInterval_) {
+      MapContainer.getInstance().listen(MapEvent.VIEW_CHANGE, this.onViewChange_, false, this);
+      this.viewRefreshTimer_ = new Delay(this.onRefreshTimer_, this.viewRefreshInterval_, this);
+    } else {
+      MapContainer.getInstance().unlisten(MapEvent.VIEW_CHANGE, this.onViewChange_, false, this);
+      this.viewRefreshTimer_ = null;
     }
-
-    this.durationStart_ = Date.now();
-    this.request_.load();
-  } else {
-    this.handleError_('source is null');
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.setSource = function(source) {
-  if (this.source) {
-    ol.events.unlisten(this.source, plugin.file.kml.KMLSourceEvent.REFRESH, this.onSourceRefresh_, this);
   }
 
-  plugin.file.kml.ui.KMLNetworkLinkNode.base(this, 'setSource', source);
-
-  if (this.source) {
-    ol.events.listen(this.source, plugin.file.kml.KMLSourceEvent.REFRESH, this.onSourceRefresh_, this);
-  }
-};
-
-
-/**
- * Refresh the network link when the source is refreshed.
- *
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.onSourceRefresh_ = function() {
-  if (this.getState() != os.structs.TriState.OFF) {
-    this.refresh();
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.setState = function(value) {
-  var old = this.getState();
-  plugin.file.kml.ui.KMLNetworkLinkNode.base(this, 'setState', value);
-  var s = this.getState();
-
-  if (old != s) {
-    if (s == os.structs.TriState.OFF) {
-      // network link has been disabled, so stop everything!
-      if (this.refreshTimer_) {
-        this.refreshTimer_.stop();
-      }
-
-      if (this.request_) {
+  /**
+   * Handles changes to the view.
+   *
+   * @private
+   */
+  onViewChange_() {
+    if (this.viewRefreshTimer_ && this.getState() != TriState.OFF) {
+      if (this.isLoading() && this.request_) {
+        // cancel the pending request
         this.request_.abort();
       }
 
-      if (this.importer_) {
-        this.importer_.stop();
-      }
-
-      this.clear_();
-      this.setIcon_(plugin.file.kml.ui.NetworkLinkIcons.INACTIVE);
-      this.setLoading(false);
-    } else if (this.source) {
-      if (!this.importer_) {
-        // first time activating - get an importer from the source. the importer can't be created here because we'll
-        // introduce a circular dependency with the parser.
-        this.importer_ = this.source.createImporter();
-        this.importer_.setTrustHTML(os.net.isTrustedUri(this.uri_));
-        this.importer_.listen(os.thread.EventType.PROGRESS, this.onImportProgress_, false, this);
-        this.importer_.listen(os.events.EventType.COMPLETE, this.onImportComplete_, false, this);
-      }
-
-      if (this.refreshTimer_ && !this.refreshTimer_.isActive() && old == os.structs.TriState.OFF) {
-        this.refreshTimer_.fire();
-      }
+      this.viewRefreshTimer_.start();
     }
   }
-};
 
-
-/**
- * Request success handler.
- *
- * @param {goog.events.Event} event
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.onRequestComplete_ = function(event) {
-  var msg = 'Request complete for ' + this.getLabel() + this.urlLogString_() + this.durationString_();
-  goog.log.info(this.log, msg);
-
-  var response = /** @type {string} */ (this.request_.getResponse());
-  this.request_.clearResponse();
-
-  if (response) {
-    if (this.importer_) {
-      this.importer_.startImport(response);
+  /**
+   * Manually trigger a network link refresh.
+   */
+  refresh() {
+    if (this.refreshTimer_) {
+      this.refreshTimer_.fire();
     } else {
-      this.handleError_('importer is null');
+      this.onRefreshTimer_();
     }
-  } else {
-    this.handleError_('response is empty');
-  }
-};
-
-
-/**
- * Request error handler.
- *
- * @param {goog.events.Event} event
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.onRequestError_ = function(event) {
-  this.handleError_(this.request_ ? this.request_.getErrors().join(' ') : 'unknown error');
-  this.request_.clearResponse();
-};
-
-
-/**
- * Import success handler.
- *
- * @param {goog.events.Event} event
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.onImportProgress_ = function(event) {
-  // KML parsing is about 30% faster in FF if this is done in one shot in the complete handler, instead of here. the
-  // slowdown is caused by the renderer and parser competing for resources, since FF has a much slower canvas renderer.
-  // moving this to the complete handler will prevent any features from displaying until the parser is done, instead of
-  // displaying them piecemeal and providing the user with some feedback.
-  if (this.importer_ && this.source) {
-    this.source.addNodes(this.importer_.getData());
-  }
-};
-
-
-/**
- * Import success handler.
- *
- * @param {goog.events.Event} event
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.onImportComplete_ = function(event) {
-  var msg = 'Import complete for ' + this.getLabel() + this.urlLogString_() + this.durationString_();
-  goog.log.info(this.log, msg);
-
-  this.setLoading(false);
-
-  var children = this.getChildren();
-  var currentRoot = children && children.length > 0 ? children[0] : null;
-  var rootNode = this.importer_.getRootNode();
-  var rootChildren = rootNode ? rootNode.getChildren() : [];
-  var firstRootChild = rootChildren && rootChildren.length > 0 ? rootChildren[0] : null;
-  if (currentRoot !== firstRootChild || ((children) && (children.length != rootChildren.length))) {
-    // the root node will only change on the first parse, or when the root name changes and we can't merge
-    this.setChildren(rootChildren ? rootChildren : null);
-    this.collapsed = rootNode == null;
   }
 
-  // TODO: increase the refresh interval for lengthy imports? waiting to start the timer helps, but if the interval is
-  // short you'll hardly have a chance to look at the data.
+  /**
+   * Handle the refresh timer firing.
+   *
+   * @private
+   */
+  onRefreshTimer_() {
+    if (!this.request_) {
+      this.request_ = new Request(this.uri_);
 
-  if (this.getState() != os.structs.TriState.OFF) {
-    // network link still active - good to go!
-    this.setIcon_(plugin.file.kml.ui.NetworkLinkIcons.ACTIVE);
+      // requesting a Document in the response was slightly faster in testing, but only works for KML (not KMZ). if we run
+      // into related issues of parsing speed, we should try to determine the content type ahead of time and change this.
+      if (!userAgent.IE || userAgent.isVersionOrHigher(10)) {
+        this.request_.setResponseType(ResponseType.ARRAY_BUFFER);
+      }
 
-    // use min refresh interval defined by NetworkLinkControl
-    this.setMinRefreshPeriod(this.importer_.getMinRefreshPeriod());
-
-    // start the refresh timer after the entire import process is complete to avoid refreshing mid-import
-    if (this.refreshTimer_ && this.getRefreshInterval() > 0) {
-      this.refreshTimer_.start();
+      this.request_.listen(EventType.SUCCESS, this.onRequestComplete_, false, this);
+      this.request_.listen(EventType.ERROR, this.onRequestError_, false, this);
     }
-  } else {
-    // network link was disabled - drop the imported features from the source
-    this.clear_();
+
+    if (this.source) {
+      // clear previous features loaded by the network link.
+      // TODO it would be better to gracefully replace features instead of clearing everything prior to loading the
+      //      request. this causes all features to be wiped from the application on every refresh which could be annoying
+      //      to the user.
+      this.source.clearNode(this);
+
+      this.setLoading(true);
+      this.setIcon_(NetworkLinkIcons.LOADING);
+
+      if (this.viewRefreshMode_ !== kml.ViewRefreshMode.NEVER) {
+        // include the BBOX as part of the request URL, the {extent} tag is handled by the variable replacer
+        var uri = this.request_.getUri();
+        uri.setParameterValue('BBOX', '{extent:west},{extent:south},{extent:east},{extent:north}');
+      }
+
+      this.durationStart_ = Date.now();
+      this.request_.load();
+    } else {
+      this.handleError_('source is null');
+    }
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  setSource(source) {
+    if (this.source) {
+      events.unlisten(this.source, KMLSourceEvent.REFRESH, this.onSourceRefresh_, this);
+    }
+
+    super.setSource(source);
+
+    if (this.source) {
+      events.listen(this.source, KMLSourceEvent.REFRESH, this.onSourceRefresh_, this);
+    }
+  }
+
+  /**
+   * Refresh the network link when the source is refreshed.
+   *
+   * @private
+   */
+  onSourceRefresh_() {
+    if (this.getState() != TriState.OFF) {
+      this.refresh();
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setState(value) {
+    var old = this.getState();
+    super.setState(value);
+    var s = this.getState();
+
+    if (old != s) {
+      if (s == TriState.OFF) {
+        // network link has been disabled, so stop everything!
+        if (this.refreshTimer_) {
+          this.refreshTimer_.stop();
+        }
+
+        if (this.request_) {
+          this.request_.abort();
+        }
+
+        if (this.importer_) {
+          this.importer_.stop();
+        }
+
+        this.clear_();
+        this.setIcon_(NetworkLinkIcons.INACTIVE);
+        this.setLoading(false);
+      } else if (this.source) {
+        if (!this.importer_) {
+          // first time activating - get an importer from the source. the importer can't be created here because we'll
+          // introduce a circular dependency with the parser.
+          this.importer_ = this.source.createImporter();
+          this.importer_.setTrustHTML(net.isTrustedUri(this.uri_));
+          this.importer_.listen(osThreadEventType.PROGRESS, this.onImportProgress_, false, this);
+          this.importer_.listen(osEventsEventType.COMPLETE, this.onImportComplete_, false, this);
+        }
+
+        if (this.refreshTimer_ && !this.refreshTimer_.isActive() && old == TriState.OFF) {
+          this.refreshTimer_.fire();
+        }
+      }
+    }
+  }
+
+  /**
+   * Request success handler.
+   *
+   * @param {goog.events.Event} event
+   * @private
+   */
+  onRequestComplete_(event) {
+    var msg = 'Request complete for ' + this.getLabel() + this.urlLogString_() + this.durationString_();
+    log.info(this.log, msg);
+
+    var response = /** @type {string} */ (this.request_.getResponse());
+    this.request_.clearResponse();
+
+    if (response) {
+      if (this.importer_) {
+        this.importer_.startImport(response);
+      } else {
+        this.handleError_('importer is null');
+      }
+    } else {
+      this.handleError_('response is empty');
+    }
+  }
+
+  /**
+   * Request error handler.
+   *
+   * @param {goog.events.Event} event
+   * @private
+   */
+  onRequestError_(event) {
+    this.handleError_(this.request_ ? this.request_.getErrors().join(' ') : 'unknown error');
+    this.request_.clearResponse();
+  }
+
+  /**
+   * Import success handler.
+   *
+   * @param {goog.events.Event} event
+   * @private
+   */
+  onImportProgress_(event) {
+    // KML parsing is about 30% faster in FF if this is done in one shot in the complete handler, instead of here. the
+    // slowdown is caused by the renderer and parser competing for resources, since FF has a much slower canvas renderer.
+    // moving this to the complete handler will prevent any features from displaying until the parser is done, instead of
+    // displaying them piecemeal and providing the user with some feedback.
+    if (this.importer_ && this.source) {
+      this.source.addNodes(this.importer_.getData());
+    }
+  }
+
+  /**
+   * Import success handler.
+   *
+   * @param {goog.events.Event} event
+   * @private
+   */
+  onImportComplete_(event) {
+    var msg = 'Import complete for ' + this.getLabel() + this.urlLogString_() + this.durationString_();
+    log.info(this.log, msg);
+
+    this.setLoading(false);
+
+    var children = this.getChildren();
+    var currentRoot = children && children.length > 0 ? children[0] : null;
+    var rootNode = this.importer_.getRootNode();
+    var rootChildren = rootNode ? rootNode.getChildren() : [];
+    var firstRootChild = rootChildren && rootChildren.length > 0 ? rootChildren[0] : null;
+    if (currentRoot !== firstRootChild || ((children) && (children.length != rootChildren.length))) {
+      // the root node will only change on the first parse, or when the root name changes and we can't merge
+      this.setChildren(rootChildren ? rootChildren : null);
+      this.collapsed = rootNode == null;
+    }
+
+    // TODO: increase the refresh interval for lengthy imports? waiting to start the timer helps, but if the interval is
+    // short you'll hardly have a chance to look at the data.
+
+    if (this.getState() != TriState.OFF) {
+      // network link still active - good to go!
+      this.setIcon_(NetworkLinkIcons.ACTIVE);
+
+      // use min refresh interval defined by NetworkLinkControl
+      this.setMinRefreshPeriod(this.importer_.getMinRefreshPeriod());
+
+      // start the refresh timer after the entire import process is complete to avoid refreshing mid-import
+      if (this.refreshTimer_ && this.getRefreshInterval() > 0) {
+        this.refreshTimer_.start();
+      }
+    } else {
+      // network link was disabled - drop the imported features from the source
+      this.clear_();
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  formatIcons() {
+    return this.icon_;
+  }
+
+  /**
+   * Set the network link icon displayed on the node.
+   *
+   * @param {NetworkLinkIcons} value The icon to display
+   * @private
+   */
+  setIcon_(value) {
+    this.icon_ = value;
+    this.dispatchEvent(new PropertyChangeEvent('icons'));
+  }
+}
 
 /**
- * @inheritDoc
+ * Logger
+ * @type {Logger}
  */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.formatIcons = function() {
-  return this.icon_;
-};
+const logger = log.getLogger('plugin.file.kml.ui.KMLNetworkLinkNode');
 
 
-/**
- * Set the network link icon displayed on the node.
- *
- * @param {plugin.file.kml.ui.NetworkLinkIcons} value The icon to display
- * @private
- */
-plugin.file.kml.ui.KMLNetworkLinkNode.prototype.setIcon_ = function(value) {
-  this.icon_ = value;
-  this.dispatchEvent(new os.events.PropertyChangeEvent('icons'));
-};
+exports = KMLNetworkLinkNode;

--- a/src/plugin/file/kml/ui/kmlnode.js
+++ b/src/plugin/file/kml/ui/kmlnode.js
@@ -1,980 +1,981 @@
-goog.provide('plugin.file.kml.ui.KMLNode');
-goog.provide('plugin.file.kml.ui.KMLNodeAction');
+goog.module('plugin.file.kml.ui.KMLNode');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.events.EventType');
-goog.require('goog.log');
-goog.require('goog.log.Logger');
-goog.require('ol.Feature');
-goog.require('ol.events');
-goog.require('ol.extent');
-goog.require('ol.geom.GeometryType');
-goog.require('ol.geom.Polygon');
-goog.require('os.annotation');
-goog.require('os.annotation.FeatureAnnotation');
-goog.require('os.data.IExtent');
-goog.require('os.data.ISearchable');
-goog.require('os.events.PropertyChangeEvent');
-goog.require('os.fn');
-goog.require('os.structs.TriState');
-goog.require('os.ui.ILayerUIProvider');
-goog.require('os.ui.ScreenOverlayCtrl');
-goog.require('os.ui.feature.featureInfoDirective');
 goog.require('os.ui.node.defaultLayerNodeUIDirective');
-goog.require('os.ui.slick.SlickTreeNode');
-goog.require('plugin.file.kml.ui.GeometryIcons');
-goog.require('plugin.file.kml.ui.kmlNodeUIDirective');
+
+const dispose = goog.require('goog.dispose');
+const GoogEventType = goog.require('goog.events.EventType');
+const log = goog.require('goog.log');
+const Feature = goog.require('ol.Feature');
+const events = goog.require('ol.events');
+const olExtent = goog.require('ol.extent');
+const Polygon = goog.require('ol.geom.Polygon');
+const ImageStatic = goog.require('ol.source.ImageStatic');
+const annotation = goog.require('os.annotation');
+const FeatureAnnotation = goog.require('os.annotation.FeatureAnnotation');
+const osColor = goog.require('os.color');
+const IExtent = goog.require('os.data.IExtent');
+const ISearchable = goog.require('os.data.ISearchable');
+const PropertyChangeEvent = goog.require('os.events.PropertyChangeEvent');
+const osFeature = goog.require('os.feature');
+const fn = goog.require('os.fn');
+const osImplements = goog.require('os.implements');
+const TriState = goog.require('os.structs.TriState');
+const ILayerUIProvider = goog.require('os.ui.ILayerUIProvider');
+const launchMultiFeatureInfo = goog.require('os.ui.feature.launchMultiFeatureInfo');
+const launchScreenOverlay = goog.require('os.ui.launchScreenOverlay');
+const SlickTreeNode = goog.require('os.ui.slick.SlickTreeNode');
+const osWindow = goog.require('os.ui.window');
+const {directiveTag: kmlNodeLayerUi} = goog.require('plugin.file.kml.KMLNodeLayerUI');
+const {directiveTag: kmlNodeUi} = goog.require('plugin.file.kml.ui.KMLNodeUI');
+const {
+  createOrEditPlace,
+  setCreateFolderNodeFn,
+  setCreatePlacemarkNodeFn,
+  updatePlacemark
+} = goog.require('plugin.file.kml.ui');
+const GeometryIcons = goog.require('plugin.file.kml.ui.GeometryIcons');
+const KMLNodeAction = goog.require('plugin.file.kml.ui.KMLNodeAction');
+
+const Logger = goog.requireType('goog.log.Logger');
+const {PlacemarkOptions} = goog.requireType('plugin.file.kml.ui');
 
 
 /**
- * KML node actions
- * @enum {string}
+ * Create a new KML placemark node.
+ * @return {!KMLNode} The placemark node.
  */
-plugin.file.kml.ui.KMLNodeAction = {
-  FEATURE_INFO: 'featureInfo'
+const createPlacemarkNode = () => {
+  const placemark = new KMLNode();
+  placemark.canAddChildren = false;
+  placemark.editable = true;
+  placemark.internalDrag = true;
+  placemark.removable = true;
+  placemark.layerUI = kmlNodeLayerUi;
+
+  return placemark;
 };
+
+
+/**
+ * Create a new KML folder node.
+ * @return {!KMLNode} The folder node.
+ */
+const createFolderNode = () => {
+  const folder = new KMLNode();
+  folder.collapsed = false;
+  folder.canAddChildren = true;
+  folder.editable = true;
+  folder.internalDrag = true;
+  folder.removable = true;
+
+  return folder;
+};
+
+// Register functions used to create KML folder/placemark nodes.
+setCreateFolderNodeFn(createFolderNode);
+setCreatePlacemarkNodeFn(createPlacemarkNode);
 
 
 /**
  * Base KML tree node
  *
- * @extends {os.ui.slick.SlickTreeNode}
- * @implements {os.data.ISearchable}
- * @implements {os.data.IExtent}
- * @implements {os.ui.ILayerUIProvider}
- * @constructor
+ * @implements {ISearchable}
+ * @implements {IExtent}
+ * @implements {ILayerUIProvider}
  */
-plugin.file.kml.ui.KMLNode = function() {
-  plugin.file.kml.ui.KMLNode.base(this, 'constructor');
-  this.checkboxTooltip = 'Show/hide the node';
-  this.nodeUI = '<kmlnodeui></kmlnodeui>';
+class KMLNode extends SlickTreeNode {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.checkboxTooltip = 'Show/hide the node';
+    this.nodeUI = `<${kmlNodeUi}></${kmlNodeUi}>`;
 
-  // KML nodes should save their collapsed state in the file content if needed because their getId values are not
-  // reliable for saving collapsed state.
-  this.saveCollapsed = false;
+    // KML nodes should save their collapsed state in the file content if needed because their getId values are not
+    // reliable for saving collapsed state.
+    this.saveCollapsed = false;
 
-  // default KML nodes to being turned on
-  this.setState(os.structs.TriState.ON);
+    // default KML nodes to being turned on
+    this.setState(TriState.ON);
+
+    /**
+     * @type {Logger}
+     * @protected
+     */
+    this.log = logger;
+
+    /**
+     * If children can be added to the node.
+     * @type {boolean}
+     */
+    this.canAddChildren = false;
+
+    /**
+     * If the node can be edited by the user.
+     * @type {boolean}
+     */
+    this.editable = false;
+
+    /**
+     * If the node can be removed by the user.
+     * @type {boolean}
+     */
+    this.removable = false;
+
+    /**
+     * If the node is loading.
+     * @type {boolean}
+     * @protected
+     */
+    this.loading = false;
+
+    /**
+     * If the node is marked for removal.
+     * @type {boolean}
+     */
+    this.marked = false;
+
+    /**
+     * If the node should be shown during animation.
+     * @type {boolean}
+     * @private
+     */
+    this.animationState_ = true;
+
+    /**
+     * The feature annotation.
+     * @type {FeatureAnnotation}
+     * @protected
+     */
+    this.annotation_ = null;
+
+    /**
+     * The kml ground image
+     * @type {os.layer.Image}
+     * @private
+     */
+    this.image_ = null;
+
+    /**
+     * The KML screen overlay options.
+     * @type {?osx.window.ScreenOverlayOptions}
+     * @private
+     */
+    this.overlayOptions_ = null;
+
+    /**
+     * The map feature
+     * @type {Feature}
+     * @private
+     */
+    this.feature_ = null;
+
+    /**
+     * Flag to track when the mouse is hovering a feature node
+     * @type {boolean}
+     * @private
+     */
+    this.highlight_ = false;
+
+    /**
+     * The KML source
+     * @type {plugin.file.kml.KMLSource}
+     * @protected
+     */
+    this.source = null;
+
+    /**
+     * If the source should be updated on state change
+     * @type {boolean}
+     * @private
+     */
+    this.updateSource_ = true;
+
+    /**
+     * @type {Object<string, !Array<!KMLNode>>}
+     * @protected
+     */
+    this.childLabelMap = {};
+
+    /**
+     * @type {?string}
+     */
+    this.layerUI = null;
+  }
 
   /**
-   * @type {goog.log.Logger}
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
+
+    this.setFeature(null);
+    this.setImage(null);
+    this.source = null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  canDropInternal(dropItem, moveMode) {
+    return dropItem.isFolder() || moveMode == SlickTreeNode.MOVE_MODE.SIBLING;
+  }
+
+  /**
+   * Get the feature for this node.
+   *
+   * @return {Feature} The feature
+   */
+  getFeature() {
+    return this.feature_;
+  }
+
+  /**
+   * Set the feature for this node.
+   *
+   * @param {Feature} feature The feature
+   */
+  setFeature(feature) {
+    if (this.feature_) {
+      events.unlisten(this.feature_, GoogEventType.PROPERTYCHANGE, this.onFeatureChange, this);
+      this.clearAnnotations();
+    }
+
+    this.feature_ = feature;
+
+    if (this.feature_) {
+      events.listen(this.feature_, GoogEventType.PROPERTYCHANGE, this.onFeatureChange, this);
+    }
+    this.loadAnnotation();
+
+    this.dispatchEvent(new PropertyChangeEvent('icons'));
+    this.dispatchEvent(new PropertyChangeEvent('label'));
+  }
+
+  /**
+   * Clean up the annotation for the node and all children.
+   */
+  clearAnnotations() {
+    if (this.annotation_) {
+      dispose(this.annotation_);
+      this.annotation_ = null;
+    }
+
+    var children = this.getChildren();
+    if (children) {
+      for (var i = 0, n = children.length; i < n; i++) {
+        children[i].clearAnnotations();
+      }
+    }
+  }
+
+  /**
+   * Set up the annotation for the node.
+   */
+  loadAnnotation() {
+    if (this.feature_ && !this.annotation_) {
+      var annotationOptions = /** @type {osx.annotation.Options|undefined} */ (
+        this.feature_.get(annotation.OPTIONS_FIELD));
+      if (annotationOptions && annotationOptions.show) {
+        if (annotationOptions['showBackground'] === undefined) {
+          annotationOptions['showBackground'] = annotation.DEFAULT_OPTIONS['showBackground'];
+        }
+        this.annotation_ = new FeatureAnnotation(this.feature_);
+
+        // set initial visibility based on the tree/animation state
+        this.setAnnotationVisibility_(this.getState() === TriState.ON && this.animationState_);
+      }
+    }
+  }
+
+  /**
+   * Handle property change events fired on a feature.
+   *
+   * @param {PropertyChangeEvent|ol.Object.Event} event The change event.
    * @protected
    */
-  this.log = plugin.file.kml.ui.KMLNode.LOGGER_;
+  onFeatureChange(event) {
+    if (event instanceof PropertyChangeEvent) {
+      var p = event.getProperty();
+      switch (p) {
+        case 'loading':
+          this.setLoading(!!event.getNewValue());
+          break;
+        case annotation.EventType.UPDATE_PLACEMARK:
+          // this event needs to update the placemark (tree node) in addition to dispatching the event
+          updatePlacemark(/** @type {!PlacemarkOptions} */ ({
+            'feature': this.feature_,
+            'node': this
+          }));
+
+          this.dispatchEvent(new PropertyChangeEvent(annotation.EventType.CHANGE));
+          break;
+        case GoogEventType.CHANGE:
+        case annotation.EventType.CHANGE:
+          // this event just needs to resave the tree
+          this.dispatchEvent(new PropertyChangeEvent(annotation.EventType.CHANGE));
+          break;
+        case annotation.EventType.EDIT:
+          createOrEditPlace(/** @type {!PlacemarkOptions} */ ({
+            'feature': this.feature_,
+            'node': this
+          }));
+          break;
+        case annotation.EventType.HIDE:
+          this.clearAnnotations();
+          this.dispatchEvent(new PropertyChangeEvent('icons'));
+          this.dispatchEvent(new PropertyChangeEvent(annotation.EventType.CHANGE));
+          break;
+        case 'colors':
+          this.dispatchEvent(new PropertyChangeEvent('icons'));
+          this.dispatchEvent(new PropertyChangeEvent(annotation.EventType.CHANGE));
+          break;
+        default:
+          break;
+      }
+    }
+  }
 
   /**
-   * If children can be added to the node.
-   * @type {boolean}
+   * If the node has one or more features beneath it.
+   *
+   * @param {boolean=} opt_unchecked If unchecked nodes should be included, defaults to false.
+   * @return {boolean} If the node has one or more features beneath it.
    */
-  this.canAddChildren = false;
+  hasFeatures(opt_unchecked) {
+    if (this.feature_) {
+      return true;
+    }
+
+    var children = this.getChildren();
+    return !!children && children.some(function(child) {
+      return (opt_unchecked || child.getState() != TriState.OFF) && child.hasFeatures(opt_unchecked);
+    });
+  }
 
   /**
-   * If the node can be edited by the user.
-   * @type {boolean}
+   * Get the feature(s) associated with this node.
+   *
+   * @param {boolean=} opt_unchecked If unchecked nodes should be included, defaults to false.
+   * @return {!Array<!Feature>} The features
    */
-  this.editable = false;
+  getFeatures(opt_unchecked) {
+    if (this.feature_) {
+      return [this.feature_];
+    }
+
+    var features = [];
+    var children = this.getChildren();
+    if (children) {
+      for (var i = 0, n = children.length; i < n; i++) {
+        var node = children[i];
+        if (node.getState() != TriState.OFF || opt_unchecked) {
+          // unchecked nodes are hidden from the map so exclude them unless the flag is set.
+          var childFeatures = node.getFeatures(opt_unchecked);
+          if (childFeatures) {
+            features = features.concat(childFeatures);
+          }
+        }
+      }
+    }
+
+    return features;
+  }
 
   /**
-   * If the node can be removed by the user.
-   * @type {boolean}
+   * Get the image layer for this node.
+   *
+   * @return {os.layer.Image} The feature
    */
-  this.removable = false;
+  getImage() {
+    return this.image_;
+  }
 
   /**
-   * If the node is loading.
-   * @type {boolean}
+   * Set the image layer for this node.
+   *
+   * @param {os.layer.Image} image The feature
+   */
+  setImage(image) {
+    this.image_ = image;
+  }
+
+  /**
+   * Get the overlay window ID for this node.
+   *
+   * @return {?string} The overlay window ID.
+   */
+  getOverlayId() {
+    return this.overlayOptions_ ? this.overlayOptions_.id : null;
+  }
+
+  /**
+   * Set the overlay window options for this node.
+   *
+   * @param {osx.window.ScreenOverlayOptions} options The overlay options.
+   */
+  setOverlayOptions(options) {
+    this.overlayOptions_ = options;
+  }
+
+  /**
+   * Set the timeline animation state of the node.
+   *
+   * @param {boolean} value If the node should be shown.
+   */
+  setAnimationState(value) {
+    if (this.animationState_ != value) {
+      this.animationState_ = value;
+
+      var state = this.getState();
+      this.setAnnotationVisibility_(state === TriState.ON && value);
+      this.setImageVisibility_(state === TriState.ON && value);
+      this.setOverlayVisibility_(state === TriState.ON && value);
+    }
+  }
+
+  /**
+   * Set the visibility of the annotation.
+   *
+   * @param {boolean} shown If the annotation should be shown.
+   * @private
+   */
+  setAnnotationVisibility_(shown) {
+    if (this.annotation_) {
+      this.annotation_.setVisible(shown);
+    }
+  }
+
+  /**
+   * Set the visibility of the image.
+   *
+   * @param {boolean} shown If the image should be shown.
+   * @private
+   */
+  setImageVisibility_(shown) {
+    if (this.image_) {
+      this.image_.setLayerVisible(shown);
+    }
+  }
+
+  /**
+   * Set the visibility of the overlay.
+   *
+   * @param {boolean} shown If the overlay should be shown.
+   * @private
+   */
+  setOverlayVisibility_(shown) {
+    if (this.overlayOptions_) {
+      var overlayWin = osWindow.getById(this.overlayOptions_.id);
+      if (!overlayWin && shown) {
+        // window does not exist and we want to show it. launch a new window.
+        launchScreenOverlay(this.overlayOptions_);
+      } else if (overlayWin) {
+        // window exists, toggle it.
+        overlayWin.removeClass(shown ? 'd-none' : 'd-flex');
+        overlayWin.addClass(shown ? 'd-flex' : 'd-none');
+      }
+    }
+  }
+
+  /**
+   * Get the images(s) associated with this node.
+   *
+   * @param {boolean=} opt_unchecked If unchecked nodes should be included, defaults to false
+   * @return {!Array<!os.layer.Image>} The image layers
+   */
+  getImages(opt_unchecked) {
+    if (this.image_) {
+      return [this.image_];
+    }
+
+    var images = [];
+    var children = this.getChildren();
+    if (children) {
+      for (var i = 0, n = children.length; i < n; i++) {
+        var node = children[i];
+        if (node.getState() != TriState.OFF || opt_unchecked) {
+          // unchecked nodes are hidden from the map so exclude them unless the flag is set.
+          var childImages = node.getImages(opt_unchecked);
+          if (childImages) {
+            images = images.concat(childImages);
+          }
+        }
+      }
+    }
+
+    return images;
+  }
+
+  /**
+   * Get the overlay(s) associated with this node.
+   *
+   * @param {boolean=} opt_unchecked If unchecked nodes should be included, defaults to false
+   * @return {!Array<!string>} The overlay window IDs
+   */
+  getOverlays(opt_unchecked) {
+    var overlayId = this.getOverlayId();
+    if (overlayId) {
+      return [overlayId];
+    }
+
+    var overlays = [];
+    var children = this.getChildren();
+    if (children) {
+      for (var i = 0, n = children.length; i < n; i++) {
+        var node = children[i];
+        if (node.getState() != TriState.OFF || opt_unchecked) {
+          // unchecked nodes are hidden from the map so exclude them unless the flag is set.
+          var childOverlays = node.getOverlays(opt_unchecked);
+          if (childOverlays) {
+            overlays = overlays.concat(childOverlays);
+          }
+        }
+      }
+    }
+
+    return overlays;
+  }
+
+  /**
+   * @inheritDoc
+   * @suppress {accessControls}
+   */
+  getExtent() {
+    var extent = null;
+
+    var children = this.getChildren();
+    if (children && children.length) {
+      for (var i = 0, n = children.length; i < n; i++) {
+        if (osImplements(children[i], IExtent.ID)) {
+          var child = /** @type {IExtent} */ (children[i]);
+          var ex = child.getExtent();
+          if (extent && ex) {
+            olExtent.extend(extent, ex);
+          } else if (!extent) {
+            extent = ex;
+          }
+        }
+      }
+    } else if (this.image_) {
+      var source = this.image_.getSource();
+
+      if (source instanceof ImageStatic) {
+        extent = /** @type {ol.source.ImageStatic} */ (source).image_.getExtent();
+      }
+    } else {
+      var geoms = this.getFeatures().map(fn.mapFeatureToGeometry);
+      extent = geoms.reduce(fn.reduceExtentFromGeometries, olExtent.createEmpty());
+    }
+
+    return extent;
+  }
+
+  /**
+   * @return {Array<!Feature>|undefined}
+   */
+  getZoomFeatures() {
+    var children = this.getChildren();
+    if (children && children.length) {
+      var features;
+      for (var i = 0, n = children.length; i < n; i++) {
+        var childFeatures = children[i].getZoomFeatures();
+        if (childFeatures) {
+          features = features ? features.concat(childFeatures) : childFeatures;
+        }
+      }
+
+      return features;
+    } else if (this.image_) {
+      var extent = this.getExtent();
+      if (extent && !olExtent.isEmpty(extent)) {
+        return [new Feature(Polygon.fromExtent(extent))];
+      }
+    }
+
+    return this.getFeatures();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getId() {
+    if (this.feature_) {
+      var id = this.feature_.getId();
+      if (id) {
+        return id.toString();
+      }
+    }
+
+    return super.getId();
+  }
+
+  /**
+   * Whether or not the KML node is loading.
+   *
+   * @return {boolean}
+   * @export
+   */
+  isLoading() {
+    return this.loading;
+  }
+
+  /**
+   * Set if the node is loading.
+   *
+   * @param {boolean} value The new value
    * @protected
    */
-  this.loading = false;
+  setLoading(value) {
+    if (this.loading != value) {
+      this.loading = value;
+      this.dispatchEvent(new PropertyChangeEvent('loading', value, !value));
+    }
+  }
 
   /**
-   * If the node is marked for removal.
-   * @type {boolean}
+   * @inheritDoc
    */
-  this.marked = false;
+  getSearchText() {
+    return this.getLabel() || '';
+  }
 
   /**
-   * If the node should be shown during animation.
-   * @type {boolean}
-   * @private
+   * Get the KML source associated with the node.
+   *
+   * @return {plugin.file.kml.KMLSource}
    */
-  this.animationState_ = true;
+  getSource() {
+    return this.source;
+  }
 
   /**
-   * The feature annotation.
-   * @type {os.annotation.FeatureAnnotation}
-   * @protected
+   * @inheritDoc
    */
-  this.annotation_ = null;
+  getTags() {
+    return null;
+  }
 
   /**
-   * The kml ground image
-   * @type {os.layer.Image}
-   * @private
+   * The KML merge requires quick access to the node. Also, the KML parser does not produce consistent
+   * IDs for the nodes on subsequent runs. Therefore, the label is going to be used for the index. To
+   * support multiple items with the same label, the index points to a list of those items.
    */
-  this.image_ = null;
+
 
   /**
-   * The KML screen overlay options.
-   * @type {?osx.window.ScreenOverlayOptions}
-   * @private
+   * @inheritDoc
    */
-  this.overlayOptions_ = null;
+  index(child) {
+    var label = child.getLabel() || '';
+
+    if (child instanceof KMLNode) {
+      if (!(label in this.childLabelMap)) {
+        this.childLabelMap[label] = [];
+      }
+
+      this.childLabelMap[label].push(child);
+    }
+  }
 
   /**
-   * The map feature
-   * @type {ol.Feature}
-   * @private
+   * @inheritDoc
    */
-  this.feature_ = null;
+  unindex(child) {
+    var label = child.getLabel() || '';
+
+    if (label in this.childLabelMap) {
+      var list = /** @type {Array<KMLNode>} */ (this.childLabelMap[label]);
+
+      var x = list.indexOf(/** @type {KMLNode} */ (child));
+      if (x > -1) {
+        list.splice(x, 1);
+      }
+
+      if (list.length === 0) {
+        delete this.childLabelMap[label];
+      }
+    }
+  }
 
   /**
-   * Flag to track when the mouse is hovering a feature node
-   * @type {boolean}
-   * @private
+   * @inheritDoc
    */
-  this.highlight_ = false;
+  hasChild(child) {
+    var label = child.getLabel() || '';
+    if (label in this.childLabelMap) {
+      return /** @type {Array<KMLNode>} */ (
+        this.childLabelMap[label]).indexOf(/** @type {KMLNode} */ (child)) !== -1;
+    }
+
+    return false;
+  }
 
   /**
-   * The KML source
-   * @type {plugin.file.kml.KMLSource}
-   * @protected
+   * @inheritDoc
    */
-  this.source = null;
+  addChild(child, opt_skipaddparent, opt_index) {
+    if (child instanceof KMLNode) {
+      var previous = this.merge(child);
+
+      if (!previous) {
+        return super.addChild(child, opt_skipaddparent, opt_index);
+      } else {
+        // node was merged with an existing one, so clean up the extra node
+        dispose(child);
+      }
+
+      return previous;
+    }
+
+    log.error(this.log, 'Unable to add non-KML node "' + child.getLabel() + '" to the KML tree!');
+    return null;
+  }
 
   /**
-   * If the source should be updated on state change
-   * @type {boolean}
-   * @private
+   * @param {!KMLNode} child
+   * @return {?KMLNode}
    */
-  this.updateSource_ = true;
+  merge(child) {
+    var children = /** {Array<!KMLNode>|undefined} */ (this.childLabelMap[child.getLabel() || '']);
+
+    if (children) {
+      for (var i = 0, n = children.length; i < n; i++) {
+        var prevChild = children[i];
+
+        if (prevChild.marked) {
+          prevChild.setFeature(child.getFeature());
+          prevChild.marked = false;
+          prevChild.setId(child.getId());
+          return prevChild;
+        }
+      }
+    }
+
+    return null;
+  }
 
   /**
-   * @type {Object<string, !Array<!plugin.file.kml.ui.KMLNode>>}
-   * @protected
+   * If the node is a KML Folder.
+   *
+   * @return {boolean}
    */
-  this.childLabelMap = {};
+  isFolder() {
+    return (this.feature_ == null && this.image_ == null && this.overlayOptions_ == null);
+  }
 
   /**
-   * @type {?string}
+   * @inheritDoc
    */
-  this.layerUI = null;
-};
-goog.inherits(plugin.file.kml.ui.KMLNode, os.ui.slick.SlickTreeNode);
-os.implements(plugin.file.kml.ui.KMLNode, os.data.IExtent.ID);
-os.implements(plugin.file.kml.ui.KMLNode, os.data.ISearchable.ID);
-os.implements(plugin.file.kml.ui.KMLNode, os.ui.ILayerUIProvider.ID);
+  formatIcons() {
+    if (this.isFolder()) {
+      var open = this.hasChildren() && !this.collapsed;
+      return '<i class="fa fa-folder' + (open ? '-open' : '') + ' fa-fw"></i>';
+    } else if (this.image_) {
+      return '<i class="fa fa-photo fa-fw compact" title="Ground Overlay"></i>';
+    } else if (this.overlayOptions_) {
+      return '<i class="fa fa-photo fa-fw compact" title="Screen Overlay"></i>';
+    } else {
+      var icons = [];
+
+      // if the node has a geometry, add the geometry icon
+      var geom = this.feature_.getGeometry();
+      if (geom) {
+        var type = geom.getType();
+        if (type in GeometryIcons) {
+          var geomIcon = GeometryIcons[type];
+          var color = /** @type {string|undefined} */ (osFeature.getColor(this.feature_));
+          if (color) {
+            // disregard opacity - only interested in displaying the color
+            geomIcon = geomIcon.replace('><', ' style="color:' + osColor.toHexString(color) + '"><');
+          }
+
+          icons.push(geomIcon);
+        }
+      }
+
+      // if an annotation is displayed, add an icon for it
+      if (this.annotation_) {
+        icons.push('<i class="fa fa-comment fa-fw" title="Text box"></i>');
+      }
+
+      // add an info icon to launch feature info
+      icons.push('<i class="fa fa-info-circle fa-fw c-glyph" title="Feature Info" ' +
+          'ng-click="itemAction(\'' + KMLNodeAction.FEATURE_INFO + '\')"></i>');
+
+      return icons.join('');
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  performAction(type) {
+    if (type == KMLNodeAction.FEATURE_INFO) {
+      if (this.feature_) {
+        var title = this.source ? this.source.getTitle() : undefined;
+        launchMultiFeatureInfo(this.feature_, title);
+      }
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  onChildChange(e) {
+    var p = e.getProperty();
+
+    // if the source is loading, filter out which events are handled to avoid excessive tree updates
+    if (this.source && this.source.isLoading() &&
+        p && childLoadingEvents.indexOf(p) == -1) {
+      return;
+    }
+
+    super.onChildChange(e);
+
+    if (p === 'collapsed' || p === annotation.EventType.CHANGE) {
+      // propagate the event up the tree so the KML can be saved if necessary
+      this.dispatchEvent(new PropertyChangeEvent(p));
+    } else if (p === 'loading') {
+      // propagate loading events up the tree so the layer can show the overall loading state
+      this.dispatchEvent(new PropertyChangeEvent(p, e.getNewValue(), e.getOldValue()));
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  onMouseEnter() {
+    if (this.feature_ && this.source) {
+      // always set this to ensure features are immediately highlighted when enabled via their own checkbox
+      this.highlight_ = true;
+
+      if (!this.source.isHidden(this.feature_)) {
+        // only highlight the feature if it isn't hidden
+        this.source.setHighlightedItems([this.feature_]);
+      }
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  onMouseLeave() {
+    if (this.feature_ && this.source) {
+      this.highlight_ = false;
+      this.source.setHighlightedItems(null);
+    }
+  }
+
+  /**
+   * Set the KML source for this node.
+   *
+   * @param {plugin.file.kml.KMLSource} source The source
+   */
+  setSource(source) {
+    this.source = source;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setState(value) {
+    var old = this.getState();
+
+    super.setState(value);
+
+    var s = this.getState();
+
+    this.setAnnotationVisibility_(s === TriState.ON && this.animationState_);
+    this.setImageVisibility_(s === TriState.ON && this.animationState_);
+    this.setOverlayVisibility_(s === TriState.ON && this.animationState_);
+
+    if (old != s && this.updateSource_ && this.source) {
+      if (s !== TriState.BOTH) {
+        this.source.scheduleUpdateFromNodes();
+
+        if (this.highlight_) {
+          if (s === TriState.ON) {
+            // mouse is on a leaf node, so highlight the feature
+            this.source.setHighlightedItems([this.feature_]);
+          } else {
+            // mouse is on a leaf node, so remove the highlight feature
+            this.source.setHighlightedItems(null);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Sets the state without trying to update features on the source. This is used to prevent duplicate source visibility
+   * calls when the source caused the state change, or the state is being propagated through the tree.
+   *
+   * @param {string} value The new state value
+   */
+  setStateOnly(value) {
+    this.updateSource_ = false;
+    this.setState(value);
+    this.updateSource_ = true;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  updateChild(child, state) {
+    // avoid changing source visibility when updating children, so the visibility calls aren't massively duplicated. the
+    // visibility will be changed at the level toggled by the user, resulting in a single call to the source.
+    child.setStateOnly(state);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLayerUI(item) {
+    if (item && item instanceof KMLNode && item.editable && item.feature_) {
+      return item.layerUI || 'defaultlayerui';
+    }
+
+    return null;
+  }
+
+  /**
+   * Collapses all nodes under the target that do not have children.
+   *
+   * @param {!KMLNode} target The target node to collapse
+   */
+  static collapseEmpty(target) {
+    var children = target.getChildren();
+    if (children && children.length > 0) {
+      for (var i = 0, n = children.length; i < n; i++) {
+        KMLNode.collapseEmpty(/** @type {!KMLNode} */ (children[i]));
+      }
+    } else {
+      target.collapsed = true;
+    }
+  }
+}
+
+osImplements(KMLNode, IExtent.ID);
+osImplements(KMLNode, ISearchable.ID);
+osImplements(KMLNode, ILayerUIProvider.ID);
 
 
 /**
  * Logger
- * @type {goog.log.Logger}
- * @private
- * @const
+ * @type {Logger}
  */
-plugin.file.kml.ui.KMLNode.LOGGER_ = goog.log.getLogger('plugin.file.kml.ui.KMLNode');
+const logger = log.getLogger('plugin.file.kml.ui.KMLNode');
 
 
 /**
  * Tree events that should be handled while the source is loading. Handling all events while loading will result in
  * the Layers window hanging.
  * @type {!Array<string>}
- * @private
- * @const
  */
-plugin.file.kml.ui.KMLNode.CHILD_LOADING_EVENTS_ = ['children', 'state', 'collapsed'];
+const childLoadingEvents = ['children', 'state', 'collapsed'];
 
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.disposeInternal = function() {
-  plugin.file.kml.ui.KMLNode.base(this, 'disposeInternal');
-
-  this.setFeature(null);
-  this.setImage(null);
-  this.source = null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.canDropInternal = function(dropItem, moveMode) {
-  return dropItem.isFolder() || moveMode == os.ui.slick.SlickTreeNode.MOVE_MODE.SIBLING;
-};
-
-
-/**
- * Get the feature for this node.
- *
- * @return {ol.Feature} The feature
- */
-plugin.file.kml.ui.KMLNode.prototype.getFeature = function() {
-  return this.feature_;
-};
-
-
-/**
- * Set the feature for this node.
- *
- * @param {ol.Feature} feature The feature
- */
-plugin.file.kml.ui.KMLNode.prototype.setFeature = function(feature) {
-  if (this.feature_) {
-    ol.events.unlisten(this.feature_, goog.events.EventType.PROPERTYCHANGE, this.onFeatureChange, this);
-    this.clearAnnotations();
-  }
-
-  this.feature_ = feature;
-
-  if (this.feature_) {
-    ol.events.listen(this.feature_, goog.events.EventType.PROPERTYCHANGE, this.onFeatureChange, this);
-  }
-  this.loadAnnotation();
-
-  this.dispatchEvent(new os.events.PropertyChangeEvent('icons'));
-  this.dispatchEvent(new os.events.PropertyChangeEvent('label'));
-};
-
-
-/**
- * Clean up the annotation for the node and all children.
- */
-plugin.file.kml.ui.KMLNode.prototype.clearAnnotations = function() {
-  if (this.annotation_) {
-    goog.dispose(this.annotation_);
-    this.annotation_ = null;
-  }
-
-  var children = this.getChildren();
-  if (children) {
-    for (var i = 0, n = children.length; i < n; i++) {
-      children[i].clearAnnotations();
-    }
-  }
-};
-
-
-/**
- * Set up the annotation for the node.
- */
-plugin.file.kml.ui.KMLNode.prototype.loadAnnotation = function() {
-  if (this.feature_ && !this.annotation_) {
-    var annotationOptions = /** @type {osx.annotation.Options|undefined} */ (
-      this.feature_.get(os.annotation.OPTIONS_FIELD));
-    if (annotationOptions && annotationOptions.show) {
-      if (annotationOptions['showBackground'] === undefined) {
-        annotationOptions['showBackground'] = os.annotation.DEFAULT_OPTIONS['showBackground'];
-      }
-      this.annotation_ = new os.annotation.FeatureAnnotation(this.feature_);
-
-      // set initial visibility based on the tree/animation state
-      this.setAnnotationVisibility_(this.getState() === os.structs.TriState.ON && this.animationState_);
-    }
-  }
-};
-
-
-/**
- * Handle property change events fired on a feature.
- *
- * @param {os.events.PropertyChangeEvent|ol.Object.Event} event The change event.
- * @protected
- */
-plugin.file.kml.ui.KMLNode.prototype.onFeatureChange = function(event) {
-  if (event instanceof os.events.PropertyChangeEvent) {
-    var p = event.getProperty();
-    switch (p) {
-      case 'loading':
-        this.setLoading(!!event.getNewValue());
-        break;
-      case os.annotation.EventType.UPDATE_PLACEMARK:
-        // this event needs to update the placemark (tree node) in addition to dispatching the event
-        plugin.file.kml.ui.updatePlacemark(/** @type {!plugin.file.kml.ui.PlacemarkOptions} */ ({
-          'feature': this.feature_,
-          'node': this
-        }));
-
-        this.dispatchEvent(new os.events.PropertyChangeEvent(os.annotation.EventType.CHANGE));
-        break;
-      case goog.events.EventType.CHANGE:
-      case os.annotation.EventType.CHANGE:
-        // this event just needs to resave the tree
-        this.dispatchEvent(new os.events.PropertyChangeEvent(os.annotation.EventType.CHANGE));
-        break;
-      case os.annotation.EventType.EDIT:
-        plugin.file.kml.ui.createOrEditPlace(/** @type {!plugin.file.kml.ui.PlacemarkOptions} */ ({
-          'feature': this.feature_,
-          'node': this
-        }));
-        break;
-      case os.annotation.EventType.HIDE:
-        this.clearAnnotations();
-        this.dispatchEvent(new os.events.PropertyChangeEvent('icons'));
-        this.dispatchEvent(new os.events.PropertyChangeEvent(os.annotation.EventType.CHANGE));
-        break;
-      case 'colors':
-        this.dispatchEvent(new os.events.PropertyChangeEvent('icons'));
-        this.dispatchEvent(new os.events.PropertyChangeEvent(os.annotation.EventType.CHANGE));
-        break;
-      default:
-        break;
-    }
-  }
-};
-
-
-/**
- * If the node has one or more features beneath it.
- *
- * @param {boolean=} opt_unchecked If unchecked nodes should be included, defaults to false.
- * @return {boolean} If the node has one or more features beneath it.
- */
-plugin.file.kml.ui.KMLNode.prototype.hasFeatures = function(opt_unchecked) {
-  if (this.feature_) {
-    return true;
-  }
-
-  var children = this.getChildren();
-  return !!children && children.some(function(child) {
-    return (opt_unchecked || child.getState() != os.structs.TriState.OFF) && child.hasFeatures(opt_unchecked);
-  });
-};
-
-
-/**
- * Get the feature(s) associated with this node.
- *
- * @param {boolean=} opt_unchecked If unchecked nodes should be included, defaults to false.
- * @return {!Array<!ol.Feature>} The features
- */
-plugin.file.kml.ui.KMLNode.prototype.getFeatures = function(opt_unchecked) {
-  if (this.feature_) {
-    return [this.feature_];
-  }
-
-  var features = [];
-  var children = this.getChildren();
-  if (children) {
-    for (var i = 0, n = children.length; i < n; i++) {
-      var node = children[i];
-      if (node.getState() != os.structs.TriState.OFF || opt_unchecked) {
-        // unchecked nodes are hidden from the map so exclude them unless the flag is set.
-        var childFeatures = node.getFeatures(opt_unchecked);
-        if (childFeatures) {
-          features = features.concat(childFeatures);
-        }
-      }
-    }
-  }
-
-  return features;
-};
-
-
-/**
- * Get the image layer for this node.
- *
- * @return {os.layer.Image} The feature
- */
-plugin.file.kml.ui.KMLNode.prototype.getImage = function() {
-  return this.image_;
-};
-
-
-/**
- * Set the image layer for this node.
- *
- * @param {os.layer.Image} image The feature
- */
-plugin.file.kml.ui.KMLNode.prototype.setImage = function(image) {
-  this.image_ = image;
-};
-
-
-/**
- * Get the overlay window ID for this node.
- *
- * @return {?string} The overlay window ID.
- */
-plugin.file.kml.ui.KMLNode.prototype.getOverlayId = function() {
-  return this.overlayOptions_ ? this.overlayOptions_.id : null;
-};
-
-
-/**
- * Set the overlay window options for this node.
- *
- * @param {osx.window.ScreenOverlayOptions} options The overlay options.
- */
-plugin.file.kml.ui.KMLNode.prototype.setOverlayOptions = function(options) {
-  this.overlayOptions_ = options;
-};
-
-
-/**
- * Set the timeline animation state of the node.
- *
- * @param {boolean} value If the node should be shown.
- */
-plugin.file.kml.ui.KMLNode.prototype.setAnimationState = function(value) {
-  if (this.animationState_ != value) {
-    this.animationState_ = value;
-
-    var state = this.getState();
-    this.setAnnotationVisibility_(state === os.structs.TriState.ON && value);
-    this.setImageVisibility_(state === os.structs.TriState.ON && value);
-    this.setOverlayVisibility_(state === os.structs.TriState.ON && value);
-  }
-};
-
-
-/**
- * Set the visibility of the annotation.
- *
- * @param {boolean} shown If the annotation should be shown.
- * @private
- */
-plugin.file.kml.ui.KMLNode.prototype.setAnnotationVisibility_ = function(shown) {
-  if (this.annotation_) {
-    this.annotation_.setVisible(shown);
-  }
-};
-
-
-/**
- * Set the visibility of the image.
- *
- * @param {boolean} shown If the image should be shown.
- * @private
- */
-plugin.file.kml.ui.KMLNode.prototype.setImageVisibility_ = function(shown) {
-  if (this.image_) {
-    this.image_.setLayerVisible(shown);
-  }
-};
-
-
-/**
- * Set the visibility of the overlay.
- *
- * @param {boolean} shown If the overlay should be shown.
- * @private
- */
-plugin.file.kml.ui.KMLNode.prototype.setOverlayVisibility_ = function(shown) {
-  if (this.overlayOptions_) {
-    var overlayWin = os.ui.window.getById(this.overlayOptions_.id);
-    if (!overlayWin && shown) {
-      // window does not exist and we want to show it. launch a new window.
-      os.ui.launchScreenOverlay(this.overlayOptions_);
-    } else if (overlayWin) {
-      // window exists, toggle it.
-      overlayWin.removeClass(shown ? 'd-none' : 'd-flex');
-      overlayWin.addClass(shown ? 'd-flex' : 'd-none');
-    }
-  }
-};
-
-
-/**
- * Get the images(s) associated with this node.
- *
- * @param {boolean=} opt_unchecked If unchecked nodes should be included, defaults to false
- * @return {!Array<!os.layer.Image>} The image layers
- */
-plugin.file.kml.ui.KMLNode.prototype.getImages = function(opt_unchecked) {
-  if (this.image_) {
-    return [this.image_];
-  }
-
-  var images = [];
-  var children = this.getChildren();
-  if (children) {
-    for (var i = 0, n = children.length; i < n; i++) {
-      var node = children[i];
-      if (node.getState() != os.structs.TriState.OFF || opt_unchecked) {
-        // unchecked nodes are hidden from the map so exclude them unless the flag is set.
-        var childImages = node.getImages(opt_unchecked);
-        if (childImages) {
-          images = images.concat(childImages);
-        }
-      }
-    }
-  }
-
-  return images;
-};
-
-
-/**
- * Get the overlay(s) associated with this node.
- *
- * @param {boolean=} opt_unchecked If unchecked nodes should be included, defaults to false
- * @return {!Array<!string>} The overlay window IDs
- */
-plugin.file.kml.ui.KMLNode.prototype.getOverlays = function(opt_unchecked) {
-  var overlayId = this.getOverlayId();
-  if (overlayId) {
-    return [overlayId];
-  }
-
-  var overlays = [];
-  var children = this.getChildren();
-  if (children) {
-    for (var i = 0, n = children.length; i < n; i++) {
-      var node = children[i];
-      if (node.getState() != os.structs.TriState.OFF || opt_unchecked) {
-        // unchecked nodes are hidden from the map so exclude them unless the flag is set.
-        var childOverlays = node.getOverlays(opt_unchecked);
-        if (childOverlays) {
-          overlays = overlays.concat(childOverlays);
-        }
-      }
-    }
-  }
-
-  return overlays;
-};
-
-
-/**
- * @inheritDoc
- * @suppress {accessControls}
- */
-plugin.file.kml.ui.KMLNode.prototype.getExtent = function() {
-  var extent = null;
-
-  var children = this.getChildren();
-  if (children && children.length) {
-    for (var i = 0, n = children.length; i < n; i++) {
-      if (os.implements(children[i], os.data.IExtent.ID)) {
-        var child = /** @type {os.data.IExtent} */ (children[i]);
-        var ex = child.getExtent();
-        if (extent && ex) {
-          ol.extent.extend(extent, ex);
-        } else if (!extent) {
-          extent = ex;
-        }
-      }
-    }
-  } else if (this.image_) {
-    var source = this.image_.getSource();
-
-    if (source instanceof ol.source.ImageStatic) {
-      extent = /** @type {ol.source.ImageStatic} */ (source).image_.getExtent();
-    }
-  } else {
-    var geoms = this.getFeatures().map(os.fn.mapFeatureToGeometry);
-    extent = geoms.reduce(os.fn.reduceExtentFromGeometries, ol.extent.createEmpty());
-  }
-
-  return extent;
-};
-
-
-/**
- * @return {Array<!ol.Feature>|undefined}
- */
-plugin.file.kml.ui.KMLNode.prototype.getZoomFeatures = function() {
-  var children = this.getChildren();
-  if (children && children.length) {
-    var features;
-    for (var i = 0, n = children.length; i < n; i++) {
-      var childFeatures = children[i].getZoomFeatures();
-      if (childFeatures) {
-        features = features ? features.concat(childFeatures) : childFeatures;
-      }
-    }
-
-    return features;
-  } else if (this.image_) {
-    var extent = this.getExtent();
-    if (extent && !ol.extent.isEmpty(extent)) {
-      return [new ol.Feature(ol.geom.Polygon.fromExtent(extent))];
-    }
-  }
-
-  return this.getFeatures();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.getId = function() {
-  if (this.feature_) {
-    var id = this.feature_.getId();
-    if (id) {
-      return id.toString();
-    }
-  }
-
-  return plugin.file.kml.ui.KMLNode.base(this, 'getId');
-};
-
-
-/**
- * Whether or not the KML node is loading.
- *
- * @return {boolean}
- * @export
- */
-plugin.file.kml.ui.KMLNode.prototype.isLoading = function() {
-  return this.loading;
-};
-
-
-/**
- * Set if the node is loading.
- *
- * @param {boolean} value The new value
- * @protected
- */
-plugin.file.kml.ui.KMLNode.prototype.setLoading = function(value) {
-  if (this.loading != value) {
-    this.loading = value;
-    this.dispatchEvent(new os.events.PropertyChangeEvent('loading', value, !value));
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.getSearchText = function() {
-  return this.getLabel() || '';
-};
-
-
-/**
- * Get the KML source associated with the node.
- *
- * @return {plugin.file.kml.KMLSource}
- */
-plugin.file.kml.ui.KMLNode.prototype.getSource = function() {
-  return this.source;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.getTags = function() {
-  return null;
-};
-
-
-/**
- * The KML merge requires quick access to the node. Also, the KML parser does not produce consistent
- * IDs for the nodes on subsequent runs. Therefore, the label is going to be used for the index. To
- * support multiple items with the same label, the index points to a list of those items.
- */
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.index = function(child) {
-  var label = child.getLabel() || '';
-
-  if (child instanceof plugin.file.kml.ui.KMLNode) {
-    if (!(label in this.childLabelMap)) {
-      this.childLabelMap[label] = [];
-    }
-
-    this.childLabelMap[label].push(child);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.unindex = function(child) {
-  var label = child.getLabel() || '';
-
-  if (label in this.childLabelMap) {
-    var list = /** @type {Array<plugin.file.kml.ui.KMLNode>} */ (this.childLabelMap[label]);
-
-    var x = list.indexOf(/** @type {plugin.file.kml.ui.KMLNode} */ (child));
-    if (x > -1) {
-      list.splice(x, 1);
-    }
-
-    if (list.length === 0) {
-      delete this.childLabelMap[label];
-    }
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.hasChild = function(child) {
-  var label = child.getLabel() || '';
-  if (label in this.childLabelMap) {
-    return /** @type {Array<plugin.file.kml.ui.KMLNode>} */ (
-      this.childLabelMap[label]).indexOf(/** @type {plugin.file.kml.ui.KMLNode} */ (child)) !== -1;
-  }
-
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.addChild = function(child, opt_skipaddparent, opt_index) {
-  if (child instanceof plugin.file.kml.ui.KMLNode) {
-    var previous = this.merge(child);
-
-    if (!previous) {
-      return plugin.file.kml.ui.KMLNode.base(this, 'addChild', child, opt_skipaddparent, opt_index);
-    } else {
-      // node was merged with an existing one, so clean up the extra node
-      goog.dispose(child);
-    }
-
-    return previous;
-  }
-
-  goog.log.error(this.log, 'Unable to add non-KML node "' + child.getLabel() + '" to the KML tree!');
-  return null;
-};
-
-
-/**
- * @param {!plugin.file.kml.ui.KMLNode} child
- * @return {?plugin.file.kml.ui.KMLNode}
- */
-plugin.file.kml.ui.KMLNode.prototype.merge = function(child) {
-  var children = /** {Array<!plugin.file.kml.ui.KMLNode>|undefined} */ (this.childLabelMap[child.getLabel() || '']);
-
-  if (children) {
-    for (var i = 0, n = children.length; i < n; i++) {
-      var prevChild = children[i];
-
-      if (prevChild.marked) {
-        prevChild.setFeature(child.getFeature());
-        prevChild.marked = false;
-        prevChild.setId(child.getId());
-        return prevChild;
-      }
-    }
-  }
-
-  return null;
-};
-
-
-/**
- * If the node is a KML Folder.
- *
- * @return {boolean}
- */
-plugin.file.kml.ui.KMLNode.prototype.isFolder = function() {
-  return (this.feature_ == null && this.image_ == null && this.overlayOptions_ == null);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.formatIcons = function() {
-  if (this.isFolder()) {
-    var open = this.hasChildren() && !this.collapsed;
-    return '<i class="fa fa-folder' + (open ? '-open' : '') + ' fa-fw"></i>';
-  } else if (this.image_) {
-    return '<i class="fa fa-photo fa-fw compact" title="Ground Overlay"></i>';
-  } else if (this.overlayOptions_) {
-    return '<i class="fa fa-photo fa-fw compact" title="Screen Overlay"></i>';
-  } else {
-    var icons = [];
-
-    // if the node has a geometry, add the geometry icon
-    var geom = this.feature_.getGeometry();
-    if (geom) {
-      var type = geom.getType();
-      if (type in plugin.file.kml.ui.GeometryIcons) {
-        var geomIcon = plugin.file.kml.ui.GeometryIcons[type];
-        var color = /** @type {string|undefined} */ (os.feature.getColor(this.feature_));
-        if (color) {
-          // disregard opacity - only interested in displaying the color
-          geomIcon = geomIcon.replace('><', ' style="color:' + os.color.toHexString(color) + '"><');
-        }
-
-        icons.push(geomIcon);
-      }
-    }
-
-    // if an annotation is displayed, add an icon for it
-    if (this.annotation_) {
-      icons.push('<i class="fa fa-comment fa-fw" title="Text box"></i>');
-    }
-
-    // add an info icon to launch feature info
-    icons.push('<i class="fa fa-info-circle fa-fw c-glyph" title="Feature Info" ' +
-        'ng-click="itemAction(\'' + plugin.file.kml.ui.KMLNodeAction.FEATURE_INFO + '\')"></i>');
-
-    return icons.join('');
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.performAction = function(type) {
-  if (type == plugin.file.kml.ui.KMLNodeAction.FEATURE_INFO) {
-    if (this.feature_) {
-      var title = this.source ? this.source.getTitle() : undefined;
-      os.ui.feature.launchMultiFeatureInfo(this.feature_, title);
-    }
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.onChildChange = function(e) {
-  var p = e.getProperty();
-
-  // if the source is loading, filter out which events are handled to avoid excessive tree updates
-  if (this.source && this.source.isLoading() &&
-      p && plugin.file.kml.ui.KMLNode.CHILD_LOADING_EVENTS_.indexOf(p) == -1) {
-    return;
-  }
-
-  plugin.file.kml.ui.KMLNode.base(this, 'onChildChange', e);
-
-  if (p === 'collapsed' || p === os.annotation.EventType.CHANGE) {
-    // propagate the event up the tree so the KML can be saved if necessary
-    this.dispatchEvent(new os.events.PropertyChangeEvent(p));
-  } else if (p === 'loading') {
-    // propagate loading events up the tree so the layer can show the overall loading state
-    this.dispatchEvent(new os.events.PropertyChangeEvent(p, e.getNewValue(), e.getOldValue()));
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.onMouseEnter = function() {
-  if (this.feature_ && this.source) {
-    // always set this to ensure features are immediately highlighted when enabled via their own checkbox
-    this.highlight_ = true;
-
-    if (!this.source.isHidden(this.feature_)) {
-      // only highlight the feature if it isn't hidden
-      this.source.setHighlightedItems([this.feature_]);
-    }
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.onMouseLeave = function() {
-  if (this.feature_ && this.source) {
-    this.highlight_ = false;
-    this.source.setHighlightedItems(null);
-  }
-};
-
-
-/**
- * Set the KML source for this node.
- *
- * @param {plugin.file.kml.KMLSource} source The source
- */
-plugin.file.kml.ui.KMLNode.prototype.setSource = function(source) {
-  this.source = source;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.setState = function(value) {
-  var old = this.getState();
-
-  plugin.file.kml.ui.KMLNode.base(this, 'setState', value);
-
-  var s = this.getState();
-
-  this.setAnnotationVisibility_(s === os.structs.TriState.ON && this.animationState_);
-  this.setImageVisibility_(s === os.structs.TriState.ON && this.animationState_);
-  this.setOverlayVisibility_(s === os.structs.TriState.ON && this.animationState_);
-
-  if (old != s && this.updateSource_ && this.source) {
-    if (s !== os.structs.TriState.BOTH) {
-      this.source.scheduleUpdateFromNodes();
-
-      if (this.highlight_) {
-        if (s === os.structs.TriState.ON) {
-          // mouse is on a leaf node, so highlight the feature
-          this.source.setHighlightedItems([this.feature_]);
-        } else {
-          // mouse is on a leaf node, so remove the highlight feature
-          this.source.setHighlightedItems(null);
-        }
-      }
-    }
-  }
-};
-
-
-/**
- * Sets the state without trying to update features on the source. This is used to prevent duplicate source visibility
- * calls when the source caused the state change, or the state is being propagated through the tree.
- *
- * @param {string} value The new state value
- */
-plugin.file.kml.ui.KMLNode.prototype.setStateOnly = function(value) {
-  this.updateSource_ = false;
-  this.setState(value);
-  this.updateSource_ = true;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.updateChild = function(child, state) {
-  // avoid changing source visibility when updating children, so the visibility calls aren't massively duplicated. the
-  // visibility will be changed at the level toggled by the user, resulting in a single call to the source.
-  child.setStateOnly(state);
-};
-
-
-/**
- * Collapses all nodes under the target that do not have children.
- *
- * @param {!plugin.file.kml.ui.KMLNode} target The target node to collapse
- */
-plugin.file.kml.ui.KMLNode.collapseEmpty = function(target) {
-  var children = target.getChildren();
-  if (children && children.length > 0) {
-    for (var i = 0, n = children.length; i < n; i++) {
-      plugin.file.kml.ui.KMLNode.collapseEmpty(/** @type {!plugin.file.kml.ui.KMLNode} */ (children[i]));
-    }
-  } else {
-    target.collapsed = true;
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLNode.prototype.getLayerUI = function(item) {
-  if (item && item instanceof plugin.file.kml.ui.KMLNode && item.editable && item.feature_) {
-    return item.layerUI || 'defaultlayerui';
-  }
-
-  return null;
-};
+exports = KMLNode;

--- a/src/plugin/file/kml/ui/kmlnodeaction.js
+++ b/src/plugin/file/kml/ui/kmlnodeaction.js
@@ -1,0 +1,11 @@
+goog.module('plugin.file.kml.ui.KMLNodeAction');
+goog.module.declareLegacyNamespace();
+
+
+/**
+ * KML node actions
+ * @enum {string}
+ */
+exports = {
+  FEATURE_INFO: 'featureInfo'
+};

--- a/src/plugin/file/kml/ui/kmltournode.js
+++ b/src/plugin/file/kml/ui/kmltournode.js
@@ -1,79 +1,80 @@
-goog.provide('plugin.file.kml.ui.KMLTourNode');
+goog.module('plugin.file.kml.ui.KMLTourNode');
+goog.module.declareLegacyNamespace();
 
-goog.require('plugin.file.kml.ui.KMLNode');
-goog.require('plugin.file.kml.ui.kmlTourNodeUIDirective');
+const dispose = goog.require('goog.dispose');
+
+const KMLNode = goog.require('plugin.file.kml.ui.KMLNode');
+const {directiveTag: kmlTourNodeUi} = goog.require('plugin.file.kml.ui.KMLTourNodeUI');
 
 
 /**
  * Tree node for a KML tour.
- *
- * @param {!plugin.file.kml.tour.Tour} tour The KML tour.
- * @extends {plugin.file.kml.ui.KMLNode}
- * @constructor
  */
-plugin.file.kml.ui.KMLTourNode = function(tour) {
-  plugin.file.kml.ui.KMLTourNode.base(this, 'constructor');
-  this.setCheckboxVisible(false);
-  this.nodeUI = '<kmltournodeui></kmltournodeui>';
+class KMLTourNode extends KMLNode {
+  /**
+   * Constructor.
+   * @param {!plugin.file.kml.tour.Tour} tour The KML tour.
+   */
+  constructor(tour) {
+    super();
+    this.setCheckboxVisible(false);
+    this.nodeUI = `<${kmlTourNodeUi}></${kmlTourNodeUi}>`;
+
+    /**
+     * The KML tour.
+     * @type {plugin.file.kml.tour.Tour|undefined}
+     * @private
+     */
+    this.tour_ = tour;
+  }
 
   /**
-   * The KML tour.
-   * @type {plugin.file.kml.tour.Tour|undefined}
-   * @private
+   * @inheritDoc
    */
-  this.tour_ = tour;
-};
-goog.inherits(plugin.file.kml.ui.KMLTourNode, plugin.file.kml.ui.KMLNode);
+  disposeInternal() {
+    super.disposeInternal();
 
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLTourNode.prototype.disposeInternal = function() {
-  plugin.file.kml.ui.KMLTourNode.base(this, 'disposeInternal');
-
-  goog.dispose(this.tour_);
-  this.tour_ = undefined;
-};
-
-
-/**
- * Get the KML tour object for the node.
- *
- * @return {plugin.file.kml.tour.Tour|undefined}
- */
-plugin.file.kml.ui.KMLTourNode.prototype.getTour = function() {
-  return this.tour_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLTourNode.prototype.getLabel = function() {
-  if (this.tour_) {
-    return this.tour_['name'];
+    dispose(this.tour_);
+    this.tour_ = undefined;
   }
 
-  return plugin.file.kml.ui.KMLTourNode.base(this, 'getLabel');
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLTourNode.prototype.getToolTip = function() {
-  if (this.tour_) {
-    return this.tour_['description'];
+  /**
+   * Get the KML tour object for the node.
+   *
+   * @return {plugin.file.kml.tour.Tour|undefined}
+   */
+  getTour() {
+    return this.tour_;
   }
 
-  return plugin.file.kml.ui.KMLTourNode.base(this, 'getToolTip');
-};
+  /**
+   * @inheritDoc
+   */
+  getLabel() {
+    if (this.tour_) {
+      return this.tour_['name'];
+    }
 
+    return super.getLabel();
+  }
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.KMLTourNode.prototype.formatIcons = function() {
-  return '<i class="fa fa-video-camera fa-fw" title="KML Tour"></i>';
-};
+  /**
+   * @inheritDoc
+   */
+  getToolTip() {
+    if (this.tour_) {
+      return this.tour_['description'];
+    }
+
+    return super.getToolTip();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  formatIcons() {
+    return '<i class="fa fa-video-camera fa-fw" title="KML Tour"></i>';
+  }
+}
+
+exports = KMLTourNode;

--- a/src/plugin/file/kml/ui/kmltreeexportui.js
+++ b/src/plugin/file/kml/ui/kmltreeexportui.js
@@ -1,12 +1,14 @@
-goog.provide('plugin.file.kml.ui.KMLTreeExportCtrl');
-goog.provide('plugin.file.kml.ui.kmlTreeExportDirective');
+goog.module('plugin.file.kml.ui.KMLTreeExportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
-goog.require('os');
-goog.require('os.ui.Module');
-goog.require('os.ui.window');
-goog.require('plugin.file.kml.KMLTreeExporter');
-goog.require('plugin.file.kml.ui.kmlExportDirective');
+const asserts = goog.require('goog.asserts');
+const {ROOT} = goog.require('os');
+const config = goog.require('os.config');
+const Module = goog.require('os.ui.Module');
+const WindowEventType = goog.require('os.ui.WindowEventType');
+const exportManager = goog.require('os.ui.exportManager');
+const osWindow = goog.require('os.ui.window');
+const KMLTreeExporter = goog.require('plugin.file.kml.KMLTreeExporter');
 
 
 /**
@@ -14,24 +16,28 @@ goog.require('plugin.file.kml.ui.kmlExportDirective');
  *
  * @return {angular.Directive}
  */
-plugin.file.kml.ui.kmlTreeExportDirective = function() {
-  return {
-    restrict: 'E',
-    scope: {
-      'rootNode': '=',
-      'options': '='
-    },
-    templateUrl: os.ROOT + 'views/plugin/kml/kmltreeexport.html',
-    controller: plugin.file.kml.ui.KMLTreeExportCtrl,
-    controllerAs: 'treeExport'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  scope: {
+    'rootNode': '=',
+    'options': '='
+  },
+  templateUrl: ROOT + 'views/plugin/kml/kmltreeexport.html',
+  controller: Controller,
+  controllerAs: 'treeExport'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'kmltreeexport';
 
 
 /**
  * Add the directive to the module.
  */
-os.ui.Module.directive('kmltreeexport', [plugin.file.kml.ui.kmlTreeExportDirective]);
+Module.directive('kmltreeexport', [directive]);
 
 
 /**
@@ -40,7 +46,7 @@ os.ui.Module.directive('kmltreeexport', [plugin.file.kml.ui.kmlTreeExportDirecti
  * @param {string=} opt_winLabel The window label
  * @param {os.ex.ExportOptions=} opt_addOptions
  */
-plugin.file.kml.ui.launchTreeExport = function(rootNode, opt_winLabel, opt_addOptions) {
+const launchTreeExport = function(rootNode, opt_winLabel, opt_addOptions) {
   var scopeOptions = {
     'rootNode': rootNode,
     'options': opt_addOptions
@@ -58,8 +64,8 @@ plugin.file.kml.ui.launchTreeExport = function(rootNode, opt_winLabel, opt_addOp
     'show-close': true
   };
 
-  var template = '<kmltreeexport root-node="rootNode" options="options"></kmltreeexport>';
-  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+  var template = `<${directiveTag} root-node="rootNode" options="options"></${directiveTag}>`;
+  osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
 };
 
 
@@ -67,156 +73,163 @@ plugin.file.kml.ui.launchTreeExport = function(rootNode, opt_winLabel, opt_addOp
 /**
  * Controller function for the kmltreeexport directive
  *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @constructor
- * @ngInject
  * @template T
+ * @unrestricted
  */
-plugin.file.kml.ui.KMLTreeExportCtrl = function($scope, $element) {
+class Controller {
   /**
-   * @type {?angular.Scope}
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    /**
+     * @type {?angular.Scope}
+     * @protected
+     */
+    this.scope = $scope;
+
+    /**
+     * @type {?angular.JQLite}
+     * @protected
+     */
+    this.element = $element;
+
+    var root = /** @type {plugin.file.kml.ui.KMLNode} */ (this.scope['rootNode']);
+
+    /**
+     * @type {string}
+     */
+    this['title'] = root && root.getLabel() || (config.getAppName() + ' KML Tree').trim();
+
+    /**
+     * @type {!KMLTreeExporter}
+     */
+    this['exporter'] = new KMLTreeExporter();
+
+    /**
+     * @type {!Object<string, os.ex.IPersistenceMethod>}
+     */
+    this['persisters'] = {};
+
+    /**
+     * @type {os.ex.IPersistenceMethod}
+     */
+    this['persister'] = null;
+
+    const options = this.scope['options'];
+
+    /**
+     * @type {boolean}
+     */
+    this['additionalOptions'] = (options && options.additionalOptions) || false;
+
+    /**
+     * The data to be exported
+     * @type {boolean}
+     */
+    this.scope['exportData'] = this.scope['rootNode'].getChildren();
+
+    var persisters = exportManager.getPersistenceMethods();
+    if (persisters && persisters.length > 0) {
+      this['persister'] = persisters[0];
+
+      for (var i = 0, n = persisters.length; i < n; i++) {
+        this['persisters'][persisters[i].getLabel()] = persisters[i];
+      }
+    }
+
+    $scope.$on('$destroy', this.destroy.bind(this));
+
+    // Don't listen for this if we don't have additional options
+    if (this['additionalOptions']) {
+      $scope.$on('addexportoptions.updateitem', function(event, items) {
+        this.scope['exportData'] = items || [];
+      }.bind(this));
+    }
+
+    // fire auto height event
+    setTimeout(function() {
+      $scope.$emit(WindowEventType.READY);
+    }, 0);
+  }
+
+  /**
+   * Clean up.
+   *
    * @protected
    */
-  this.scope = $scope;
+  destroy() {
+    this.scope = null;
+    this.element = null;
+  }
 
   /**
-   * @type {?angular.JQLite}
-   * @protected
+   * Fire the cancel callback and close the window.
+   *
+   * @export
    */
-  this.element = $element;
-
-  var root = /** @type {plugin.file.kml.ui.KMLNode} */ (this.scope['rootNode']);
+  cancel() {
+    this.close_();
+  }
 
   /**
-   * @type {string}
+   * Fire the confirmation callback and close the window.
+   *
+   * @export
    */
-  this['title'] = root && root.getLabel() || (os.config.getAppName() + ' KML Tree').trim();
+  confirm() {
+    asserts.assert(this.scope != null, 'scope is not defined');
+    asserts.assert(this.scope['rootNode'] != null, 'KML root is not defined');
+    asserts.assert(this['exporter'] != null, 'exporter is not defined');
+    asserts.assert(this['persister'] != null, 'persister is not defined');
+    asserts.assert(!!this['title'], 'export title is empty/null');
 
-  /**
-   * @type {!plugin.file.kml.KMLTreeExporter}
-   */
-  this['exporter'] = new plugin.file.kml.KMLTreeExporter();
+    var root = /** @type {plugin.file.kml.ui.KMLNode} */ (this.scope['rootNode']);
+    if (root) {
+      var items = root.getChildren() || [root];
+      items = this['additionalOptions'] ? this.scope['exportData'] : items;
 
-  /**
-   * @type {!Object<string, os.ex.IPersistenceMethod>}
-   */
-  this['persisters'] = {};
+      var options = /** @type {os.ex.ExportOptions} */ ({
+        items: items,
+        fields: null,
+        title: this['title'],
+        exporter: this['exporter'],
+        persister: this['persister']
+      });
 
-  /**
-   * @type {os.ex.IPersistenceMethod}
-   */
-  this['persister'] = null;
-
-  const options = this.scope['options'];
-
-  /**
-   * @type {boolean}
-   */
-  this['additionalOptions'] = (options && options.additionalOptions) || false;
-
-  /**
-   * The data to be exported
-   * @type {boolean}
-   */
-  this.scope['exportData'] = this.scope['rootNode'].getChildren();
-
-  var persisters = os.ui.exportManager.getPersistenceMethods();
-  if (persisters && persisters.length > 0) {
-    this['persister'] = persisters[0];
-
-    for (var i = 0, n = persisters.length; i < n; i++) {
-      this['persisters'][persisters[i].getLabel()] = persisters[i];
+      exportManager.exportItems(options);
+      this.close_();
     }
   }
 
-  $scope.$on('$destroy', this.destroy.bind(this));
-
-  // Don't listen for this if we don't have additional options
-  if (this['additionalOptions']) {
-    $scope.$on('addexportoptions.updateitem', function(event, items) {
-      this.scope['exportData'] = items || [];
-    }.bind(this));
+  /**
+   * Close the window.
+   *
+   * @private
+   */
+  close_() {
+    osWindow.close(this.element);
   }
 
-  // fire auto height event
-  setTimeout(function() {
-    $scope.$emit(os.ui.WindowEventType.READY);
-  }, 0);
-};
-
-
-/**
- * Clean up.
- *
- * @protected
- */
-plugin.file.kml.ui.KMLTreeExportCtrl.prototype.destroy = function() {
-  this.scope = null;
-  this.element = null;
-};
-
-
-/**
- * Fire the cancel callback and close the window.
- *
- * @export
- */
-plugin.file.kml.ui.KMLTreeExportCtrl.prototype.cancel = function() {
-  this.close_();
-};
-
-
-/**
- * Fire the confirmation callback and close the window.
- *
- * @export
- */
-plugin.file.kml.ui.KMLTreeExportCtrl.prototype.confirm = function() {
-  goog.asserts.assert(this.scope != null, 'scope is not defined');
-  goog.asserts.assert(this.scope['rootNode'] != null, 'KML root is not defined');
-  goog.asserts.assert(this['exporter'] != null, 'exporter is not defined');
-  goog.asserts.assert(this['persister'] != null, 'persister is not defined');
-  goog.asserts.assert(!!this['title'], 'export title is empty/null');
-
-  var root = /** @type {plugin.file.kml.ui.KMLNode} */ (this.scope['rootNode']);
-  if (root) {
-    var items = root.getChildren() || [root];
-    items = this['additionalOptions'] ? this.scope['exportData'] : items;
-
-    var options = /** @type {os.ex.ExportOptions} */ ({
-      items: items,
-      fields: null,
-      title: this['title'],
-      exporter: this['exporter'],
-      persister: this['persister']
-    });
-
-    os.ui.exportManager.exportItems(options);
-    this.close_();
+  /**
+   * Disables the OK button.
+   * @return {boolean}
+   * @export
+   */
+  disable() {
+    if (this['additionalOptions'] && this.scope['exportData']) {
+      return this.scope['exportData'].length <= 0;
+    } else {
+      return false;
+    }
   }
-};
+}
 
-
-/**
- * Close the window.
- *
- * @private
- */
-plugin.file.kml.ui.KMLTreeExportCtrl.prototype.close_ = function() {
-  os.ui.window.close(this.element);
-};
-
-
-/**
- * Disables the OK button.
- * @return {boolean}
- * @export
- */
-plugin.file.kml.ui.KMLTreeExportCtrl.prototype.disable = function() {
-  if (this['additionalOptions'] && this.scope['exportData']) {
-    return this.scope['exportData'].length <= 0;
-  } else {
-    return false;
-  }
+exports = {
+  Controller,
+  directive,
+  directiveTag,
+  launchTreeExport
 };

--- a/src/plugin/file/kml/ui/networklinkicons.js
+++ b/src/plugin/file/kml/ui/networklinkicons.js
@@ -1,0 +1,14 @@
+goog.module('plugin.file.kml.ui.NetworkLinkIcons');
+goog.module.declareLegacyNamespace();
+
+
+/**
+ * KML network link icons.
+ * @enum {string}
+ */
+exports = {
+  ACTIVE: '<i class="fa fa-link fa-fw compact text-success" title="KML network link"></i>',
+  ERROR: '<i class="fa fa-unlink fa-fw compact text-danger" title="Unable to load network link"></i>',
+  INACTIVE: '<i class="fa fa-link fa-fw compact" title="KML network link - enable to load"></i>',
+  LOADING: '<i class="fa fa-link fa-fw compact text-warning" title="Loading network link..."></i>'
+};

--- a/src/plugin/file/kml/ui/placemarkedit.js
+++ b/src/plugin/file/kml/ui/placemarkedit.js
@@ -19,7 +19,7 @@ const AnyDateType = goog.require('os.ui.datetime.AnyDateType');
 const featureEditDirective = goog.require('os.ui.featureEditDirective');
 const list = goog.require('os.ui.list');
 const kml = goog.require('plugin.file.kml');
-const {updatePlacemark} = goog.require('plugin.file.kml.ui');
+const kmlUI = goog.require('plugin.file.kml.ui');
 const PlacesManager = goog.require('plugin.places.PlacesManager');
 
 const KMLNode = goog.requireType('plugin.file.kml.ui.KMLNode');
@@ -188,7 +188,7 @@ class Controller extends FeatureEditCtrl {
       feature.setId(getUid(feature));
     }
 
-    updatePlacemark(this.options);
+    kmlUI.updatePlacemark(this.options);
 
     if (this.callback) {
       this.callback(this.options);

--- a/src/plugin/file/kml/ui/placemarkedit.js
+++ b/src/plugin/file/kml/ui/placemarkedit.js
@@ -1,18 +1,28 @@
-goog.provide('plugin.file.kml.ui.PlacemarkEditCtrl');
-goog.provide('plugin.file.kml.ui.placemarkEditDirective');
+goog.module('plugin.file.kml.ui.PlacemarkEditUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.Feature');
-goog.require('os.annotation');
-goog.require('os.annotation.FeatureAnnotation');
 goog.require('os.annotation.annotationOptionsDirective');
-goog.require('os.data.ColumnDefinition');
-goog.require('os.structs');
-goog.require('os.ui.FeatureEditCtrl');
-goog.require('os.ui.Module');
-goog.require('os.ui.list');
-goog.require('plugin.file.kml.KMLField');
-goog.require('plugin.file.kml.ui');
-goog.require('plugin.places.PlacesManager');
+
+const dispose = goog.require('goog.dispose');
+const {getUid} = goog.require('ol');
+const Feature = goog.require('ol.Feature');
+const annotation = goog.require('os.annotation');
+const FeatureAnnotation = goog.require('os.annotation.FeatureAnnotation');
+const ColumnDefinition = goog.require('os.data.ColumnDefinition');
+const osFeature = goog.require('os.feature');
+const osObject = goog.require('os.object');
+const structs = goog.require('os.structs');
+const osStyle = goog.require('os.style');
+const FeatureEditCtrl = goog.require('os.ui.FeatureEditCtrl');
+const Module = goog.require('os.ui.Module');
+const AnyDateType = goog.require('os.ui.datetime.AnyDateType');
+const featureEditDirective = goog.require('os.ui.featureEditDirective');
+const list = goog.require('os.ui.list');
+const kml = goog.require('plugin.file.kml');
+const {updatePlacemark} = goog.require('plugin.file.kml.ui');
+const PlacesManager = goog.require('plugin.places.PlacesManager');
+
+const KMLNode = goog.requireType('plugin.file.kml.ui.KMLNode');
 
 
 /**
@@ -20,313 +30,313 @@ goog.require('plugin.places.PlacesManager');
  *
  * @return {angular.Directive}
  */
-plugin.file.kml.ui.placemarkEditDirective = function() {
-  var dir = os.ui.featureEditDirective();
-  dir.controller = plugin.file.kml.ui.PlacemarkEditCtrl;
+const directive = () => {
+  var dir = featureEditDirective();
+  dir.controller = Controller;
   return dir;
 };
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'placemarkedit';
 
 
 /**
  * Add the directive to the module.
  */
-os.ui.Module.directive('placemarkedit', [plugin.file.kml.ui.placemarkEditDirective]);
+Module.directive('placemarkedit', [directive]);
 
 
 
 /**
  * Controller function for the placemarkedit directive
- *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout
- * @extends {os.ui.FeatureEditCtrl}
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.file.kml.ui.PlacemarkEditCtrl = function($scope, $element, $timeout) {
-  plugin.file.kml.ui.PlacemarkEditCtrl.base(this, 'constructor', $scope, $element, $timeout);
-
-  // if the name wasn't set in the base class, set it to New Place
-  this['name'] = this['name'] || 'New Place';
-
-  this['customFoldersEnabled'] = false;
-
-  // by default, show column choices for the default KML source. remove internal columns because they're not generally
-  // useful to a user.
-  var defaultColumns = plugin.file.kml.SOURCE_FIELDS.filter(function(field) {
-    return !os.feature.isInternalField(field);
-  }).map(function(col) {
-    return new os.data.ColumnDefinition(col);
-  });
-
+class Controller extends FeatureEditCtrl {
   /**
-   * The preview annotation.
-   * @type {os.annotation.FeatureAnnotation|undefined}
-   * @protected
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @param {!angular.$timeout} $timeout
+   * @ngInject
    */
-  this.previewAnnotation;
+  constructor($scope, $element, $timeout) {
+    super($scope, $element, $timeout);
 
-  /**
-   * @type {!Array<string>}
-   */
-  this['labelColumns'] = defaultColumns;
+    // if the name wasn't set in the base class, set it to New Place
+    this['name'] = this['name'] || 'New Place';
 
-  /**
-   * tempHeaderColor
-   * @type {string|undefined}
-   */
-  this['tempHeaderBG'] = this['annotationOptions'].headerBG || undefined;
+    this['customFoldersEnabled'] = false;
 
-  /**
-   * tempBodyColor
-   * @type {string|undefined}
-   */
-  this['tempBodyBG'] = this['annotationOptions'].bodyBG || undefined;
-
-  var time = this.options['time'];
-
-  if (time) {
-    this['startTime'] = time.getStart();
-    this['startTimeISO'] = this['startTime'] ? new Date(this['startTime']).toISOString() : undefined;
-    this['endTime'] = time.getEnd() === this['startTime'] ? undefined : time.getEnd();
-    this['endTimeISO'] = this['endTime'] ? new Date(this['endTime']).toISOString() : undefined;
-    if (this['endTime'] > this['startTime']) {
-      this['dateType'] = os.ui.datetime.AnyDateType.RANGE;
-    } else {
-      this['dateType'] = os.ui.datetime.AnyDateType.INSTANT;
-    }
-  }
-
-  if (!this.isFeatureDynamic()) {
-    var optionsListId = 'optionsList' + this['uid'];
-
-    os.ui.list.add(optionsListId,
-        '<annotationoptions options="ctrl.annotationOptions"></annotationoptions>');
-
-    if (this.options['annotation']) {
-      // if creating a new annotation, expand the Annotation Options section by default
-      this.defaultExpandedOptionsId = 'featureAnnotation' + this['uid'];
-    }
-
-    this['customFoldersEnabled'] = true;
-
-    var folders = [];
-    var rootFolder = plugin.places.PlacesManager.getInstance().getPlacesRoot();
-    os.structs.flattenTree(rootFolder, folders, function(node) {
-      return /** @type {plugin.file.kml.ui.KMLNode} */ (node).isFolder();
+    // by default, show column choices for the default KML source. remove internal columns because they're not generally
+    // useful to a user.
+    var defaultColumns = kml.SOURCE_FIELDS.filter(function(field) {
+      return !osFeature.isInternalField(field);
+    }).map(function(col) {
+      return new ColumnDefinition(col);
     });
-    this['folderOptions'] = folders;
 
-    var parentFolder = this.options['parent'];
-    if (!parentFolder && this.options['node']) {
-      parentFolder = this.options['node'].getParent();
-    }
+    /**
+     * The preview annotation.
+     * @type {FeatureAnnotation|undefined}
+     * @protected
+     */
+    this.previewAnnotation;
 
-    this['folder'] = parentFolder || rootFolder;
-  }
+    /**
+     * @type {!Array<string>}
+     */
+    this['labelColumns'] = defaultColumns;
 
-  $scope.$on('headerColor.reset', this.resetHeaderBackgroundColor_.bind(this));
-  $scope.$on('bodyColor.reset', this.resetBodyBackgroundColor_.bind(this));
-  $scope.$on('headerColor.change', this.saveHeaderBackgroundColor_.bind(this));
-  $scope.$on('bodyColor.change', this.saveBodyBackgroundColor_.bind(this));
-};
-goog.inherits(plugin.file.kml.ui.PlacemarkEditCtrl, os.ui.FeatureEditCtrl);
+    /**
+     * tempHeaderColor
+     * @type {string|undefined}
+     */
+    this['tempHeaderBG'] = this['annotationOptions'].headerBG || undefined;
 
+    /**
+     * tempBodyColor
+     * @type {string|undefined}
+     */
+    this['tempBodyBG'] = this['annotationOptions'].bodyBG || undefined;
 
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.PlacemarkEditCtrl.prototype.disposeInternal = function() {
-  plugin.file.kml.ui.PlacemarkEditCtrl.base(this, 'disposeInternal');
+    var time = this.options['time'];
 
-  if (this.previewAnnotation) {
-    goog.dispose(this.previewAnnotation);
-    this.previewAnnotation = null;
-  }
-
-  if (this.options['feature']) {
-    this.options['feature'].changed();
-  }
-};
-
-
-/**
- * @inheritDoc
- * @export
- */
-plugin.file.kml.ui.PlacemarkEditCtrl.prototype.accept = function() {
-  // create a new feature if necessary
-  var feature = this.options['feature'] = this.options['feature'] || new ol.Feature();
-
-  // filter out empty labels when the placemark is saved
-  if (this['labels']) {
-    this['labels'] = this['labels'].filter(function(label) {
-      return label['column'] != null;
-    });
-  }
-
-  // enable editing the annotation when the feature is saved
-  this['annotationOptions'].editable = true;
-
-  this.saveToFeature(feature);
-
-  if (!feature.getId()) {
-    feature.setId(ol.getUid(feature));
-  }
-
-  plugin.file.kml.ui.updatePlacemark(this.options);
-
-  if (this.callback) {
-    this.callback(this.options);
-  }
-
-  this.close();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.PlacemarkEditCtrl.prototype.createPreviewFeature = function() {
-  plugin.file.kml.ui.PlacemarkEditCtrl.base(this, 'createPreviewFeature');
-
-  // set the default options for the annotation
-  this['annotationOptions'] = os.object.unsafeClone(os.annotation.DEFAULT_OPTIONS);
-
-  // disable annotation edit when creating an annotation
-  this['annotationOptions'].editable = false;
-
-  if (this.options['annotation']) {
-    this.previewFeature.set(os.annotation.OPTIONS_FIELD, this['annotationOptions']);
-
-    if (!this.originalGeometry) {
-      // default to hiding the geometry for points as it tends to visually obscure what you're annotating
-      this['shape'] = os.style.ShapeType.NONE;
-    }
-
-    // don't display a label, but leave the config present to populate the UI
-    this['labels'][0]['column'] = '';
-  } else {
-    this['annotationOptions'].show = false;
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.PlacemarkEditCtrl.prototype.loadFromFeature = function(feature) {
-  plugin.file.kml.ui.PlacemarkEditCtrl.base(this, 'loadFromFeature', feature);
-
-  var currentOptions = feature.get(os.annotation.OPTIONS_FIELD);
-  this['annotationOptions'] = os.object.unsafeClone(currentOptions || os.annotation.DEFAULT_OPTIONS);
-
-  if (!currentOptions) {
-    this['annotationOptions'].show = false;
-  }
-
-  // disable annotation edit when editing an annotation
-  this['annotationOptions'].editable = false;
-};
-
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.ui.PlacemarkEditCtrl.prototype.saveToFeature = function(feature) {
-  plugin.file.kml.ui.PlacemarkEditCtrl.base(this, 'saveToFeature', feature);
-
-  feature.set(os.annotation.OPTIONS_FIELD, this['annotationOptions']);
-};
-
-
-/**
- * @inheritDoc
- * @export
- */
-plugin.file.kml.ui.PlacemarkEditCtrl.prototype.updatePreview = function() {
-  plugin.file.kml.ui.PlacemarkEditCtrl.base(this, 'updatePreview');
-  this.updateAnnotation();
-};
-
-
-/**
- * Updates the option for the placemark's parent folder
- *
- * @export
- */
-plugin.file.kml.ui.PlacemarkEditCtrl.prototype.updateFolder = function() {
-  if (this['folder']) {
-    this.options['parent'] = this['folder'];
-  }
-};
-
-
-/**
- * Updates the temporary annotation.
- *
- * @export
- */
-plugin.file.kml.ui.PlacemarkEditCtrl.prototype.updateAnnotation = function() {
-  if (this.previewFeature) {
-    if (this['annotationOptions'].show) {
-      // only create the preview annotation if not already present, and the feature isn't already displaying an
-      // annotation overlay
-      if (!this.previewAnnotation && !os.annotation.hasOverlay(this.previewFeature)) {
-        this.previewAnnotation = new os.annotation.FeatureAnnotation(this.previewFeature);
+    if (time) {
+      this['startTime'] = time.getStart();
+      this['startTimeISO'] = this['startTime'] ? new Date(this['startTime']).toISOString() : undefined;
+      this['endTime'] = time.getEnd() === this['startTime'] ? undefined : time.getEnd();
+      this['endTimeISO'] = this['endTime'] ? new Date(this['endTime']).toISOString() : undefined;
+      if (this['endTime'] > this['startTime']) {
+        this['dateType'] = AnyDateType.RANGE;
+      } else {
+        this['dateType'] = AnyDateType.INSTANT;
       }
-    } else {
-      // dispose the preview
-      goog.dispose(this.previewAnnotation);
+    }
+
+    if (!this.isFeatureDynamic()) {
+      var optionsListId = 'optionsList' + this['uid'];
+
+      list.add(optionsListId,
+          '<annotationoptions options="ctrl.annotationOptions"></annotationoptions>');
+
+      if (this.options['annotation']) {
+        // if creating a new annotation, expand the Annotation Options section by default
+        this.defaultExpandedOptionsId = 'featureAnnotation' + this['uid'];
+      }
+
+      this['customFoldersEnabled'] = true;
+
+      var folders = [];
+      var rootFolder = PlacesManager.getInstance().getPlacesRoot();
+      structs.flattenTree(rootFolder, folders, (node) => /** @type {KMLNode} */ (node).isFolder());
+      this['folderOptions'] = folders;
+
+      var parentFolder = this.options['parent'];
+      if (!parentFolder && this.options['node']) {
+        parentFolder = this.options['node'].getParent();
+      }
+
+      this['folder'] = parentFolder || rootFolder;
+    }
+
+    $scope.$on('headerColor.reset', this.resetHeaderBackgroundColor_.bind(this));
+    $scope.$on('bodyColor.reset', this.resetBodyBackgroundColor_.bind(this));
+    $scope.$on('headerColor.change', this.saveHeaderBackgroundColor_.bind(this));
+    $scope.$on('bodyColor.change', this.saveBodyBackgroundColor_.bind(this));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
+
+    if (this.previewAnnotation) {
+      dispose(this.previewAnnotation);
       this.previewAnnotation = null;
     }
 
-    // fire a change event on the feature to trigger an overlay update (if present)
-    this.previewFeature.changed();
+    if (this.options['feature']) {
+      this.options['feature'].changed();
+    }
   }
-};
 
+  /**
+   * @inheritDoc
+   * @export
+   */
+  accept() {
+    // create a new feature if necessary
+    var feature = this.options['feature'] = this.options['feature'] || new Feature();
 
-/**
- * Resets the header background to the current default theme color
- *
- * @private
- */
-plugin.file.kml.ui.PlacemarkEditCtrl.prototype.resetHeaderBackgroundColor_ = function() {
-  this['annotationOptions'].headerBG = undefined;
-  this['tempHeaderBG'] = undefined;
-};
+    // filter out empty labels when the placemark is saved
+    if (this['labels']) {
+      this['labels'] = this['labels'].filter(function(label) {
+        return label['column'] != null;
+      });
+    }
 
+    // enable editing the annotation when the feature is saved
+    this['annotationOptions'].editable = true;
 
-/**
- * Resets the body background to the current default theme color
- *
- * @private
- */
-plugin.file.kml.ui.PlacemarkEditCtrl.prototype.resetBodyBackgroundColor_ = function() {
-  this['annotationOptions'].bodyBG = undefined;
-  this['tempBodyBG'] = undefined;
-};
+    this.saveToFeature(feature);
 
+    if (!feature.getId()) {
+      feature.setId(getUid(feature));
+    }
 
-/**
- * Save color to feature
- *
- * @param {angular.Scope.Event} event
- * @param {string} color The new color
- */
-plugin.file.kml.ui.PlacemarkEditCtrl.prototype.saveHeaderBackgroundColor_ = function(event, color) {
-  this['annotationOptions'].headerBG = color;
-};
+    updatePlacemark(this.options);
 
-/**
- * Save color to feature
- *
- * @param {angular.Scope.Event} event
- * @param {string} color The new color
- */
-plugin.file.kml.ui.PlacemarkEditCtrl.prototype.saveBodyBackgroundColor_ = function(event, color) {
-  this['annotationOptions'].bodyBG = color;
+    if (this.callback) {
+      this.callback(this.options);
+    }
+
+    this.close();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  createPreviewFeature() {
+    super.createPreviewFeature();
+
+    // set the default options for the annotation
+    this['annotationOptions'] = osObject.unsafeClone(annotation.DEFAULT_OPTIONS);
+
+    // disable annotation edit when creating an annotation
+    this['annotationOptions'].editable = false;
+
+    if (this.options['annotation']) {
+      this.previewFeature.set(annotation.OPTIONS_FIELD, this['annotationOptions']);
+
+      if (!this.originalGeometry) {
+        // default to hiding the geometry for points as it tends to visually obscure what you're annotating
+        this['shape'] = osStyle.ShapeType.NONE;
+      }
+
+      // don't display a label, but leave the config present to populate the UI
+      this['labels'][0]['column'] = '';
+    } else {
+      this['annotationOptions'].show = false;
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  loadFromFeature(feature) {
+    super.loadFromFeature(feature);
+
+    var currentOptions = feature.get(annotation.OPTIONS_FIELD);
+    this['annotationOptions'] = osObject.unsafeClone(currentOptions || annotation.DEFAULT_OPTIONS);
+
+    if (!currentOptions) {
+      this['annotationOptions'].show = false;
+    }
+
+    // disable annotation edit when editing an annotation
+    this['annotationOptions'].editable = false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  saveToFeature(feature) {
+    super.saveToFeature(feature);
+
+    feature.set(annotation.OPTIONS_FIELD, this['annotationOptions']);
+  }
+
+  /**
+   * @inheritDoc
+   * @export
+   */
+  updatePreview() {
+    super.updatePreview();
+    this.updateAnnotation();
+  }
+
+  /**
+   * Updates the option for the placemark's parent folder
+   *
+   * @export
+   */
+  updateFolder() {
+    if (this['folder']) {
+      this.options['parent'] = this['folder'];
+    }
+  }
+
+  /**
+   * Updates the temporary annotation.
+   *
+   * @export
+   */
+  updateAnnotation() {
+    if (this.previewFeature) {
+      if (this['annotationOptions'].show) {
+        // only create the preview annotation if not already present, and the feature isn't already displaying an
+        // annotation overlay
+        if (!this.previewAnnotation && !annotation.hasOverlay(this.previewFeature)) {
+          this.previewAnnotation = new FeatureAnnotation(this.previewFeature);
+        }
+      } else {
+        // dispose the preview
+        dispose(this.previewAnnotation);
+        this.previewAnnotation = null;
+      }
+
+      // fire a change event on the feature to trigger an overlay update (if present)
+      this.previewFeature.changed();
+    }
+  }
+
+  /**
+   * Resets the header background to the current default theme color
+   *
+   * @private
+   */
+  resetHeaderBackgroundColor_() {
+    this['annotationOptions'].headerBG = undefined;
+    this['tempHeaderBG'] = undefined;
+  }
+
+  /**
+   * Resets the body background to the current default theme color
+   *
+   * @private
+   */
+  resetBodyBackgroundColor_() {
+    this['annotationOptions'].bodyBG = undefined;
+    this['tempBodyBG'] = undefined;
+  }
+
+  /**
+   * Save color to feature
+   *
+   * @param {angular.Scope.Event} event
+   * @param {string} color The new color
+   */
+  saveHeaderBackgroundColor_(event, color) {
+    this['annotationOptions'].headerBG = color;
+  }
+
+  /**
+   * Save color to feature
+   *
+   * @param {angular.Scope.Event} event
+   * @param {string} color The new color
+   */
+  saveBodyBackgroundColor_(event, color) {
+    this['annotationOptions'].bodyBG = color;
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/file/shp/data/dbffield.js
+++ b/src/plugin/file/shp/data/dbffield.js
@@ -1,26 +1,32 @@
-goog.provide('plugin.file.shp.data.DBFField');
-
+goog.module('plugin.file.shp.data.DBFField');
+goog.module.declareLegacyNamespace();
 
 
 /**
- * @param {string} name
- * @param {string} type
- * @param {number} length
- * @constructor
  */
-plugin.file.shp.data.DBFField = function(name, type, length) {
+class DBFField {
   /**
-   * @type {string}
+   * Constructor.
+   * @param {string} name
+   * @param {string} type
+   * @param {number} length
    */
-  this.name = name;
+  constructor(name, type, length) {
+    /**
+     * @type {string}
+     */
+    this.name = name;
 
-  /**
-   * @type {string}
-   */
-  this.type = type;
+    /**
+     * @type {string}
+     */
+    this.type = type;
 
-  /**
-   * @type {number}
-   */
-  this.length = length;
-};
+    /**
+     * @type {number}
+     */
+    this.length = length;
+  }
+}
+
+exports = DBFField;

--- a/src/plugin/file/shp/data/dbfheader.js
+++ b/src/plugin/file/shp/data/dbfheader.js
@@ -1,40 +1,52 @@
-goog.provide('plugin.file.shp.data.DBFHeader');
-goog.require('plugin.file.shp.data.DBFField');
+goog.module('plugin.file.shp.data.DBFHeader');
+goog.module.declareLegacyNamespace();
 
+const DBFField = goog.requireType('plugin.file.shp.data.DBFField');
 
 
 /**
- * @constructor
  */
-plugin.file.shp.data.DBFHeader = function() {
+class DBFHeader {
   /**
-   * @type {ArrayBuffer}
+   * Constructor.
    */
-  this.data = null;
+  constructor() {
+    /**
+     * @type {ArrayBuffer}
+     */
+    this.data = null;
 
-  /**
-   * @type {number}
-   */
-  this.numRecords = 0;
+    /**
+     * @type {number}
+     */
+    this.numRecords = 0;
 
-  /**
-   * @type {number}
-   */
-  this.recordSize = 0;
+    /**
+     * @type {number}
+     */
+    this.recordSize = 0;
 
-  /**
-   * @type {number}
-   */
-  this.recordStart = 0;
+    /**
+     * @type {number}
+     */
+    this.recordStart = 0;
 
-  /**
-   * @type {Array.<plugin.file.shp.data.DBFField>}
-   */
-  this.fields = [];
+    /**
+     * @type {Array.<DBFField>}
+     */
+    this.fields = [];
 
-  /**
-   * Since we use an array buffer, we have to know how big it is before writing to it
-   * @type {number}
-   */
-  this.allocation = 0;
-};
+    /**
+     * Since we use an array buffer, we have to know how big it is before writing to it
+     * @type {number}
+     */
+    this.allocation = 0;
+
+    /**
+     * @type {number}
+     */
+    this.position = 0;
+  }
+}
+
+exports = DBFHeader;

--- a/src/plugin/file/shp/data/shpheader.js
+++ b/src/plugin/file/shp/data/shpheader.js
@@ -1,41 +1,48 @@
-goog.provide('plugin.file.shp.data.SHPHeader');
-goog.require('plugin.file.shp.data.DBFHeader');
-goog.require('plugin.file.shp.data.SHXHeader');
+goog.module('plugin.file.shp.data.SHPHeader');
+goog.module.declareLegacyNamespace();
 
+const DBFHeader = goog.require('plugin.file.shp.data.DBFHeader');
+const SHXHeader = goog.require('plugin.file.shp.data.SHXHeader');
 
 
 /**
- * @constructor
  */
-plugin.file.shp.data.SHPHeader = function() {
+class SHPHeader {
   /**
-   * @type {ArrayBuffer}
+   * Constructor.
    */
-  this.data = null;
+  constructor() {
+    /**
+     * @type {ArrayBuffer}
+     */
+    this.data = null;
 
-  /**
-   * @type {plugin.file.shp.data.DBFHeader}
-   */
-  this.dbf = new plugin.file.shp.data.DBFHeader();
+    /**
+     * @type {DBFHeader}
+     */
+    this.dbf = new DBFHeader();
 
-  /**
-   * @type {plugin.file.shp.data.SHXHeader}
-   */
-  this.shx = new plugin.file.shp.data.SHXHeader();
+    /**
+     * @type {SHXHeader}
+     */
+    this.shx = new SHXHeader();
 
-  /**
-   * @type {number}
-   */
-  this.curRecord = 0;
+    /**
+     * @type {number}
+     */
+    this.curRecord = 0;
 
-  /**
-   * @type {number}
-   */
-  this.position = 0;
+    /**
+     * @type {number}
+     */
+    this.position = 0;
 
-  /**
-   * Since we use an array buffer, we have to know how big it is before writing to it
-   * @type {number}
-   */
-  this.allocation = 0;
-};
+    /**
+     * Since we use an array buffer, we have to know how big it is before writing to it
+     * @type {number}
+     */
+    this.allocation = 0;
+  }
+}
+
+exports = SHPHeader;

--- a/src/plugin/file/shp/data/shxheader.js
+++ b/src/plugin/file/shp/data/shxheader.js
@@ -1,24 +1,30 @@
-goog.provide('plugin.file.shp.data.SHXHeader');
-
+goog.module('plugin.file.shp.data.SHXHeader');
+goog.module.declareLegacyNamespace();
 
 
 /**
- * @constructor
  */
-plugin.file.shp.data.SHXHeader = function() {
+class SHXHeader {
   /**
-   * @type {ArrayBuffer}
+   * Constructor.
    */
-  this.data = null;
+  constructor() {
+    /**
+     * @type {ArrayBuffer}
+     */
+    this.data = null;
 
-  /**
-   * @type {number}
-   */
-  this.position = 0;
+    /**
+     * @type {number}
+     */
+    this.position = 0;
 
-  /**
-   * Since we use an array buffer, we have to know how big it is before writing to it
-   * @type {number}
-   */
-  this.allocation = 0;
-};
+    /**
+     * Since we use an array buffer, we have to know how big it is before writing to it
+     * @type {number}
+     */
+    this.allocation = 0;
+  }
+}
+
+exports = SHXHeader;

--- a/src/plugin/file/shp/mime.js
+++ b/src/plugin/file/shp/mime.js
@@ -1,52 +1,49 @@
-goog.provide('plugin.file.shp.mime');
+goog.module('plugin.file.shp.mime');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.file.mime');
-goog.require('os.file.mime.zip');
-goog.require('plugin.file.shp');
+const Promise = goog.require('goog.Promise');
 
+const mime = goog.require('os.file.mime');
+const zip = goog.require('os.file.mime.zip');
+const shp = goog.require('plugin.file.shp');
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.shp.mime.TYPE = 'application/shapefile';
-
+const TYPE = 'application/shapefile';
 
 /**
  * @param {ArrayBuffer} buffer
  * @return {!goog.Promise<boolean>}
  */
-plugin.file.shp.mime.detect = function(buffer) {
-  return /** @type {!goog.Promise<boolean>} */ (goog.Promise.resolve(buffer && (plugin.file.shp.isSHPFileType(buffer) ||
-      plugin.file.shp.isDBFFileType(buffer))));
+const detect = function(buffer) {
+  return /** @type {!goog.Promise<boolean>} */ (Promise.resolve(buffer && (shp.isSHPFileType(buffer) ||
+      shp.isDBFFileType(buffer))));
 };
-
-
-os.file.mime.register(plugin.file.shp.mime.TYPE, plugin.file.shp.mime.detect);
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.shp.mime.ZIP_TYPE = 'application/zip; subtype=shape';
-
-
-os.file.mime.register(
-    plugin.file.shp.mime.ZIP_TYPE,
-    os.file.mime.zip.createDetect(/\.shp$/i),
-    0, os.file.mime.zip.TYPE);
-
+const ZIP_TYPE = 'application/zip; subtype=shape';
 
 /**
  * @type {RegExp}
- * @const
  */
-plugin.file.shp.mime.SHP_EXT_REGEXP = /\.shp$/i;
-
+const SHP_EXT_REGEXP = /\.shp$/i;
 
 /**
  * @type {RegExp}
- * @const
  */
-plugin.file.shp.mime.DBF_EXT_REGEXP = /\.dbf$/i;
+const DBF_EXT_REGEXP = /\.dbf$/i;
+
+mime.register(TYPE, detect);
+mime.register(ZIP_TYPE, zip.createDetect(/\.shp$/i), 0, zip.TYPE);
+
+exports = {
+  TYPE,
+  detect,
+  ZIP_TYPE,
+  SHP_EXT_REGEXP,
+  DBF_EXT_REGEXP
+};

--- a/src/plugin/file/shp/shp.js
+++ b/src/plugin/file/shp/shp.js
@@ -1,11 +1,11 @@
-goog.provide('plugin.file.shp');
+goog.module('plugin.file.shp');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * @enum {number}
- * @const
  */
-plugin.file.shp.TYPE = {
+const TYPE = {
   NULLRECORD: 0,
   POINT: 1,
   POLYLINE: 3,
@@ -21,15 +21,13 @@ plugin.file.shp.TYPE = {
   MULTIPOINTM: 28
 };
 
-
 /**
  * @typedef {{
  *   data: DataView,
  *   numRecords: number
  * }}
  */
-plugin.file.shp.DBFData;
-
+let DBFData;
 
 /**
  * Tests if the supplied content is for a DBF file.
@@ -37,7 +35,7 @@ plugin.file.shp.DBFData;
  * @param {ArrayBuffer} content
  * @return {boolean}
  */
-plugin.file.shp.isDBFFileType = function(content) {
+const isDBFFileType = function(content) {
   if (!content) {
     return false;
   }
@@ -57,18 +55,24 @@ plugin.file.shp.isDBFFileType = function(content) {
   return version == 3 && (date >= 1 && date <= 31) && (month >= 1 && month <= 12);
 };
 
-
 /**
  * Tests if the supplied content is for a SHP file.
  *
  * @param {ArrayBuffer} content
  * @return {boolean}
  */
-plugin.file.shp.isSHPFileType = function(content) {
+const isSHPFileType = function(content) {
   var dv = new DataView(content.slice(0, 4));
   try {
     return dv.getUint32(0) == 9994;
   } catch (e) {
     return false;
   }
+};
+
+exports = {
+  TYPE,
+  isDBFFileType,
+  isSHPFileType,
+  DBFData
 };

--- a/src/plugin/file/shp/shpdescriptor.js
+++ b/src/plugin/file/shp/shpdescriptor.js
@@ -1,196 +1,178 @@
-goog.provide('plugin.file.shp.SHPDescriptor');
+goog.module('plugin.file.shp.SHPDescriptor');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.FileDescriptor');
-goog.require('os.file');
-goog.require('os.file.FileStorage');
-goog.require('os.layer.LayerType');
-goog.require('plugin.file.shp.SHPExporter');
-goog.require('plugin.file.shp.SHPParserConfig');
-goog.require('plugin.file.shp.SHPProvider');
-
+const FileDescriptor = goog.require('os.data.FileDescriptor');
+const osFile = goog.require('os.file');
+const FileStorage = goog.require('os.file.FileStorage');
+const LayerType = goog.require('os.layer.LayerType');
+const SHPExporter = goog.require('plugin.file.shp.SHPExporter');
+const SHPParserConfig = goog.require('plugin.file.shp.SHPParserConfig');
 
 
 /**
  * SHP file descriptor.
- *
- * @param {plugin.file.shp.SHPParserConfig=} opt_config
- * @extends {os.data.FileDescriptor}
- * @constructor
  */
-plugin.file.shp.SHPDescriptor = function(opt_config) {
-  plugin.file.shp.SHPDescriptor.base(this, 'constructor');
-  this.descriptorType = 'shp';
-  this.parserConfig = opt_config || new plugin.file.shp.SHPParserConfig();
+class SHPDescriptor extends FileDescriptor {
+  /**
+   * Constructor.
+   * @param {SHPParserConfig=} opt_config
+   */
+  constructor(opt_config) {
+    super();
+    this.descriptorType = 'shp';
+    this.parserConfig = opt_config || new SHPParserConfig();
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.originalUrl2_ = null;
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.url2_ = null;
+  }
 
   /**
-   * @type {?string}
-   * @private
+   * @inheritDoc
    */
-  this.originalUrl2_ = null;
+  getType() {
+    return LayerType.FEATURES;
+  }
 
   /**
-   * @type {?string}
-   * @private
+   * @inheritDoc
    */
-  this.url2_ = null;
-};
-goog.inherits(plugin.file.shp.SHPDescriptor, os.data.FileDescriptor);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPDescriptor.prototype.getType = function() {
-  return os.layer.LayerType.FEATURES;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPDescriptor.prototype.getLayerOptions = function() {
-  var options = plugin.file.shp.SHPDescriptor.base(this, 'getLayerOptions');
-  options['type'] = 'SHP';
-  options['originalUrl2'] = this.getOriginalUrl2();
-  options['url2'] = this.getUrl2();
-  return options;
-};
-
-
-/**
- * Get the original URL for this file.
- *
- * @return {?string}
- */
-plugin.file.shp.SHPDescriptor.prototype.getOriginalUrl2 = function() {
-  return this.originalUrl2_;
-};
-
-
-/**
- * Set the original URL for this file.
- *
- * @param {?string} value
- */
-plugin.file.shp.SHPDescriptor.prototype.setOriginalUrl2 = function(value) {
-  this.originalUrl2_ = value;
-};
-
-
-/**
- * Get the URL for this descriptor.
- *
- * @return {?string}
- */
-plugin.file.shp.SHPDescriptor.prototype.getUrl2 = function() {
-  return this.url2_;
-};
-
-
-/**
- * Set the URL for this descriptor.
- *
- * @param {?string} value
- */
-plugin.file.shp.SHPDescriptor.prototype.setUrl2 = function(value) {
-  this.url2_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPDescriptor.prototype.matchesURL = function(url) {
-  return url == this.getUrl() || url == this.getUrl2();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPDescriptor.prototype.clearData = function() {
-  plugin.file.shp.SHPDescriptor.base(this, 'clearData');
-
-  var url2 = this.getUrl2();
-  if (url2 && os.file.isLocal(url2)) {
-    var fs = os.file.FileStorage.getInstance();
-    fs.deleteFile(url2);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPDescriptor.prototype.getExporter = function() {
-  return new plugin.file.shp.SHPExporter();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPDescriptor.prototype.onFileChange = function(options) {
-  plugin.file.shp.SHPDescriptor.base(this, 'onFileChange', options);
-
-  // ensure that the URL is set correctly in case we are converting from a shp/dbf file to a zip shp file
-  const url2 = this.getUrl2();
-  if (url2 && os.file.isLocal(url2)) {
-    const fs = os.file.FileStorage.getInstance();
-    fs.deleteFile(url2);
-    this.setUrl2('');
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPDescriptor.prototype.persist = function(opt_obj) {
-  if (!opt_obj) {
-    opt_obj = {};
+  getLayerOptions() {
+    var options = super.getLayerOptions();
+    options['type'] = 'SHP';
+    options['originalUrl2'] = this.getOriginalUrl2();
+    options['url2'] = this.getUrl2();
+    return options;
   }
 
-  opt_obj['originalUrl2'] = this.getOriginalUrl2();
-  opt_obj['url2'] = this.getUrl2();
-
-  return plugin.file.shp.SHPDescriptor.base(this, 'persist', opt_obj);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPDescriptor.prototype.restore = function(conf) {
-  this.setOriginalUrl2(conf['originalUrl2'] || null);
-  this.setUrl2(conf['url2'] || null);
-
-  plugin.file.shp.SHPDescriptor.base(this, 'restore', conf);
-};
-
-
-/**
- * Creates a new descriptor from a parser configuration.
- *
- * @param {!plugin.file.shp.SHPParserConfig} config
- * @return {!plugin.file.shp.SHPDescriptor}
- */
-plugin.file.shp.SHPDescriptor.createFromConfig = function(config) {
-  // use the ZIP file first, SHP second. the import UI uses the extracted files for easier (synchronous) processing
-  // but the ZIP should be used for parsing data with the importer. ignore the DBF if we have a zip file.
-  var provider = plugin.file.shp.SHPProvider.getInstance();
-  var descriptor = new plugin.file.shp.SHPDescriptor(config);
-  os.data.FileDescriptor.createFromConfig(descriptor, provider, config);
-
-  var file = config['zipFile'] || config['file'];
-  descriptor.setUrl(file.getUrl());
-
-  var file2 = config['zipFile'] ? null : config['file2'];
-  if (file2) {
-    descriptor.setUrl2(file2.getUrl());
+  /**
+   * Get the original URL for this file.
+   *
+   * @return {?string}
+   */
+  getOriginalUrl2() {
+    return this.originalUrl2_;
   }
 
-  descriptor.updateFromConfig(config);
+  /**
+   * Set the original URL for this file.
+   *
+   * @param {?string} value
+   */
+  setOriginalUrl2(value) {
+    this.originalUrl2_ = value;
+  }
 
-  return descriptor;
-};
+  /**
+   * Get the URL for this descriptor.
+   *
+   * @return {?string}
+   */
+  getUrl2() {
+    return this.url2_;
+  }
+
+  /**
+   * Set the URL for this descriptor.
+   *
+   * @param {?string} value
+   */
+  setUrl2(value) {
+    this.url2_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  matchesURL(url) {
+    return url == this.getUrl() || url == this.getUrl2();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  clearData() {
+    super.clearData();
+
+    var url2 = this.getUrl2();
+    if (url2 && osFile.isLocal(url2)) {
+      var fs = FileStorage.getInstance();
+      fs.deleteFile(url2);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getExporter() {
+    return new SHPExporter();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  onFileChange(options) {
+    super.onFileChange(options);
+
+    // ensure that the URL is set correctly in case we are converting from a shp/dbf file to a zip shp file
+    const url2 = this.getUrl2();
+    if (url2 && osFile.isLocal(url2)) {
+      const fs = FileStorage.getInstance();
+      fs.deleteFile(url2);
+      this.setUrl2('');
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  persist(opt_obj) {
+    if (!opt_obj) {
+      opt_obj = {};
+    }
+
+    opt_obj['originalUrl2'] = this.getOriginalUrl2();
+    opt_obj['url2'] = this.getUrl2();
+
+    return super.persist(opt_obj);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  restore(conf) {
+    this.setOriginalUrl2(conf['originalUrl2'] || null);
+    this.setUrl2(conf['url2'] || null);
+
+    super.restore(conf);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  static createFromConfig(descriptor, provider, config, opt_useDefaultColor) {
+    super.createFromConfig(descriptor, provider, config);
+
+    // use the ZIP file first, SHP second. the import UI uses the extracted files for easier (synchronous) processing
+    // but the ZIP should be used for parsing data with the importer. ignore the DBF if we have a zip file.
+    var file = config['zipFile'] || config['file'];
+    descriptor.setUrl(file.getUrl());
+
+    var file2 = config['zipFile'] ? null : config['file2'];
+    if (file2) {
+      descriptor.setUrl2(file2.getUrl());
+    }
+
+    descriptor.updateFromConfig(config);
+  }
+}
+
+exports = SHPDescriptor;

--- a/src/plugin/file/shp/shpexporter.js
+++ b/src/plugin/file/shp/shpexporter.js
@@ -1,137 +1,1131 @@
-goog.provide('plugin.file.shp.SHPExporter');
+goog.module('plugin.file.shp.SHPExporter');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.crypt');
-goog.require('goog.log');
-goog.require('ol.Feature');
-goog.require('ol.geom.GeometryCollection');
-goog.require('ol.geom.SimpleGeometry');
-goog.require('os.array');
-goog.require('os.data.OSDataManager');
-goog.require('os.ex.ZipExporter');
-goog.require('os.file.File');
-goog.require('os.source.Vector');
-goog.require('os.time.ITime');
-goog.require('plugin.file.shp.data.SHPHeader');
-goog.require('plugin.file.shp.mime');
-goog.require('plugin.file.shp.ui.shpExportDirective');
+const crypt = goog.require('goog.crypt');
+const log = goog.require('goog.log');
+const googObject = goog.require('goog.object');
+const googString = goog.require('goog.string');
+const olExtent = goog.require('ol.extent');
+const GeometryCollection = goog.require('ol.geom.GeometryCollection');
+const GeometryType = goog.require('ol.geom.GeometryType');
+const Point = goog.require('ol.geom.Point');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const AlertManager = goog.require('os.alert.AlertManager');
+const osArray = goog.require('os.array');
+const OSDataManager = goog.require('os.data.OSDataManager');
+const RecordField = goog.require('os.data.RecordField');
+const ZipExporter = goog.require('os.ex.ZipExporter');
+const osFeature = goog.require('os.feature');
+const OSFile = goog.require('os.file.File');
+const osImplements = goog.require('os.implements');
+const ITime = goog.require('os.time.ITime');
+const shp = goog.require('plugin.file.shp');
+const SHPHeader = goog.require('plugin.file.shp.data.SHPHeader');
+const mime = goog.require('plugin.file.shp.mime');
+const {directiveTag: shpExportUi} = goog.require('plugin.file.shp.ui.SHPExportUI');
 
+const Feature = goog.requireType('ol.Feature');
+const SimpleGeometry = goog.requireType('ol.geom.SimpleGeometry');
+const VectorSource = goog.requireType('os.source.Vector');
 
 
 /**
  * A SHP exporter
  *
- * @extends {os.ex.ZipExporter.<T>}
- * @constructor
+ * @extends {ZipExporter.<T>}
  * @template T
  */
-plugin.file.shp.SHPExporter = function() {
-  plugin.file.shp.SHPExporter.base(this, 'constructor');
-  this.log = plugin.file.shp.SHPExporter.LOGGER_;
-
+class SHPExporter extends ZipExporter {
   /**
-   * Tell the abstract zipper to zip the files
-   * @type {boolean}
+   * Constructor.
    */
-  this.compress = true;
+  constructor() {
+    super();
+    this.log = logger;
+
+    /**
+     * Tell the abstract zipper to zip the files
+     * @type {boolean}
+     */
+    this.compress = true;
+
+    /**
+     * Keep track of the column names because we can get dupes due to the 10 character name limitation.
+     * @type {Object}
+     * @private
+     */
+    this.columnName_ = {};
+
+    /**
+     * unique name counter
+     * @type {Object}
+     * @private
+     */
+    this.columnNameCounter_ = {};
+
+    /**
+     * @type {Object}
+     * @private
+     */
+    this.columnTypes_ = {};
+    /**
+     * @type {Object}
+     * @private
+     */
+    this.columnLengths_ = {};
+
+    /**
+     * @type {Object}
+     * @private
+     */
+    this.columnPrecisions_ = {};
+
+    /**
+     * @type {Array}
+     * @private
+     */
+    this.columns_ = [];
+
+    /**
+     * @type {SHPHeader}
+     * @private
+     */
+    this.header_ = new SHPHeader();
+
+    /**
+     * @type {number}
+     * @private
+     */
+    this.recNum_ = 0;
+
+    /**
+     * The global shape type for the shape file
+     * @type {number}
+     * @private
+     */
+    this.shpType_ = -1;
+
+    /**
+     * Export the ellipses
+     * @type {boolean}
+     * @private
+     */
+    this.exportEllipses_ = false;
+
+    /**
+     * The global extent that contains all extents
+     * @type {ol.Extent}
+     * @private
+     */
+    this.extent_ = null;
+
+    /**
+     * @type {DataView}
+     * @private
+     */
+    this.dvShp_ = null;
+
+    /**
+     * @type {DataView}
+     * @private
+     */
+    this.dvDbf_ = null;
+
+    /**
+     * @type {DataView}
+     * @private
+     */
+    this.dvShx_ = null;
+  }
 
   /**
-   * Keep track of the column names because we can get dupes due to the 10 character name limitation.
-   * @type {Object}
+   * @inheritDoc
+   */
+  getExtension() {
+    return 'zip';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLabel() {
+    return 'SHP';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getMimeType() {
+    return mime.ZIP_TYPE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  cancel() {}
+
+  /**
+   * Get the feature's source.
+   *
+   * @param {Feature} feature The feature
+   * @return {VectorSource} The source
    * @private
    */
-  this.columnName_ = {};
+  getSource_(feature) {
+    var source = null;
+    if (feature) {
+      var sourceId = feature.get(RecordField.SOURCE_ID);
+      if (typeof sourceId === 'string') {
+        source = /** @type {VectorSource} */ (OSDataManager.getInstance().getSource(sourceId));
+      }
+    }
+
+    return source;
+  }
 
   /**
-   * unique name counter
-   * @type {Object}
+   * Parse the column
+   *
+   * @param {T} item
+   * @param {Object} col
    * @private
+   * @template T
    */
-  this.columnNameCounter_ = {};
+  parseColumn_(item, col) {
+    var name = col['name'];
+    var field = col['field'];
+    var value = item.get(field);
+    var valueType = typeof value;
+
+    // columns starting with '_' are considered private and will be ignored
+    if (field.indexOf('_') != 0 && field != 'geometry') {
+      // convert the value to a string
+      if (value instanceof Date) {
+        // ITime implementations override toString, so the else block will handle it
+        value = value.toISOString();
+      } else {
+        value = googString.makeSafe(value);
+        value = googString.trim(value);
+      }
+
+      // determine the column name to use in the shapefile
+      if (!(name in this.columnName_)) {
+        // can only be 10 characters with terminating null
+        // so pad with null characters and truncate to 10 characters
+        var fieldName = (name.replace(' ', '_') +
+            '\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000').substr(0, 10);
+
+        if (googObject.containsValue(this.columnName_, fieldName)) {
+          if (!(fieldName in this.columnNameCounter_)) {
+            this.columnNameCounter_[fieldName] = 0;
+          }
+          this.columnNameCounter_[fieldName]++;
+
+          // Since the 10char name is the same. attempt to make it unique
+          fieldName = (fieldName.substr(0, 9) + String(this.columnNameCounter_[fieldName])).substr(0, 10);
+        }
+
+        this.columnName_[name] = fieldName;
+      }
+      var valueAsByteArrayLength = crypt.stringToUtf8ByteArray(value).length;
+
+      // determine the maximum length for column values
+      if (name in this.columnTypes_) {
+        this.columnLengths_[name] = Math.min(Math.max(this.columnLengths_[name], valueAsByteArrayLength), 255);
+      } else {
+        this.columnLengths_[name] = Math.min(valueAsByteArrayLength, 255);
+        this.columns_.push(col);
+      }
+
+      // determine the value type
+      if (!(name in this.columnTypes_)) {
+        if (valueType == 'boolean') {
+          this.columnTypes_[name] = 'L';
+        } else if (valueType == 'number') {
+          this.columnTypes_[name] = 'N';
+        } else {
+          this.columnTypes_[name] = 'C';
+        }
+      } else if (this.columnTypes_[name] == 'L' && valueType != 'boolean') {
+        this.columnTypes_[name] = 'C';
+      } else if (this.columnTypes_[name] == 'N' && valueType != 'number') {
+        this.columnTypes_[name] = 'C';
+      }
+
+      // determine the precision for numeric columns
+      if (this.columnTypes_[name] == 'N' && value.match(/^[+-]?\d*\.\d+$/)) {
+        var currentPrecision = this.columnPrecisions_[name] || 0;
+        this.columnPrecisions_[name] = Math.min(Math.max(currentPrecision, value.replace(/^[+-]?\d*\./, '').length), 255);
+      } else {
+        this.columnPrecisions_[name] = 0;
+      }
+    }
+  }
 
   /**
-   * @type {Object}
-   * @private
+   * @inheritDoc
    */
-  this.columnTypes_ = {};
-  /**
-   * @type {Object}
-   * @private
-   */
-  this.columnLengths_ = {};
+  setItems(items) {
+    super.setItems(items);
+
+    // parse columns from the new items
+    this.parseColumns();
+
+    // reset the exporter
+    this.extent_ = null;
+    this.recNum_ = 0;
+    this.shpType_ = -1;
+    this.dvShp_ = null;
+    this.dvDbf_ = null;
+    this.dvShx_ = null;
+  }
 
   /**
-   * @type {Object}
-   * @private
+   * Parse the columns to include in the shapefile.
+   *
+   * @protected
    */
-  this.columnPrecisions_ = {};
+  parseColumns() {
+    this.columns_ = [];
+    this.columnLengths_ = {};
+    this.columnPrecisions_ = {};
+    this.columnTypes_ = {};
+    this.columnName_ = {};
+    this.columnNameCounter_ = {};
+
+    if (this.items && this.items.length > 0) {
+      var item = this.items[0];
+      var source = this.getSource_(item);
+      var columns = source && source.getColumnsArray() || googObject.getKeys(item.getProperties());
+
+      for (var i = 0; i < this.items.length; i++) {
+        item = this.items[i];
+
+        if (source) {
+          // Layer
+          for (var j = 0; j < columns.length; j++) {
+            var column = columns[j];
+            var colNameField = {
+              'name': column['name'],
+              'field': column['field']
+            };
+            if (columns[j]['visible'] && !googString.isEmptyOrWhitespace(googString.makeSafe(colNameField['name']))) {
+              this.parseColumn_(item, colNameField);
+            }
+          }
+        } else {
+          // Areas, other
+          for (var j = 0; j < columns.length; j++) {
+            var column = columns[j];
+            var colNameField = {
+              'name': column,
+              'field': column
+            };
+            if (!googString.isEmptyOrWhitespace(googString.makeSafe(colNameField['name']))) {
+              this.parseColumn_(item, colNameField);
+            }
+          }
+        }
+      }
+    }
+  }
 
   /**
-   * @type {Array}
-   * @private
+   * Add the shapefile header
    */
-  this.columns_ = [];
+  appendHeader() {
+    // Dumb... better way?
+    this.allocateArrays_();
+
+    // With Array Buffers, we need to allocate all the space for the array before we set anything.
+    this.header_.data = new ArrayBuffer(this.header_.allocation);
+    this.header_.dbf.data = new ArrayBuffer(this.header_.dbf.allocation);
+    this.header_.shx.data = new ArrayBuffer(this.header_.shx.allocation);
+
+    this.dvShp_ = new DataView(this.header_.data);
+    this.dvDbf_ = new DataView(this.header_.dbf.data);
+    this.dvShx_ = new DataView(this.header_.shx.data);
+
+    this.appendSHPHeader();
+    this.appendDBFHeader();
+    this.appendSHXHeader();
+  }
 
   /**
-   * @type {plugin.file.shp.data.SHPHeader}
+   * Allocate space for headers
+   *
    * @private
    */
-  this.header_ = new plugin.file.shp.data.SHPHeader();
+  allocateArrays_() {
+    // SHP
+    this.header_.allocation = 100;
+
+    // DBF
+    var headerSize = 32 + (this.columns_.length * 32);
+    this.header_.dbf.allocation = headerSize + 1;
+
+    // SHX
+    this.header_.shx.allocation = 100;
+
+    // Items
+    for (var i = 0, n = this.items.length; i < n; i++) {
+      var item = this.items[i];
+      var geom = this.getGeometry_(item);
+      if (geom != null) {
+        if (geom instanceof GeometryCollection) {
+          osArray.forEach(geom.getGeometries(), function(geometry) {
+            this.allocateItem_(item, /** @type {SimpleGeometry} */ (geometry));
+          }, this);
+        } else {
+          this.allocateItem_(item, geom);
+        }
+      }
+    }
+  }
 
   /**
-   * @type {number}
+   * Allocate space for this item
+   *
+   * @param {T} item The item
+   * @param {SimpleGeometry} geom
    * @private
+   * @template T
    */
-  this.recNum_ = 0;
+  allocateItem_(item, geom) {
+    // Doesnt seem like shapefiles support multi polygon. Just polygons with multiple stuff (like holes)
+    if (geom.getType() == GeometryType.MULTI_POLYGON) {
+      geom = /** @type {ol.geom.MultiPolygon} */ (geom);
+      osArray.forEach(geom.getPolygons(), function(polygon) {
+        this.allocateItemForGeom_(item, polygon);
+      }, this);
+    } else if (geom.getType() == GeometryType.MULTI_POINT) {
+      geom = /** @type {ol.geom.MultiPoint} */ (geom);
+      osArray.forEach(geom.getPoints(), function(point) {
+        this.allocateItemForGeom_(item, point);
+      }, this);
+    } else {
+      this.allocateItemForGeom_(item, geom);
+    }
+  }
 
   /**
-   * The global shape type for the shape file
-   * @type {number}
+   * Allocate space for this item
+   *
+   * @param {T} item The item
+   * @param {SimpleGeometry} geom
    * @private
+   * @template T
    */
-  this.shpType_ = -1;
+  allocateItemForGeom_(item, geom) {
+    var geomType = geom.getType();
+    this.isSupportedType_(geomType);
+
+    this.header_.shx.allocation += 8;
+    this.header_.allocation += 8;
+
+    var recLength = 0;
+    if (geomType == GeometryType.POINT) {
+      var coord = geom.getCoordinates();
+      recLength = 20;
+      if (geom.getLayout() == 'XYZ' && coord[2] != 0) {
+        recLength = 36;
+      }
+    } else if (geomType == GeometryType.LINE_STRING ||
+        geomType == GeometryType.MULTI_LINE_STRING ||
+        geomType == GeometryType.POLYGON) {
+      var numParts = 1;
+      var flatGroupCoords = [];
+      if (geomType == GeometryType.LINE_STRING) {
+        flatGroupCoords = geom.getCoordinates();
+      } else {
+        var coords = geom.getCoordinates();
+        numParts = coords.length;
+
+        // Flatten down the coordinates one level
+        osArray.forEach(coords, function(coord) {
+          osArray.forEach(coord, function(point) {
+            flatGroupCoords.push(point);
+          });
+        });
+      }
+
+      var numPoints = flatGroupCoords.length;
+      var partsLen = numParts * 4;
+      var pointsLen = numPoints * 16;
+      recLength = 44 + partsLen + pointsLen;
+
+      if (geom.getLayout() == 'XYZ') {
+        // add the z components if available
+        for (var i = 0; i < flatGroupCoords.length; i++) {
+          if (flatGroupCoords[i][2] != 0) {
+            // 4 min max's (z & m) + 2x8xlength (z points, m points)
+            recLength += (8 * 4) + (numPoints * 16);
+            break;
+          }
+        }
+      }
+    }
+    this.header_.allocation += recLength;
+
+    // Add the DBF Metadata for this geometry
+    osArray.forEach(this.columns_, function(col) {
+      var name = col['name'];
+      this.header_.dbf.allocation += this.columnLengths_[name];
+    }, this);
+    this.header_.dbf.allocation++;
+  }
 
   /**
-   * Export the ellipses
-   * @type {boolean}
-   * @private
+   * Append the SHP Header
    */
-  this.exportEllipses_ = false;
+  appendSHPHeader() {
+    /* Shape File Header
+     *                                                    Byte
+     * Position  Field           Value           Type     Order
+     * Byte 0    File Type       9994            Integer  Big
+     * Byte 4    Unused?
+     * Byte 24   File Length     # 16bit Words   Integer  Big
+     * Byte 28   Version         1000            Integer  Little
+     * Byte 32   Shape Type      0, *1, *3, *5   Integer  Little
+     * Byte 36   Min Lon         Degrees         Double   Little
+     * Byte 44   Min Lat         Degrees         Double   Little
+     * Byte 52   Max Lon         Degrees         Double   Little
+     * Byte 60   Max Lat         Degrees         Double   Little
+     * Byte 68   Unused                          Double   Little
+     * Byte 76   Unused                          Double   Little
+     * Byte 84   Unused                          Double   Little
+     * Byte 92   Unused                          Double   Little
+     * Byte 100  End Of Header
+     */
+    // file type
+    this.dvShp_.setUint32(0, 9994);
+    // file version
+    this.dvShp_.setUint32(28, 1000, true);
+
+    this.header_.position = 100;
+  }
 
   /**
-   * The global extent that contains all extents
-   * @type {ol.Extent}
-   * @private
+   * Append the DBF Header
    */
-  this.extent_ = null;
+  appendDBFHeader() {
+    /*                                                                  Byte
+     * Position   Field                          Units         Type      Order
+     * Byte 0     Version                        Version       Byte      n/a
+     * Byte 1     Year                           Year+1900     Byte      n/a
+     * Byte 2     Month                          Month (1-12)  Byte      n/a
+     * Byte 3     Date                           Date of Month Byte      n/a
+     * Byte 4     NumRecords                     Count         Integer   Little
+     * Byte 8     HeaderSize                     Bytes         Short     Little
+     * Byte 10    RecordSize                     Bytes         Short     Little
+     * Byte 12    reserved                                     Byte[2]   n/a
+     * Byte 14    Incomplete transaction flag                  Byte      n/a
+     * Byte 15    Encryption Flag                              Byte      n/a
+     * Byte 16    Free record thread (reserved)                Byte[4]   n/a
+     * Byte 20    Reserved for multi-user                      Byte[8]   n/a
+     * Byte 28    MDX Flag (reserved)                          Byte      n/a
+     * Byte 29    Language driver (reserved)                   Byte      n/a
+     * Byte 30    Reserved                                     Byte[2]   n/a
+     * Byte 32    Table Field descriptor Array                 Byte[32]  n/a
+     * Byte 64-n  repeated for each field                      Byte[32]  n/a
+     * Byte n     Terminator                     '0Dh'         Byte      n/a
+     * Byte n+1   ASCII Records separated by a 'space' (20h)
+     *
+     * Within Fields
+     * Byte 0    Field Name                                    Byte[11]  n/a
+     * Byte 12   Field Type                                    Byte      n/a
+     * Byte 16   Field Length                                  Byte      n/a
+     */
+    var headerSize = 32 + (this.columns_.length * 32);
+
+    // version
+    this.dvDbf_.setUint8(0, 3);
+
+    var date = new Date();
+    // Year
+    this.dvDbf_.setUint8(1, date.getUTCFullYear() - 1900);
+    // Month
+    this.dvDbf_.setUint8(2, date.getUTCMonth() + 1);
+    // Date
+    this.dvDbf_.setUint8(3, date.getUTCDate());
+
+    // write header size
+    this.dvDbf_.setUint16(8, headerSize, true);
+
+    // determine record size
+    var recordSize = 0;
+    googObject.forEach(this.columnLengths_, function(len) {
+      recordSize += len;
+    });
+
+    // write record size
+    this.dvDbf_.setUint16(10, recordSize + 1, true);
+
+    // language driver ID (ANSI)
+    this.dvDbf_.setUint16(29, 0x57, true);
+
+    // write header (column info)
+    osArray.forEach(this.columns_, function(col, index) {
+      var startPos = 32 + index * 32;
+      var name = col['name'];
+
+      // Field Name
+      this.writeMultiByte(this.dvDbf_, startPos, this.columnName_[name]);
+
+      // Field Type
+      this.writeMultiByte(this.dvDbf_, startPos + 11, this.columnTypes_[name]);
+      // Field Length
+      this.dvDbf_.setUint8(startPos + 16, this.columnLengths_[name]);
+      // Field Precision
+      this.dvDbf_.setUint8(startPos + 17, this.columnPrecisions_[name]);
+    }, this);
+
+    // position at end of header
+    this.dvDbf_.setUint8(headerSize, 0x0D);
+    // done with header, setup for records
+    this.header_.dbf.position = headerSize + 1;
+  }
 
   /**
-   * @type {DataView}
-   * @private
+   * Append the SHX Header
    */
-  this.dvShp_ = null;
+  appendSHXHeader() {
+    // file type
+    this.dvShx_.setUint32(0, 9994);
+    // file version
+    this.dvShx_.setUint32(28, 1000, true);
+    this.header_.shx.position = 100;
+  }
 
   /**
-   * @type {DataView}
-   * @private
+   * Convert string to byte
+   *
+   * @param {DataView} dv
+   * @param {number} pos - the position
+   * @param {string} str - the string to convert to bytes
+   * @return {number} the number of bytes written
    */
-  this.dvDbf_ = null;
+  writeMultiByte(dv, pos, str) {
+    var ba = crypt.stringToUtf8ByteArray(str);
+    for (var i = 0; ba && i < ba.length; ++i) {
+      dv.setUint8(pos, ba[i]);
+      pos++;
+    }
+    return ba.length;
+  }
 
   /**
-   * @type {DataView}
+   * @inheritDoc
+   */
+  processItems() {
+    this.appendHeader();
+
+    var skipped = 0;
+    for (var i = 0, n = this.items.length; i < n; i++) {
+      if (!this.processItem(this.items[i])) {
+        skipped++;
+      }
+    }
+
+    // notify the user if any features were not included in the shapefile
+    if (skipped > 0) {
+      var skipMsg = 'Skipped ' + skipped + ' feature' + (skipped > 1 ? 's' : '') + ' that did not have a geometry.';
+      AlertManager.getInstance().sendAlert(skipMsg, AlertEventSeverity.WARNING, this.log);
+    }
+
+    // only add the footer if one or more items were added, otherwise exporting the SHP will fail.
+    if (skipped < this.items.length) {
+      this.appendFooter();
+    }
+  }
+
+  /**
+   * Process a single item, returning a Placemark element to add to the SHP.
+   *
+   * @param {T} item The item
+   * @return {boolean} If the item was added
+   * @protected
+   * @template T
+   */
+  processItem(item) {
+    var geom = this.getGeometry_(item);
+    if (geom != null) {
+      if (geom instanceof GeometryCollection) {
+        osArray.forEach(geom.getGeometries(), function(geometry) {
+          this.appendItem_(item, /** @type {SimpleGeometry} */ (geometry));
+        }, this);
+      } else {
+        this.appendItem_(item, geom);
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Get the geometry for a feature.
+   *
+   * @param {Feature} feature The feature
+   * @return {GeometryCollection|SimpleGeometry|undefined}
    * @private
    */
-  this.dvShx_ = null;
-};
-goog.inherits(plugin.file.shp.SHPExporter, os.ex.ZipExporter);
+  getGeometry_(feature) {
+    var geometry;
+    if (feature) {
+      geometry = /** @type {(SimpleGeometry|undefined)} */ (feature.get(RecordField.GEOM));
 
+      if (geometry) {
+        geometry = /** @type {(SimpleGeometry|undefined)} */ (geometry.clone().toLonLat());
+
+        if (this.exportEllipses_) {
+          var ellipse = osFeature.createEllipse(feature);
+          if (ellipse && !(ellipse instanceof Point)) {
+            geometry = /** @type {(SimpleGeometry|undefined)} */ (ellipse);
+          }
+        }
+      }
+    }
+
+    return geometry;
+  }
+
+  /**
+   * Only put entries in if they are supported
+   *
+   * @param {ol.geom.GeometryType} type
+   * @private
+   */
+  isSupportedType_(type) {
+    if (type != GeometryType.POINT &&
+        type != GeometryType.MULTI_POINT &&
+        type != GeometryType.LINE_STRING &&
+        type != GeometryType.MULTI_LINE_STRING &&
+        type != GeometryType.MULTI_POLYGON &&
+        type != GeometryType.POLYGON) {
+      throw new Error(type + ' is not supported');
+    }
+  }
+
+  /**
+   * Add this geometry to the shape file
+   *
+   * @param {T} item The item
+   * @param {SimpleGeometry} geom
+   * @private
+   * @template T
+   */
+  appendItemForGeom_(item, geom) {
+    var geomType = geom.getType();
+    this.isSupportedType_(geomType);
+
+    // write offset
+    this.dvShx_.setUint32(this.header_.shx.position, this.header_.position / 2); // words not bytes
+    this.header_.shx.position += 4;
+
+    /* Shape File Record Header (big endian)
+     *                                                    Byte
+     * Position  Field           Value           Type     Order
+     * Byte 0    Record Number   Record Num      Integer  Big
+     * Byte 4    Record Length   # 16-bit Words  Integer  Big
+     * Byte 8    Start of Shape File Record
+     */
+    // write record number
+    if (item.get('RECNUM')) {
+      this.dvShp_.setUint32(this.header_.position, item.get('RECNUM'));
+    } else {
+      this.dvShp_.setUint32(this.header_.position, ++this.recNum_);
+    }
+    this.header_.position += 8;
+
+    // save position for record length
+    var recordStart = this.header_.position;
+    var extent = geom.getExtent();
+
+    // Make sure the global extent includes this extent
+    if (extent) {
+      if (this.extent_) {
+        this.extent_ = olExtent.extend(this.extent_, extent);
+      } else {
+        this.extent_ = olExtent.clone(extent);
+      }
+    }
+
+    var recLength = 0;
+    var shapeType = -1;
+    if (geomType == GeometryType.POINT) {
+      /* Shape File Point Record (little endian)
+       *                                          Byte
+       * Position  Field       Value     Type     Order
+       * Byte 0    Shape Type  *1        Integer  Little
+       * Byte 4    Longitude   Degrees   Double   Little
+       * Byte 12   Latitude    Degrees   Double   Little
+       * Byte 20   End Record Normal Point
+       *
+       * The "M" adds:
+       * Byte 20   M           M         Double   Little
+       *
+       * The "Z" adds:
+       * Byte 20   Z           Z         Double   Little
+       * Byte 28   M           M         Double   Little
+       */
+      var coord = geom.getCoordinates();
+      shapeType = shp.TYPE.POINT;
+      recLength = 20;
+      if (geom.getLayout() == 'XYZ' && coord[2] != 0) {
+        shapeType = shp.TYPE.POINTZ;
+        recLength = 36;
+      }
+
+      this.dvShp_.setFloat64(recordStart + 4, coord[0], true);
+      this.dvShp_.setFloat64(recordStart + 12, coord[1], true);
+      if (shapeType == shp.TYPE.POINTZ) {
+        this.dvShp_.setFloat64(recordStart + 20, coord[2], true);
+      }
+      // } else if (geom.getType() == ol.geom.GeometryType.MULTI_POINT) {
+      //   /**
+      //    * MultiPoint
+      //    *                                                  Byte
+      //    * Position   Field       Value     Type    Number    Order
+      //    * Byte 0     Shape Type  8         Integer 1         Little
+      //    * Byte 4     Box         Box       Double  4         Little
+      //    * Byte 36    NumPoints   NumPoints Integer 1         Little
+      //    * Byte 40    Points      Points    Point   NumPoints Little
+      //    *
+      //    * Byte X     Zmin        Zmin      Double  1         Little
+      //    * Byte X+8   Zmax        Zmax      Double  1         Little
+      //    * Byte X+16  Zarray      Zarray    Double  NumPoints Little
+      //    * Byte Y*    Mmin        Mmin      Double  1         Little
+      //    * Byte Y+8*  Mmax        Mmax      Double  1         Little
+      //    * Byte Y+16* Marray      Marray    Double  NumPoints Little
+      //    * Note: X = 40 + (16 * NumPoints); Y = X + 16 + (8 * NumPoints)
+      //    */
+      //   shapeType = plugin.file.shp.TYPE.MULTIPOINT;
+      //   var coords = geom.getCoordinates();
+      //   var numPoints = coords.length;
+      //   var pointsLen = numPoints * 16;
+
+      //   recLength = 40 + pointsLen;
+      //   if (geom.getLayout() == 'XYZ') {
+      //     for (var i = 0; i < coords.length; i++) {
+      //       if (coords[i][2] != 0) {
+      //         shapeType = plugin.file.shp.TYPE.MULTIPOINTZ;
+      //         recLength += 16 + (16 * numPoints);
+      //         break;
+      //       }
+      //     }
+      //   }
+
+      //   // Box
+      //   this.dvShp_.setFloat64(recordStart + 4, extent[0], true);
+      //   this.dvShp_.setFloat64(recordStart + 12, extent[1], true);
+      //   this.dvShp_.setFloat64(recordStart + 20, extent[2], true);
+      //   this.dvShp_.setFloat64(recordStart + 28, extent[3], true);
+
+      //   // Num points
+      //   this.dvShp_.setInt32(recordStart + 40, numPoints, true);
+
+      //   // Points
+      //   var pointsStart = recordStart + 40;
+      //   var zpointsStart = pointsStart + pointsLen;
+      //   osArray.forEach(coords, function(coord, index) {
+      //     var offset = index * 16;
+      //     this.dvShp_.setFloat64(pointsStart + offset, coord[0], true);
+      //     this.dvShp_.setFloat64(pointsStart + offset + 8, coord[1], true);
+
+    //     if (shapeType == plugin.file.shp.TYPE.MULTIPOINTZ) {
+    //       this.dvShp_.setFloat64(zpointsStart + (8 * index), coord[2], true);
+    //     }
+    //   }, this);
+    } else if (geomType == GeometryType.LINE_STRING ||
+        geomType == GeometryType.MULTI_LINE_STRING ||
+        geomType == GeometryType.POLYGON) {
+      /* Shape File Polyline/Polygon Record
+       *                                                   Byte
+       * Position  Field       Value            Type       Order
+       * Byte 0    Shape Type  *3 or *5         Integer    Little
+       * Byte 4    Min Lon     Degrees          Double     Little
+       * Byte 12   Min Lat     Degrees          Double     Little
+       * Byte 20   Max Lon     Degrees          Double     Little
+       * Byte 28   Max Lat     Degrees          Double     Little
+       * Byte 36   Num Parts   Num Parts        Integer    Little
+       * Byte 40   Num Points  Num Points       Integer    Little
+       * Byte 44   Parts[]     Start Indices    Integer    Little
+       * Byte xx   Points[]    Lon & Lat Pairs  2 Doubles  Little
+       * Note: xx = 44 + 4 * NumParts
+       *
+       * The "Z" adds:
+       * Byte Y    Zmin        Zmin             Double     Little
+       * Byte Y+8  Zmax        Zmax             Double     Little
+       * Byte Y+16 Z[]         Zarray           Doubles    Little
+       *
+       * The "M" adds:
+       * Byte Y    Mmin        Mmin            Double      Little
+       * Byte Y+8  Mmax        Mmax            Double      Little
+       * Byte Y+16 M[]         Marray          Doubles     Little
+       * Byte zz   End Record
+       */
+
+      switch (geomType) {
+        case GeometryType.LINE_STRING:
+        case GeometryType.MULTI_LINE_STRING:
+          shapeType = shp.TYPE.POLYLINE;
+          break;
+        case GeometryType.POLYGON:
+          shapeType = shp.TYPE.POLYGON;
+          break;
+        default:
+          break;
+      }
+
+      var numParts = 1;
+      var flatGroupCoords = [];
+      if (geomType == GeometryType.LINE_STRING) {
+        flatGroupCoords = geom.getCoordinates();
+
+        // Only 1 part for line strings
+        this.dvShp_.setInt32(recordStart + 44, 0, true);
+      } else {
+        var coords = geom.getCoordinates();
+        numParts = coords.length;
+
+        // Flatten down the coordinates one level
+        osArray.forEach(coords, function(coord) {
+          osArray.forEach(coord, function(point) {
+            flatGroupCoords.push(point);
+          });
+        });
+
+        // Part Indexes
+        var partStartIndex = 0;
+        for (var i = 0; i < numParts; i++) {
+          this.dvShp_.setInt32(recordStart + 44 + (i * 4), partStartIndex, true);
+          partStartIndex += coords[i].length;
+        }
+      }
+
+      var numPoints = flatGroupCoords.length;
+      var partsLen = numParts * 4;
+      var pointsLen = numPoints * 16;
+      recLength = 44 + partsLen + pointsLen;
+
+      if (geom.getLayout() == 'XYZ') {
+        // add the z components if available
+        for (var i = 0; i < flatGroupCoords.length; i++) {
+          if (flatGroupCoords[i][2] != 0) {
+            // 4 min max's (z & m) + 2x8xlength (z points, m points)
+            recLength += (8 * 4) + (numPoints * 16);
+            if (shapeType == shp.TYPE.POLYLINE) {
+              shapeType = shp.TYPE.POLYLINEZ;
+              break;
+            } else {
+              shapeType = shp.TYPE.POLYGONZ;
+              break;
+            }
+          }
+        }
+      }
+
+      this.dvShp_.setFloat64(recordStart + 4, extent[0], true);
+      this.dvShp_.setFloat64(recordStart + 12, extent[1], true);
+      this.dvShp_.setFloat64(recordStart + 20, extent[2], true);
+      this.dvShp_.setFloat64(recordStart + 28, extent[3], true);
+
+      // Start Indices
+      this.dvShp_.setInt32(recordStart + 36, numParts, true);
+
+      // Lon & Lat Pairs
+      this.dvShp_.setInt32(recordStart + 40, numPoints, true);
+
+      // Points
+      var pointsStart = recordStart + 44 + partsLen;
+      var zpointsStart = pointsStart + pointsLen + (2 * 8);
+      for (var i = 0; i < flatGroupCoords.length; i++) {
+        var offset = i * 16;
+        this.dvShp_.setFloat64(pointsStart + offset, flatGroupCoords[i][0], true);
+        this.dvShp_.setFloat64(pointsStart + offset + 8, flatGroupCoords[i][1], true);
+
+        if (shapeType == shp.TYPE.POLYLINEZ ||
+            shapeType == shp.TYPE.POLYGONZ) {
+          this.dvShp_.setFloat64(zpointsStart + (i * 8), flatGroupCoords[i][2], true);
+        }
+      }
+    }
+    /* Shape File Record (little endian)
+     *                                                      Byte
+     * Position  Field           Value             Type     Order
+     * Byte 0    Shape Type      0, *1, *3, *5     Integer  Little
+     * Byte 4    Specific for each Shape Type
+     */
+    if (this.shpType_ < 0 || (this.shpType_ == shp.TYPE.POINT && shapeType != shp.TYPE.POINT)) {
+      // write shape type in header
+      this.shpType_ = shapeType;
+      this.dvShp_.setUint32(32, this.shpType_, true);
+    }
+
+    // write record shape type
+    this.dvShp_.setUint32(recordStart, shapeType, true);
+    this.header_.position += recLength;
+
+    this.dvShp_.setUint32(recordStart - 4, recLength / 2);
+    this.dvShx_.setUint32(this.header_.shx.position, recLength / 2);
+    this.header_.shx.position += 4;
+
+    // Add the DBF Metadata for this geometry
+    this.addMetadata_(item);
+  }
+
+  /**
+   * First check to see if this is a multipolygon and break it up
+   *
+   * @param {T} item The item
+   * @param {SimpleGeometry} geom
+   * @private
+   * @template T
+   */
+  appendItem_(item, geom) {
+    // Doesnt seem like shapefiles support multi polygon. Just polygons with multiple stuff (like holes)
+    if (geom.getType() == GeometryType.MULTI_POLYGON) {
+      geom = /** @type {ol.geom.MultiPolygon} */ (geom);
+      osArray.forEach(geom.getPolygons(), function(polygon) {
+        this.appendItemForGeom_(item, polygon);
+      }, this);
+    } else if (geom.getType() == GeometryType.MULTI_POINT) {
+      geom = /** @type {ol.geom.MultiPoint} */ (geom);
+      osArray.forEach(geom.getPoints(), function(point) {
+        this.appendItemForGeom_(item, point);
+      }, this);
+    } else {
+      this.appendItemForGeom_(item, geom);
+    }
+  }
+
+  /**
+   * Process a single item adding the metadata to the DBF file.
+   * Do this for each geometry added even if its a duplicate
+   *
+   * @param {T} item The item
+   * @private
+   * @template T
+   */
+  addMetadata_(item) {
+    osArray.forEach(this.columns_, function(col) {
+      var name = col['name'];
+      var field = col['field'];
+
+      var value = item.get(field);
+      value = value == null ? '' : value;
+
+      if (field == RecordField.TIME && osImplements(value, ITime.ID)) {
+        value = /** @type {ITime} */ (value).toISOString();
+      } else {
+        value = googString.makeSafe(value);
+        value = googString.trim(value);
+      }
+
+      if (value.length > this.columnLengths_[name]) {
+        value = value.substr(0, this.columnLengths_[name]);
+      }
+
+      var numBytes = this.writeMultiByte(this.dvDbf_, this.header_.dbf.position, value);
+
+      // fill with nulls
+      for (var i = numBytes; i < this.columnLengths_[name]; ++i) {
+        this.dvDbf_.setUint8(this.header_.dbf.position + i, 0x0);
+      }
+
+      this.header_.dbf.position += this.columnLengths_[name];
+    }, this);
+    this.dvDbf_.setUint8(this.header_.dbf.position, 0x20);
+    this.header_.dbf.position++;
+  }
+
+  /**
+   * Add the shapefile footer
+   */
+  appendFooter() {
+    // SHP file length. words not bytes
+    this.dvShp_.setUint32(24, this.header_.position / 2);
+
+    // SHP file min/max lon/lat
+    this.dvShp_.setFloat64(36, this.extent_[0], true);
+    this.dvShp_.setFloat64(44, this.extent_[1], true);
+    this.dvShp_.setFloat64(52, this.extent_[2], true);
+    this.dvShp_.setFloat64(60, this.extent_[3], true);
+
+    // SHX file length. words not bytes
+    this.dvShx_.setUint32(24, this.header_.shx.position / 2);
+
+    // SHX file min/max lon/lat
+    this.dvShx_.setFloat64(36, this.extent_[0], true);
+    this.dvShx_.setFloat64(44, this.extent_[1], true);
+    this.dvShx_.setFloat64(52, this.extent_[2], true);
+    this.dvShx_.setFloat64(60, this.extent_[3], true);
+
+    // SHX shape type
+    this.dvShx_.setUint32(32, this.shpType_, true);
+
+    // number of records
+    this.dvDbf_.setUint32(4, this.recNum_, true);
+
+    var shpFile = new OSFile();
+    shpFile.setContent(this.header_.data.slice(0, this.header_.position));
+    shpFile.setFileName(this.name + '.shp');
+    this.addFile(shpFile);
+
+    var dbfFile = new OSFile();
+    dbfFile.setContent(this.header_.dbf.data.slice(0, this.header_.dbf.position));
+    dbfFile.setFileName(this.name + '.dbf');
+    this.addFile(dbfFile);
+
+    var shxFile = new OSFile();
+    shxFile.setContent(this.header_.shx.data.slice(0, this.header_.shx.position));
+    shxFile.setFileName(this.name + '.shx');
+    this.addFile(shxFile);
+
+    var prjFile = new OSFile();
+    prjFile.setContent(SHPExporter.PRJ_WGS84);
+    prjFile.setFileName(this.name + '.prj');
+    this.addFile(prjFile);
+
+    var cpgFile = new OSFile();
+    cpgFile.setContent(SHPExporter.CPG_UTF8);
+    cpgFile.setFileName(this.name + '.cpg');
+    this.addFile(cpgFile);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getUI() {
+    return `<${shpExportUi} exporter="exporter"></${shpExportUi}>`;
+  }
+
+  /**
+   * Get if ellipses should be exported.
+   *
+   * @return {boolean}
+   */
+  getExportEllipses() {
+    return this.exportEllipses_;
+  }
+
+  /**
+   * Set if ellipses should be exported.
+   *
+   * @param {boolean} value
+   */
+  setExportEllipses(value) {
+    this.exportEllipses_ = value;
+  }
+}
 
 /**
  * Logger
- * @type {goog.log.Logger}
- * @private
- * @const
+ * @type {log.Logger}
  */
-plugin.file.shp.SHPExporter.LOGGER_ = goog.log.getLogger('plugin.file.shp.SHPExporter');
+const logger = log.getLogger('plugin.file.shp.SHPExporter');
 
 
 /**
@@ -139,7 +1133,7 @@ plugin.file.shp.SHPExporter.LOGGER_ = goog.log.getLogger('plugin.file.shp.SHPExp
  * @type {string}
  * @const
  */
-plugin.file.shp.SHPExporter.PRJ_WGS84 = 'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",' +
+SHPExporter.PRJ_WGS84 = 'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",' +
     'SPHEROID["WGS_1984",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]]';
 
 /**
@@ -150,1012 +1144,6 @@ plugin.file.shp.SHPExporter.PRJ_WGS84 = 'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984
  * @type {string}
  * @const
  */
-plugin.file.shp.SHPExporter.CPG_UTF8 = 'UTF-8';
+SHPExporter.CPG_UTF8 = 'UTF-8';
 
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPExporter.prototype.getExtension = function() {
-  return 'zip';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPExporter.prototype.getLabel = function() {
-  return 'SHP';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPExporter.prototype.getMimeType = function() {
-  return plugin.file.shp.mime.ZIP_TYPE;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPExporter.prototype.cancel = function() {};
-
-
-/**
- * Get the feature's source.
- *
- * @param {ol.Feature} feature The feature
- * @return {os.source.Vector} The source
- * @private
- */
-plugin.file.shp.SHPExporter.prototype.getSource_ = function(feature) {
-  var source = null;
-  if (feature) {
-    var sourceId = feature.get(os.data.RecordField.SOURCE_ID);
-    if (typeof sourceId === 'string') {
-      source = /** @type {os.source.Vector} */ (os.osDataManager.getSource(sourceId));
-    }
-  }
-
-  return source;
-};
-
-
-/**
- * Parse the column
- *
- * @param {T} item
- * @param {Object} col
- * @private
- * @template T
- */
-plugin.file.shp.SHPExporter.prototype.parseColumn_ = function(item, col) {
-  var name = col['name'];
-  var field = col['field'];
-  var value = item.get(field);
-  var valueType = typeof value;
-
-  // columns starting with '_' are considered private and will be ignored
-  if (field.indexOf('_') != 0 && field != 'geometry') {
-    // convert the value to a string
-    if (value instanceof Date) {
-      // os.time.ITime implementations override toString, so the else block will handle it
-      value = value.toISOString();
-    } else {
-      value = goog.string.makeSafe(value);
-      value = goog.string.trim(value);
-    }
-
-    // determine the column name to use in the shapefile
-    if (!(name in this.columnName_)) {
-      // can only be 10 characters with terminating null
-      // so pad with null characters and truncate to 10 characters
-      var fieldName = (name.replace(' ', '_') +
-          '\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000').substr(0, 10);
-
-      if (goog.object.containsValue(this.columnName_, fieldName)) {
-        if (!(fieldName in this.columnNameCounter_)) {
-          this.columnNameCounter_[fieldName] = 0;
-        }
-        this.columnNameCounter_[fieldName]++;
-
-        // Since the 10char name is the same. attempt to make it unique
-        fieldName = (fieldName.substr(0, 9) + String(this.columnNameCounter_[fieldName])).substr(0, 10);
-      }
-
-      this.columnName_[name] = fieldName;
-    }
-    var valueAsByteArrayLength = goog.crypt.stringToUtf8ByteArray(value).length;
-
-    // determine the maximum length for column values
-    if (name in this.columnTypes_) {
-      this.columnLengths_[name] = Math.min(Math.max(this.columnLengths_[name], valueAsByteArrayLength), 255);
-    } else {
-      this.columnLengths_[name] = Math.min(valueAsByteArrayLength, 255);
-      this.columns_.push(col);
-    }
-
-    // determine the value type
-    if (!(name in this.columnTypes_)) {
-      if (valueType == 'boolean') {
-        this.columnTypes_[name] = 'L';
-      } else if (valueType == 'number') {
-        this.columnTypes_[name] = 'N';
-      } else {
-        this.columnTypes_[name] = 'C';
-      }
-    } else if (this.columnTypes_[name] == 'L' && valueType != 'boolean') {
-      this.columnTypes_[name] = 'C';
-    } else if (this.columnTypes_[name] == 'N' && valueType != 'number') {
-      this.columnTypes_[name] = 'C';
-    }
-
-    // determine the precision for numeric columns
-    if (this.columnTypes_[name] == 'N' && value.match(/^[+-]?\d*\.\d+$/)) {
-      var currentPrecision = this.columnPrecisions_[name] || 0;
-      this.columnPrecisions_[name] = Math.min(Math.max(currentPrecision, value.replace(/^[+-]?\d*\./, '').length), 255);
-    } else {
-      this.columnPrecisions_[name] = 0;
-    }
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPExporter.prototype.setItems = function(items) {
-  plugin.file.shp.SHPExporter.base(this, 'setItems', items);
-
-  // parse columns from the new items
-  this.parseColumns();
-
-  // reset the exporter
-  this.extent_ = null;
-  this.recNum_ = 0;
-  this.shpType_ = -1;
-  this.dvShp_ = null;
-  this.dvDbf_ = null;
-  this.dvShx_ = null;
-};
-
-
-/**
- * Parse the columns to include in the shapefile.
- *
- * @protected
- */
-plugin.file.shp.SHPExporter.prototype.parseColumns = function() {
-  this.columns_ = [];
-  this.columnLengths_ = {};
-  this.columnPrecisions_ = {};
-  this.columnTypes_ = {};
-  this.columnName_ = {};
-  this.columnNameCounter_ = {};
-
-  if (this.items && this.items.length > 0) {
-    var item = this.items[0];
-    var source = this.getSource_(item);
-    var columns = source && source.getColumnsArray() || goog.object.getKeys(item.getProperties());
-
-    for (var i = 0; i < this.items.length; i++) {
-      item = this.items[i];
-
-      if (source) {
-        // Layer
-        for (var j = 0; j < columns.length; j++) {
-          var column = columns[j];
-          var colNameField = {
-            'name': column['name'],
-            'field': column['field']
-          };
-          if (columns[j]['visible'] && !goog.string.isEmptyOrWhitespace(goog.string.makeSafe(colNameField['name']))) {
-            this.parseColumn_(item, colNameField);
-          }
-        }
-      } else {
-        // Areas, other
-        for (var j = 0; j < columns.length; j++) {
-          var column = columns[j];
-          var colNameField = {
-            'name': column,
-            'field': column
-          };
-          if (!goog.string.isEmptyOrWhitespace(goog.string.makeSafe(colNameField['name']))) {
-            this.parseColumn_(item, colNameField);
-          }
-        }
-      }
-    }
-  }
-};
-
-
-/**
- * Add the shapefile header
- */
-plugin.file.shp.SHPExporter.prototype.appendHeader = function() {
-  // Dumb... better way?
-  this.allocateArrays_();
-
-  // With Array Buffers, we need to allocate all the space for the array before we set anything.
-  this.header_.data = new ArrayBuffer(this.header_.allocation);
-  this.header_.dbf.data = new ArrayBuffer(this.header_.dbf.allocation);
-  this.header_.shx.data = new ArrayBuffer(this.header_.shx.allocation);
-
-  this.dvShp_ = new DataView(this.header_.data);
-  this.dvDbf_ = new DataView(this.header_.dbf.data);
-  this.dvShx_ = new DataView(this.header_.shx.data);
-
-  this.appendSHPHeader();
-  this.appendDBFHeader();
-  this.appendSHXHeader();
-};
-
-
-/**
- * Allocate space for headers
- *
- * @private
- */
-plugin.file.shp.SHPExporter.prototype.allocateArrays_ = function() {
-  // SHP
-  this.header_.allocation = 100;
-
-  // DBF
-  var headerSize = 32 + (this.columns_.length * 32);
-  this.header_.dbf.allocation = headerSize + 1;
-
-  // SHX
-  this.header_.shx.allocation = 100;
-
-  // Items
-  for (var i = 0, n = this.items.length; i < n; i++) {
-    var item = this.items[i];
-    var geom = this.getGeometry_(item);
-    if (geom != null) {
-      if (geom instanceof ol.geom.GeometryCollection) {
-        os.array.forEach(geom.getGeometries(), function(geometry) {
-          this.allocateItem_(item, /** @type {ol.geom.SimpleGeometry} */ (geometry));
-        }, this);
-      } else {
-        this.allocateItem_(item, geom);
-      }
-    }
-  }
-};
-
-
-/**
- * Allocate space for this item
- *
- * @param {T} item The item
- * @param {ol.geom.SimpleGeometry} geom
- * @private
- * @template T
- */
-plugin.file.shp.SHPExporter.prototype.allocateItem_ = function(item, geom) {
-  // Doesnt seem like shapefiles support multi polygon. Just polygons with multiple stuff (like holes)
-  if (geom.getType() == ol.geom.GeometryType.MULTI_POLYGON) {
-    geom = /** @type {ol.geom.MultiPolygon} */ (geom);
-    os.array.forEach(geom.getPolygons(), function(polygon) {
-      this.allocateItemForGeom_(item, polygon);
-    }, this);
-  } else if (geom.getType() == ol.geom.GeometryType.MULTI_POINT) {
-    geom = /** @type {ol.geom.MultiPoint} */ (geom);
-    os.array.forEach(geom.getPoints(), function(point) {
-      this.allocateItemForGeom_(item, point);
-    }, this);
-  } else {
-    this.allocateItemForGeom_(item, geom);
-  }
-};
-
-
-/**
- * Allocate space for this item
- *
- * @param {T} item The item
- * @param {ol.geom.SimpleGeometry} geom
- * @private
- * @template T
- */
-plugin.file.shp.SHPExporter.prototype.allocateItemForGeom_ = function(item, geom) {
-  var geomType = geom.getType();
-  this.isSupportedType_(geomType);
-
-  this.header_.shx.allocation += 8;
-  this.header_.allocation += 8;
-
-  var recLength = 0;
-  if (geomType == ol.geom.GeometryType.POINT) {
-    var coord = geom.getCoordinates();
-    recLength = 20;
-    if (geom.getLayout() == 'XYZ' && coord[2] != 0) {
-      recLength = 36;
-    }
-  } else if (geomType == ol.geom.GeometryType.LINE_STRING ||
-      geomType == ol.geom.GeometryType.MULTI_LINE_STRING ||
-      geomType == ol.geom.GeometryType.POLYGON) {
-    var numParts = 1;
-    var flatGroupCoords = [];
-    if (geomType == ol.geom.GeometryType.LINE_STRING) {
-      flatGroupCoords = geom.getCoordinates();
-    } else {
-      var coords = geom.getCoordinates();
-      numParts = coords.length;
-
-      // Flatten down the coordinates one level
-      os.array.forEach(coords, function(coord) {
-        os.array.forEach(coord, function(point) {
-          flatGroupCoords.push(point);
-        });
-      });
-    }
-
-    var numPoints = flatGroupCoords.length;
-    var partsLen = numParts * 4;
-    var pointsLen = numPoints * 16;
-    recLength = 44 + partsLen + pointsLen;
-
-    if (geom.getLayout() == 'XYZ') {
-      // add the z components if available
-      for (var i = 0; i < flatGroupCoords.length; i++) {
-        if (flatGroupCoords[i][2] != 0) {
-          // 4 min max's (z & m) + 2x8xlength (z points, m points)
-          recLength += (8 * 4) + (numPoints * 16);
-          break;
-        }
-      }
-    }
-  }
-  this.header_.allocation += recLength;
-
-  // Add the DBF Metadata for this geometry
-  os.array.forEach(this.columns_, function(col) {
-    var name = col['name'];
-    this.header_.dbf.allocation += this.columnLengths_[name];
-  }, this);
-  this.header_.dbf.allocation++;
-};
-
-
-/**
- * Append the SHP Header
- */
-plugin.file.shp.SHPExporter.prototype.appendSHPHeader = function() {
-  /* Shape File Header
-   *                                                    Byte
-   * Position  Field           Value           Type     Order
-   * Byte 0    File Type       9994            Integer  Big
-   * Byte 4    Unused?
-   * Byte 24   File Length     # 16bit Words   Integer  Big
-   * Byte 28   Version         1000            Integer  Little
-   * Byte 32   Shape Type      0, *1, *3, *5   Integer  Little
-   * Byte 36   Min Lon         Degrees         Double   Little
-   * Byte 44   Min Lat         Degrees         Double   Little
-   * Byte 52   Max Lon         Degrees         Double   Little
-   * Byte 60   Max Lat         Degrees         Double   Little
-   * Byte 68   Unused                          Double   Little
-   * Byte 76   Unused                          Double   Little
-   * Byte 84   Unused                          Double   Little
-   * Byte 92   Unused                          Double   Little
-   * Byte 100  End Of Header
-   */
-  // file type
-  this.dvShp_.setUint32(0, 9994);
-  // file version
-  this.dvShp_.setUint32(28, 1000, true);
-
-  this.header_.position = 100;
-};
-
-
-/**
- * Append the DBF Header
- */
-plugin.file.shp.SHPExporter.prototype.appendDBFHeader = function() {
-  /*                                                                  Byte
-   * Position   Field                          Units         Type      Order
-   * Byte 0     Version                        Version       Byte      n/a
-   * Byte 1     Year                           Year+1900     Byte      n/a
-   * Byte 2     Month                          Month (1-12)  Byte      n/a
-   * Byte 3     Date                           Date of Month Byte      n/a
-   * Byte 4     NumRecords                     Count         Integer   Little
-   * Byte 8     HeaderSize                     Bytes         Short     Little
-   * Byte 10    RecordSize                     Bytes         Short     Little
-   * Byte 12    reserved                                     Byte[2]   n/a
-   * Byte 14    Incomplete transaction flag                  Byte      n/a
-   * Byte 15    Encryption Flag                              Byte      n/a
-   * Byte 16    Free record thread (reserved)                Byte[4]   n/a
-   * Byte 20    Reserved for multi-user                      Byte[8]   n/a
-   * Byte 28    MDX Flag (reserved)                          Byte      n/a
-   * Byte 29    Language driver (reserved)                   Byte      n/a
-   * Byte 30    Reserved                                     Byte[2]   n/a
-   * Byte 32    Table Field descriptor Array                 Byte[32]  n/a
-   * Byte 64-n  repeated for each field                      Byte[32]  n/a
-   * Byte n     Terminator                     '0Dh'         Byte      n/a
-   * Byte n+1   ASCII Records separated by a 'space' (20h)
-   *
-   * Within Fields
-   * Byte 0    Field Name                                    Byte[11]  n/a
-   * Byte 12   Field Type                                    Byte      n/a
-   * Byte 16   Field Length                                  Byte      n/a
-   */
-  var headerSize = 32 + (this.columns_.length * 32);
-
-  // version
-  this.dvDbf_.setUint8(0, 3);
-
-  var date = new Date();
-  // Year
-  this.dvDbf_.setUint8(1, date.getUTCFullYear() - 1900);
-  // Month
-  this.dvDbf_.setUint8(2, date.getUTCMonth() + 1);
-  // Date
-  this.dvDbf_.setUint8(3, date.getUTCDate());
-
-  // write header size
-  this.dvDbf_.setUint16(8, headerSize, true);
-
-  // determine record size
-  var recordSize = 0;
-  goog.object.forEach(this.columnLengths_, function(len) {
-    recordSize += len;
-  });
-
-  // write record size
-  this.dvDbf_.setUint16(10, recordSize + 1, true);
-
-  // language driver ID (ANSI)
-  this.dvDbf_.setUint16(29, 0x57, true);
-
-  // write header (column info)
-  os.array.forEach(this.columns_, function(col, index) {
-    var startPos = 32 + index * 32;
-    var name = col['name'];
-
-    // Field Name
-    this.writeMultiByte(this.dvDbf_, startPos, this.columnName_[name]);
-
-    // Field Type
-    this.writeMultiByte(this.dvDbf_, startPos + 11, this.columnTypes_[name]);
-    // Field Length
-    this.dvDbf_.setUint8(startPos + 16, this.columnLengths_[name]);
-    // Field Precision
-    this.dvDbf_.setUint8(startPos + 17, this.columnPrecisions_[name]);
-  }, this);
-
-  // position at end of header
-  this.dvDbf_.setUint8(headerSize, 0x0D);
-  // done with header, setup for records
-  this.header_.dbf.position = headerSize + 1;
-};
-
-
-/**
- * Append the SHX Header
- */
-plugin.file.shp.SHPExporter.prototype.appendSHXHeader = function() {
-  // file type
-  this.dvShx_.setUint32(0, 9994);
-  // file version
-  this.dvShx_.setUint32(28, 1000, true);
-  this.header_.shx.position = 100;
-};
-
-
-/**
- * Convert string to byte
- *
- * @param {DataView} dv
- * @param {number} pos - the position
- * @param {string} str - the string to convert to bytes
- * @return {number} the number of bytes written
- */
-plugin.file.shp.SHPExporter.prototype.writeMultiByte = function(dv, pos, str) {
-  var ba = goog.crypt.stringToUtf8ByteArray(str);
-  for (var i = 0; ba && i < ba.length; ++i) {
-    dv.setUint8(pos, ba[i]);
-    pos++;
-  }
-  return ba.length;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPExporter.prototype.processItems = function() {
-  this.appendHeader();
-
-  var skipped = 0;
-  for (var i = 0, n = this.items.length; i < n; i++) {
-    if (!this.processItem(this.items[i])) {
-      skipped++;
-    }
-  }
-
-  // notify the user if any features were not included in the shapefile
-  if (skipped > 0) {
-    var skipMsg = 'Skipped ' + skipped + ' feature' + (skipped > 1 ? 's' : '') + ' that did not have a geometry.';
-    os.alertManager.sendAlert(skipMsg, os.alert.AlertEventSeverity.WARNING, this.log);
-  }
-
-  // only add the footer if one or more items were added, otherwise exporting the SHP will fail.
-  if (skipped < this.items.length) {
-    this.appendFooter();
-  }
-};
-
-
-/**
- * Process a single item, returning a Placemark element to add to the SHP.
- *
- * @param {T} item The item
- * @return {boolean} If the item was added
- * @protected
- * @template T
- */
-plugin.file.shp.SHPExporter.prototype.processItem = function(item) {
-  var geom = this.getGeometry_(item);
-  if (geom != null) {
-    if (geom instanceof ol.geom.GeometryCollection) {
-      os.array.forEach(geom.getGeometries(), function(geometry) {
-        this.appendItem_(item, /** @type {ol.geom.SimpleGeometry} */ (geometry));
-      }, this);
-    } else {
-      this.appendItem_(item, geom);
-    }
-
-    return true;
-  }
-
-  return false;
-};
-
-
-/**
- * Get the geometry for a feature.
- *
- * @param {ol.Feature} feature The feature
- * @return {ol.geom.GeometryCollection|ol.geom.SimpleGeometry|undefined}
- * @private
- */
-plugin.file.shp.SHPExporter.prototype.getGeometry_ = function(feature) {
-  var geometry;
-  if (feature) {
-    geometry = /** @type {(ol.geom.SimpleGeometry|undefined)} */ (feature.get(os.data.RecordField.GEOM));
-
-    if (geometry) {
-      geometry = /** @type {(ol.geom.SimpleGeometry|undefined)} */ (geometry.clone().toLonLat());
-
-      if (this.exportEllipses_) {
-        var ellipse = os.feature.createEllipse(feature);
-        if (ellipse && !(ellipse instanceof ol.geom.Point)) {
-          geometry = /** @type {(ol.geom.SimpleGeometry|undefined)} */ (ellipse);
-        }
-      }
-    }
-  }
-
-  return geometry;
-};
-
-
-/**
- * Only put entries in if they are supported
- *
- * @param {ol.geom.GeometryType} type
- * @private
- */
-plugin.file.shp.SHPExporter.prototype.isSupportedType_ = function(type) {
-  if (type != ol.geom.GeometryType.POINT &&
-      type != ol.geom.GeometryType.MULTI_POINT &&
-      type != ol.geom.GeometryType.LINE_STRING &&
-      type != ol.geom.GeometryType.MULTI_LINE_STRING &&
-      type != ol.geom.GeometryType.MULTI_POLYGON &&
-      type != ol.geom.GeometryType.POLYGON) {
-    throw new Error(type + ' is not supported');
-  }
-};
-
-
-/**
- * Add this geometry to the shape file
- *
- * @param {T} item The item
- * @param {ol.geom.SimpleGeometry} geom
- * @private
- * @template T
- */
-plugin.file.shp.SHPExporter.prototype.appendItemForGeom_ = function(item, geom) {
-  var geomType = geom.getType();
-  this.isSupportedType_(geomType);
-
-  // write offset
-  this.dvShx_.setUint32(this.header_.shx.position, this.header_.position / 2); // words not bytes
-  this.header_.shx.position += 4;
-
-  /* Shape File Record Header (big endian)
-   *                                                    Byte
-   * Position  Field           Value           Type     Order
-   * Byte 0    Record Number   Record Num      Integer  Big
-   * Byte 4    Record Length   # 16-bit Words  Integer  Big
-   * Byte 8    Start of Shape File Record
-   */
-  // write record number
-  if (item.get('RECNUM')) {
-    this.dvShp_.setUint32(this.header_.position, item.get('RECNUM'));
-  } else {
-    this.dvShp_.setUint32(this.header_.position, ++this.recNum_);
-  }
-  this.header_.position += 8;
-
-  // save position for record length
-  var recordStart = this.header_.position;
-  var extent = geom.getExtent();
-
-  // Make sure the global extent includes this extent
-  if (extent) {
-    if (this.extent_) {
-      this.extent_ = ol.extent.extend(this.extent_, extent);
-    } else {
-      this.extent_ = ol.extent.clone(extent);
-    }
-  }
-
-  var recLength = 0;
-  var shapeType = -1;
-  if (geomType == ol.geom.GeometryType.POINT) {
-    /* Shape File Point Record (little endian)
-     *                                          Byte
-     * Position  Field       Value     Type     Order
-     * Byte 0    Shape Type  *1        Integer  Little
-     * Byte 4    Longitude   Degrees   Double   Little
-     * Byte 12   Latitude    Degrees   Double   Little
-     * Byte 20   End Record Normal Point
-     *
-     * The "M" adds:
-     * Byte 20   M           M         Double   Little
-     *
-     * The "Z" adds:
-     * Byte 20   Z           Z         Double   Little
-     * Byte 28   M           M         Double   Little
-     */
-    var coord = geom.getCoordinates();
-    shapeType = plugin.file.shp.TYPE.POINT;
-    recLength = 20;
-    if (geom.getLayout() == 'XYZ' && coord[2] != 0) {
-      shapeType = plugin.file.shp.TYPE.POINTZ;
-      recLength = 36;
-    }
-
-    this.dvShp_.setFloat64(recordStart + 4, coord[0], true);
-    this.dvShp_.setFloat64(recordStart + 12, coord[1], true);
-    if (shapeType == plugin.file.shp.TYPE.POINTZ) {
-      this.dvShp_.setFloat64(recordStart + 20, coord[2], true);
-    }
-    // } else if (geom.getType() == ol.geom.GeometryType.MULTI_POINT) {
-    //   /**
-    //    * MultiPoint
-    //    *                                                  Byte
-    //    * Position   Field       Value     Type    Number    Order
-    //    * Byte 0     Shape Type  8         Integer 1         Little
-    //    * Byte 4     Box         Box       Double  4         Little
-    //    * Byte 36    NumPoints   NumPoints Integer 1         Little
-    //    * Byte 40    Points      Points    Point   NumPoints Little
-    //    *
-    //    * Byte X     Zmin        Zmin      Double  1         Little
-    //    * Byte X+8   Zmax        Zmax      Double  1         Little
-    //    * Byte X+16  Zarray      Zarray    Double  NumPoints Little
-    //    * Byte Y*    Mmin        Mmin      Double  1         Little
-    //    * Byte Y+8*  Mmax        Mmax      Double  1         Little
-    //    * Byte Y+16* Marray      Marray    Double  NumPoints Little
-    //    * Note: X = 40 + (16 * NumPoints); Y = X + 16 + (8 * NumPoints)
-    //    */
-    //   shapeType = plugin.file.shp.TYPE.MULTIPOINT;
-    //   var coords = geom.getCoordinates();
-    //   var numPoints = coords.length;
-    //   var pointsLen = numPoints * 16;
-
-    //   recLength = 40 + pointsLen;
-    //   if (geom.getLayout() == 'XYZ') {
-    //     for (var i = 0; i < coords.length; i++) {
-    //       if (coords[i][2] != 0) {
-    //         shapeType = plugin.file.shp.TYPE.MULTIPOINTZ;
-    //         recLength += 16 + (16 * numPoints);
-    //         break;
-    //       }
-    //     }
-    //   }
-
-    //   // Box
-    //   this.dvShp_.setFloat64(recordStart + 4, extent[0], true);
-    //   this.dvShp_.setFloat64(recordStart + 12, extent[1], true);
-    //   this.dvShp_.setFloat64(recordStart + 20, extent[2], true);
-    //   this.dvShp_.setFloat64(recordStart + 28, extent[3], true);
-
-    //   // Num points
-    //   this.dvShp_.setInt32(recordStart + 40, numPoints, true);
-
-    //   // Points
-    //   var pointsStart = recordStart + 40;
-    //   var zpointsStart = pointsStart + pointsLen;
-    //   os.array.forEach(coords, function(coord, index) {
-    //     var offset = index * 16;
-    //     this.dvShp_.setFloat64(pointsStart + offset, coord[0], true);
-    //     this.dvShp_.setFloat64(pointsStart + offset + 8, coord[1], true);
-
-  //     if (shapeType == plugin.file.shp.TYPE.MULTIPOINTZ) {
-  //       this.dvShp_.setFloat64(zpointsStart + (8 * index), coord[2], true);
-  //     }
-  //   }, this);
-  } else if (geomType == ol.geom.GeometryType.LINE_STRING ||
-      geomType == ol.geom.GeometryType.MULTI_LINE_STRING ||
-      geomType == ol.geom.GeometryType.POLYGON) {
-    /* Shape File Polyline/Polygon Record
-     *                                                   Byte
-     * Position  Field       Value            Type       Order
-     * Byte 0    Shape Type  *3 or *5         Integer    Little
-     * Byte 4    Min Lon     Degrees          Double     Little
-     * Byte 12   Min Lat     Degrees          Double     Little
-     * Byte 20   Max Lon     Degrees          Double     Little
-     * Byte 28   Max Lat     Degrees          Double     Little
-     * Byte 36   Num Parts   Num Parts        Integer    Little
-     * Byte 40   Num Points  Num Points       Integer    Little
-     * Byte 44   Parts[]     Start Indices    Integer    Little
-     * Byte xx   Points[]    Lon & Lat Pairs  2 Doubles  Little
-     * Note: xx = 44 + 4 * NumParts
-     *
-     * The "Z" adds:
-     * Byte Y    Zmin        Zmin             Double     Little
-     * Byte Y+8  Zmax        Zmax             Double     Little
-     * Byte Y+16 Z[]         Zarray           Doubles    Little
-     *
-     * The "M" adds:
-     * Byte Y    Mmin        Mmin            Double      Little
-     * Byte Y+8  Mmax        Mmax            Double      Little
-     * Byte Y+16 M[]         Marray          Doubles     Little
-     * Byte zz   End Record
-     */
-
-    switch (geomType) {
-      case ol.geom.GeometryType.LINE_STRING:
-      case ol.geom.GeometryType.MULTI_LINE_STRING:
-        shapeType = plugin.file.shp.TYPE.POLYLINE;
-        break;
-      case ol.geom.GeometryType.POLYGON:
-        shapeType = plugin.file.shp.TYPE.POLYGON;
-        break;
-      default:
-        break;
-    }
-
-    var numParts = 1;
-    var flatGroupCoords = [];
-    if (geomType == ol.geom.GeometryType.LINE_STRING) {
-      flatGroupCoords = geom.getCoordinates();
-
-      // Only 1 part for line strings
-      this.dvShp_.setInt32(recordStart + 44, 0, true);
-    } else {
-      var coords = geom.getCoordinates();
-      numParts = coords.length;
-
-      // Flatten down the coordinates one level
-      os.array.forEach(coords, function(coord) {
-        os.array.forEach(coord, function(point) {
-          flatGroupCoords.push(point);
-        });
-      });
-
-      // Part Indexes
-      var partStartIndex = 0;
-      for (var i = 0; i < numParts; i++) {
-        this.dvShp_.setInt32(recordStart + 44 + (i * 4), partStartIndex, true);
-        partStartIndex += coords[i].length;
-      }
-    }
-
-    var numPoints = flatGroupCoords.length;
-    var partsLen = numParts * 4;
-    var pointsLen = numPoints * 16;
-    recLength = 44 + partsLen + pointsLen;
-
-    if (geom.getLayout() == 'XYZ') {
-      // add the z components if available
-      for (var i = 0; i < flatGroupCoords.length; i++) {
-        if (flatGroupCoords[i][2] != 0) {
-          // 4 min max's (z & m) + 2x8xlength (z points, m points)
-          recLength += (8 * 4) + (numPoints * 16);
-          if (shapeType == plugin.file.shp.TYPE.POLYLINE) {
-            shapeType = plugin.file.shp.TYPE.POLYLINEZ;
-            break;
-          } else {
-            shapeType = plugin.file.shp.TYPE.POLYGONZ;
-            break;
-          }
-        }
-      }
-    }
-
-    this.dvShp_.setFloat64(recordStart + 4, extent[0], true);
-    this.dvShp_.setFloat64(recordStart + 12, extent[1], true);
-    this.dvShp_.setFloat64(recordStart + 20, extent[2], true);
-    this.dvShp_.setFloat64(recordStart + 28, extent[3], true);
-
-    // Start Indices
-    this.dvShp_.setInt32(recordStart + 36, numParts, true);
-
-    // Lon & Lat Pairs
-    this.dvShp_.setInt32(recordStart + 40, numPoints, true);
-
-    // Points
-    var pointsStart = recordStart + 44 + partsLen;
-    var zpointsStart = pointsStart + pointsLen + (2 * 8);
-    for (var i = 0; i < flatGroupCoords.length; i++) {
-      var offset = i * 16;
-      this.dvShp_.setFloat64(pointsStart + offset, flatGroupCoords[i][0], true);
-      this.dvShp_.setFloat64(pointsStart + offset + 8, flatGroupCoords[i][1], true);
-
-      if (shapeType == plugin.file.shp.TYPE.POLYLINEZ ||
-          shapeType == plugin.file.shp.TYPE.POLYGONZ) {
-        this.dvShp_.setFloat64(zpointsStart + (i * 8), flatGroupCoords[i][2], true);
-      }
-    }
-  }
-  /* Shape File Record (little endian)
-   *                                                      Byte
-   * Position  Field           Value             Type     Order
-   * Byte 0    Shape Type      0, *1, *3, *5     Integer  Little
-   * Byte 4    Specific for each Shape Type
-   */
-  if (this.shpType_ < 0 || (this.shpType_ == plugin.file.shp.TYPE.POINT && shapeType != plugin.file.shp.TYPE.POINT)) {
-    // write shape type in header
-    this.shpType_ = shapeType;
-    this.dvShp_.setUint32(32, this.shpType_, true);
-  }
-
-  // write record shape type
-  this.dvShp_.setUint32(recordStart, shapeType, true);
-  this.header_.position += recLength;
-
-  this.dvShp_.setUint32(recordStart - 4, recLength / 2);
-  this.dvShx_.setUint32(this.header_.shx.position, recLength / 2);
-  this.header_.shx.position += 4;
-
-  // Add the DBF Metadata for this geometry
-  this.addMetadata_(item);
-};
-
-
-/**
- * First check to see if this is a multipolygon and break it up
- *
- * @param {T} item The item
- * @param {ol.geom.SimpleGeometry} geom
- * @private
- * @template T
- */
-plugin.file.shp.SHPExporter.prototype.appendItem_ = function(item, geom) {
-  // Doesnt seem like shapefiles support multi polygon. Just polygons with multiple stuff (like holes)
-  if (geom.getType() == ol.geom.GeometryType.MULTI_POLYGON) {
-    geom = /** @type {ol.geom.MultiPolygon} */ (geom);
-    os.array.forEach(geom.getPolygons(), function(polygon) {
-      this.appendItemForGeom_(item, polygon);
-    }, this);
-  } else if (geom.getType() == ol.geom.GeometryType.MULTI_POINT) {
-    geom = /** @type {ol.geom.MultiPoint} */ (geom);
-    os.array.forEach(geom.getPoints(), function(point) {
-      this.appendItemForGeom_(item, point);
-    }, this);
-  } else {
-    this.appendItemForGeom_(item, geom);
-  }
-};
-
-
-/**
- * Process a single item adding the metadata to the DBF file.
- * Do this for each geometry added even if its a duplicate
- *
- * @param {T} item The item
- * @private
- * @template T
- */
-plugin.file.shp.SHPExporter.prototype.addMetadata_ = function(item) {
-  os.array.forEach(this.columns_, function(col) {
-    var name = col['name'];
-    var field = col['field'];
-
-    var value = item.get(field);
-    value = value == null ? '' : value;
-
-    if (field == os.data.RecordField.TIME && os.implements(value, os.time.ITime.ID)) {
-      value = /** @type {os.time.ITime} */ (value).toISOString();
-    } else {
-      value = goog.string.makeSafe(value);
-      value = goog.string.trim(value);
-    }
-
-    if (value.length > this.columnLengths_[name]) {
-      value = value.substr(0, this.columnLengths_[name]);
-    }
-
-    var numBytes = this.writeMultiByte(this.dvDbf_, this.header_.dbf.position, value);
-
-    // fill with nulls
-    for (var i = numBytes; i < this.columnLengths_[name]; ++i) {
-      this.dvDbf_.setUint8(this.header_.dbf.position + i, 0x0);
-    }
-
-    this.header_.dbf.position += this.columnLengths_[name];
-  }, this);
-  this.dvDbf_.setUint8(this.header_.dbf.position, 0x20);
-  this.header_.dbf.position++;
-};
-
-
-/**
- * Add the shapefile footer
- */
-plugin.file.shp.SHPExporter.prototype.appendFooter = function() {
-  // SHP file length. words not bytes
-  this.dvShp_.setUint32(24, this.header_.position / 2);
-
-  // SHP file min/max lon/lat
-  this.dvShp_.setFloat64(36, this.extent_[0], true);
-  this.dvShp_.setFloat64(44, this.extent_[1], true);
-  this.dvShp_.setFloat64(52, this.extent_[2], true);
-  this.dvShp_.setFloat64(60, this.extent_[3], true);
-
-  // SHX file length. words not bytes
-  this.dvShx_.setUint32(24, this.header_.shx.position / 2);
-
-  // SHX file min/max lon/lat
-  this.dvShx_.setFloat64(36, this.extent_[0], true);
-  this.dvShx_.setFloat64(44, this.extent_[1], true);
-  this.dvShx_.setFloat64(52, this.extent_[2], true);
-  this.dvShx_.setFloat64(60, this.extent_[3], true);
-
-  // SHX shape type
-  this.dvShx_.setUint32(32, this.shpType_, true);
-
-  // number of records
-  this.dvDbf_.setUint32(4, this.recNum_, true);
-
-  var shpFile = new os.file.File();
-  shpFile.setContent(this.header_.data.slice(0, this.header_.position));
-  shpFile.setFileName(this.name + '.shp');
-  this.addFile(shpFile);
-
-  var dbfFile = new os.file.File();
-  dbfFile.setContent(this.header_.dbf.data.slice(0, this.header_.dbf.position));
-  dbfFile.setFileName(this.name + '.dbf');
-  this.addFile(dbfFile);
-
-  var shxFile = new os.file.File();
-  shxFile.setContent(this.header_.shx.data.slice(0, this.header_.shx.position));
-  shxFile.setFileName(this.name + '.shx');
-  this.addFile(shxFile);
-
-  var prjFile = new os.file.File();
-  prjFile.setContent(plugin.file.shp.SHPExporter.PRJ_WGS84);
-  prjFile.setFileName(this.name + '.prj');
-  this.addFile(prjFile);
-
-  var cpgFile = new os.file.File();
-  cpgFile.setContent(plugin.file.shp.SHPExporter.CPG_UTF8);
-  cpgFile.setFileName(this.name + '.cpg');
-  this.addFile(cpgFile);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPExporter.prototype.getUI = function() {
-  return '<shpexport exporter="exporter"></shpexport>';
-};
-
-
-/**
- * Get if ellipses should be exported.
- *
- * @return {boolean}
- */
-plugin.file.shp.SHPExporter.prototype.getExportEllipses = function() {
-  return this.exportEllipses_;
-};
-
-
-/**
- * Set if ellipses should be exported.
- *
- * @param {boolean} value
- */
-plugin.file.shp.SHPExporter.prototype.setExportEllipses = function(value) {
-  this.exportEllipses_ = value;
-};
+exports = SHPExporter;

--- a/src/plugin/file/shp/shplayerconfig.js
+++ b/src/plugin/file/shp/shplayerconfig.js
@@ -1,153 +1,153 @@
-goog.provide('plugin.file.shp.SHPLayerConfig');
-goog.require('goog.log');
-goog.require('goog.log.Logger');
-goog.require('os.layer.config.AbstractDataSourceLayerConfig');
-goog.require('os.source.MultiRequest');
-goog.require('os.source.Request');
-goog.require('plugin.file.shp.SHPParser');
-goog.require('plugin.file.shp.SHPParserConfig');
+goog.module('plugin.file.shp.SHPLayerConfig');
+goog.module.declareLegacyNamespace();
 
+const log = goog.require('goog.log');
+const ResponseType = goog.require('goog.net.XhrIo.ResponseType');
+const userAgent = goog.require('goog.userAgent');
+const AbstractDataSourceLayerConfig = goog.require('os.layer.config.AbstractDataSourceLayerConfig');
+const MultiRequest = goog.require('os.source.MultiRequest');
+const RequestSource = goog.require('os.source.Request');
+const SHPParser = goog.require('plugin.file.shp.SHPParser');
+const SHPParserConfig = goog.require('plugin.file.shp.SHPParserConfig');
+
+const Logger = goog.requireType('goog.log.Logger');
 
 
 /**
- * @extends {os.layer.config.AbstractDataSourceLayerConfig}
- * @constructor
  */
-plugin.file.shp.SHPLayerConfig = function() {
-  plugin.file.shp.SHPLayerConfig.base(this, 'constructor');
-  this.log = plugin.file.shp.SHPLayerConfig.LOGGER_;
+class SHPLayerConfig extends AbstractDataSourceLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.log = logger;
+
+    /**
+     * @type {SHPParserConfig}
+     * @protected
+     */
+    this.parserConfig = null;
+  }
 
   /**
-   * @type {plugin.file.shp.SHPParserConfig}
-   * @protected
+   * @inheritDoc
    */
-  this.parserConfig = null;
-};
-goog.inherits(plugin.file.shp.SHPLayerConfig, os.layer.config.AbstractDataSourceLayerConfig);
+  initializeConfig(options) {
+    super.initializeConfig(options);
 
+    this.parserConfig = options['parserConfig'] || new SHPParserConfig();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  createLayer(options) {
+    this.initializeConfig(options);
+
+    if (!options['url']) {
+      log.error(this.log, 'Unable to create SHP layer without a source URL!');
+      return null;
+    }
+
+    var source = null;
+    if (options['url2']) {
+      source = new MultiRequest(undefined);
+      source.setRequests(this.getRequests(options));
+    } else {
+      this.url = /** @type {string} */ (options['url']);
+      source = new RequestSource(undefined);
+      source.setRequest(this.getRequest(options));
+    }
+
+    source.setId(this.id);
+    source.setImporter(this.getImporter(options));
+    source.setTitle(this.title);
+    source.setTimeEnabled(this.animate);
+
+    var layer = this.getLayer(source, options);
+    if (options) {
+      layer.restore(options);
+    }
+
+    if (options['load']) {
+      source.refresh();
+    }
+
+    return layer;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getImporter(options) {
+    var importer = super.getImporter(options);
+
+    // setAutoMappings() ignores manual configs (e.g. custom Datetime format) since it re-autodetects
+    importer.setExecMappings(this.parserConfig['mappings']);
+
+    return importer;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getParser(options) {
+    var config = this.parserConfig || new SHPParserConfig();
+
+    if (options['lineAlpha'] !== undefined) {
+      config['lineAlpha'] = options['lineAlpha'];
+    }
+    if (options['fillAlpha'] !== undefined) {
+      config['fillAlpha'] = options['fillAlpha'];
+    }
+    if (options['append'] !== undefined) {
+      config['append'] = options['append'];
+    }
+
+    return new SHPParser(config);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getRequest(options) {
+    var request = super.getRequest(options);
+
+    // IE9 doesn't support arraybuffer as a response type
+    if (!userAgent.IE || userAgent.isVersionOrHigher(10)) {
+      request.setResponseType(ResponseType.ARRAY_BUFFER);
+    }
+
+    return request;
+  }
+
+  /**
+   * Assembles an array of requests for the SHP/DBF files.
+   *
+   * @param {Object.<string, *>} options Layer configuration options.
+   * @return {!Array.<!os.net.Request>}
+   */
+  getRequests(options) {
+    var requests = [];
+
+    // request for SHP file
+    this.url = /** @type {string} */ (options['url']);
+    requests.push(this.getRequest(options));
+
+    // request for DBF file
+    this.url = /** @type {string} */ (options['url2']);
+    requests.push(this.getRequest(options));
+
+    return requests;
+  }
+}
 
 /**
  * Logger
- * @type {goog.log.Logger}
- * @private
- * @const
+ * @type {Logger}
  */
-plugin.file.shp.SHPLayerConfig.LOGGER_ = goog.log.getLogger('plugin.file.shp.SHPLayerConfig');
+const logger = log.getLogger('plugin.file.shp.SHPLayerConfig');
 
 
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPLayerConfig.prototype.initializeConfig = function(options) {
-  plugin.file.shp.SHPLayerConfig.superClass_.initializeConfig.call(this, options);
-
-  this.parserConfig = options['parserConfig'] || new plugin.file.shp.SHPParserConfig();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPLayerConfig.prototype.createLayer = function(options) {
-  this.initializeConfig(options);
-
-  if (!options['url']) {
-    goog.log.error(this.log, 'Unable to create SHP layer without a source URL!');
-    return null;
-  }
-
-  var source = null;
-  if (options['url2']) {
-    source = new os.source.MultiRequest(undefined);
-    source.setRequests(this.getRequests(options));
-  } else {
-    this.url = /** @type {string} */ (options['url']);
-    source = new os.source.Request(undefined);
-    source.setRequest(this.getRequest(options));
-  }
-
-  source.setId(this.id);
-  source.setImporter(this.getImporter(options));
-  source.setTitle(this.title);
-  source.setTimeEnabled(this.animate);
-
-  var layer = this.getLayer(source, options);
-  if (options) {
-    layer.restore(options);
-  }
-
-  if (options['load']) {
-    source.refresh();
-  }
-
-  return layer;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPLayerConfig.prototype.getImporter = function(options) {
-  var importer = plugin.file.shp.SHPLayerConfig.base(this, 'getImporter', options);
-
-  // setAutoMappings() ignores manual configs (e.g. custom Datetime format) since it re-autodetects
-  importer.setExecMappings(this.parserConfig['mappings']);
-
-  return importer;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPLayerConfig.prototype.getParser = function(options) {
-  var config = this.parserConfig || new plugin.file.shp.SHPParserConfig();
-
-  if (options['lineAlpha'] !== undefined) {
-    config['lineAlpha'] = options['lineAlpha'];
-  }
-  if (options['fillAlpha'] !== undefined) {
-    config['fillAlpha'] = options['fillAlpha'];
-  }
-  if (options['append'] !== undefined) {
-    config['append'] = options['append'];
-  }
-
-  return new plugin.file.shp.SHPParser(config);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPLayerConfig.prototype.getRequest = function(options) {
-  var request = plugin.file.shp.SHPLayerConfig.base(this, 'getRequest', options);
-
-  // IE9 doesn't support arraybuffer as a response type
-  if (!goog.userAgent.IE || goog.userAgent.isVersionOrHigher(10)) {
-    request.setResponseType(goog.net.XhrIo.ResponseType.ARRAY_BUFFER);
-  }
-
-  return request;
-};
-
-
-/**
- * Assembles an array of requests for the SHP/DBF files.
- *
- * @param {Object.<string, *>} options Layer configuration options.
- * @return {!Array.<!os.net.Request>}
- */
-plugin.file.shp.SHPLayerConfig.prototype.getRequests = function(options) {
-  var requests = [];
-
-  // request for SHP file
-  this.url = /** @type {string} */ (options['url']);
-  requests.push(this.getRequest(options));
-
-  // request for DBF file
-  this.url = /** @type {string} */ (options['url2']);
-  requests.push(this.getRequest(options));
-
-  return requests;
-};
+exports = SHPLayerConfig;

--- a/src/plugin/file/shp/shpparser.js
+++ b/src/plugin/file/shp/shpparser.js
@@ -1,680 +1,664 @@
-goog.provide('plugin.file.shp.SHPParser');
+goog.module('plugin.file.shp.SHPParser');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Disposable');
-goog.require('goog.log');
-goog.require('goog.log.Logger');
-goog.require('goog.string');
-goog.require('ol.Feature');
-goog.require('ol.geom.LineString');
-goog.require('ol.geom.MultiLineString');
-goog.require('ol.geom.MultiPolygon');
-goog.require('ol.geom.Point');
-goog.require('ol.geom.Polygon');
-goog.require('os.data.ColumnDefinition');
-goog.require('os.file');
-goog.require('os.file.mime.text');
-goog.require('os.file.mime.zip');
-goog.require('os.geo');
-goog.require('os.parse.AsyncZipParser');
-goog.require('plugin.file.shp');
-goog.require('plugin.file.shp.data.DBFField');
-goog.require('plugin.file.shp.data.DBFHeader');
-goog.require('plugin.file.shp.data.SHPHeader');
+const log = goog.require('goog.log');
+const googString = goog.require('goog.string');
+const ol = goog.require('ol');
+const Feature = goog.require('ol.Feature');
+const LineString = goog.require('ol.geom.LineString');
+const MultiLineString = goog.require('ol.geom.MultiLineString');
+const MultiPolygon = goog.require('ol.geom.MultiPolygon');
+const Point = goog.require('ol.geom.Point');
+const Polygon = goog.require('ol.geom.Polygon');
+const Fields = goog.require('os.Fields');
+const ColumnDefinition = goog.require('os.data.ColumnDefinition');
+const text = goog.require('os.file.mime.text');
+const mimeZip = goog.require('os.file.mime.zip');
+const geo = goog.require('os.geo');
+const AsyncZipParser = goog.require('os.parse.AsyncZipParser');
+const shp = goog.require('plugin.file.shp');
+const DBFField = goog.require('plugin.file.shp.data.DBFField');
+const SHPHeader = goog.require('plugin.file.shp.data.SHPHeader');
 
+const Logger = goog.requireType('goog.log.Logger');
 
 
 /**
  * A Shapefile parser
  *
- * @param {plugin.file.shp.SHPParserConfig} config
- * @extends {os.parse.AsyncZipParser<ol.Feature>}
- * @constructor
+ * @extends {AsyncZipParser<Feature>}
  */
-plugin.file.shp.SHPParser = function(config) {
-  plugin.file.shp.SHPParser.base(this, 'constructor');
-
+class SHPParser extends AsyncZipParser {
   /**
-   * @type {Array.<os.data.ColumnDefinition>}
-   * @private
+   * Constructor.
+   * @param {shp.SHPParserConfig} config
    */
-  this.columns_ = [];
+  constructor(config) {
+    super();
 
-  /**
-   * @type {plugin.file.shp.data.SHPHeader}
-   * @private
-   */
-  this.header_ = null;
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  this.initialized_ = false;
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  this.processingZip_ = false;
-
-  /**
-   * @type {Array.<ArrayBuffer>}
-   * @private
-   */
-  this.source_ = [];
-};
-goog.inherits(plugin.file.shp.SHPParser, os.parse.AsyncZipParser);
-
-
-/**
- * Logger
- * @type {goog.log.Logger}
- * @private
- * @const
- */
-plugin.file.shp.SHPParser.LOGGER_ = goog.log.getLogger('plugin.file.shp.SHPParser');
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPParser.prototype.cleanup = function() {
-  this.header_ = null;
-  this.initialized_ = false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPParser.prototype.disposeInternal = function() {
-  plugin.file.shp.SHPParser.base(this, 'disposeInternal');
-  this.cleanup();
-  this.source_.length = 0;
-};
-
-
-/**
- * @return {Array.<os.data.ColumnDefinition>}
- */
-plugin.file.shp.SHPParser.prototype.getColumns = function() {
-  return this.columns_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPParser.prototype.hasNext = function() {
-  return this.initialized_ && !!this.header_ && !!this.header_.data &&
-      this.header_.position < this.header_.data.byteLength;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPParser.prototype.parseNext = function() {
-  var feature = null;
-
-  try {
-    /* Shape File Record Header (big endian)
-     *                                                    Byte
-     * Position  Field           Value           Type     Order
-     * Byte 0    Record Number   Record Num      Integer  Big
-     * Byte 4    Record Length   # 16-bit Words  Integer  Big
-     * Byte 8    Start of Shape File Record
+    /**
+     * @type {Array.<ColumnDefinition>}
+     * @private
      */
-    var dv = new DataView(this.header_.data.slice(this.header_.position, this.header_.position + 8));
-    var recLen = dv.getUint32(4) * 2; // want bytes not words
-    this.header_.curRecord = dv.getUint32(0);
-    this.header_.position += 8;
+    this.columns_ = [];
 
-    /* Shape File Record (little endian)
-     *                                                      Byte
-     * Position  Field           Value             Type     Order
-     * Byte 0    Shape Type      0, *1, *3, *5     Integer  Little
-     * Byte 4    Specific for each Shape Type
+    /**
+     * @type {SHPHeader}
+     * @private
      */
-    dv = new DataView(this.header_.data.slice(this.header_.position, this.header_.position + recLen));
-    var shapeType = dv.getUint32(0, true);
+    this.header_ = null;
 
-    if (shapeType == plugin.file.shp.TYPE.POINT ||
-        shapeType == plugin.file.shp.TYPE.POINTZ ||
-        shapeType == plugin.file.shp.TYPE.POINTM) {
-      feature = new ol.Feature();
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.initialized_ = false;
 
-      /* Shape File Point Record (little endian)
-       *                                          Byte
-       * Position  Field       Value     Type     Order
-       * Byte 0    Shape Type  *1        Integer  Little
-       * Byte 4    Longitude   Degrees   Double   Little
-       * Byte 12   Latitude    Degrees   Double   Little
-       * Byte 20   End Record Normal Point
-       *
-       * The "M" adds:
-       * Byte 20   M           M         Double   Little
-       *
-       * The "Z" adds:
-       * Byte 20   Z           Z         Double   Little
-       * Byte 28   M           M         Double   Little
-       */
-      var lon = dv.getFloat64(4, true);
-      var lat = dv.getFloat64(12, true);
-      var coords = [lon, lat];
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.processingZip_ = false;
 
-      if (shapeType == plugin.file.shp.TYPE.POINTZ) {
-        var alt = dv.getFloat64(20, true);
-        coords.push(alt);
-        feature.set(os.Fields.ALT, alt);
-      }
-
-      feature.set(os.Fields.LAT, lat);
-      feature.set(os.Fields.LAT_DDM, os.geo.toDegreesDecimalMinutes(lat, false));
-      feature.set(os.Fields.LAT_DMS, os.geo.toSexagesimal(lat, false));
-      feature.set(os.Fields.LON, lon);
-      feature.set(os.Fields.LON_DDM, os.geo.toDegreesDecimalMinutes(lon, true));
-      feature.set(os.Fields.LON_DMS, os.geo.toSexagesimal(lon, true));
-
-      // TODO: there should be a way to determine the projection from the SHP file rather than assuming EPSG:4326
-      feature.setGeometry(new ol.geom.Point(coords).osTransform());
-    } else if (shapeType == plugin.file.shp.TYPE.POLYLINE ||
-        shapeType == plugin.file.shp.TYPE.POLYGON ||
-        shapeType == plugin.file.shp.TYPE.POLYLINEZ ||
-        shapeType == plugin.file.shp.TYPE.POLYGONZ ||
-        shapeType == plugin.file.shp.TYPE.POLYLINEM ||
-        shapeType == plugin.file.shp.TYPE.POLYGONM) {
-      feature = new ol.Feature();
-
-      /* Shape File Polyline/Polygon Record
-       *                                                   Byte
-       * Position  Field       Value            Type       Order
-       * Byte 0    Shape Type  *3 or *5         Integer    Little
-       * Byte 4    Min Lon     Degrees          Double     Little
-       * Byte 12   Min Lat     Degrees          Double     Little
-       * Byte 20   Max Lon     Degrees          Double     Little
-       * Byte 28   Max Lat     Degrees          Double     Little
-       * Byte 36   Num Parts   Num Parts        Integer    Little
-       * Byte 40   Num Points  Num Points       Integer    Little
-       * Byte 44   Parts[]     Start Indices    Integer    Little
-       * Byte xx   Points[]    Lon & Lat Pairs  2 Doubles  Little
-       *
-       * The "Z" adds:
-       * Byte Y    Zmin        Zmin             Double     Little
-       * Byte Y+8  Zmax        Zmax             Double     Little
-       * Byte Y+16 Z[]         Zarray           Doubles    Little
-       *
-       * The "M" adds:
-       * Byte Y    Mmin        Mmin            Double      Little
-       * Byte Y+8  Mmax        Mmax            Double      Little
-       * Byte Y+16 M[]         Marray          Doubles     Little
-       * Byte zz   End Record
-       */
-      var numParts = dv.getInt32(36, true);
-      var numPoints = dv.getInt32(40, true);
-      var partsLen = numParts * 4;
-      var pointsLen = numPoints * 16;
-
-      // read the start indices into the points array for each part
-      var partIdx = [];
-      for (var i = 0; i < numParts; i++) {
-        var partStartIndex = dv.getInt32(44 + (i * 4), true);
-        partIdx.push(partStartIndex);
-      }
-
-      if (partIdx.length == 0) {
-        partIdx.push(0);
-      }
-
-      // TODO: this should be set up in the feature style config
-      // feature.set('lineAlpha', this.config_['lineAlpha']);
-      // feature.set('fillAlpha', this.config_['fillAlpha']);
-
-      // parse the z components if available
-      var zArray = null;
-      if (shapeType == plugin.file.shp.TYPE.POLYLINEZ ||
-          shapeType == plugin.file.shp.TYPE.POLYGONZ) {
-        zArray = [];
-
-        var zMinMax = 2 * 8;
-        var zStart = 44 + partsLen + pointsLen + zMinMax;
-        for (var i = 0; i < numPoints; i++) {
-          var zVal = dv.getFloat64(zStart + (i * 8), true);
-          zArray.push(zVal);
-        }
-      }
-
-      // read parts for each polygon/polyline
-      var parts = [];
-      var pointsStart = 44 + partsLen;
-      var zIdx = 0;
-      for (var k = 0; k < partIdx.length; k++) {
-        // read points for each part, ending at the next index or max points reached
-        var points = [];
-        var partEnd = k + 1 < partIdx.length ? partIdx[k + 1] : numPoints;
-        for (var j = partIdx[k]; j < partEnd; j++, zIdx++) {
-          // the start offset for each point is (index * 16), because each point is two doubles (lon/lat)
-          var offset = j * 16;
-          var lon = dv.getFloat64(pointsStart + offset, true);
-          var lat = dv.getFloat64(pointsStart + offset + 8, true);
-          if (!isNaN(lon) && !isNaN(lat)) {
-            var coord = [lon, lat];
-            if (zArray && zIdx < zArray.length && !isNaN(zArray[zIdx])) {
-              coord.push(zArray[zIdx]);
-            }
-
-            points.push(coord);
-          } else {
-            this.logWarning_('Record #' + this.header_.curRecord + ' lat/lon could not be parsed!');
-          }
-        }
-
-        parts.push(points);
-      }
-
-      var geom = null;
-      if (shapeType == plugin.file.shp.TYPE.POLYGON || shapeType == plugin.file.shp.TYPE.POLYGONZ ||
-          shapeType == plugin.file.shp.TYPE.POLYGONM) {
-        if (parts.length > 1) {
-          var rings = [];
-          for (var i = 0; i < parts.length; i++) {
-            // if the first ring is CCW, that's technically invalid but let's try to make it work...
-            var p = parts[i];
-            if (rings.length > 0 && os.geo.isCCW(p)) {
-              rings[rings.length - 1].push(p);
-            } else {
-              rings.push([p]);
-            }
-          }
-
-          geom = new ol.geom.MultiPolygon(rings);
-        } else {
-          geom = new ol.geom.Polygon(parts);
-        }
-      } else {
-        geom = parts.length > 1 ? new ol.geom.MultiLineString(parts) : new ol.geom.LineString(parts[0]);
-      }
-
-      // TODO: there should be a way to determine the projection from the SHP file rather than assuming EPSG:4326
-      // ^ There is, but it would require loading the .prj file. That's trivial from a zip but terrible when given the files one at a time.
-      feature.setGeometry(geom.osTransform());
-    } else if (shapeType != plugin.file.shp.TYPE.NULLRECORD) {
-      // skip null records, but warn on unknown types
-      this.logWarning_('Unsupported shape type (' + shapeType + ') encountered. ' +
-          'Only POINT(1,11,21), POLYLINE(3,13,23) & POLYGON(5,15,25) are supported');
-    }
-
-    if (feature && this.header_.dbf.data) {
-      this.addFields_(feature);
-    }
-
-    this.header_.position += recLen;
-  } catch (e) {
-    throw e;
+    /**
+     * @type {Array.<ArrayBuffer>}
+     * @private
+     */
+    this.source_ = [];
   }
 
-  if (feature) {
-    feature.setId(String(ol.getUid(feature)));
+  /**
+   * @inheritDoc
+   */
+  cleanup() {
+    this.header_ = null;
+    this.initialized_ = false;
   }
 
-  if (!this.hasNext()) {
-    this.closeZipReaders();
-  }
-
-  return feature;
-};
-
-
-/**
- * Adds metadata fields to a feature from the DBF file.
- *
- * @param {ol.Feature} feature
- * @private
- */
-plugin.file.shp.SHPParser.prototype.addFields_ = function(feature) {
-  var dbf = this.header_.dbf;
-  var current = this.header_.curRecord;
-  if (current <= dbf.numRecords) {
-    var position = dbf.recordStart + (current - 1) * dbf.recordSize;
-    for (var i = 0, n = dbf.fields.length; i < n; i++) {
-      var field = dbf.fields[i];
-      var fieldBuf = dbf.data.slice(position, position + field.length);
-      var s = os.file.mime.text.getText(fieldBuf);
-
-      if (s) {
-        var value = goog.string.trim(s);
-
-        if (field.type == 'N') {
-          value = Number(value);
-          if (isNaN(value)) {
-            value = null;
-          }
-        } else if (field.type == 'L') {
-          value = Boolean(value);
-        }
-
-        feature.set(field.name, value);
-      }
-
-      position += field.length;
-    }
-  }
-};
-
-
-/**
- * Parses columns from the shapefile.
- *
- * @return {Array.<ol.Feature>}
- */
-plugin.file.shp.SHPParser.prototype.parsePreview = function() {
-  var features = [];
-  if (this.initialized_) {
-    while (this.hasNext() && features.length < 50) {
-      var feature = this.parseNext();
-      if (feature) {
-        features.push(feature);
-      }
-    }
-
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
     this.cleanup();
+    this.source_.length = 0;
   }
 
-  return features;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPParser.prototype.setSource = function(source) {
-  // reset necessary values
-  this.initialized_ = false;
-  this.processingZip_ = false;
-  this.source_.length = 0;
-
-  if (!source) {
-    return;
+  /**
+   * @return {Array.<ColumnDefinition>}
+   */
+  getColumns() {
+    return this.columns_;
   }
 
-  if (Array.isArray(source)) {
-    var i = source.length;
+  /**
+   * @inheritDoc
+   */
+  hasNext() {
+    return this.initialized_ && !!this.header_ && !!this.header_.data &&
+        this.header_.position < this.header_.data.byteLength;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  parseNext() {
+    var feature = null;
+
+    try {
+      /* Shape File Record Header (big endian)
+       *                                                    Byte
+       * Position  Field           Value           Type     Order
+       * Byte 0    Record Number   Record Num      Integer  Big
+       * Byte 4    Record Length   # 16-bit Words  Integer  Big
+       * Byte 8    Start of Shape File Record
+       */
+      var dv = new DataView(this.header_.data.slice(this.header_.position, this.header_.position + 8));
+      var recLen = dv.getUint32(4) * 2; // want bytes not words
+      this.header_.curRecord = dv.getUint32(0);
+      this.header_.position += 8;
+
+      /* Shape File Record (little endian)
+       *                                                      Byte
+       * Position  Field           Value             Type     Order
+       * Byte 0    Shape Type      0, *1, *3, *5     Integer  Little
+       * Byte 4    Specific for each Shape Type
+       */
+      dv = new DataView(this.header_.data.slice(this.header_.position, this.header_.position + recLen));
+      var shapeType = dv.getUint32(0, true);
+
+      if (shapeType == shp.TYPE.POINT ||
+          shapeType == shp.TYPE.POINTZ ||
+          shapeType == shp.TYPE.POINTM) {
+        feature = new Feature();
+
+        /* Shape File Point Record (little endian)
+         *                                          Byte
+         * Position  Field       Value     Type     Order
+         * Byte 0    Shape Type  *1        Integer  Little
+         * Byte 4    Longitude   Degrees   Double   Little
+         * Byte 12   Latitude    Degrees   Double   Little
+         * Byte 20   End Record Normal Point
+         *
+         * The "M" adds:
+         * Byte 20   M           M         Double   Little
+         *
+         * The "Z" adds:
+         * Byte 20   Z           Z         Double   Little
+         * Byte 28   M           M         Double   Little
+         */
+        var lon = dv.getFloat64(4, true);
+        var lat = dv.getFloat64(12, true);
+        var coords = [lon, lat];
+
+        if (shapeType == shp.TYPE.POINTZ) {
+          var alt = dv.getFloat64(20, true);
+          coords.push(alt);
+          feature.set(Fields.ALT, alt);
+        }
+
+        feature.set(Fields.LAT, lat);
+        feature.set(Fields.LAT_DDM, geo.toDegreesDecimalMinutes(lat, false));
+        feature.set(Fields.LAT_DMS, geo.toSexagesimal(lat, false));
+        feature.set(Fields.LON, lon);
+        feature.set(Fields.LON_DDM, geo.toDegreesDecimalMinutes(lon, true));
+        feature.set(Fields.LON_DMS, geo.toSexagesimal(lon, true));
+
+        // TODO: there should be a way to determine the projection from the SHP file rather than assuming EPSG:4326
+        feature.setGeometry(new Point(coords).osTransform());
+      } else if (shapeType == shp.TYPE.POLYLINE ||
+          shapeType == shp.TYPE.POLYGON ||
+          shapeType == shp.TYPE.POLYLINEZ ||
+          shapeType == shp.TYPE.POLYGONZ ||
+          shapeType == shp.TYPE.POLYLINEM ||
+          shapeType == shp.TYPE.POLYGONM) {
+        feature = new Feature();
+
+        /* Shape File Polyline/Polygon Record
+         *                                                   Byte
+         * Position  Field       Value            Type       Order
+         * Byte 0    Shape Type  *3 or *5         Integer    Little
+         * Byte 4    Min Lon     Degrees          Double     Little
+         * Byte 12   Min Lat     Degrees          Double     Little
+         * Byte 20   Max Lon     Degrees          Double     Little
+         * Byte 28   Max Lat     Degrees          Double     Little
+         * Byte 36   Num Parts   Num Parts        Integer    Little
+         * Byte 40   Num Points  Num Points       Integer    Little
+         * Byte 44   Parts[]     Start Indices    Integer    Little
+         * Byte xx   Points[]    Lon & Lat Pairs  2 Doubles  Little
+         *
+         * The "Z" adds:
+         * Byte Y    Zmin        Zmin             Double     Little
+         * Byte Y+8  Zmax        Zmax             Double     Little
+         * Byte Y+16 Z[]         Zarray           Doubles    Little
+         *
+         * The "M" adds:
+         * Byte Y    Mmin        Mmin            Double      Little
+         * Byte Y+8  Mmax        Mmax            Double      Little
+         * Byte Y+16 M[]         Marray          Doubles     Little
+         * Byte zz   End Record
+         */
+        var numParts = dv.getInt32(36, true);
+        var numPoints = dv.getInt32(40, true);
+        var partsLen = numParts * 4;
+        var pointsLen = numPoints * 16;
+
+        // read the start indices into the points array for each part
+        var partIdx = [];
+        for (var i = 0; i < numParts; i++) {
+          var partStartIndex = dv.getInt32(44 + (i * 4), true);
+          partIdx.push(partStartIndex);
+        }
+
+        if (partIdx.length == 0) {
+          partIdx.push(0);
+        }
+
+        // TODO: this should be set up in the feature style config
+        // feature.set('lineAlpha', this.config_['lineAlpha']);
+        // feature.set('fillAlpha', this.config_['fillAlpha']);
+
+        // parse the z components if available
+        var zArray = null;
+        if (shapeType == shp.TYPE.POLYLINEZ ||
+            shapeType == shp.TYPE.POLYGONZ) {
+          zArray = [];
+
+          var zMinMax = 2 * 8;
+          var zStart = 44 + partsLen + pointsLen + zMinMax;
+          for (var i = 0; i < numPoints; i++) {
+            var zVal = dv.getFloat64(zStart + (i * 8), true);
+            zArray.push(zVal);
+          }
+        }
+
+        // read parts for each polygon/polyline
+        var parts = [];
+        var pointsStart = 44 + partsLen;
+        var zIdx = 0;
+        for (var k = 0; k < partIdx.length; k++) {
+          // read points for each part, ending at the next index or max points reached
+          var points = [];
+          var partEnd = k + 1 < partIdx.length ? partIdx[k + 1] : numPoints;
+          for (var j = partIdx[k]; j < partEnd; j++, zIdx++) {
+            // the start offset for each point is (index * 16), because each point is two doubles (lon/lat)
+            var offset = j * 16;
+            var lon = dv.getFloat64(pointsStart + offset, true);
+            var lat = dv.getFloat64(pointsStart + offset + 8, true);
+            if (!isNaN(lon) && !isNaN(lat)) {
+              var coord = [lon, lat];
+              if (zArray && zIdx < zArray.length && !isNaN(zArray[zIdx])) {
+                coord.push(zArray[zIdx]);
+              }
+
+              points.push(coord);
+            } else {
+              this.logWarning_('Record #' + this.header_.curRecord + ' lat/lon could not be parsed!');
+            }
+          }
+
+          parts.push(points);
+        }
+
+        var geom = null;
+        if (shapeType == shp.TYPE.POLYGON || shapeType == shp.TYPE.POLYGONZ ||
+            shapeType == shp.TYPE.POLYGONM) {
+          if (parts.length > 1) {
+            var rings = [];
+            for (var i = 0; i < parts.length; i++) {
+              // if the first ring is CCW, that's technically invalid but let's try to make it work...
+              var p = parts[i];
+              if (rings.length > 0 && geo.isCCW(p)) {
+                rings[rings.length - 1].push(p);
+              } else {
+                rings.push([p]);
+              }
+            }
+
+            geom = new MultiPolygon(rings);
+          } else {
+            geom = new Polygon(parts);
+          }
+        } else {
+          geom = parts.length > 1 ? new MultiLineString(parts) : new LineString(parts[0]);
+        }
+
+        // TODO: there should be a way to determine the projection from the SHP file rather than assuming EPSG:4326
+        // ^ There is, but it would require loading the .prj file. That's trivial from a zip but terrible when given the files one at a time.
+        feature.setGeometry(geom.osTransform());
+      } else if (shapeType != shp.TYPE.NULLRECORD) {
+        // skip null records, but warn on unknown types
+        this.logWarning_('Unsupported shape type (' + shapeType + ') encountered. ' +
+            'Only POINT(1,11,21), POLYLINE(3,13,23) & POLYGON(5,15,25) are supported');
+      }
+
+      if (feature && this.header_.dbf.data) {
+        this.addFields_(feature);
+      }
+
+      this.header_.position += recLen;
+    } catch (e) {
+      throw e;
+    }
+
+    if (feature) {
+      feature.setId(String(ol.getUid(feature)));
+    }
+
+    if (!this.hasNext()) {
+      this.closeZipReaders();
+    }
+
+    return feature;
+  }
+
+  /**
+   * Adds metadata fields to a feature from the DBF file.
+   *
+   * @param {Feature} feature
+   * @private
+   */
+  addFields_(feature) {
+    var dbf = this.header_.dbf;
+    var current = this.header_.curRecord;
+    if (current <= dbf.numRecords) {
+      var position = dbf.recordStart + (current - 1) * dbf.recordSize;
+      for (var i = 0, n = dbf.fields.length; i < n; i++) {
+        var field = dbf.fields[i];
+        var fieldBuf = dbf.data.slice(position, position + field.length);
+        var s = text.getText(fieldBuf);
+
+        if (s) {
+          var value = googString.trim(s);
+
+          if (field.type == 'N') {
+            value = Number(value);
+            if (isNaN(value)) {
+              value = null;
+            }
+          } else if (field.type == 'L') {
+            value = Boolean(value);
+          }
+
+          feature.set(field.name, value);
+        }
+
+        position += field.length;
+      }
+    }
+  }
+
+  /**
+   * Parses columns from the shapefile.
+   *
+   * @return {Array.<Feature>}
+   */
+  parsePreview() {
+    var features = [];
+    if (this.initialized_) {
+      while (this.hasNext() && features.length < 50) {
+        var feature = this.parseNext();
+        if (feature) {
+          features.push(feature);
+        }
+      }
+
+      this.cleanup();
+    }
+
+    return features;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setSource(source) {
+    // reset necessary values
+    this.initialized_ = false;
+    this.processingZip_ = false;
+    this.source_.length = 0;
+
+    if (!source) {
+      return;
+    }
+
+    if (Array.isArray(source)) {
+      var i = source.length;
+      while (i--) {
+        if (source[i] instanceof ArrayBuffer) {
+          this.source_.push(/** @type {ArrayBuffer} */ (source[i]));
+        } else {
+          this.logError_('Invalid SHP source!');
+        }
+      }
+    } else if (source instanceof ArrayBuffer) {
+      this.source_.push(/** @type {ArrayBuffer} */ (source));
+    } else {
+      this.logError_('Invalid SHP source!');
+    }
+
+    if (this.source_.length > 0) {
+      this.initialize_();
+    }
+  }
+
+  /**
+   * Configures the parser using the provided file(s).
+   *
+   * @private
+   */
+  initialize_() {
+    this.header_ = new SHPHeader();
+
+    var i = this.source_.length;
     while (i--) {
-      if (source[i] instanceof ArrayBuffer) {
-        this.source_.push(/** @type {ArrayBuffer} */ (source[i]));
-      } else {
-        this.logError_('Invalid SHP source!');
+      var source = this.source_[i];
+      if (mimeZip.isZip(source)) {
+        this.createZipReader(source);
+      } else if (shp.isSHPFileType(source)) {
+        if (!this.header_.data) {
+          this.setupSHPFile_(source);
+        } else {
+          this.logWarning_('Ignoring extra SHP file while trying to parse a SHP/ZIP file.');
+        }
+      } else if (shp.isDBFFileType(source)) {
+        if (!this.header_.dbf.data) {
+          this.setupDBFFile_(source);
+          this.updateColumns_();
+        } else {
+          this.logWarning_('Ignoring extra DBF file while parsing a SHP/ZIP file.');
+        }
       }
     }
-  } else if (source instanceof ArrayBuffer) {
-    this.source_.push(/** @type {ArrayBuffer} */ (source));
-  } else {
-    this.logError_('Invalid SHP source!');
-  }
 
-  if (this.source_.length > 0) {
-    this.initialize_();
-  }
-};
-
-
-/**
- * Configures the parser using the provided file(s).
- *
- * @private
- */
-plugin.file.shp.SHPParser.prototype.initialize_ = function() {
-  this.header_ = new plugin.file.shp.data.SHPHeader();
-
-  var i = this.source_.length;
-  while (i--) {
-    var source = this.source_[i];
-    if (os.file.mime.zip.isZip(source)) {
-      this.createZipReader(source);
-    } else if (plugin.file.shp.isSHPFileType(source)) {
+    if (!this.processingZip_) {
       if (!this.header_.data) {
-        this.setupSHPFile_(source);
+        this.logError_('No valid SHP file found!');
+        this.onError();
+      } else if (!this.header_.dbf.data) {
+        this.logError_('No valid DBF file found!');
+        this.onError();
       } else {
-        this.logWarning_('Ignoring extra SHP file while trying to parse a SHP/ZIP file.');
-      }
-    } else if (plugin.file.shp.isDBFFileType(source)) {
-      if (!this.header_.dbf.data) {
-        this.setupDBFFile_(source);
-        this.updateColumns_();
-      } else {
-        this.logWarning_('Ignoring extra DBF file while parsing a SHP/ZIP file.');
+        this.onReady();
       }
     }
   }
 
-  if (!this.processingZip_) {
-    if (!this.header_.data) {
+  /**
+   * @inheritDoc
+   */
+  onError() {
+    this.initialized_ = true;
+    this.processingZip_ = false;
+    super.onError();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  onReady() {
+    this.initialized_ = true;
+    this.processingZip_ = false;
+    super.onReady();
+  }
+
+  /**
+   * @param {string} msg
+   * @private
+   */
+  logWarning_(msg) {
+    log.warning(logger, msg);
+  }
+
+  /**
+   * @param {string} msg
+   * @private
+   */
+  logError_(msg) {
+    log.error(logger, msg);
+  }
+
+  /**
+   * @private
+   */
+  updateColumns_() {
+    this.columns_.length = 0;
+
+    if (this.header_ && this.header_.dbf) {
+      var fields = this.header_.dbf.fields;
+      for (var i = 0, n = fields.length; i < n; i++) {
+        var col = new ColumnDefinition(fields[i].name);
+        col['selectable'] = false;
+        col['sortable'] = false;
+        this.columns_.push(col);
+      }
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  createZipReader(source) {
+    this.processingZip_ = true;
+    super.createZipReader(source);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handleZipEntries(entries) {
+    var foundSHP = false;
+    var foundDBF = false;
+    for (var i = 0, n = entries.length; i < n; i++) {
+      // if the entry is a shp or dbf, load the content and process it. only use the first file encountered, which means
+      // archives with multiple shapefiles will only load the first
+      var entry = entries[i];
+      if (!foundSHP && shp.mime.SHP_EXT_REGEXP.test(entry.filename)) {
+        foundSHP = true;
+        entry.getData(new zip.ArrayBufferWriter(), this.processZIPEntry_.bind(this, entry));
+      } else if (!foundDBF && shp.mime.DBF_EXT_REGEXP.test(entry.filename)) {
+        foundDBF = true;
+        entry.getData(new zip.ArrayBufferWriter(), this.processZIPEntry_.bind(this, entry));
+      }
+    }
+
+    if (!foundSHP) {
       this.logError_('No valid SHP file found!');
       this.onError();
-    } else if (!this.header_.dbf.data) {
+    } else if (!foundDBF) {
       this.logError_('No valid DBF file found!');
       this.onError();
-    } else {
+    }
+  }
+
+  /**
+   * @param {zip.Entry} entry
+   * @param {*} content
+   * @private
+   */
+  processZIPEntry_(entry, content) {
+    if (content instanceof ArrayBuffer) {
+      content = /** @type {!ArrayBuffer} */ (content);
+      if (shp.mime.SHP_EXT_REGEXP.test(entry.filename)) {
+        this.setupSHPFile_(content);
+      } else if (shp.mime.DBF_EXT_REGEXP.test(entry.filename)) {
+        this.setupDBFFile_(content);
+        this.updateColumns_();
+      }
+    }
+
+    if (!this.initialized_ && this.header_ && this.header_.data && this.header_.dbf.data) {
       this.onReady();
     }
   }
-};
 
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPParser.prototype.onError = function() {
-  this.initialized_ = true;
-  this.processingZip_ = false;
-  plugin.file.shp.SHPParser.base(this, 'onError');
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPParser.prototype.onReady = function() {
-  this.initialized_ = true;
-  this.processingZip_ = false;
-  plugin.file.shp.SHPParser.base(this, 'onReady');
-};
-
-
-/**
- * @param {string} msg
- * @private
- */
-plugin.file.shp.SHPParser.prototype.logWarning_ = function(msg) {
-  goog.log.warning(plugin.file.shp.SHPParser.LOGGER_, msg);
-};
-
-
-/**
- * @param {string} msg
- * @private
- */
-plugin.file.shp.SHPParser.prototype.logError_ = function(msg) {
-  goog.log.error(plugin.file.shp.SHPParser.LOGGER_, msg);
-};
-
-
-/**
- * @private
- */
-plugin.file.shp.SHPParser.prototype.updateColumns_ = function() {
-  this.columns_.length = 0;
-
-  if (this.header_ && this.header_.dbf) {
-    var fields = this.header_.dbf.fields;
-    for (var i = 0, n = fields.length; i < n; i++) {
-      var col = new os.data.ColumnDefinition(fields[i].name);
-      col['selectable'] = false;
-      col['sortable'] = false;
-      this.columns_.push(col);
-    }
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPParser.prototype.createZipReader = function(source) {
-  this.processingZip_ = true;
-  plugin.file.shp.SHPParser.base(this, 'createZipReader', source);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPParser.prototype.handleZipEntries = function(entries) {
-  var foundSHP = false;
-  var foundDBF = false;
-  for (var i = 0, n = entries.length; i < n; i++) {
-    // if the entry is a shp or dbf, load the content and process it. only use the first file encountered, which means
-    // archives with multiple shapefiles will only load the first
-    var entry = entries[i];
-    if (!foundSHP && plugin.file.shp.mime.SHP_EXT_REGEXP.test(entry.filename)) {
-      foundSHP = true;
-      entry.getData(new zip.ArrayBufferWriter(), this.processZIPEntry_.bind(this, entry));
-    } else if (!foundDBF && plugin.file.shp.mime.DBF_EXT_REGEXP.test(entry.filename)) {
-      foundDBF = true;
-      entry.getData(new zip.ArrayBufferWriter(), this.processZIPEntry_.bind(this, entry));
-    }
-  }
-
-  if (!foundSHP) {
-    this.logError_('No valid SHP file found!');
-    this.onError();
-  } else if (!foundDBF) {
-    this.logError_('No valid DBF file found!');
-    this.onError();
-  }
-};
-
-
-/**
- * @param {zip.Entry} entry
- * @param {*} content
- * @private
- */
-plugin.file.shp.SHPParser.prototype.processZIPEntry_ = function(entry, content) {
-  if (content instanceof ArrayBuffer) {
-    content = /** @type {!ArrayBuffer} */ (content);
-    if (plugin.file.shp.mime.SHP_EXT_REGEXP.test(entry.filename)) {
-      this.setupSHPFile_(content);
-    } else if (plugin.file.shp.mime.DBF_EXT_REGEXP.test(entry.filename)) {
-      this.setupDBFFile_(content);
-      this.updateColumns_();
-    }
-  }
-
-  if (!this.initialized_ && this.header_ && this.header_.data && this.header_.dbf.data) {
-    this.onReady();
-  }
-};
-
-
-/**
- * @param {ArrayBuffer} source
- * @private
- */
-plugin.file.shp.SHPParser.prototype.setupSHPFile_ = function(source) {
-  /* Shape File Header
-   *                                                    Byte
-   * Position  Field           Value           Type     Order
-   * Byte 0    File Type       9994            Integer  Big
-   * Byte 4    Unused?
-   * Byte 24   File Length     # 16bit Words   Integer  Big
-   * Byte 28   Version         1000            Integer  Little
-   * Byte 32   Shape Type      0, *1, *3, *5   Integer  Little
-   * Byte 36   Min Lon         Degrees         Double   Little
-   * Byte 44   Min Lat         Degrees         Double   Little
-   * Byte 52   Max Lon         Degrees         Double   Little
-   * Byte 60   Max Lat         Degrees         Double   Little
-   * Byte 68   Unused                          Double   Little
-   * Byte 76   Unused                          Double   Little
-   * Byte 84   Unused                          Double   Little
-   * Byte 92   Unused                          Double   Little
-   * Byte 100  End Of Header
-   */
-  var dv = new DataView(source);
-  var version = dv.getUint32(28, true);
-  if (version != 1000) {
-    // not the correct version, bail!
-    return;
-  }
-
-  if (this.header_) {
-    this.header_.data = source;
-    this.header_.position = 100;
-  }
-};
-
-
-/**
- * @param {ArrayBuffer} source
- * @private
- */
-plugin.file.shp.SHPParser.prototype.setupDBFFile_ = function(source) {
   /**
-   * The following is for dBASE Versions III Plus, IV, and 5.
-   * @see https://www.loc.gov/preservation/digital/formats/fdd/fdd000325.shtml
-   *
-   *                                                                   Byte
-   * Position   Field                          Units         Type      Order
-   * Byte 0     Version                        Version       Byte      n/a
-   * Byte 1     Year                           Year+1900     Byte      n/a
-   * Byte 2     Month                          Month (1-12)  Byte      n/a
-   * Byte 3     Date                           Date of Month Byte      n/a
-   * Byte 4     NumRecords                     Count         Integer   Little
-   * Byte 8     HeaderSize                     Bytes         Short     Little
-   * Byte 10    RecordSize                     Bytes         Short     Little
-   * Byte 12    reserved                                     Byte[2]   n/a
-   * Byte 14    Incomplete transaction flag                  Byte      n/a
-   * Byte 15    Encryption Flag                              Byte      n/a
-   * Byte 16    Free record thread (reserved)                Byte[4]   n/a
-   * Byte 20    Reserved for multi-user                      Byte[8]   n/a
-   * Byte 28    MDX Flag (reserved)                          Byte      n/a
-   * Byte 29    Language driver (reserved)                   Byte      n/a
-   * Byte 30    Reserved                                     Byte[2]   n/a
-   * Byte 32    Table Field descriptor Array                 Byte[32]  n/a
-   * Byte 64-n  repeated for each field                      Byte[32]  n/a
-   * Byte n     Terminator                     '0Dh'         Byte      n/a
-   * Byte n+1   ASCII Records separated by a 'space' (20h)
-   *
-   * Within Fields
-   * Byte 0    Field Name                                    Byte[11]  n/a
-   * Byte 11   Field Type                                    Byte      n/a
-   * Byte 16   Field Length                                  Byte      n/a
+   * @param {ArrayBuffer} source
+   * @private
    */
-  var dbf = this.header_ ? this.header_.dbf : null;
-  if (!dbf) {
-    return;
-  }
-
-  var dv = new DataView(source);
-  dbf.numRecords = dv.getUint32(4, true);
-  dbf.recordStart = dv.getUint16(8, true) + 1;
-  dbf.recordSize = dv.getUint16(10, true);
-  dbf.fields.length = 0;
-
-  var position = 32;
-  while (position < dbf.recordStart) {
-    var name = os.file.mime.text.getText(source.slice(position, position + 10));
-    if (name.charCodeAt(0) == 0x0D) {
-      break;
+  setupSHPFile_(source) {
+    /* Shape File Header
+     *                                                    Byte
+     * Position  Field           Value           Type     Order
+     * Byte 0    File Type       9994            Integer  Big
+     * Byte 4    Unused?
+     * Byte 24   File Length     # 16bit Words   Integer  Big
+     * Byte 28   Version         1000            Integer  Little
+     * Byte 32   Shape Type      0, *1, *3, *5   Integer  Little
+     * Byte 36   Min Lon         Degrees         Double   Little
+     * Byte 44   Min Lat         Degrees         Double   Little
+     * Byte 52   Max Lon         Degrees         Double   Little
+     * Byte 60   Max Lat         Degrees         Double   Little
+     * Byte 68   Unused                          Double   Little
+     * Byte 76   Unused                          Double   Little
+     * Byte 84   Unused                          Double   Little
+     * Byte 92   Unused                          Double   Little
+     * Byte 100  End Of Header
+     */
+    var dv = new DataView(source);
+    var version = dv.getUint32(28, true);
+    if (version != 1000) {
+      // not the correct version, bail!
+      return;
     }
 
-    var type = String.fromCharCode(dv.getUint8(position + 11));
-    var length = dv.getUint8(position + 16);
-    name = goog.string.trim(name);
-    dbf.fields.push(new plugin.file.shp.data.DBFField(name, type, length));
-
-    position += 32;
+    if (this.header_) {
+      this.header_.data = source;
+      this.header_.position = 100;
+    }
   }
 
-  dbf.data = source;
-};
+  /**
+   * @param {ArrayBuffer} source
+   * @private
+   */
+  setupDBFFile_(source) {
+    /**
+     * The following is for dBASE Versions III Plus, IV, and 5.
+     * @see https://www.loc.gov/preservation/digital/formats/fdd/fdd000325.shtml
+     *
+     *                                                                   Byte
+     * Position   Field                          Units         Type      Order
+     * Byte 0     Version                        Version       Byte      n/a
+     * Byte 1     Year                           Year+1900     Byte      n/a
+     * Byte 2     Month                          Month (1-12)  Byte      n/a
+     * Byte 3     Date                           Date of Month Byte      n/a
+     * Byte 4     NumRecords                     Count         Integer   Little
+     * Byte 8     HeaderSize                     Bytes         Short     Little
+     * Byte 10    RecordSize                     Bytes         Short     Little
+     * Byte 12    reserved                                     Byte[2]   n/a
+     * Byte 14    Incomplete transaction flag                  Byte      n/a
+     * Byte 15    Encryption Flag                              Byte      n/a
+     * Byte 16    Free record thread (reserved)                Byte[4]   n/a
+     * Byte 20    Reserved for multi-user                      Byte[8]   n/a
+     * Byte 28    MDX Flag (reserved)                          Byte      n/a
+     * Byte 29    Language driver (reserved)                   Byte      n/a
+     * Byte 30    Reserved                                     Byte[2]   n/a
+     * Byte 32    Table Field descriptor Array                 Byte[32]  n/a
+     * Byte 64-n  repeated for each field                      Byte[32]  n/a
+     * Byte n     Terminator                     '0Dh'         Byte      n/a
+     * Byte n+1   ASCII Records separated by a 'space' (20h)
+     *
+     * Within Fields
+     * Byte 0    Field Name                                    Byte[11]  n/a
+     * Byte 11   Field Type                                    Byte      n/a
+     * Byte 16   Field Length                                  Byte      n/a
+     */
+    var dbf = this.header_ ? this.header_.dbf : null;
+    if (!dbf) {
+      return;
+    }
+
+    var dv = new DataView(source);
+    dbf.numRecords = dv.getUint32(4, true);
+    dbf.recordStart = dv.getUint16(8, true) + 1;
+    dbf.recordSize = dv.getUint16(10, true);
+    dbf.fields.length = 0;
+
+    var position = 32;
+    while (position < dbf.recordStart) {
+      var name = text.getText(source.slice(position, position + 10));
+      if (name.charCodeAt(0) == 0x0D) {
+        break;
+      }
+
+      var type = String.fromCharCode(dv.getUint8(position + 11));
+      var length = dv.getUint8(position + 16);
+      name = googString.trim(name);
+      dbf.fields.push(new DBFField(name, type, length));
+
+      position += 32;
+    }
+
+    dbf.data = source;
+  }
+}
+
+/**
+ * Logger
+ * @type {Logger}
+ */
+const logger = log.getLogger('plugin.file.shp.SHPParser');
+
+
+exports = SHPParser;

--- a/src/plugin/file/shp/shpparserconfig.js
+++ b/src/plugin/file/shp/shpparserconfig.js
@@ -1,123 +1,129 @@
-goog.provide('plugin.file.shp.SHPParserConfig');
-goog.require('os.parse.FileParserConfig');
-goog.require('os.ui.slick.column');
-goog.require('plugin.file.shp');
-goog.require('plugin.file.shp.SHPParser');
+goog.module('plugin.file.shp.SHPParserConfig');
+goog.module.declareLegacyNamespace();
 
+const googEvents = goog.require('goog.events');
+const EventType = goog.require('os.events.EventType');
+
+const FileParserConfig = goog.require('os.parse.FileParserConfig');
+const osUiSlickColumn = goog.require('os.ui.slick.column');
+const SHPParser = goog.require('plugin.file.shp.SHPParser');
 
 
 /**
  * Configuration for a SHP parser.
- *
- * @extends {os.parse.FileParserConfig}
- * @constructor
+ * @unrestricted
  */
-plugin.file.shp.SHPParserConfig = function() {
-  plugin.file.shp.SHPParserConfig.base(this, 'constructor');
+class SHPParserConfig extends FileParserConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    /**
+     * @type {os.file.File}
+     */
+    this['file2'] = null;
+
+    /**
+     * @type {os.file.File}
+     */
+    this['zipFile'] = null;
+
+    /**
+     * @type {number}
+     */
+    this['lineAlpha'] = SHPParserConfig.DEFAULT_LINE_ALPHA;
+
+    /**
+     * @type {number}
+     */
+    this['fillAlpha'] = SHPParserConfig.DEFAULT_FILL_ALPHA;
+
+    /**
+     * @type {number}
+     */
+    this['append'] = SHPParserConfig.DEFAULT_APPEND;
+  }
 
   /**
-   * @type {os.file.File}
+   * @param {Function} callback
    */
-  this['file2'] = null;
+  updateZipPreview(callback) {
+    this['columns'] = [];
+    this['preview'] = [];
+    var parser = new SHPParser(this);
+    parser.setSource(this['zipFile'].getContent());
+
+    googEvents.listen(parser, EventType.COMPLETE, function() {
+      this['preview'] = parser.parsePreview();
+      this['columns'] = parser.getColumns() || [];
+
+      for (var i = 0, n = this['columns'].length; i < n; i++) {
+        var column = this['columns'][i];
+        column['width'] = 0;
+        osUiSlickColumn.autoSizeColumn(column);
+      }
+
+      callback();
+
+      parser.dispose();
+    }.bind(this), false, this);
+  }
 
   /**
-   * @type {os.file.File}
+   * @inheritDoc
    */
-  this['zipFile'] = null;
+  updatePreview(opt_mappings) {
+    this['columns'] = [];
+    this['preview'] = [];
 
-  /**
-   * @type {number}
-   */
-  this['lineAlpha'] = plugin.file.shp.SHPParserConfig.DEFAULT_LINE_ALPHA;
+    if (this['file'] || this['file2']) {
+      var source = [];
+      if (this['file']) {
+        source.push(this['file'].getContent());
+      }
+      if (this['file2']) {
+        source.push(this['file2'].getContent());
+      }
 
-  /**
-   * @type {number}
-   */
-  this['fillAlpha'] = plugin.file.shp.SHPParserConfig.DEFAULT_FILL_ALPHA;
+      var parser = new SHPParser(this);
+      parser.setSource(source);
 
-  /**
-   * @type {number}
-   */
-  this['append'] = plugin.file.shp.SHPParserConfig.DEFAULT_APPEND;
-};
-goog.inherits(plugin.file.shp.SHPParserConfig, os.parse.FileParserConfig);
+      this['preview'] = parser.parsePreview();
+      this['columns'] = parser.getColumns() || [];
+
+      for (var i = 0, n = this['columns'].length; i < n; i++) {
+        var column = this['columns'][i];
+        column['width'] = 0;
+        osUiSlickColumn.autoSizeColumn(column);
+      }
+
+      parser.dispose();
+    }
+  }
+}
 
 
 /**
  * @type {number}
  * @const
  */
-plugin.file.shp.SHPParserConfig.DEFAULT_LINE_ALPHA = 1;
+SHPParserConfig.DEFAULT_LINE_ALPHA = 1;
 
 
 /**
  * @type {number}
  * @const
  */
-plugin.file.shp.SHPParserConfig.DEFAULT_FILL_ALPHA = 0.5;
+SHPParserConfig.DEFAULT_FILL_ALPHA = 0.5;
 
 
 /**
  * @type {boolean}
  * @const
  */
-plugin.file.shp.SHPParserConfig.DEFAULT_APPEND = true;
+SHPParserConfig.DEFAULT_APPEND = true;
 
 
-/**
- * @param {Function} callback
- */
-plugin.file.shp.SHPParserConfig.prototype.updateZipPreview = function(callback) {
-  this['columns'] = [];
-  this['preview'] = [];
-  var parser = new plugin.file.shp.SHPParser(this);
-  parser.setSource(this['zipFile'].getContent());
-
-  goog.events.listen(parser, os.events.EventType.COMPLETE, function() {
-    this['preview'] = parser.parsePreview();
-    this['columns'] = parser.getColumns() || [];
-
-    for (var i = 0, n = this['columns'].length; i < n; i++) {
-      var column = this['columns'][i];
-      column['width'] = 0;
-      os.ui.slick.column.autoSizeColumn(column);
-    }
-
-    callback();
-
-    parser.dispose();
-  }.bind(this), false, this);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPParserConfig.prototype.updatePreview = function(opt_mappings) {
-  this['columns'] = [];
-  this['preview'] = [];
-
-  if (this['file'] || this['file2']) {
-    var source = [];
-    if (this['file']) {
-      source.push(this['file'].getContent());
-    }
-    if (this['file2']) {
-      source.push(this['file2'].getContent());
-    }
-
-    var parser = new plugin.file.shp.SHPParser(this);
-    parser.setSource(source);
-
-    this['preview'] = parser.parsePreview();
-    this['columns'] = parser.getColumns() || [];
-
-    for (var i = 0, n = this['columns'].length; i < n; i++) {
-      var column = this['columns'][i];
-      column['width'] = 0;
-      os.ui.slick.column.autoSizeColumn(column);
-    }
-
-    parser.dispose();
-  }
-};
+exports = SHPParserConfig;

--- a/src/plugin/file/shp/shpplugin.js
+++ b/src/plugin/file/shp/shpplugin.js
@@ -1,75 +1,73 @@
-goog.provide('plugin.file.shp.SHPPlugin');
+goog.module('plugin.file.shp.SHPPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.DataManager');
-goog.require('os.data.ProviderEntry');
-goog.require('os.layer.config.LayerConfigManager');
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.ui.im.ImportManager');
-goog.require('plugin.file.shp.SHPDescriptor');
-goog.require('plugin.file.shp.SHPExporter');
-goog.require('plugin.file.shp.SHPLayerConfig');
-goog.require('plugin.file.shp.SHPParser');
-goog.require('plugin.file.shp.SHPProvider');
-goog.require('plugin.file.shp.mime');
-goog.require('plugin.file.shp.ui.SHPImportUI');
-goog.require('plugin.file.shp.ui.ZipSHPImportUI');
-
+const DataManager = goog.require('os.data.DataManager');
+const ProviderEntry = goog.require('os.data.ProviderEntry');
+const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const exportManager = goog.require('os.ui.exportManager');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const SHPDescriptor = goog.require('plugin.file.shp.SHPDescriptor');
+const SHPExporter = goog.require('plugin.file.shp.SHPExporter');
+const SHPLayerConfig = goog.require('plugin.file.shp.SHPLayerConfig');
+const SHPParser = goog.require('plugin.file.shp.SHPParser');
+const SHPProvider = goog.require('plugin.file.shp.SHPProvider');
+const mime = goog.require('plugin.file.shp.mime');
+const SHPImportUI = goog.require('plugin.file.shp.ui.SHPImportUI');
+const ZipSHPImportUI = goog.require('plugin.file.shp.ui.ZipSHPImportUI');
 
 
 /**
  * Provides SHP support
- *
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.file.shp.SHPPlugin = function() {
-  plugin.file.shp.SHPPlugin.base(this, 'constructor');
-  this.id = plugin.file.shp.SHPPlugin.ID;
-};
-goog.inherits(plugin.file.shp.SHPPlugin, os.plugin.AbstractPlugin);
+class SHPPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = ID;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    var dm = DataManager.getInstance();
+
+    // register shp provider type
+    dm.registerProviderType(new ProviderEntry(ID, SHPProvider, TYPE, TYPE));
+
+    // register the shp descriptor type
+    dm.registerDescriptorType(this.id, SHPDescriptor);
+
+    // register the shp layer config
+    var lcm = LayerConfigManager.getInstance();
+    lcm.registerLayerConfig(this.id, SHPLayerConfig);
+
+    // register the shp import ui
+    var im = ImportManager.getInstance();
+    im.registerImportDetails('Shapefile (SHP/DBF or ZIP)', true);
+    im.registerImportUI(mime.TYPE, new SHPImportUI());
+    im.registerImportUI(mime.ZIP_TYPE, new ZipSHPImportUI());
+    im.registerParser(this.id, SHPParser);
+
+    // register the shp exporter
+    exportManager.registerExportMethod(new SHPExporter());
+  }
+}
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.shp.SHPPlugin.ID = 'shp';
+const ID = 'shp';
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.shp.SHPPlugin.TYPE = 'SHP Layers';
+const TYPE = 'SHP Layers';
 
 
-/**
- * @inheritDoc
- */
-plugin.file.shp.SHPPlugin.prototype.init = function() {
-  var dm = os.dataManager;
-
-  // register shp provider type
-  dm.registerProviderType(new os.data.ProviderEntry(
-      plugin.file.shp.SHPPlugin.ID,
-      plugin.file.shp.SHPProvider,
-      plugin.file.shp.SHPPlugin.TYPE,
-      plugin.file.shp.SHPPlugin.TYPE));
-
-  // register the shp descriptor type
-  dm.registerDescriptorType(this.id, plugin.file.shp.SHPDescriptor);
-
-  // register the shp layer config
-  var lcm = os.layer.config.LayerConfigManager.getInstance();
-  lcm.registerLayerConfig(this.id, plugin.file.shp.SHPLayerConfig);
-
-  // register the shp import ui
-  var im = os.ui.im.ImportManager.getInstance();
-  im.registerImportDetails('Shapefile (SHP/DBF or ZIP)', true);
-  im.registerImportUI(plugin.file.shp.mime.TYPE, new plugin.file.shp.ui.SHPImportUI());
-  im.registerImportUI(plugin.file.shp.mime.ZIP_TYPE, new plugin.file.shp.ui.ZipSHPImportUI());
-  im.registerParser(this.id, plugin.file.shp.SHPParser);
-
-  // register the shp exporter
-  os.ui.exportManager.registerExportMethod(new plugin.file.shp.SHPExporter());
-};
+exports = SHPPlugin;

--- a/src/plugin/file/shp/shpprovider.js
+++ b/src/plugin/file/shp/shpprovider.js
@@ -23,32 +23,8 @@ class SHPProvider extends FileProvider {
     this.setId('shp');
     this.setLabel('SHP Files');
   }
-
-  /**
-   * Get the global instance.
-   * @return {!SHPProvider}
-   */
-  static getInstance() {
-    if (!instance) {
-      instance = new SHPProvider();
-    }
-
-    return instance;
-  }
-
-  /**
-   * Set the global instance.
-   * @param {SHPProvider} value
-   */
-  static setInstance(value) {
-    instance = value;
-  }
 }
+goog.addSingletonGetter(SHPProvider);
 
-/**
- * Global instance.
- * @type {SHPProvider|undefined}
- */
-let instance;
 
 exports = SHPProvider;

--- a/src/plugin/file/shp/shpprovider.js
+++ b/src/plugin/file/shp/shpprovider.js
@@ -1,26 +1,54 @@
-goog.provide('plugin.file.shp.SHPProvider');
-goog.require('os.data.FileProvider');
+goog.module('plugin.file.shp.SHPProvider');
+goog.module.declareLegacyNamespace();
 
+const FileProvider = goog.require('os.data.FileProvider');
 
 
 /**
  * SHP file provider
- *
- * @extends {os.data.FileProvider}
- * @constructor
  */
-plugin.file.shp.SHPProvider = function() {
-  plugin.file.shp.SHPProvider.base(this, 'constructor');
-};
-goog.inherits(plugin.file.shp.SHPProvider, os.data.FileProvider);
-goog.addSingletonGetter(plugin.file.shp.SHPProvider);
+class SHPProvider extends FileProvider {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
 
+  /**
+   * @inheritDoc
+   */
+  configure(config) {
+    super.configure(config);
+    this.setId('shp');
+    this.setLabel('SHP Files');
+  }
+
+  /**
+   * Get the global instance.
+   * @return {!SHPProvider}
+   */
+  static getInstance() {
+    if (!instance) {
+      instance = new SHPProvider();
+    }
+
+    return instance;
+  }
+
+  /**
+   * Set the global instance.
+   * @param {SHPProvider} value
+   */
+  static setInstance(value) {
+    instance = value;
+  }
+}
 
 /**
- * @inheritDoc
+ * Global instance.
+ * @type {SHPProvider|undefined}
  */
-plugin.file.shp.SHPProvider.prototype.configure = function(config) {
-  plugin.file.shp.SHPProvider.base(this, 'configure', config);
-  this.setId('shp');
-  this.setLabel('SHP Files');
-};
+let instance;
+
+exports = SHPProvider;

--- a/src/plugin/file/shp/ui/shpexportui.js
+++ b/src/plugin/file/shp/ui/shpexportui.js
@@ -1,8 +1,8 @@
-goog.provide('plugin.file.shp.ui.SHPExportCtrl');
-goog.provide('plugin.file.shp.ui.shpExportDirective');
+goog.module('plugin.file.shp.ui.SHPExportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os');
-goog.require('os.ui.Module');
+const {ROOT} = goog.require('os');
+const Module = goog.require('os.ui.Module');
 
 
 /**
@@ -10,76 +10,88 @@ goog.require('os.ui.Module');
  *
  * @return {angular.Directive}
  */
-plugin.file.shp.ui.shpExportDirective = function() {
-  return {
-    restrict: 'E',
-    scope: {
-      'exporter': '='
-    },
-    templateUrl: os.ROOT + 'views/plugin/shp/shpexport.html',
-    controller: plugin.file.shp.ui.SHPExportCtrl,
-    controllerAs: 'shpexport'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  scope: {
+    'exporter': '='
+  },
+  templateUrl: ROOT + 'views/plugin/shp/shpexport.html',
+  controller: Controller,
+  controllerAs: 'shpexport'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'shpexport';
 
 
 /**
  * Add the directive to the module.
  */
-os.ui.Module.directive('shpexport', [plugin.file.shp.ui.shpExportDirective]);
+Module.directive('shpexport', [directive]);
 
 
 
 /**
  * Controller function for the shpexport directive
- *
- * @param {!angular.Scope} $scope
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.file.shp.ui.SHPExportCtrl = function($scope) {
+class Controller {
   /**
-   * @type {?angular.Scope}
-   * @private
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @ngInject
    */
-  this.scope_ = $scope;
+  constructor($scope) {
+    /**
+     * @type {?angular.Scope}
+     * @private
+     */
+    this.scope_ = $scope;
 
-  /**
-   * @type {plugin.file.shp.SHPExporter}
-   * @private
-   */
-  this.exporter_ = /** @type {plugin.file.shp.SHPExporter} */ ($scope['exporter']);
+    /**
+     * @type {plugin.file.shp.SHPExporter}
+     * @private
+     */
+    this.exporter_ = /** @type {plugin.file.shp.SHPExporter} */ ($scope['exporter']);
 
-  /**
-   * @type {boolean}
-   */
-  $scope['exportEllipses'] = this.exporter_.getExportEllipses();
+    /**
+     * @type {boolean}
+     */
+    $scope['exportEllipses'] = this.exporter_.getExportEllipses();
 
-  $scope.$watch('exportEllipses', this.updateExporter_.bind(this));
-  $scope.$on('$destroy', this.destroy_.bind(this));
+    $scope.$watch('exportEllipses', this.updateExporter_.bind(this));
+    $scope.$on('$destroy', this.destroy_.bind(this));
 
-  this.updateExporter_();
-};
-
-
-/**
- * Clean up.
- *
- * @private
- */
-plugin.file.shp.ui.SHPExportCtrl.prototype.destroy_ = function() {
-  this.scope_ = null;
-  this.exporter_ = null;
-};
-
-
-/**
- * Updates the SHP exporter with the current UI configuration.
- *
- * @private
- */
-plugin.file.shp.ui.SHPExportCtrl.prototype.updateExporter_ = function() {
-  if (this.exporter_ && this.scope_) {
-    this.exporter_.setExportEllipses(this.scope_['exportEllipses']);
+    this.updateExporter_();
   }
+
+  /**
+   * Clean up.
+   *
+   * @private
+   */
+  destroy_() {
+    this.scope_ = null;
+    this.exporter_ = null;
+  }
+
+  /**
+   * Updates the SHP exporter with the current UI configuration.
+   *
+   * @private
+   */
+  updateExporter_() {
+    if (this.exporter_ && this.scope_) {
+      this.exporter_.setExportEllipses(this.scope_['exportEllipses']);
+    }
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/file/shp/ui/shpimport.js
+++ b/src/plugin/file/shp/ui/shpimport.js
@@ -1,129 +1,140 @@
-goog.provide('plugin.file.shp.ui.SHPImportCtrl');
-goog.provide('plugin.file.shp.ui.shpImportDirective');
+goog.module('plugin.file.shp.ui.SHPImport');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.DataManager');
-goog.require('os.file.FileStorage');
-goog.require('os.ui.Module');
-goog.require('os.ui.im.FileImportWizard');
-goog.require('os.ui.wiz.wizardDirective');
-goog.require('plugin.file.shp.SHPDescriptor');
-goog.require('plugin.file.shp.SHPParserConfig');
-goog.require('plugin.file.shp.SHPProvider');
+const osFile = goog.require('os.file');
 
+const Module = goog.require('os.ui.Module');
+const FileImportWizard = goog.require('os.ui.im.FileImportWizard');
+const wizardDirective = goog.require('os.ui.wiz.wizardDirective');
+const SHPDescriptor = goog.require('plugin.file.shp.SHPDescriptor');
+const SHPProvider = goog.require('plugin.file.shp.SHPProvider');
+const SHPParserConfig = goog.requireType('plugin.file.shp.SHPParserConfig');
 
 
 /**
  * Controller for the SHP import wizard window
  *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout
- * @param {!Object.<string, string>} $attrs
- * @extends {os.ui.im.FileImportWizard.<!plugin.file.shp.SHPParserConfig,!plugin.file.shp.SHPDescriptor>}
- * @constructor
- * @ngInject
+ * @extends {FileImportWizard.<!SHPParserConfig,!SHPDescriptor>}
+ * @unrestricted
  */
-plugin.file.shp.ui.SHPImportCtrl = function($scope, $element, $timeout, $attrs) {
-  plugin.file.shp.ui.SHPImportCtrl.base(this, 'constructor', $scope, $element, $timeout, $attrs);
-};
-goog.inherits(plugin.file.shp.ui.SHPImportCtrl, os.ui.im.FileImportWizard);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.ui.SHPImportCtrl.prototype.cleanConfig = function() {
-  if (this.config) {
-    this.config['file2'] = null;
-    this.config['zipFile'] = null;
+class Controller extends FileImportWizard {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @param {!angular.$timeout} $timeout
+   * @param {!Object.<string, string>} $attrs
+   * @ngInject
+   */
+  constructor($scope, $element, $timeout, $attrs) {
+    super($scope, $element, $timeout, $attrs);
   }
 
-  plugin.file.shp.ui.SHPImportCtrl.base(this, 'cleanConfig');
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.ui.SHPImportCtrl.prototype.storeAndFinish = function(descriptor) {
-  if (this.config['zipFile']) {
-    if (os.file.isLocal(this.config['zipFile'])) {
-      // store the ZIP
-      this.fs.storeFile(this.config['zipFile'], true)
-          .addCallbacks(goog.partial(this.finishImport, descriptor), this.onPersistError, this);
-    } else {
-      // local zip - finish up
-      this.finishImport(descriptor);
+  /**
+   * @inheritDoc
+   */
+  cleanConfig() {
+    if (this.config) {
+      this.config['file2'] = null;
+      this.config['zipFile'] = null;
     }
-  } else {
-    var localShp = os.file.isLocal(this.config['file']);
-    var localDbf = os.file.isLocal(this.config['file2']);
-    if (localShp && localDbf) {
-      // store both the SHP and DBF
-      this.fs.storeFile(this.config['file2'], true)
-          .awaitDeferred(this.fs.storeFile(this.config['file'], true))
-          .addCallbacks(goog.partial(this.finishImport, descriptor), this.onPersistError, this);
-    } else if (localShp) {
-      // store the SHP
-      this.fs.storeFile(this.config['file'], true)
-          .addCallbacks(goog.partial(this.finishImport, descriptor), this.onPersistError, this);
-    } else if (localDbf) {
-      // store the DBF
-      this.fs.storeFile(this.config['file2'], true)
-          .addCallbacks(goog.partial(this.finishImport, descriptor), this.onPersistError, this);
+
+    super.cleanConfig();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  storeAndFinish(descriptor) {
+    if (this.config['zipFile']) {
+      if (osFile.isLocal(this.config['zipFile'])) {
+        // store the ZIP
+        this.fs.storeFile(this.config['zipFile'], true)
+            .addCallbacks(goog.partial(this.finishImport, descriptor), this.onPersistError, this);
+      } else {
+        // local zip - finish up
+        this.finishImport(descriptor);
+      }
     } else {
-      // both local - finish up
-      this.finishImport(descriptor);
+      var localShp = osFile.isLocal(this.config['file']);
+      var localDbf = osFile.isLocal(this.config['file2']);
+      if (localShp && localDbf) {
+        // store both the SHP and DBF
+        this.fs.storeFile(this.config['file2'], true)
+            .awaitDeferred(this.fs.storeFile(this.config['file'], true))
+            .addCallbacks(goog.partial(this.finishImport, descriptor), this.onPersistError, this);
+      } else if (localShp) {
+        // store the SHP
+        this.fs.storeFile(this.config['file'], true)
+            .addCallbacks(goog.partial(this.finishImport, descriptor), this.onPersistError, this);
+      } else if (localDbf) {
+        // store the DBF
+        this.fs.storeFile(this.config['file2'], true)
+            .addCallbacks(goog.partial(this.finishImport, descriptor), this.onPersistError, this);
+      } else {
+        // both local - finish up
+        this.finishImport(descriptor);
+      }
     }
   }
-};
 
+  /**
+   * @param {!SHPDescriptor} descriptor
+   * @protected
+   * @override
+   */
+  addDescriptorToProvider(descriptor) {
+    SHPProvider.getInstance().addDescriptor(descriptor);
+  }
 
-/**
- * @param {!plugin.file.shp.SHPDescriptor} descriptor
- * @protected
- * @override
- */
-plugin.file.shp.ui.SHPImportCtrl.prototype.addDescriptorToProvider = function(descriptor) {
-  plugin.file.shp.SHPProvider.getInstance().addDescriptor(descriptor);
-};
+  /**
+   * @param {!SHPParserConfig} config
+   * @return {!SHPDescriptor}
+   * @protected
+   * @override
+   */
+  createFromConfig(config) {
+    const descriptor = new SHPDescriptor(this.config);
+    SHPDescriptor.createFromConfig(descriptor, SHPProvider.getInstance(), this.config);
+    return descriptor;
+  }
 
-
-/**
- * @param {!plugin.file.shp.SHPParserConfig} config
- * @return {!plugin.file.shp.SHPDescriptor}
- * @protected
- * @override
- */
-plugin.file.shp.ui.SHPImportCtrl.prototype.createFromConfig = function(config) {
-  return plugin.file.shp.SHPDescriptor.createFromConfig(this.config);
-};
-
-
-/**
- * @param {!plugin.file.shp.SHPDescriptor} descriptor
- * @param {!plugin.file.shp.SHPParserConfig} config
- * @protected
- * @override
- */
-plugin.file.shp.ui.SHPImportCtrl.prototype.updateFromConfig = function(descriptor, config) {
-  descriptor.updateFromConfig(config);
-};
-
+  /**
+   * @param {!SHPDescriptor} descriptor
+   * @param {!SHPParserConfig} config
+   * @protected
+   * @override
+   */
+  updateFromConfig(descriptor, config) {
+    descriptor.updateFromConfig(config);
+  }
+}
 
 /**
  * The SHP import wizard directive.
  *
  * @return {angular.Directive}
  */
-plugin.file.shp.ui.shpImportDirective = function() {
-  var dir = os.ui.wiz.wizardDirective();
-  dir.controller = plugin.file.shp.ui.SHPImportCtrl;
+const directive = () => {
+  var dir = wizardDirective();
+  dir.controller = Controller;
   return dir;
 };
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'shpimport';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('shpimport', [plugin.file.shp.ui.shpImportDirective]);
+Module.directive('shpimport', [directive]);
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
+};

--- a/src/plugin/file/shp/ui/shpimportui.js
+++ b/src/plugin/file/shp/ui/shpimportui.js
@@ -1,80 +1,85 @@
-goog.provide('plugin.file.shp.ui.SHPImportUI');
-goog.require('os.ui.im.FileImportUI');
-goog.require('os.ui.window');
-goog.require('os.ui.wiz.OptionsStep');
-goog.require('os.ui.wiz.step.TimeStep');
-goog.require('plugin.file.shp.SHPParserConfig');
-goog.require('plugin.file.shp.mime');
-goog.require('plugin.file.shp.ui.SHPFilesStep');
-goog.require('plugin.file.shp.ui.shpImportDirective');
+goog.module('plugin.file.shp.ui.SHPImportUI');
+goog.module.declareLegacyNamespace();
 
-
-
-/**
- * @extends {os.ui.im.FileImportUI.<plugin.file.shp.SHPParserConfig>}
- * @constructor
- */
-plugin.file.shp.ui.SHPImportUI = function() {
-  plugin.file.shp.ui.SHPImportUI.base(this, 'constructor');
-};
-goog.inherits(plugin.file.shp.ui.SHPImportUI, os.ui.im.FileImportUI);
+const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const osWindow = goog.require('os.ui.window');
+const windowSelector = goog.require('os.ui.windowSelector');
+const OptionsStep = goog.require('os.ui.wiz.OptionsStep');
+const TimeStep = goog.require('os.ui.wiz.step.TimeStep');
+const SHPParserConfig = goog.require('plugin.file.shp.SHPParserConfig');
+const mime = goog.require('plugin.file.shp.mime');
+const SHPFilesStep = goog.require('plugin.file.shp.ui.SHPFilesStep');
+const {directiveTag: shpImportUi} = goog.require('plugin.file.shp.ui.SHPImport');
 
 
 /**
- * @inheritDoc
+ * @extends {FileImportUI<SHPParserConfig>}
  */
-plugin.file.shp.ui.SHPImportUI.prototype.getTitle = function() {
-  return 'SHP';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.ui.SHPImportUI.prototype.launchUI = function(file, opt_config) {
-  plugin.file.shp.ui.SHPImportUI.base(this, 'launchUI', file, opt_config);
-
-  var steps = [
-    new plugin.file.shp.ui.SHPFilesStep(),
-    new os.ui.wiz.step.TimeStep(),
-    new os.ui.wiz.OptionsStep()
-  ];
-
-  var config = new plugin.file.shp.SHPParserConfig();
-
-  // if a configuration was provided, merge it in
-  if (opt_config) {
-    this.mergeConfig(opt_config, config);
+class SHPImportUI extends FileImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
 
-  // determine if the initial file is the DBF or SHP file
-  var name = file.getFileName();
-  if (plugin.file.shp.mime.SHP_EXT_REGEXP.test(name)) {
-    config['file'] = file;
-    config['title'] = name;
-  } else {
-    config['file2'] = file;
-    config['title'] = name.split(plugin.file.shp.mime.DBF_EXT_REGEXP)[0] + '.shp';
+  /**
+   * @inheritDoc
+   */
+  getTitle() {
+    return 'SHP';
   }
 
-  var scopeOptions = {
-    'config': config,
-    'steps': steps
-  };
-  var windowOptions = {
-    'label': 'SHP Import',
-    'icon': 'fa fa-sign-in',
-    'x': 'center',
-    'y': 'center',
-    'width': '850',
-    'min-width': '500',
-    'max-width': '1200',
-    'height': '650',
-    'min-height': '300',
-    'max-height': '1000',
-    'modal': 'true',
-    'show-close': 'true'
-  };
-  var template = '<shpimport resize-with="' + os.ui.windowSelector.WINDOW + '"></shpimport>';
-  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
-};
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    super.launchUI(file, opt_config);
+
+    var steps = [
+      new SHPFilesStep(),
+      new TimeStep(),
+      new OptionsStep()
+    ];
+
+    var config = new SHPParserConfig();
+
+    // if a configuration was provided, merge it in
+    if (opt_config) {
+      this.mergeConfig(opt_config, config);
+    }
+
+    // determine if the initial file is the DBF or SHP file
+    var name = file.getFileName();
+    if (mime.SHP_EXT_REGEXP.test(name)) {
+      config['file'] = file;
+      config['title'] = name;
+    } else {
+      config['file2'] = file;
+      config['title'] = name.split(mime.DBF_EXT_REGEXP)[0] + '.shp';
+    }
+
+    var scopeOptions = {
+      'config': config,
+      'steps': steps
+    };
+    var windowOptions = {
+      'label': 'SHP Import',
+      'icon': 'fa fa-sign-in',
+      'x': 'center',
+      'y': 'center',
+      'width': '850',
+      'min-width': '500',
+      'max-width': '1200',
+      'height': '650',
+      'min-height': '300',
+      'max-height': '1000',
+      'modal': 'true',
+      'show-close': 'true'
+    };
+    var template = `<${shpImportUi} resize-with="${windowSelector.WINDOW}"></${shpImportUi}>`;
+    osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+  }
+}
+
+exports = SHPImportUI;

--- a/src/plugin/file/shp/ui/zipshpimportui.js
+++ b/src/plugin/file/shp/ui/zipshpimportui.js
@@ -1,248 +1,257 @@
-goog.provide('plugin.file.shp.ui.ZipSHPImportUI');
+goog.module('plugin.file.shp.ui.ZipSHPImportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.DataManager');
-goog.require('os.file');
-goog.require('os.file.File');
-goog.require('os.ui.im.FileImportUI');
-goog.require('os.ui.window');
-goog.require('os.ui.wiz.OptionsStep');
-goog.require('os.ui.wiz.step.TimeStep');
-goog.require('plugin.file.shp.SHPDescriptor');
-goog.require('plugin.file.shp.SHPParserConfig');
-goog.require('plugin.file.shp.SHPProvider');
-goog.require('plugin.file.shp.mime');
-goog.require('plugin.file.shp.ui.shpImportDirective');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const AlertManager = goog.require('os.alert.AlertManager');
 
+const DataManager = goog.require('os.data.DataManager');
+const osFile = goog.require('os.file');
+const MappingManager = goog.require('os.im.mapping.MappingManager');
+const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const osWindow = goog.require('os.ui.window');
+const windowSelector = goog.require('os.ui.windowSelector');
+const OptionsStep = goog.require('os.ui.wiz.OptionsStep');
+const TimeStep = goog.require('os.ui.wiz.step.TimeStep');
+const SHPDescriptor = goog.require('plugin.file.shp.SHPDescriptor');
+const SHPParserConfig = goog.require('plugin.file.shp.SHPParserConfig');
+const SHPProvider = goog.require('plugin.file.shp.SHPProvider');
+const mime = goog.require('plugin.file.shp.mime');
+const {directiveTag: shpImportUi} = goog.require('plugin.file.shp.ui.SHPImport');
+
+const OSFile = goog.requireType('os.file.File');
 
 
 /**
- * @extends {os.ui.im.FileImportUI.<plugin.file.shp.SHPParserConfig>}
- * @constructor
+ * @extends {FileImportUI.<SHPParserConfig>}
  */
-plugin.file.shp.ui.ZipSHPImportUI = function() {
+class ZipSHPImportUI extends FileImportUI {
   /**
-   * @type {os.file.File}
-   * @private
+   * Constructor.
    */
-  this.shpFile_ = null;
+  constructor() {
+    super();
+
+    /**
+     * @type {OSFile}
+     * @private
+     */
+    this.shpFile_ = null;
+
+    /**
+     * @type {OSFile}
+     * @private
+     */
+    this.dbfFile_ = null;
+
+    /**
+     * @type {OSFile}
+     * @private
+     */
+    this.zipFile_ = null;
+
+    /**
+     * @type {SHPParserConfig}
+     * @private
+     */
+    this.config_ = null;
+
+    /**
+     * @type {!Array<!zip.Reader>}
+     * @protected
+     */
+    this.zipReaders = [];
+  }
 
   /**
-   * @type {os.file.File}
-   * @private
+   * @inheritDoc
    */
-  this.dbfFile_ = null;
+  launchUI(file, opt_config) {
+    super.launchUI(file, opt_config);
+
+    this.shpFile_ = null;
+    this.dbfFile_ = null;
+    this.zipFile_ = file;
+
+    if (opt_config !== undefined) {
+      this.config_ = opt_config;
+    }
+
+    const content = /** @type {ArrayBuffer|Blob} */ (file.getContent());
+
+    if (content instanceof ArrayBuffer) {
+      zip.createReader(new zip.ArrayBufferReader(content),
+          this.handleZipReader.bind(this), this.handleZipReaderError.bind(this));
+    } else if (content instanceof Blob) {
+      // convert the blob to an ArrayBuffer and proceed down the normal path
+      content.arrayBuffer().then((arrayBuffer) => {
+        this.zipFile_.setContent(arrayBuffer);
+        zip.createReader(new zip.ArrayBufferReader(arrayBuffer),
+            this.handleZipReader.bind(this), this.handleZipReaderError.bind(this));
+      }, (reason) => {
+        this.handleZipReaderError(reason);
+      });
+    }
+  }
 
   /**
-   * @type {os.file.File}
-   * @private
-   */
-  this.zipFile_ = null;
-
-  /**
-   * @type {plugin.file.shp.SHPParserConfig}
-   * @private
-   */
-  this.config_ = null;
-
-  /**
-   * @type {!Array<!zip.Reader>}
+   * @param {!zip.Reader} reader
    * @protected
    */
-  this.zipReaders = [];
-};
-goog.inherits(plugin.file.shp.ui.ZipSHPImportUI, os.ui.im.FileImportUI);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.shp.ui.ZipSHPImportUI.prototype.launchUI = function(file, opt_config) {
-  plugin.file.shp.ui.ZipSHPImportUI.base(this, 'launchUI', file, opt_config);
-
-  this.shpFile_ = null;
-  this.dbfFile_ = null;
-  this.zipFile_ = file;
-
-  if (opt_config !== undefined) {
-    this.config_ = opt_config;
+  handleZipReader(reader) {
+    this.zipReaders.push(reader);
+    reader.getEntries(this.processEntries_.bind(this));
   }
 
-  const content = /** @type {ArrayBuffer|Blob} */ (file.getContent());
+  /**
+   * Handles ZIP reader errors.
+   * @param {*} opt_error Optional error message/exception.
+   * @protected
+   */
+  handleZipReaderError(opt_error) {
+    // failed reading the zip file
+    var msg = 'Error reading zip file!"';
 
-  if (content instanceof ArrayBuffer) {
-    zip.createReader(new zip.ArrayBufferReader(content),
-        this.handleZipReader.bind(this), this.handleZipReaderError.bind(this));
-  } else if (content instanceof Blob) {
-    // convert the blob to an ArrayBuffer and proceed down the normal path
-    content.arrayBuffer().then((arrayBuffer) => {
-      this.zipFile_.setContent(arrayBuffer);
-      zip.createReader(new zip.ArrayBufferReader(arrayBuffer),
-          this.handleZipReader.bind(this), this.handleZipReaderError.bind(this));
-    }, (reason) => {
-      this.handleZipReaderError(reason);
-    });
-  }
-};
-
-
-/**
- * @param {!zip.Reader} reader
- * @protected
- */
-plugin.file.shp.ui.ZipSHPImportUI.prototype.handleZipReader = function(reader) {
-  this.zipReaders.push(reader);
-  reader.getEntries(this.processEntries_.bind(this));
-};
-
-
-/**
- * Handles ZIP reader errors.
- * @param {*} opt_error Optional error message/exception.
- * @protected
- */
-plugin.file.shp.ui.ZipSHPImportUI.prototype.handleZipReaderError = function(opt_error) {
-  // failed reading the zip file
-  var msg = 'Error reading zip file!"';
-
-  if (typeof opt_error == 'string') {
-    msg += ` Details: ${opt_error}`;
-  } else if (opt_error instanceof Error) {
-    msg += ` Details: ${opt_error.message}.`;
-  }
-
-  os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.ERROR);
-};
-
-
-/**
- * @param {Array.<!zip.Entry>} entries
- * @private
- */
-plugin.file.shp.ui.ZipSHPImportUI.prototype.processEntries_ = function(entries) {
-  for (var i = 0, n = entries.length; i < n; i++) {
-    var entry = entries[i];
-    if (plugin.file.shp.mime.SHP_EXT_REGEXP.test(entry.filename) ||
-        plugin.file.shp.mime.DBF_EXT_REGEXP.test(entry.filename)) {
-      // if the entry is a shp or dbf, load the content and process it
-      entry.getData(new zip.ArrayBufferWriter(), this.processEntry_.bind(this, entry));
+    if (typeof opt_error == 'string') {
+      msg += ` Details: ${opt_error}`;
+    } else if (opt_error instanceof Error) {
+      msg += ` Details: ${opt_error.message}.`;
     }
+
+    AlertManager.getInstance().sendAlert(msg, AlertEventSeverity.ERROR);
   }
-};
 
-
-/**
- * @param {zip.Entry} entry
- * @param {*} content
- * @private
- */
-plugin.file.shp.ui.ZipSHPImportUI.prototype.processEntry_ = function(entry, content) {
-  if (content instanceof ArrayBuffer) {
-    // only use the first file encountered, which means archives with multiple shapefiles will only load the first
-    content = /** @type {!ArrayBuffer} */ (content);
-    if (!this.shpFile_ && plugin.file.shp.mime.SHP_EXT_REGEXP.test(entry.filename)) {
-      this.shpFile_ =
-          os.file.createFromContent(entry.filename, os.file.getLocalUrl(entry.filename), undefined, content);
-    } else if (!this.dbfFile_ && plugin.file.shp.mime.DBF_EXT_REGEXP.test(entry.filename)) {
-      this.dbfFile_ =
-          os.file.createFromContent(entry.filename, os.file.getLocalUrl(entry.filename), undefined, content);
+  /**
+   * @param {Array.<!zip.Entry>} entries
+   * @private
+   */
+  processEntries_(entries) {
+    for (var i = 0, n = entries.length; i < n; i++) {
+      var entry = entries[i];
+      if (mime.SHP_EXT_REGEXP.test(entry.filename) ||
+          mime.DBF_EXT_REGEXP.test(entry.filename)) {
+        // if the entry is a shp or dbf, load the content and process it
+        entry.getData(new zip.ArrayBufferWriter(), this.processEntry_.bind(this, entry));
+      }
     }
   }
 
-  if (this.shpFile_ && this.dbfFile_) {
-    this.launchUIInternal_();
-  }
-};
-
-
-/**
- * @private
- */
-plugin.file.shp.ui.ZipSHPImportUI.prototype.launchUIInternal_ = function() {
-  if (this.shpFile_ && this.dbfFile_) {
-    var config = new plugin.file.shp.SHPParserConfig();
-    let defaultImport = false;
-
-    // if a configuration was provided, merge it in
-    if (this.config_) {
-      defaultImport = this.config_['defaultImport'] || false;
-      this.mergeConfig(this.config_, config);
-      this.config_ = null;
-    }
-
-    config['file'] = this.shpFile_;
-    config['file2'] = this.dbfFile_;
-    config['zipFile'] = this.zipFile_;
-    config['title'] = this.zipFile_.getFileName();
-
-    // generate preview data from the config and try to auto detect mappings
-    config.updatePreview();
-    var features = config['preview'];
-    if ((!config['mappings'] || config['mappings'].length <= 0) && features && features.length > 0) {
-      // no mappings have been set yet, so try to auto detect them
-      var mm = os.im.mapping.MappingManager.getInstance();
-      var mappings = mm.autoDetect(features);
-      if (mappings && mappings.length > 0) {
-        config['mappings'] = mappings;
+  /**
+   * @param {zip.Entry} entry
+   * @param {*} content
+   * @private
+   */
+  processEntry_(entry, content) {
+    if (content instanceof ArrayBuffer) {
+      // only use the first file encountered, which means archives with multiple shapefiles will only load the first
+      content = /** @type {!ArrayBuffer} */ (content);
+      if (!this.shpFile_ && mime.SHP_EXT_REGEXP.test(entry.filename)) {
+        this.shpFile_ =
+            osFile.createFromContent(entry.filename, osFile.getLocalUrl(entry.filename), undefined, content);
+      } else if (!this.dbfFile_ && mime.DBF_EXT_REGEXP.test(entry.filename)) {
+        this.dbfFile_ =
+            osFile.createFromContent(entry.filename, osFile.getLocalUrl(entry.filename), undefined, content);
       }
     }
 
-    if (defaultImport) {
-      this.handleDefaultImport(this.shpFile_, config);
-      return;
+    if (this.shpFile_ && this.dbfFile_) {
+      this.launchUIInternal_();
+    }
+  }
+
+  /**
+   * @private
+   */
+  launchUIInternal_() {
+    if (this.shpFile_ && this.dbfFile_) {
+      var config = new SHPParserConfig();
+      let defaultImport = false;
+
+      // if a configuration was provided, merge it in
+      if (this.config_) {
+        defaultImport = this.config_['defaultImport'] || false;
+        this.mergeConfig(this.config_, config);
+        this.config_ = null;
+      }
+
+      config['file'] = this.shpFile_;
+      config['file2'] = this.dbfFile_;
+      config['zipFile'] = this.zipFile_;
+      config['title'] = this.zipFile_.getFileName();
+
+      // generate preview data from the config and try to auto detect mappings
+      config.updatePreview();
+      var features = config['preview'];
+      if ((!config['mappings'] || config['mappings'].length <= 0) && features && features.length > 0) {
+        // no mappings have been set yet, so try to auto detect them
+        var mm = MappingManager.getInstance();
+        var mappings = mm.autoDetect(features);
+        if (mappings && mappings.length > 0) {
+          config['mappings'] = mappings;
+        }
+      }
+
+      if (defaultImport) {
+        this.handleDefaultImport(this.shpFile_, config);
+        return;
+      }
+
+      var steps = [
+        new TimeStep(),
+        new OptionsStep()
+      ];
+
+      var scopeOptions = {
+        'config': config,
+        'steps': steps
+      };
+      var windowOptions = {
+        'label': 'SHP Import',
+        'icon': 'fa fa-sign-in',
+        'x': 'center',
+        'y': 'center',
+        'width': '850',
+        'min-width': '500',
+        'max-width': '1200',
+        'height': '650',
+        'min-height': '300',
+        'max-height': '1000',
+        'modal': 'true',
+        'show-close': 'true'
+      };
+      var template = `<${shpImportUi} resize-with="${windowSelector.WINDOW}"></${shpImportUi}>`;
+      osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+    } else {
+      var msg = 'Zip file does not contain both SHP and DBF files!';
+      AlertManager.getInstance().sendAlert(msg, AlertEventSeverity.ERROR);
     }
 
-    var steps = [
-      new os.ui.wiz.step.TimeStep(),
-      new os.ui.wiz.OptionsStep()
-    ];
-
-    var scopeOptions = {
-      'config': config,
-      'steps': steps
-    };
-    var windowOptions = {
-      'label': 'SHP Import',
-      'icon': 'fa fa-sign-in',
-      'x': 'center',
-      'y': 'center',
-      'width': '850',
-      'min-width': '500',
-      'max-width': '1200',
-      'height': '650',
-      'min-height': '300',
-      'max-height': '1000',
-      'modal': 'true',
-      'show-close': 'true'
-    };
-    var template = '<shpimport resize-with="' + os.ui.windowSelector.WINDOW + '"></shpimport>';
-    os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
-  } else {
-    var msg = 'Zip file does not contain both SHP and DBF files!';
-    os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.ERROR);
+    // drop file references once the UI is launched
+    this.zipReaders.forEach(function(reader) {
+      reader.close();
+    });
+    this.zipReaders.length = 0;
+    this.shpFile_ = null;
+    this.dbfFile_ = null;
+    this.zipFile_ = null;
   }
 
-  // drop file references once the UI is launched
-  this.zipReaders.forEach(function(reader) {
-    reader.close();
-  });
-  this.zipReaders.length = 0;
-  this.shpFile_ = null;
-  this.dbfFile_ = null;
-  this.zipFile_ = null;
-};
+  /**
+   * @inheritDoc
+   */
+  handleDefaultImport(file, config) {
+    config = this.getDefaultConfig(file, config);
 
+    // create the descriptor and add it
+    if (config) {
+      const provider = SHPProvider.getInstance();
+      const descriptor = new SHPDescriptor(config);
+      SHPDescriptor.createFromConfig(descriptor, provider, config);
 
-/**
- * @inheritDoc
- */
-plugin.file.shp.ui.ZipSHPImportUI.prototype.handleDefaultImport = function(file, config) {
-  config = this.getDefaultConfig(file, config);
-
-  // create the descriptor and add it
-  if (config) {
-    const descriptor = plugin.file.shp.SHPDescriptor.createFromConfig(config);
-    os.data.DataManager.getInstance().addDescriptor(descriptor);
-    plugin.file.shp.SHPProvider.getInstance().addDescriptor(descriptor);
-    descriptor.setActive(true);
+      DataManager.getInstance().addDescriptor(descriptor);
+      provider.addDescriptor(descriptor);
+      descriptor.setActive(true);
+    }
   }
-};
+}
+
+exports = ZipSHPImportUI;

--- a/src/plugin/file/zip/ui/zipimport.js
+++ b/src/plugin/file/zip/ui/zipimport.js
@@ -1,28 +1,30 @@
-goog.provide('plugin.file.zip.ui.ZIPImportCtrl');
-goog.provide('plugin.file.zip.ui.zipImportDirective');
+goog.module('plugin.file.zip.ui.ZIPImport');
+goog.module.declareLegacyNamespace();
 
-goog.require('os');
-goog.require('os.alert.AlertEventSeverity');
-goog.require('os.alert.AlertManager');
-goog.require('os.data.FileDescriptor');
-goog.require('os.file.File');
-goog.require('os.im.ImportProcess');
-goog.require('os.ui.Module');
-goog.require('os.ui.file.FileImportCtrl');
-goog.require('os.ui.im.ImportEvent');
-goog.require('os.ui.im.ImportEventType');
-goog.require('os.ui.im.ImportManager');
-goog.require('os.ui.wiz.wizardDirective');
-goog.require('plugin.file.zip.ZIPParser');
+const {ROOT} = goog.require('os');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const AlertManager = goog.require('os.alert.AlertManager');
+const ImportProcess = goog.require('os.im.ImportProcess');
+const Module = goog.require('os.ui.Module');
+const WindowEventType = goog.require('os.ui.WindowEventType');
+const FileImportCtrl = goog.require('os.ui.file.FileImportCtrl');
+const ImportEvent = goog.require('os.ui.im.ImportEvent');
+const ImportEventType = goog.require('os.ui.im.ImportEventType');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const ZIPParser = goog.require('plugin.file.zip.ZIPParser');
+
+const OSFile = goog.requireType('os.file.File');
+const IImportUI = goog.requireType('os.ui.im.IImportUI');
+const ZIPParserConfig = goog.requireType('plugin.file.zip.ZIPParserConfig');
 
 
 /**
  * @typedef {{
- *   file: os.file.File,
- *   ui: os.ui.im.IImportUI
+ *   file: OSFile,
+ *   ui: IImportUI
  * }}
  */
-plugin.file.zip.ImporterPair;
+let ImporterPair;
 
 
 /**
@@ -30,314 +32,318 @@ plugin.file.zip.ImporterPair;
  *
  * @return {angular.Directive}
  */
-plugin.file.zip.ui.zipImportDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    templateUrl: os.ROOT + 'views/plugin/zip/zipimport.html',
-    controller: plugin.file.zip.ui.ZIPImportCtrl,
-    controllerAs: 'ctrl'
-  };
-};
-os.ui.Module.directive('zipimport', [plugin.file.zip.ui.zipImportDirective]);
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  templateUrl: ROOT + 'views/plugin/zip/zipimport.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'zipimport';
+
+Module.directive('zipimport', [directive]);
 
 
 /**
  * Controller for the ZIP import dialog
- *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout
- * @param {!Object.<string, string>} $attrs
- * @extends {os.ui.file.FileImportCtrl}
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.file.zip.ui.ZIPImportCtrl = function($scope, $element, $timeout, $attrs) {
-  plugin.file.zip.ui.ZIPImportCtrl.base(this, 'constructor', $scope, $element, $timeout);
-
+class Controller extends FileImportCtrl {
   /**
-   * @type {angular.$timeout|null}
-   * @private
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @param {!angular.$timeout} $timeout
+   * @param {!Object.<string, string>} $attrs
+   * @ngInject
    */
-  this.timeout__ = $timeout;
+  constructor($scope, $element, $timeout, $attrs) {
+    super($scope, $element, $timeout);
 
-  /**
-   * @type {os.ui.im.ImportManager}
-   * @private
-   */
-  this.im_ = os.ui.im.ImportManager.getInstance();
+    /**
+     * @type {angular.$timeout|null}
+     * @private
+     */
+    this.timeout__ = $timeout;
 
-  /**
-   * @type {!Array<plugin.file.zip.ImporterPair>|null}
-   * @private
-   */
-  this.importers_;
+    /**
+     * @type {ImportManager}
+     * @private
+     */
+    this.im_ = ImportManager.getInstance();
 
-  /**
-   * Group of objects related to each step in the chain of importers
-   *
-   * @type {plugin.file.zip.ImporterPair|null}
-   * @private
-   */
-  this.curImporter_ = null;
+    /**
+     * @type {!Array<ImporterPair>|null}
+     * @private
+     */
+    this.importers_;
 
-  /**
-   * Group of objects related to each step in the chain of importers
-   *
-   * @type {function()|null}
-   * @private
-   */
-  this.curListener_ = null;
+    /**
+     * Group of objects related to each step in the chain of importers
+     *
+     * @type {ImporterPair|null}
+     * @private
+     */
+    this.curImporter_ = null;
 
-  /**
-   * Group of objects related to each step in the chain of importers
-   *
-   * @type {angular.$q.Promise|null}
-   * @private
-   */
-  this.curTimeout_ = null;
+    /**
+     * Group of objects related to each step in the chain of importers
+     *
+     * @type {function()|null}
+     * @private
+     */
+    this.curListener_ = null;
 
-  /**
-   * @type {plugin.file.zip.ZIPParserConfig}
-   * @private
-   */
-  this.config_ = /** @type {plugin.file.zip.ZIPParserConfig} */ ($scope['config']);
+    /**
+     * Group of objects related to each step in the chain of importers
+     *
+     * @type {angular.$q.Promise|null}
+     * @private
+     */
+    this.curTimeout_ = null;
 
-  /**
-   * @type {number}
-   * @private
-   */
-  this.wait_ = 0;
+    /**
+     * @type {ZIPParserConfig}
+     * @private
+     */
+    this.config_ = /** @type {ZIPParserConfig} */ ($scope['config']);
 
-  /**
-   * @type {Array.<osx.import.FileWrapper>|null}
-   */
-  this['files'] = this.config_['files'];
+    /**
+     * @type {number}
+     * @private
+     */
+    this.wait_ = 0;
 
-  /**
-   * @type {boolean}
-   */
-  this['loading'] = false;
+    /**
+     * @type {Array.<osx.import.FileWrapper>|null}
+     */
+    this['files'] = this.config_['files'];
 
-  /**
-   * @type {boolean}
-   */
-  this['valid'] = false;
+    /**
+     * @type {boolean}
+     */
+    this['loading'] = false;
 
-  this.init_();
-};
-goog.inherits(plugin.file.zip.ui.ZIPImportCtrl, os.ui.file.FileImportCtrl);
+    /**
+     * @type {boolean}
+     */
+    this['valid'] = false;
 
-
-/**
- * @export
- */
-plugin.file.zip.ui.ZIPImportCtrl.prototype.finish = function() {
-  var entries = this['files'];
-
-  if (!entries) {
-    var msg = 'No files selected to import from ZIP';
-    os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.WARNING);
-    return;
+    this.init_();
   }
 
-  this.importers_ = [];
-  var unsupported = {};
+  /**
+   * @export
+   */
+  finish() {
+    var entries = this['files'];
 
-  for (var i = 0; i < entries.length; i++) {
-    var entry = entries[i];
-    if (entry.enabled === true) {
-      var file = entry.file;
-      var type = file.getType();
-      var ui = this.im_.getImportUI(type);
-      if (ui) {
-        var importer = /** @type plugin.file.zip.ImporterPair */ ({file, ui});
-        this.importers_.push(importer);
-      } else unsupported[type] = true; // store the filetype to report to user later
+    if (!entries) {
+      var msg = 'No files selected to import from ZIP';
+      AlertManager.getInstance().sendAlert(msg, AlertEventSeverity.WARNING);
+      return;
+    }
+
+    this.importers_ = [];
+    var unsupported = {};
+
+    for (var i = 0; i < entries.length; i++) {
+      var entry = entries[i];
+      if (entry.enabled === true) {
+        var file = entry.file;
+        var type = file.getType();
+        var ui = this.im_.getImportUI(type);
+        if (ui) {
+          var importer = /** @type ImporterPair */ ({file, ui});
+          this.importers_.push(importer);
+        } else unsupported[type] = true; // store the filetype to report to user later
+      }
+    }
+
+    var keys = Object.keys(unsupported);
+
+    if (keys && keys.length > 0) {
+      var err = 'Unsupported filetype(s).<br />' + keys.join(', ');
+      AlertManager.getInstance().sendAlert(err, AlertEventSeverity.ERROR);
+    }
+
+    // either close after the chain completes, or close since there is no chain
+    if (this.importers_ && this.importers_.length > 0) this.chain();
+    else this.close(); // for now, close this and rely on the chain; possible future improvement: use slickgrid and show import status
+  }
+
+  /**
+   * Kick off the import of an unzipped file
+   */
+  chain() {
+    if (typeof this.importers_ == 'undefined' || this.importers_ == null || this.importers_.length == 0) {
+      if (this.curListener_) this.curListener_(); // kill the listener that was created by the previous chain()
+      this.close();
+      return;
+    }
+
+    var onSuccess = function() {
+      // file successfully read and importer kicked off... so one of two things happened:
+      // 1. asycnhronous window process kicked off...
+      // 2. assume the importer just did some processing then finished; so chain()
+      this.curListener_ = this.scope_.$root.$on(WindowEventType.OPEN, this.onWindowOpen_.bind(this));
+
+      var wait = 1350;
+      this.curTimeout_ = this.timeout__(this.onWindowTimeout_.bind(this), wait);
+    };
+
+    var onFailure = function() {
+      this.chain(); // continue
+    };
+
+    this.curImporter_ = this.importers_.splice(0, 1)[0]; // remove the current importer from the queue
+
+    // Currently, the duplicate dialog is created by setEvent(), so the deferred is not called when
+    // that dialog is canceled.  So for now, use ImportProcess instead of DuplicateImportProcess here
+    var process = new ImportProcess();
+    process.setSkipDuplicates(true);
+    process.setEvent(new ImportEvent(ImportEventType.FILE, this.curImporter_['file']));
+
+    var deferred = process.begin();
+    deferred.then(onSuccess, onFailure, this); // called back when import process starts or fails...
+  }
+
+  /**
+   * Checks to see if the window created is an ImporterUI with the expected file
+   *
+   * @param {angular.Scope.Event} event
+   * @return {boolean}
+   */
+  windowMatches(event) {
+    var filename = (this.curImporter_.file) ? this.curImporter_.file.getFileName() : '';
+    var config = (event && event.targetScope) ? event.targetScope.config : null;
+
+    return (config &&
+      config.file &&
+      config.file.getFileName() == filename);
+  }
+
+  /**
+   * Handles the generic listener for any window events
+   *
+   * @param {angular.Scope.Event} event
+   */
+  onWindowOpen_(event) {
+    // if the window scope has the expected file, then listen to that scope for window CLOSE
+    if (this.windowMatches(event)) {
+      if (this.curTimeout_) this.timeout__.cancel(this.curTimeout_); // kill the timeout
+      if (this.curListener_) this.curListener_(); // kill the listener that was created by the previous chain()
+
+      // because this is listening to the event.targetScope, this is definitely the window with
+      // the expected file, so simply chain
+      this.curListener_ = event.targetScope.$on(WindowEventType.CLOSE, this.chain.bind(this));
     }
   }
 
-  var keys = Object.keys(unsupported);
-
-  if (keys && keys.length > 0) {
-    var err = 'Unsupported filetype(s).<br />' + keys.join(', ');
-    os.alert.AlertManager.getInstance().sendAlert(err, os.alert.AlertEventSeverity.ERROR);
-  }
-
-  // either close after the chain completes, or close since there is no chain
-  if (this.importers_ && this.importers_.length > 0) this.chain();
-  else this.close(); // for now, close this and rely on the chain; possible future improvement: use slickgrid and show import status
-};
-
-
-/**
- * Kick off the import of an unzipped file
- */
-plugin.file.zip.ui.ZIPImportCtrl.prototype.chain = function() {
-  if (typeof this.importers_ == 'undefined' || this.importers_ == null || this.importers_.length == 0) {
-    if (this.curListener_) this.curListener_(); // kill the listener that was created by the previous chain()
-    this.close();
-    return;
-  }
-
-  var onSuccess = function() {
-    // file successfully read and importer kicked off... so one of two things happened:
-    // 1. asycnhronous window process kicked off...
-    // 2. assume the importer just did some processing then finished; so chain()
-    this.curListener_ = this.scope_.$root.$on(os.ui.WindowEventType.OPEN, this.onWindowOpen_.bind(this));
-
-    var wait = 1350;
-    this.curTimeout_ = this.timeout__(this.onWindowTimeout_.bind(this), wait);
-  };
-
-  var onFailure = function() {
-    this.chain(); // continue
-  };
-
-  this.curImporter_ = this.importers_.splice(0, 1)[0]; // remove the current importer from the queue
-
-  // Currently, the duplicate dialog is created by setEvent(), so the deferred is not called when
-  // that dialog is canceled.  So for now, use ImportProcess instead of DuplicateImportProcess here
-  var process = new os.im.ImportProcess();
-  process.setSkipDuplicates(true);
-  process.setEvent(new os.ui.im.ImportEvent(os.ui.im.ImportEventType.FILE, this.curImporter_['file']));
-
-  var deferred = process.begin();
-  deferred.then(onSuccess, onFailure, this); // called back when import process starts or fails...
-};
-
-
-/**
- * Checks to see if the window created is an ImporterUI with the expected file
- *
- * @param {angular.Scope.Event} event
- * @return {boolean}
- */
-plugin.file.zip.ui.ZIPImportCtrl.prototype.windowMatches = function(event) {
-  var filename = (this.curImporter_.file) ? this.curImporter_.file.getFileName() : '';
-  var config = (event && event.targetScope) ? event.targetScope.config : null;
-
-  return (config &&
-    config.file &&
-    config.file.getFileName() == filename);
-};
-
-
-/**
- * Handles the generic listener for any window events
- *
- * @param {angular.Scope.Event} event
- */
-plugin.file.zip.ui.ZIPImportCtrl.prototype.onWindowOpen_ = function(event) {
-  // if the window scope has the expected file, then listen to that scope for window CLOSE
-  if (this.windowMatches(event)) {
-    if (this.curTimeout_) this.timeout__.cancel(this.curTimeout_); // kill the timeout
+  /**
+   * Handles calling he next chain() when an Importer is a background run (doesn't create a window)
+   */
+  onWindowTimeout_() {
     if (this.curListener_) this.curListener_(); // kill the listener that was created by the previous chain()
 
-    // because this is listening to the event.targetScope, this is definitely the window with
-    // the expected file, so simply chain
-    this.curListener_ = event.targetScope.$on(os.ui.WindowEventType.CLOSE, this.chain.bind(this));
+    // assume that the importer ran a background process that succeeded or failed without user input
+    this.chain();
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  onDestroy() {
+    super.onDestroy();
 
-/**
- * Handles calling he next chain() when an Importer is a background run (doesn't create a window)
- */
-plugin.file.zip.ui.ZIPImportCtrl.prototype.onWindowTimeout_ = function() {
-  if (this.curListener_) this.curListener_(); // kill the listener that was created by the previous chain()
+    this.timeout__ = null;
+    this.config_ = null;
+    this.importers_ = null;
+    this.curImporter_ = null;
+    this.curListener_ = null;
+    this.curTimeout_ = null;
+    this.files = null;
+    this.loading = null;
+    this.valid = null;
+    this.wait_ = 0;
+  }
 
-  // assume that the importer ran a background process that succeeded or failed without user input
-  this.chain();
-};
+  /**
+   * Starts the unzip process...
+   *
+   * @private
+   */
+  init_() {
+    // wait for the unzip to finish, or timeout
+    this.validate_();
 
-/**
- * @inheritDoc
- */
-plugin.file.zip.ui.ZIPImportCtrl.prototype.onDestroy = function() {
-  plugin.file.zip.ui.ZIPImportCtrl.base(this, 'onDestroy');
+    this.parser_ = new ZIPParser(this.config_);
+    this.parser_.unzip();
+  }
 
-  this.timeout__ = null;
-  this.config_ = null;
-  this.importers_ = null;
-  this.curImporter_ = null;
-  this.curListener_ = null;
-  this.curTimeout_ = null;
-  this.files = null;
-  this.loading = null;
-  this.valid = null;
-  this.wait_ = 0;
-};
+  /**
+   * @param {string=} msg
+   * @private
+   */
+  onError_(msg) {
+    this['loading'] = false;
+    this['valid'] = false;
 
+    this.config_.cleanup(); // clean up the config
+    this.parser_.dispose(); // clean up the unzipper
 
-/**
- * Starts the unzip process...
- *
- * @private
- */
-plugin.file.zip.ui.ZIPImportCtrl.prototype.init_ = function() {
-  // wait for the unzip to finish, or timeout
-  this.validate_();
+    if (msg) AlertManager.getInstance().sendAlert(msg, AlertEventSeverity.ERROR);
+  }
 
-  this.parser_ = new plugin.file.zip.ZIPParser(this.config_);
-  this.parser_.unzip();
-};
+  /**
+   * Checks if files have been chosen/validated.
+   *
+   * @private
+   */
+  validate_() {
+    var wait = 750;
+    var maxWait = 30 * wait; // 22.5 seconds
 
+    if (!this.config_) return;
 
-/**
- * @param {string=} msg
- * @private
- */
-plugin.file.zip.ui.ZIPImportCtrl.prototype.onError_ = function(msg) {
-  this['loading'] = false;
-  this['valid'] = false;
+    var status = this.config_['status'];
+    var loading = (status == -1 || status == 1); // initializing or parsing
 
-  this.config_.cleanup(); // clean up the config
-  this.parser_.dispose(); // clean up the unzipper
+    this['loading'] = loading;
+    this['valid'] = !loading;
 
-  if (msg) os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.ERROR);
-};
-
-
-/**
- * Checks if files have been chosen/validated.
- *
- * @private
- */
-plugin.file.zip.ui.ZIPImportCtrl.prototype.validate_ = function() {
-  var wait = 750;
-  var maxWait = 30 * wait; // 22.5 seconds
-
-  if (!this.config_) return;
-
-  var status = this.config_['status'];
-  var loading = (status == -1 || status == 1); // initializing or parsing
-
-  this['loading'] = loading;
-  this['valid'] = !loading;
-
-  if (loading) {
-    if (this.wait_ < maxWait) this.timeout__(this.validate_.bind(this), wait);
-    else {
-      this.onError_('Unzipping file took too long in browser.  Try unzipping locally first.');
+    if (loading) {
+      if (this.wait_ < maxWait) this.timeout__(this.validate_.bind(this), wait);
+      else {
+        this.onError_('Unzipping file took too long in browser.  Try unzipping locally first.');
+      }
+      this.wait_ += wait;
+    } else if (status == -2) {
+      this.onError_('Failed to unzip file in browser.  Try unzipping it locally first.');
     }
-    this.wait_ += wait;
-  } else if (status == -2) {
-    this.onError_('Failed to unzip file in browser.  Try unzipping it locally first.');
   }
-};
 
+  /**
+   * Returns a count of the number of "selected" files for the UI
+   * @return {number}
+   */
+  count() {
+    return (this['files']) ?
+      this['files'].reduce(
+          (count, file) => file.enabled ? count + 1 : count,
+          0 // this optional reduce() param initializes the accumulator
+      ) :
+      0;
+  }
+}
 
-/**
- * Returns a count of the number of "selected" files for the UI
- * @return {number}
- */
-plugin.file.zip.ui.ZIPImportCtrl.prototype.count = function() {
-  return (this['files']) ?
-    this['files'].reduce(
-        (count, file) => file.enabled ? count + 1 : count,
-        0 // this optional reduce() param initializes the accumulator
-    ) :
-    0;
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/file/zip/ui/zipimportui.js
+++ b/src/plugin/file/zip/ui/zipimportui.js
@@ -1,64 +1,69 @@
-goog.provide('plugin.file.zip.ui.ZIPImportUI');
+goog.module('plugin.file.zip.ui.ZIPImportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.ui.im.FileImportUI');
-goog.require('os.ui.window');
-goog.require('plugin.file.zip.ZIPParserConfig');
-goog.require('plugin.file.zip.ui.zipImportDirective');
-
-
-/**
- * @extends {os.ui.im.FileImportUI.<plugin.file.zip.ZIPParserConfig>}
- * @constructor
- */
-plugin.file.zip.ui.ZIPImportUI = function() {
-  plugin.file.zip.ui.ZIPImportUI.base(this, 'constructor');
-
-  // file contents are only used in memory, not loaded from storage
-  this.requiresStorage = false;
-};
-goog.inherits(plugin.file.zip.ui.ZIPImportUI, os.ui.im.FileImportUI);
+const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const osWindow = goog.require('os.ui.window');
+const windowSelector = goog.require('os.ui.windowSelector');
+const ZIPParserConfig = goog.require('plugin.file.zip.ZIPParserConfig');
+const {directiveTag: zipImportUi} = goog.require('plugin.file.zip.ui.ZIPImport');
 
 
 /**
- * @inheritDoc
+ * @extends {FileImportUI.<ZIPParserConfig>}
  */
-plugin.file.zip.ui.ZIPImportUI.prototype.getTitle = function() {
-  return 'ZIP';
-};
+class ZIPImportUI extends FileImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
 
-
-/**
- * @inheritDoc
- */
-plugin.file.zip.ui.ZIPImportUI.prototype.launchUI = function(file, opt_config) {
-  plugin.file.zip.ui.ZIPImportUI.base(this, 'launchUI', file, opt_config);
-
-  var config = new plugin.file.zip.ZIPParserConfig();
-
-  // if a configuration was provided, merge it in
-  if (opt_config) {
-    this.mergeConfig(opt_config, config);
+    // file contents are only used in memory, not loaded from storage
+    this.requiresStorage = false;
   }
 
-  config['file'] = file; // set the file
+  /**
+   * @inheritDoc
+   */
+  getTitle() {
+    return 'ZIP';
+  }
 
-  var scopeOptions = {
-    'config': config
-  };
-  var windowOptions = {
-    'label': 'ZIP Import',
-    'icon': 'fa fa-sign-in',
-    'x': 'center',
-    'y': 'center',
-    'width': '650',
-    'min-width': '500',
-    'max-width': '1200',
-    'height': '360',
-    'min-height': '300',
-    'max-height': '1000',
-    'modal': 'true',
-    'show-close': 'true'
-  };
-  var template = '<zipimport resize-with="' + os.ui.windowSelector.WINDOW + '"></zipimport>';
-  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
-};
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    super.launchUI(file, opt_config);
+
+    var config = new ZIPParserConfig();
+
+    // if a configuration was provided, merge it in
+    if (opt_config) {
+      this.mergeConfig(opt_config, config);
+    }
+
+    config['file'] = file; // set the file
+
+    var scopeOptions = {
+      'config': config
+    };
+    var windowOptions = {
+      'label': 'ZIP Import',
+      'icon': 'fa fa-sign-in',
+      'x': 'center',
+      'y': 'center',
+      'width': '650',
+      'min-width': '500',
+      'max-width': '1200',
+      'height': '360',
+      'min-height': '300',
+      'max-height': '1000',
+      'modal': 'true',
+      'show-close': 'true'
+    };
+    var template = `<${zipImportUi} resize-with="${windowSelector.WINDOW}"></${zipImportUi}>`;
+    osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+  }
+}
+
+exports = ZIPImportUI;

--- a/src/plugin/file/zip/zipparserconfig.js
+++ b/src/plugin/file/zip/zipparserconfig.js
@@ -1,40 +1,41 @@
-goog.provide('plugin.file.zip.ZIPParserConfig');
+goog.module('plugin.file.zip.ZIPParserConfig');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.parse.FileParserConfig');
-goog.require('os.ui.slick.column');
-goog.require('plugin.file.zip.ZIPParser');
-
+const FileParserConfig = goog.require('os.parse.FileParserConfig');
 
 
 /**
  * Configuration for a ZIP parser.
- *
- * @extends {os.parse.FileParserConfig}
- * @constructor
+ * @unrestricted
  */
-plugin.file.zip.ZIPParserConfig = function() {
-  plugin.file.zip.ZIPParserConfig.base(this, 'constructor');
+class ZIPParserConfig extends FileParserConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    /**
+     * @type {number}
+     */
+    this['status'] = -1;
+
+    /**
+     * The destination where ZIPParser drops the unzipped files
+     * @type {Array.<osx.import.FileWrapper>}
+     */
+    this['files'] = [];
+  }
 
   /**
-   * @type {number}
+   * Helper function to clean up memory if the parser is taking too long, user cancels/abandons the thread, etc
+   * @public
    */
-  this['status'] = -1;
+  cleanup() {
+    this['file'] = null;
+    if (this['files'].length > 0) this['files'] = [];
+    this['status'] = -1; // uninitialized state
+  }
+}
 
-  /**
-   * The destination where ZIPParser drops the unzipped files
-   * @type {Array.<osx.import.FileWrapper>}
-   */
-  this['files'] = [];
-};
-goog.inherits(plugin.file.zip.ZIPParserConfig, os.parse.FileParserConfig);
-
-
-/**
- * Helper function to clean up memory if the parser is taking too long, user cancels/abandons the thread, etc
- * @public
- */
-plugin.file.zip.ZIPParserConfig.prototype.cleanup = function() {
-  this['file'] = null;
-  if (this['files'].length > 0) this['files'] = [];
-  this['status'] = -1; // uninitialized state
-};
+exports = ZIPParserConfig;

--- a/src/plugin/file/zip/zipplugin.js
+++ b/src/plugin/file/zip/zipplugin.js
@@ -1,51 +1,42 @@
-goog.provide('plugin.file.zip.ZIPPlugin');
+goog.module('plugin.file.zip.ZIPPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.DataManager');
-goog.require('os.data.ProviderEntry');
-goog.require('os.file.mime.zip');
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.ui.im.ImportManager');
-goog.require('plugin.file.zip.ZIPParser');
-goog.require('plugin.file.zip.ui.ZIPImportUI');
-
+const zip = goog.require('os.file.mime.zip');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const ZIPParser = goog.require('plugin.file.zip.ZIPParser');
+const ZIPImportUI = goog.require('plugin.file.zip.ui.ZIPImportUI');
 
 
 /**
  * Provides ZIP support
- *
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.file.zip.ZIPPlugin = function() {
-  plugin.file.zip.ZIPPlugin.base(this, 'constructor');
-  this.id = plugin.file.zip.ZIPPlugin.ID;
-};
+class ZIPPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = ID;
+  }
 
-
-goog.inherits(plugin.file.zip.ZIPPlugin, os.plugin.AbstractPlugin);
+  /**
+   * @inheritDoc
+   */
+  init() {
+    // register the zip import ui
+    var im = ImportManager.getInstance();
+    im.registerImportDetails('ZIP file (*.ZIP)', true);
+    im.registerImportUI(zip.TYPE, new ZIPImportUI());
+    im.registerParser(this.id, ZIPParser);
+  }
+}
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.file.zip.ZIPPlugin.ID = 'zip';
+const ID = 'zip';
 
 
-/**
- * @type {string}
- * @const
- */
-plugin.file.zip.ZIPPlugin.TYPE = 'ZIP Layers';
-
-
-/**
- * @inheritDoc
- */
-plugin.file.zip.ZIPPlugin.prototype.init = function() {
-  // register the zip import ui
-  var im = os.ui.im.ImportManager.getInstance();
-  im.registerImportDetails('ZIP file (*.ZIP)', true);
-  im.registerImportUI(os.file.mime.zip.TYPE, new plugin.file.zip.ui.ZIPImportUI());
-  im.registerParser(this.id, plugin.file.zip.ZIPParser);
-};
+exports = ZIPPlugin;

--- a/src/plugin/places/places.js
+++ b/src/plugin/places/places.js
@@ -12,6 +12,7 @@ goog.require('os.time.TimeRange');
 goog.require('plugin.file.kml.KMLField');
 goog.require('plugin.file.kml.KMLTreeExporter');
 goog.require('plugin.file.kml.cmd.KMLNodeAdd');
+goog.require('plugin.file.kml.ui');
 
 
 /**

--- a/src/plugin/places/placeslayer.js
+++ b/src/plugin/places/placeslayer.js
@@ -1,20 +1,24 @@
-goog.provide('plugin.places.PlacesLayer');
+goog.module('plugin.places.PlacesLayer');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.fn');
-goog.require('plugin.file.kml.KMLLayer');
-
+const fn = goog.require('os.fn');
+const KMLLayer = goog.require('plugin.file.kml.KMLLayer');
 
 
 /**
  * KML Layer for organizing Places.
- * @param {olx.layer.VectorOptions} options Vector layer options
- * @extends {plugin.file.kml.KMLLayer}
- * @constructor
  */
-plugin.places.PlacesLayer = function(options) {
-  plugin.places.PlacesLayer.base(this, 'constructor', options);
+class PlacesLayer extends KMLLayer {
+  /**
+   * Constructor.
+   * @param {olx.layer.VectorOptions} options Vector layer options
+   */
+  constructor(options) {
+    super(options);
 
-  // TODO add specialized legend rendering for Places
-  this.renderLegend = os.fn.noop;
-};
-goog.inherits(plugin.places.PlacesLayer, plugin.file.kml.KMLLayer);
+    // TODO add specialized legend rendering for Places
+    this.renderLegend = fn.noop;
+  }
+}
+
+exports = PlacesLayer;

--- a/src/plugin/places/placeslayerconfig.js
+++ b/src/plugin/places/placeslayerconfig.js
@@ -1,20 +1,38 @@
-goog.provide('plugin.places.PlacesLayerConfig');
+goog.module('plugin.places.PlacesLayerConfig');
+goog.module.declareLegacyNamespace();
 
-goog.require('plugin.file.kml.KMLLayerConfig');
-goog.require('plugin.places.PlacesLayer');
-goog.require('plugin.places.PlacesSource');
-
+const KMLLayerConfig = goog.require('plugin.file.kml.KMLLayerConfig');
+const PlacesLayer = goog.require('plugin.places.PlacesLayer');
+const PlacesSource = goog.require('plugin.places.PlacesSource');
 
 
 /**
  * Creates a KML layer for organizing Places.
- * @extends {plugin.file.kml.KMLLayerConfig}
- * @constructor
  */
-plugin.places.PlacesLayerConfig = function() {
-  plugin.places.PlacesLayerConfig.base(this, 'constructor');
-};
-goog.inherits(plugin.places.PlacesLayerConfig, plugin.file.kml.KMLLayerConfig);
+class PlacesLayerConfig extends KMLLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLayer(source) {
+    return new PlacesLayer({
+      source: source
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getSource(options) {
+    return new PlacesSource(undefined);
+  }
+}
 
 
 /**
@@ -22,22 +40,7 @@ goog.inherits(plugin.places.PlacesLayerConfig, plugin.file.kml.KMLLayerConfig);
  * @type {string}
  * @const
  */
-plugin.places.PlacesLayerConfig.ID = 'places';
+PlacesLayerConfig.ID = 'places';
 
 
-/**
- * @inheritDoc
- */
-plugin.places.PlacesLayerConfig.prototype.getLayer = function(source) {
-  return new plugin.places.PlacesLayer({
-    source: source
-  });
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.places.PlacesLayerConfig.prototype.getSource = function(options) {
-  return new plugin.places.PlacesSource(undefined);
-};
+exports = PlacesLayerConfig;

--- a/src/plugin/places/placesmenu.js
+++ b/src/plugin/places/placesmenu.js
@@ -12,6 +12,8 @@ goog.require('os.ui.menu.map');
 goog.require('os.ui.menu.spatial');
 goog.require('plugin.file.kml.cmd.KMLNodeAdd');
 goog.require('plugin.file.kml.cmd.KMLNodeRemove');
+goog.require('plugin.file.kml.ui');
+goog.require('plugin.file.kml.ui.KMLTreeExportUI');
 goog.require('plugin.places');
 goog.require('plugin.places.ui.savePlacesDirective');
 
@@ -536,7 +538,7 @@ plugin.places.menu.onLayerEvent_ = function(event) {
             }));
             break;
           case plugin.places.menu.EventType.EXPORT:
-            plugin.file.kml.ui.launchTreeExport(node, 'Export Places');
+            plugin.file.kml.ui.KMLTreeExportUI.launchTreeExport(node, 'Export Places');
             break;
           case plugin.places.menu.EventType.REMOVE_PLACE:
             var cmd = new plugin.file.kml.cmd.KMLNodeRemove(node);
@@ -564,7 +566,7 @@ plugin.places.menu.onLayerEvent_ = function(event) {
             plugin.places.ui.QuickAddPlacesCtrl.launch();
             break;
           case plugin.places.menu.EventType.EXPORT:
-            plugin.file.kml.ui.launchTreeExport(/** @type {!plugin.file.kml.ui.KMLNode} */
+            plugin.file.kml.ui.KMLTreeExportUI.launchTreeExport(/** @type {!plugin.file.kml.ui.KMLNode} */
                 (rootNode), 'Export Places');
             break;
           case plugin.places.menu.EventType.REMOVE_ALL:

--- a/src/plugin/places/placessource.js
+++ b/src/plugin/places/placessource.js
@@ -1,95 +1,92 @@
-goog.provide('plugin.places.PlacesSource');
+goog.module('plugin.places.PlacesSource');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.feature');
-goog.require('os.geom.GeometryField');
-goog.require('os.interpolate');
-goog.require('os.track');
-goog.require('plugin.file.kml.KMLSource');
-goog.require('plugin.file.kml.ui.KMLNode');
-
+const osFeature = goog.require('os.feature');
+const interpolate = goog.require('os.interpolate');
+const track = goog.require('os.track');
+const KMLSource = goog.require('plugin.file.kml.KMLSource');
+const {updatePlacemark} = goog.require('plugin.file.kml.ui');
 
 
 /**
  * Vector source to manage places created in the application. Also adds specialized handling for tracks.
- * @param {olx.source.VectorOptions=} opt_options OpenLayers vector source options.
- * @extends {plugin.file.kml.KMLSource}
- * @constructor
  */
-plugin.places.PlacesSource = function(opt_options) {
-  plugin.places.PlacesSource.base(this, 'constructor', opt_options);
+class PlacesSource extends KMLSource {
+  /**
+   * Constructor.
+   * @param {olx.source.VectorOptions=} opt_options OpenLayers vector source options.
+   */
+  constructor(opt_options) {
+    super(opt_options);
 
-  // don't allow refreshing the places layer - it won't do anything useful
-  this.refreshEnabled = false;
-};
-goog.inherits(plugin.places.PlacesSource, plugin.file.kml.KMLSource);
-
-
-/**
- * @inheritDoc
- */
-plugin.places.PlacesSource.prototype.supportsModify = function() {
-  return true;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.places.PlacesSource.prototype.getModifyFunction = function() {
-  return (originalFeature, modifiedFeature) => {
-    const node = this.getFeatureNode(originalFeature);
-
-    if (node) {
-      originalFeature.setGeometry(modifiedFeature.getGeometry());
-      originalFeature.unset(os.interpolate.ORIGINAL_GEOM_FIELD, true);
-      os.interpolate.interpolateFeature(originalFeature);
-
-      const options = {
-        'node': node,
-        'feature': originalFeature
-      };
-
-      plugin.file.kml.ui.updatePlacemark(options);
-      os.feature.createEllipse(originalFeature, true);
-      this.notifyDataChange();
-    }
-  };
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.places.PlacesSource.prototype.getFilteredFeatures = function(opt_allTime) {
-  // the most recent track position is always displayed, so force all time for track layers
-  return plugin.places.PlacesSource.base(this, 'getFilteredFeatures', true);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.places.PlacesSource.prototype.processDeferred = function(features) {
-  plugin.places.PlacesSource.base(this, 'processDeferred', features);
-  this.updateTrackZIndex();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.places.PlacesSource.prototype.updateVisibilityFromNodes = function() {
-  plugin.places.PlacesSource.base(this, 'updateVisibilityFromNodes');
-  this.updateTrackZIndex();
-};
-
-
-/**
- * Updates the z-index of all tracks in the layer.
- * @protected
- */
-plugin.places.PlacesSource.prototype.updateTrackZIndex = function() {
-  if (this.rootNode) {
-    os.track.updateTrackZIndex(this.rootNode.getFeatures(false));
+    // don't allow refreshing the places layer - it won't do anything useful
+    this.refreshEnabled = false;
   }
-};
+
+  /**
+   * @inheritDoc
+   */
+  supportsModify() {
+    return true;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getModifyFunction() {
+    return (originalFeature, modifiedFeature) => {
+      const node = this.getFeatureNode(originalFeature);
+
+      if (node) {
+        originalFeature.setGeometry(modifiedFeature.getGeometry());
+        originalFeature.unset(interpolate.ORIGINAL_GEOM_FIELD, true);
+        interpolate.interpolateFeature(originalFeature);
+
+        const options = {
+          'node': node,
+          'feature': originalFeature
+        };
+
+        updatePlacemark(options);
+        osFeature.createEllipse(originalFeature, true);
+        this.notifyDataChange();
+      }
+    };
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getFilteredFeatures(opt_allTime) {
+    // the most recent track position is always displayed, so force all time for track layers
+    return super.getFilteredFeatures(true);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  processDeferred(features) {
+    super.processDeferred(features);
+    this.updateTrackZIndex();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  updateVisibilityFromNodes() {
+    super.updateVisibilityFromNodes();
+    this.updateTrackZIndex();
+  }
+
+  /**
+   * Updates the z-index of all tracks in the layer.
+   * @protected
+   */
+  updateTrackZIndex() {
+    if (this.rootNode) {
+      track.updateTrackZIndex(this.rootNode.getFeatures(false));
+    }
+  }
+}
+
+exports = PlacesSource;

--- a/src/plugin/places/ui/placesnodeui.js
+++ b/src/plugin/places/ui/placesnodeui.js
@@ -4,6 +4,7 @@ goog.provide('plugin.places.ui.placesNodeUIDirective');
 goog.require('goog.events.EventType');
 goog.require('os.ui.Module');
 goog.require('os.ui.node.DefaultLayerNodeUICtrl');
+goog.require('plugin.file.kml.ui');
 goog.require('plugin.places');
 
 

--- a/src/plugin/places/ui/placesui.js
+++ b/src/plugin/places/ui/placesui.js
@@ -11,7 +11,8 @@ goog.require('os.ui.menu.layer');
 goog.require('os.ui.uiSwitchDirective');
 goog.require('plugin.file.kml.ui');
 goog.require('plugin.file.kml.ui.KMLNode');
-goog.require('plugin.file.kml.ui.placemarkEditDirective');
+goog.require('plugin.file.kml.ui.KMLTreeExportUI');
+goog.require('plugin.file.kml.ui.PlacemarkEditUI');
 goog.require('plugin.places.ui.QuickAddPlacesCtrl');
 goog.require('plugin.places.ui.placesButtonDirective');
 
@@ -151,7 +152,7 @@ plugin.places.ui.PlacesCtrl.prototype.export = function() {
       fields: []
     });
 
-    plugin.file.kml.ui.launchTreeExport(this.placesRoot_, 'Export Places', options);
+    plugin.file.kml.ui.KMLTreeExportUI.launchTreeExport(this.placesRoot_, 'Export Places', options);
     os.metrics.Metrics.getInstance().updateMetric(os.metrics.Places.EXPORT, 1);
   } else {
     os.alertManager.sendAlert('Nothing to export.', os.alert.AlertEventSeverity.WARNING);

--- a/src/plugin/track/track.js
+++ b/src/plugin/track/track.js
@@ -456,7 +456,7 @@ let createAndAdd_ = function(options) {
   });
 
   var rootNode = PlacesManager.getInstance().getPlacesRoot();
-  if (rootNode) {
+  if (rootNode && trackNode) {
     var cmd = new KMLNodeAdd(trackNode, rootNode);
     cmd.title = 'Create Track';
     CommandProcessor.getInstance().addCommand(cmd);

--- a/test/plugin/file/csv/csvexporter.test.js
+++ b/test/plugin/file/csv/csvexporter.test.js
@@ -1,6 +1,8 @@
+goog.require('goog.object');
 goog.require('ol.Feature');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.Point');
+goog.require('ol.geom.Polygon');
 goog.require('os.Fields');
 goog.require('os.osasm.wait');
 goog.require('os.time.TimeInstant');
@@ -8,15 +10,24 @@ goog.require('os.time.TimeRange');
 goog.require('plugin.file.csv.CSVExporter');
 
 describe('plugin.file.csv.CSVExporter', function() {
-  var ex = new plugin.file.csv.CSVExporter();
+  const googObject = goog.module.get('goog.object');
+  const Feature = goog.module.get('ol.Feature');
+  const LineString = goog.module.get('ol.geom.LineString');
+  const Point = goog.module.get('ol.geom.Point');
+  const Polygon = goog.module.get('ol.geom.Polygon');
+  const Fields = goog.module.get('os.Fields');
+  const TimeInstant = goog.module.get('os.time.TimeInstant');
+  const TimeRange = goog.module.get('os.time.TimeRange');
+  const CSVExporter = goog.module.get('plugin.file.csv.CSVExporter');
+  var ex = new CSVExporter();
   var lineFeature;
   var pointFeature;
   var polygonFeature;
 
   beforeEach(function() {
-    lineFeature = new ol.Feature(new ol.geom.LineString([[12, 34], [56, 78]]));
-    pointFeature = new ol.Feature(new ol.geom.Point([12, 34]));
-    polygonFeature = new ol.Feature(new ol.geom.Polygon([[[1, 2], [3, 4], [5, 6], [7, 8], [1, 2]]]));
+    lineFeature = new Feature(new LineString([[12, 34], [56, 78]]));
+    pointFeature = new Feature(new Point([12, 34]));
+    polygonFeature = new Feature(new Polygon([[[1, 2], [3, 4], [5, 6], [7, 8], [1, 2]]]));
 
     ex.reset();
   });
@@ -32,8 +43,8 @@ describe('plugin.file.csv.CSVExporter', function() {
       numKey: 5
     };
 
-    ex.setFields(goog.object.getKeys(props));
-    var result = ex.processItem(new ol.Feature(props));
+    ex.setFields(googObject.getKeys(props));
+    var result = ex.processItem(new Feature(props));
 
     expect(result.strKey).toBe(props.strKey);
     expect(result.numKey).toBe(props.numKey);
@@ -42,19 +53,19 @@ describe('plugin.file.csv.CSVExporter', function() {
   it('should convert features with a point geometry to JSON', function() {
     var result = ex.processItem(pointFeature);
 
-    expect(result[os.Fields.GEOMETRY].length).not.toBe(0);
+    expect(result[Fields.GEOMETRY].length).not.toBe(0);
   });
 
   it('should convert features with a linestring geometry to JSON', function() {
     var result = ex.processItem(lineFeature);
 
-    expect(result[os.Fields.GEOMETRY].length).not.toBe(0);
+    expect(result[Fields.GEOMETRY].length).not.toBe(0);
   });
 
   it('should convert features with a polygon geometry to JSON', function() {
     var result = ex.processItem(polygonFeature);
 
-    expect(result[os.Fields.GEOMETRY].length).not.toBe(0);
+    expect(result[Fields.GEOMETRY].length).not.toBe(0);
   });
 
   it('should translate fields to JSON', function() {
@@ -69,7 +80,7 @@ describe('plugin.file.csv.CSVExporter', function() {
     };
 
     pointFeature.setProperties(props);
-    ex.setFields(goog.object.getKeys(props));
+    ex.setFields(googObject.getKeys(props));
 
     var result = ex.processItem(pointFeature);
 
@@ -91,29 +102,29 @@ describe('plugin.file.csv.CSVExporter', function() {
 
   it('should export time instants correctly', function() {
     var props = {
-      recordTime: new os.time.TimeInstant(999999)
+      recordTime: new TimeInstant(999999)
     };
 
     pointFeature.setProperties(props);
-    ex.setFields(goog.object.getKeys(props));
+    ex.setFields(googObject.getKeys(props));
 
     var result = ex.processItem(pointFeature);
 
-    expect(result[os.Fields.TIME]).toBe('1970-01-01T00:16:39Z');
+    expect(result[Fields.TIME]).toBe('1970-01-01T00:16:39Z');
   });
 
   it('should export time ranges correctly', function() {
     var props = {
-      recordTime: new os.time.TimeRange(999999, 9999999)
+      recordTime: new TimeRange(999999, 9999999)
     };
 
     pointFeature.setProperties(props);
-    ex.setFields(goog.object.getKeys(props));
+    ex.setFields(googObject.getKeys(props));
 
     var result = ex.processItem(pointFeature);
 
-    expect(result[plugin.file.csv.CSVExporter.FIELDS.START_TIME]).toBe('1970-01-01T00:16:39Z');
-    expect(result[plugin.file.csv.CSVExporter.FIELDS.END_TIME]).toBe('1970-01-01T02:46:39Z');
+    expect(result[CSVExporter.FIELDS.START_TIME]).toBe('1970-01-01T00:16:39Z');
+    expect(result[CSVExporter.FIELDS.END_TIME]).toBe('1970-01-01T02:46:39Z');
   });
 
   it('should export GEOMETRY when alwaysIncludeWkt is true', function() {
@@ -121,7 +132,7 @@ describe('plugin.file.csv.CSVExporter', function() {
 
     var result = ex.processItem(pointFeature);
 
-    expect(result[os.Fields.GEOMETRY].length).not.toBe(0);
+    expect(result[Fields.GEOMETRY].length).not.toBe(0);
   });
 
   it('should not export GEOMETRY when alwaysIncludeWkt is false', function() {
@@ -130,6 +141,6 @@ describe('plugin.file.csv.CSVExporter', function() {
 
     var result = ex.processItem(pointFeature);
 
-    expect(result[os.Fields.GEOMETRY]).toBeUndefined();
+    expect(result[Fields.GEOMETRY]).toBeUndefined();
   });
 });

--- a/test/plugin/file/geojson/geojsonparser.test.js
+++ b/test/plugin/file/geojson/geojsonparser.test.js
@@ -1,11 +1,17 @@
 goog.require('goog.net.EventType');
 goog.require('ol.format.GeoJSON');
+goog.require('os.events.EventType');
 goog.require('os.im.Importer');
 goog.require('os.mock');
 goog.require('os.net.Request');
 goog.require('plugin.file.geojson.GeoJSONParser');
 
 describe('plugin.file.geojson.GeoJSONParser', function() {
+  const googNetEventType = goog.module.get('goog.net.EventType');
+  const EventType = goog.module.get('os.events.EventType');
+  const Importer = goog.module.get('os.im.Importer');
+  const Request = goog.module.get('os.net.Request');
+  const GeoJSONParser = goog.module.get('plugin.file.geojson.GeoJSONParser');
   var gj1 = {
     'type': 'FeatureCollection',
     'features': [{
@@ -39,7 +45,7 @@ describe('plugin.file.geojson.GeoJSONParser', function() {
   };
 
   it('should handle object sources', function() {
-    var p = new plugin.file.geojson.GeoJSONParser();
+    var p = new GeoJSONParser();
     p.setSource(gj1);
 
     expect(p.features_).not.toBe(null);
@@ -47,7 +53,7 @@ describe('plugin.file.geojson.GeoJSONParser', function() {
   });
 
   it('should handle string sources', function() {
-    var p = new plugin.file.geojson.GeoJSONParser();
+    var p = new GeoJSONParser();
     p.setSource('{"type": "Feature","geometry": {"type": "Point", "coordinates": [102.0, 0.5]}, "properties": ' +
         '{"prop0": "value0"}}');
 
@@ -56,7 +62,7 @@ describe('plugin.file.geojson.GeoJSONParser', function() {
   });
 
   it('should parse an object', function() {
-    var p = new plugin.file.geojson.GeoJSONParser();
+    var p = new GeoJSONParser();
     p.setSource(gj1);
 
     var step = p.parseNext();
@@ -77,15 +83,15 @@ describe('plugin.file.geojson.GeoJSONParser', function() {
   });
 
   it('should work with an importer to parse large requests', function() {
-    var r = new os.net.Request('/base/test/plugin/file/geojson/10k.json');
-    var i = new os.im.Importer(new plugin.file.geojson.GeoJSONParser());
+    var r = new Request('/base/test/plugin/file/geojson/10k.json');
+    var i = new Importer(new GeoJSONParser());
     var count = 0;
     var listener = function(e) {
       count++;
     };
 
-    r.listen(goog.net.EventType.SUCCESS, listener);
-    i.listen(os.events.EventType.COMPLETE, listener);
+    r.listen(googNetEventType.SUCCESS, listener);
+    i.listen(EventType.COMPLETE, listener);
 
     runs(function() {
       r.load();

--- a/test/plugin/file/geojson/mime.test.js
+++ b/test/plugin/file/geojson/mime.test.js
@@ -1,24 +1,27 @@
 goog.require('os.file.File');
+goog.require('os.file.mime');
 goog.require('os.file.mime.mock');
 goog.require('plugin.file.geojson.mime');
 
 describe('os.file.mime.json', function() {
+  const osFileMime = goog.module.get('os.file.mime');
+  const mime = goog.module.get('plugin.file.geojson.mime');
   it('should not detect files that are not json files', function() {
-    os.file.mime.mock.testFiles([
+    osFileMime.mock.testFiles([
       '/base/test/plugin/file/kml/kml_test.xml',
       '/base/test/resources/bin/rand.bin',
       '/base/test/resources/json/partial_object.json'],
-        os.file.mime.mock.testNo(plugin.file.geojson.mime.TYPE));
+        osFileMime.mock.testNo(mime.TYPE));
   });
 
   it('should detect files that are json files', function() {
-    os.file.mime.mock.testFiles([
+    osFileMime.mock.testFiles([
       '/base/test/plugin/file/geojson/10k.json'],
-        os.file.mime.mock.testYes(plugin.file.geojson.mime.TYPE));
+        osFileMime.mock.testYes(mime.TYPE));
   });
 
   it('should register itself with mime detection', function() {
-    var chain = os.file.mime.getTypeChain(plugin.file.geojson.mime.TYPE).join(', ');
+    var chain = osFileMime.getTypeChain(mime.TYPE).join(', ');
     expect(chain).toBe('application/octet-stream, text/plain, application/json, application/vnd.geo+json');
   });
 });

--- a/test/plugin/file/gpx/mime.test.js
+++ b/test/plugin/file/gpx/mime.test.js
@@ -1,24 +1,27 @@
 goog.require('os.file.File');
+goog.require('os.file.mime');
 goog.require('os.file.mime.mock');
 goog.require('plugin.file.gpx.mime');
 
 describe('plugin.file.gpx.mime', function() {
+  const osFileMime = goog.module.get('os.file.mime');
+  const mime = goog.module.get('plugin.file.gpx.mime');
   it('should not detect files that are not gpx files', function() {
-    os.file.mime.mock.testFiles([
+    osFileMime.mock.testFiles([
       '/base/test/resources/xml/namespaced-root-partial.xml',
       '/base/test/resources/xml/comment-with-embedded-xml.xml',
       '/base/test/plugin/file/kml/kml_test.xml'],
-        os.file.mime.mock.testNo(plugin.file.gpx.mime.TYPE));
+        osFileMime.mock.testNo(mime.TYPE));
   });
 
   it('should detect files that are gpx files', function() {
-    os.file.mime.mock.testFiles([
+    osFileMime.mock.testFiles([
       '/base/test/resources/gpx/sample.gpx'],
-        os.file.mime.mock.testYes(plugin.file.gpx.mime.TYPE));
+        osFileMime.mock.testYes(mime.TYPE));
   });
 
   it('should register itself with mime detection', function() {
-    var chain = os.file.mime.getTypeChain(plugin.file.gpx.mime.TYPE).join(', ');
-    expect(chain).toBe('application/octet-stream, text/plain, text/xml, ' + plugin.file.gpx.mime.TYPE);
+    var chain = osFileMime.getTypeChain(mime.TYPE).join(', ');
+    expect(chain).toBe('application/octet-stream, text/plain, text/xml, ' + mime.TYPE);
   });
 });

--- a/test/plugin/file/kml/kmlexporter.test.js
+++ b/test/plugin/file/kml/kmlexporter.test.js
@@ -4,16 +4,30 @@ goog.require('ol.style.Fill');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('os.MapContainer');
+goog.require('os.data.RecordField');
 goog.require('os.mock');
 goog.require('os.style.StyleManager');
 goog.require('os.time.TimeInstant');
 goog.require('os.time.TimeRange');
+goog.require('os.ui.file.kml.AbstractKMLExporter');
 goog.require('plugin.file.kml.KMLExporter');
 
 describe('plugin.file.kml.KMLExporter', function() {
+  const Feature = goog.module.get('ol.Feature');
+  const Point = goog.module.get('ol.geom.Point');
+  const Fill = goog.module.get('ol.style.Fill');
+  const Stroke = goog.module.get('ol.style.Stroke');
+  const Style = goog.module.get('ol.style.Style');
+  const MapContainer = goog.module.get('os.MapContainer');
+  const RecordField = goog.module.get('os.data.RecordField');
+  const StyleManager = goog.module.get('os.style.StyleManager');
+  const TimeInstant = goog.module.get('os.time.TimeInstant');
+  const TimeRange = goog.module.get('os.time.TimeRange');
+  const AbstractKMLExporter = goog.module.get('os.ui.file.kml.AbstractKMLExporter');
+  const KMLExporter = goog.module.get('plugin.file.kml.KMLExporter');
   // the layer/source identifier for these tests
   var testId = 'plugin_file_kml_KMLExporter';
-  var delim = os.ui.file.kml.AbstractKMLExporter.LABEL_DELIMITER_;
+  var delim = AbstractKMLExporter.LABEL_DELIMITER_;
 
   var label1 = {
     column: 'label1',
@@ -40,21 +54,21 @@ describe('plugin.file.kml.KMLExporter', function() {
   var l4Expected = null;
 
   it('gets label configs for a group', function() {
-    var exporter = new plugin.file.kml.KMLExporter();
+    var exporter = new KMLExporter();
     var groupLabels;
 
-    var sm = os.style.StyleManager.getInstance();
+    var sm = StyleManager.getInstance();
 
     // no source id set
-    var f = new ol.Feature();
+    var f = new Feature();
     exporter.reset();
     expect(exporter.getGroupLabels(f)).toBeNull();
 
     // pretend the drawing layer has labels to make sure we don't return them
-    var drawCfg = sm.getOrCreateLayerConfig(os.MapContainer.DRAW_ID);
+    var drawCfg = sm.getOrCreateLayerConfig(MapContainer.DRAW_ID);
     drawCfg['labels'] = [label1];
 
-    f.set(os.data.RecordField.SOURCE_ID, os.MapContainer.DRAW_ID, true);
+    f.set(RecordField.SOURCE_ID, MapContainer.DRAW_ID, true);
     exporter.reset();
     expect(exporter.getGroupLabels(f)).toBeNull();
 
@@ -63,7 +77,7 @@ describe('plugin.file.kml.KMLExporter', function() {
 
     // create a layer config for our imaginary source
     var cfg = sm.getOrCreateLayerConfig(testId);
-    f.set(os.data.RecordField.SOURCE_ID, testId, true);
+    f.set(RecordField.SOURCE_ID, testId, true);
 
     // labels array is not defined on the layer config
     exporter.reset();
@@ -108,9 +122,9 @@ describe('plugin.file.kml.KMLExporter', function() {
   });
 
   it('gets a label component for a feature', function() {
-    var exporter = new plugin.file.kml.KMLExporter();
+    var exporter = new KMLExporter();
 
-    var f = new ol.Feature({
+    var f = new Feature({
       label1: 'test1',
       label2: 'test2',
       label3: 'test3'
@@ -130,24 +144,24 @@ describe('plugin.file.kml.KMLExporter', function() {
   });
 
   it('creates a label for a feature', function() {
-    var exporter = new plugin.file.kml.KMLExporter();
+    var exporter = new KMLExporter();
     var defaultColumn = {
       column: 'defaultField',
       showColumn: false
     };
 
-    var sm = os.style.StyleManager.getInstance();
+    var sm = StyleManager.getInstance();
     var cfg = sm.getOrCreateLayerConfig(testId);
 
     var defaultValue = 'defaultValue';
-    var f = new ol.Feature({
+    var f = new Feature({
       labels: [label1, label2, label3, label4],
       label1: 'test1',
       label2: 'test2',
       label3: 'test3',
       defaultField: defaultValue
     });
-    f.set(os.data.RecordField.SOURCE_ID, testId, true);
+    f.set(RecordField.SOURCE_ID, testId, true);
 
     // no labels, no defaults
     exporter.reset();
@@ -199,37 +213,37 @@ describe('plugin.file.kml.KMLExporter', function() {
   });
 
   it('gets time values from a feature', function() {
-    var exporter = new plugin.file.kml.KMLExporter();
-    var f = new ol.Feature();
+    var exporter = new KMLExporter();
+    var f = new Feature();
 
     // null when field is not set
     expect(exporter.getTime(f)).toBeNull();
 
     // null when value is not an ITime object
-    f.set(os.data.RecordField.TIME, 'not an ITime object');
+    f.set(RecordField.TIME, 'not an ITime object');
     expect(exporter.getTime(f)).toBeNull();
 
     // defined when value is an ITime object
-    var instant = new os.time.TimeInstant();
-    f.set(os.data.RecordField.TIME, instant);
+    var instant = new TimeInstant();
+    f.set(RecordField.TIME, instant);
     expect(exporter.getTime(f)).toBe(instant);
 
-    var range = new os.time.TimeRange();
-    f.set(os.data.RecordField.TIME, range);
+    var range = new TimeRange();
+    f.set(RecordField.TIME, range);
     expect(exporter.getTime(f)).toBe(range);
   });
 
   it('generates proper fill booleans in styles', function() {
-    var exporter = new plugin.file.kml.KMLExporter();
-    var f = new ol.Feature(new ol.geom.Point(0, 0));
+    var exporter = new KMLExporter();
+    var f = new Feature(new Point(0, 0));
 
     expect(exporter.getFill(f)).toBe(false);
 
-    var style = new ol.style.Style();
+    var style = new Style();
     f.setStyle(style);
     expect(exporter.getFill(f)).toBe(false);
 
-    var fill = new ol.style.Fill();
+    var fill = new Fill();
     fill.setColor('rgba(255,255,255,0)');
     style.setFill(fill);
     expect(exporter.getFill(f)).toBe(false);
@@ -239,16 +253,16 @@ describe('plugin.file.kml.KMLExporter', function() {
   });
 
   it('generates proper stroke booleans in styles', function() {
-    var exporter = new plugin.file.kml.KMLExporter();
-    var f = new ol.Feature(new ol.geom.Point(0, 0));
+    var exporter = new KMLExporter();
+    var f = new Feature(new Point(0, 0));
 
     expect(exporter.getStroke(f)).toBe(false);
 
-    var style = new ol.style.Style();
+    var style = new Style();
     f.setStyle(style);
     expect(exporter.getStroke(f)).toBe(false);
 
-    var stroke = new ol.style.Stroke();
+    var stroke = new Stroke();
     stroke.setColor('rgba(255,255,255,0)');
     style.setStroke(stroke);
     expect(exporter.getStroke(f)).toBe(false);
@@ -256,5 +270,4 @@ describe('plugin.file.kml.KMLExporter', function() {
     stroke.setColor('rgba(255,255,255,1)');
     expect(exporter.getStroke(f)).toBe(true);
   });
-
 });

--- a/test/plugin/file/kml/mime.test.js
+++ b/test/plugin/file/kml/mime.test.js
@@ -1,28 +1,31 @@
 goog.require('os.file.File');
+goog.require('os.file.mime');
 goog.require('os.file.mime.mock');
 goog.require('plugin.file.kml.mime');
 
 describe('plugin.file.kml.mime', function() {
+  const osFileMime = goog.module.get('os.file.mime');
+  const mime = goog.module.get('plugin.file.kml.mime');
   it('should not detect files that are not kml files', function() {
-    os.file.mime.mock.testFiles([
+    osFileMime.mock.testFiles([
       '/base/test/resources/xml/namespaced-root-partial.xml',
       '/base/test/resources/xml/comment-with-embedded-xml.xml'],
-        os.file.mime.mock.testNo(plugin.file.kml.mime.TYPE));
+        osFileMime.mock.testNo(mime.TYPE));
   });
 
   it('should detect files that are kml files', function() {
-    os.file.mime.mock.testFiles([
+    osFileMime.mock.testFiles([
       '/base/test/plugin/file/kml/kml_test.xml'],
-        os.file.mime.mock.testYes(plugin.file.kml.mime.TYPE));
+        osFileMime.mock.testYes(mime.TYPE));
   });
 
   it('should register itself with mime detection', function() {
-    var chain = os.file.mime.getTypeChain('application/vnd.google-earth.kml+xml').join(', ');
+    var chain = osFileMime.getTypeChain('application/vnd.google-earth.kml+xml').join(', ');
     expect(chain).toBe('application/octet-stream, text/plain, text/xml, application/vnd.google-earth.kml+xml');
   });
 
   it('should detect files that are kmz files', function() {
-    os.file.mime.mock.testFiles(['/base/test/resources/zip/test.kmz'],
-        os.file.mime.mock.testYes(plugin.file.kml.mime.KMZ_TYPE), Number.POSITIVE_INFINITY);
+    osFileMime.mock.testFiles(['/base/test/resources/zip/test.kmz'],
+        osFileMime.mock.testYes(mime.KMZ_TYPE), Number.POSITIVE_INFINITY);
   });
 });

--- a/test/plugin/file/kml/tour/tour.test.js
+++ b/test/plugin/file/kml/tour/tour.test.js
@@ -1,8 +1,11 @@
+goog.require('plugin.file.kml');
 goog.require('plugin.file.kml.tour.MockTourPrimitive');
 goog.require('plugin.file.kml.tour.Tour');
 
 
 describe('plugin.file.kml.tour.Tour', function() {
+  const kml = goog.module.get('plugin.file.kml');
+  const Tour = goog.module.get('plugin.file.kml.tour.Tour');
   // test globals
   var testName = 'Test Name';
   var testDescription = 'Test Description';
@@ -11,15 +14,15 @@ describe('plugin.file.kml.tour.Tour', function() {
   var tour;
 
   // primitives that will be added to the playlist
-  var first = new plugin.file.kml.tour.MockTourPrimitive(true);
-  var second = new plugin.file.kml.tour.MockTourPrimitive(false);
-  var third = new plugin.file.kml.tour.MockTourPrimitive(true);
+  var first = new kml.tour.MockTourPrimitive(true);
+  var second = new kml.tour.MockTourPrimitive(false);
+  var third = new kml.tour.MockTourPrimitive(true);
 
   // the test tour playlist
   var playlist = [first, second, third];
 
   beforeEach(function() {
-    tour = new plugin.file.kml.tour.Tour(testName, testDescription, playlist);
+    tour = new Tour(testName, testDescription, playlist);
 
     // reset the playlist items
     playlist.forEach(function(item) {
@@ -44,15 +47,15 @@ describe('plugin.file.kml.tour.Tour', function() {
   it('adds to the playlist', function() {
     spyOn(tour, 'reset');
 
-    var fourth = new plugin.file.kml.tour.MockTourPrimitive();
+    var fourth = new kml.tour.MockTourPrimitive();
     tour.addToPlaylist(fourth);
     expect(tour.reset.callCount).toBe(1);
 
-    var fifth = new plugin.file.kml.tour.MockTourPrimitive();
+    var fifth = new kml.tour.MockTourPrimitive();
     tour.addToPlaylist(fifth);
     expect(tour.reset.callCount).toBe(2);
 
-    var sixth = new plugin.file.kml.tour.MockTourPrimitive();
+    var sixth = new kml.tour.MockTourPrimitive();
     tour.addToPlaylist(sixth);
     expect(tour.reset.callCount).toBe(3);
 

--- a/test/plugin/file/kml/tour/tourcontrol.test.js
+++ b/test/plugin/file/kml/tour/tourcontrol.test.js
@@ -2,9 +2,11 @@ goog.require('plugin.file.kml.tour.Tour');
 goog.require('plugin.file.kml.tour.TourControl');
 
 describe('plugin.file.kml.tour.TourControl', function() {
+  const Tour = goog.module.get('plugin.file.kml.tour.Tour');
+  const TourControl = goog.module.get('plugin.file.kml.tour.TourControl');
   it('pauses the tour once', function() {
-    var tour = new plugin.file.kml.tour.Tour();
-    var control = new plugin.file.kml.tour.TourControl(tour);
+    var tour = new Tour();
+    var control = new TourControl(tour);
     tour.addToPlaylist(control);
 
     spyOn(tour, 'pause').andCallThrough();

--- a/test/plugin/file/kml/tour/tourflyto.test.js
+++ b/test/plugin/file/kml/tour/tourflyto.test.js
@@ -1,9 +1,15 @@
-goog.require('os.map.FlightMode');
+goog.require('goog.Promise');
+goog.require('os.MapContainer');
 goog.require('os.map');
+goog.require('os.map.FlightMode');
 goog.require('plugin.file.kml.tour.FlyTo');
 
 
 describe('plugin.file.kml.tour.FlyTo', function() {
+  const Promise = goog.module.get('goog.Promise');
+  const MapContainer = goog.module.get('os.MapContainer');
+  const FlightMode = goog.module.get('os.map.FlightMode');
+  const FlyTo = goog.module.get('plugin.file.kml.tour.FlyTo');
   // default values for tests
   var duration = 4321;
   var timeoutId = 1234;
@@ -41,14 +47,14 @@ describe('plugin.file.kml.tour.FlyTo', function() {
 
   it('initializes correctly', function() {
     var options = {};
-    var flyTo = new plugin.file.kml.tour.FlyTo(options);
+    var flyTo = new FlyTo(options);
 
     // has a default duration and saves options
-    expect(flyTo.duration_).toBe(plugin.file.kml.tour.FlyTo.DEFAULT_DURATION);
+    expect(flyTo.duration_).toBe(FlyTo.DEFAULT_DURATION);
     expect(flyTo.options_).toBe(options);
 
     options.duration = 1234;
-    flyTo = new plugin.file.kml.tour.FlyTo(options);
+    flyTo = new FlyTo(options);
 
     // uses duration if provided on options
     expect(flyTo.duration_).toBe(1234);
@@ -56,15 +62,15 @@ describe('plugin.file.kml.tour.FlyTo', function() {
   });
 
   it('calls the map container flyTo with correct options', function() {
-    var flyTo = new plugin.file.kml.tour.FlyTo(flyToOptions);
+    var flyTo = new FlyTo(flyToOptions);
 
     spyOn(window, 'setTimeout').andCallFake(fakeSetTimeout);
-    spyOn(os.MapContainer, 'getInstance').andReturn({
+    spyOn(MapContainer, 'getInstance').andReturn({
       flyTo: fakeFlyTo
     });
 
     var flyToPromise = flyTo.execute();
-    expect(flyToPromise instanceof goog.Promise).toBe(true);
+    expect(flyToPromise instanceof Promise).toBe(true);
 
     waitsFor(function() {
       return stFn !== undefined && stInterval !== undefined && fakeFlyToOptions !== undefined;
@@ -75,14 +81,14 @@ describe('plugin.file.kml.tour.FlyTo', function() {
       expect(fakeFlyToOptions.center).toEqual(flyToOptions.center);
       expect(fakeFlyToOptions.altitude).toBe(flyToOptions.altitude);
       expect(fakeFlyToOptions.duration).toBe(duration);
-      expect(fakeFlyToOptions.flightMode).toBe(os.map.FlightMode.BOUNCE);
+      expect(fakeFlyToOptions.flightMode).toBe(FlightMode.BOUNCE);
     });
   });
 
   it('cancels flight on pause and reset if the wait is active', function() {
-    var flyTo = new plugin.file.kml.tour.FlyTo(flyToOptions);
+    var flyTo = new FlyTo(flyToOptions);
 
-    spyOn(os.MapContainer, 'getInstance').andReturn({
+    spyOn(MapContainer, 'getInstance').andReturn({
       cancelFlight: fakeCancelFlight
     });
 

--- a/test/plugin/file/kml/tour/tourparser.test.js
+++ b/test/plugin/file/kml/tour/tourparser.test.js
@@ -1,12 +1,20 @@
 goog.require('ol.xml');
 goog.require('os.map.FlightMode');
 goog.require('plugin.file.kml.tour.FlyTo');
+goog.require('plugin.file.kml.tour.SoundCue');
 goog.require('plugin.file.kml.tour.Tour');
 goog.require('plugin.file.kml.tour.TourControl');
 goog.require('plugin.file.kml.tour.Wait');
 goog.require('plugin.file.kml.tour.parseTour');
 
 describe('plugin.file.kml.tour.parseTour', function() {
+  const xml = goog.module.get('ol.xml');
+  const FlightMode = goog.module.get('os.map.FlightMode');
+  const FlyTo = goog.module.get('plugin.file.kml.tour.FlyTo');
+  const SoundCue = goog.module.get('plugin.file.kml.tour.SoundCue');
+  const TourControl = goog.module.get('plugin.file.kml.tour.TourControl');
+  const Wait = goog.module.get('plugin.file.kml.tour.Wait');
+  const parseTour = goog.module.get('plugin.file.kml.tour.parseTour');
   // match opening/closing tags for a KML tour element, with a trailing space (has attributes) or GT (no attributes)
   var tourElRegexp = /(<\/?)(Tour|Playlist|FlyTo|SoundCue|TourControl|Wait|delayedStart|duration|flyToMode)([ >])/g;
 
@@ -27,7 +35,7 @@ describe('plugin.file.kml.tour.parseTour', function() {
    * @return {Element} The root Tour element.
    */
   var getTourNode = function(text, namespace) {
-    var node = ol.xml.parse(replaceText(text, namespace));
+    var node = xml.parse(replaceText(text, namespace));
     return node.firstElementChild;
   };
 
@@ -41,7 +49,7 @@ describe('plugin.file.kml.tour.parseTour', function() {
             '  <Playlist></Playlist>' +
             '</Tour>';
 
-        var tour = plugin.file.kml.tour.parseTour(getTourNode(text));
+        var tour = parseTour(getTourNode(text));
         expect(tour).toBeDefined();
         expect(tour.name).toBe('Test Tour');
         expect(tour.description).toBe('Test Tour Description');
@@ -58,11 +66,11 @@ describe('plugin.file.kml.tour.parseTour', function() {
             '  </Playlist>' +
             '</Tour>';
 
-        var tour = plugin.file.kml.tour.parseTour(getTourNode(text));
+        var tour = parseTour(getTourNode(text));
         var flyTo = tour.getPlaylist()[0];
-        expect(flyTo instanceof plugin.file.kml.tour.FlyTo).toBe(true);
-        expect(flyTo.duration_).toBe(plugin.file.kml.tour.FlyTo.DEFAULT_DURATION);
-        expect(flyTo.options_.flightMode).toBe(os.map.FlightMode.BOUNCE);
+        expect(flyTo instanceof FlyTo).toBe(true);
+        expect(flyTo.duration_).toBe(FlyTo.DEFAULT_DURATION);
+        expect(flyTo.options_.flightMode).toBe(FlightMode.BOUNCE);
       });
 
       it('parses a ' + namespace + 'FlyTo element with duration', function() {
@@ -77,9 +85,9 @@ describe('plugin.file.kml.tour.parseTour', function() {
             '  </Playlist>' +
             '</Tour>';
 
-        var tour = plugin.file.kml.tour.parseTour(getTourNode(text));
+        var tour = parseTour(getTourNode(text));
         var flyTo = tour.getPlaylist()[0];
-        expect(flyTo instanceof plugin.file.kml.tour.FlyTo).toBe(true);
+        expect(flyTo instanceof FlyTo).toBe(true);
         expect(flyTo.duration_).toBe(10000);
       });
 
@@ -95,10 +103,10 @@ describe('plugin.file.kml.tour.parseTour', function() {
             '  </Playlist>' +
             '</Tour>';
 
-        var tour = plugin.file.kml.tour.parseTour(getTourNode(text));
+        var tour = parseTour(getTourNode(text));
         var flyTo = tour.getPlaylist()[0];
-        expect(flyTo instanceof plugin.file.kml.tour.FlyTo).toBe(true);
-        expect(flyTo.options_.flightMode).toBe(os.map.FlightMode.SMOOTH);
+        expect(flyTo instanceof FlyTo).toBe(true);
+        expect(flyTo.options_.flightMode).toBe(FlightMode.SMOOTH);
       });
 
       it('parses a ' + namespace + 'FlyTo element with invalid flyToMode', function() {
@@ -113,10 +121,10 @@ describe('plugin.file.kml.tour.parseTour', function() {
             '  </Playlist>' +
             '</Tour>';
 
-        var tour = plugin.file.kml.tour.parseTour(getTourNode(text));
+        var tour = parseTour(getTourNode(text));
         var flyTo = tour.getPlaylist()[0];
-        expect(flyTo instanceof plugin.file.kml.tour.FlyTo).toBe(true);
-        expect(flyTo.options_.flightMode).toBe(os.map.FlightMode.BOUNCE);
+        expect(flyTo instanceof FlyTo).toBe(true);
+        expect(flyTo.options_.flightMode).toBe(FlightMode.BOUNCE);
       });
 
       it('parses a ' + namespace + 'FlyTo element with a Camera definition', function() {
@@ -138,14 +146,14 @@ describe('plugin.file.kml.tour.parseTour', function() {
             '  </Playlist>' +
             '</Tour>';
 
-        var tour = plugin.file.kml.tour.parseTour(getTourNode(text));
+        var tour = parseTour(getTourNode(text));
         expect(tour).toBeDefined();
 
         var playlist = tour.getPlaylist();
         expect(playlist.length).toBe(1);
 
         var flyTo = playlist[0];
-        expect(flyTo instanceof plugin.file.kml.tour.FlyTo).toBe(true);
+        expect(flyTo instanceof FlyTo).toBe(true);
         expect(flyTo.options_.center[0]).toBe(123.45);
         expect(flyTo.options_.center[1]).toBe(-67.89);
         expect(flyTo.options_.altitude).toBe(12345);
@@ -177,14 +185,14 @@ describe('plugin.file.kml.tour.parseTour', function() {
             '  </Playlist>' +
             '</Tour>';
 
-        var tour = plugin.file.kml.tour.parseTour(getTourNode(text));
+        var tour = parseTour(getTourNode(text));
         expect(tour).toBeDefined();
 
         var playlist = tour.getPlaylist();
         expect(playlist.length).toBe(1);
 
         var flyTo = playlist[0];
-        expect(flyTo instanceof plugin.file.kml.tour.FlyTo).toBe(true);
+        expect(flyTo instanceof FlyTo).toBe(true);
         expect(flyTo.options_.center[0]).toBe(123.45);
         expect(flyTo.options_.center[1]).toBe(-67.89);
         expect(flyTo.options_.altitude).toBe(150);
@@ -211,12 +219,12 @@ describe('plugin.file.kml.tour.parseTour', function() {
             '  </Playlist>' +
             '</Tour>';
 
-        var tour = plugin.file.kml.tour.parseTour(getTourNode(text));
+        var tour = parseTour(getTourNode(text));
         expect(tour).toBeDefined();
 
         var playlist = tour.getPlaylist();
         expect(playlist.length).toBe(1);
-        expect(playlist[0] instanceof plugin.file.kml.tour.SoundCue).toBe(true);
+        expect(playlist[0] instanceof SoundCue).toBe(true);
         expect(playlist[0].href_).toBe(href);
         expect(playlist[0].duration_).toBe(delayedStart * 1000);
       });
@@ -231,12 +239,12 @@ describe('plugin.file.kml.tour.parseTour', function() {
             '  </Playlist>' +
             '</Tour>';
 
-        var tour = plugin.file.kml.tour.parseTour(getTourNode(text));
+        var tour = parseTour(getTourNode(text));
         expect(tour).toBeDefined();
 
         var playlist = tour.getPlaylist();
         expect(playlist.length).toBe(1);
-        expect(playlist[0] instanceof plugin.file.kml.tour.TourControl).toBe(true);
+        expect(playlist[0] instanceof TourControl).toBe(true);
         expect(playlist[0].tour_).toBe(tour);
       });
 
@@ -253,12 +261,12 @@ describe('plugin.file.kml.tour.parseTour', function() {
             '  </Playlist>' +
             '</Tour>';
 
-        var tour = plugin.file.kml.tour.parseTour(getTourNode(text));
+        var tour = parseTour(getTourNode(text));
         expect(tour).toBeDefined();
 
         var playlist = tour.getPlaylist();
         expect(playlist.length).toBe(1);
-        expect(playlist[0] instanceof plugin.file.kml.tour.Wait).toBe(true);
+        expect(playlist[0] instanceof Wait).toBe(true);
         expect(playlist[0].duration_).toBe(duration * 1000);
       });
     });

--- a/test/plugin/file/kml/tour/tourprimitive.mock.js
+++ b/test/plugin/file/kml/tour/tourprimitive.mock.js
@@ -1,79 +1,81 @@
-goog.provide('plugin.file.kml.tour.MockTourPrimitive');
+goog.module('plugin.file.kml.tour.MockTourPrimitive');
+goog.module.declareLegacyNamespace();
 
-goog.require('plugin.file.kml.tour.AbstractTourPrimitive');
+const AbstractTourPrimitive = goog.require('plugin.file.kml.tour.AbstractTourPrimitive');
 
 
 /**
  * Mock tour primitive.
- * @param {boolean=} opt_waitForResolve If the execute function should wait to resolve the promise.
- * @extends {plugin.file.kml.tour.AbstractTourPrimitive}
- * @constructor
  */
-plugin.file.kml.tour.MockTourPrimitive = function(opt_waitForResolve) {
-  plugin.file.kml.tour.MockTourPrimitive.base(this, 'constructor');
+class MockTourPrimitive extends AbstractTourPrimitive {
+  /**
+   * Constructor.
+   * @param {boolean=} opt_waitForResolve If the execute function should wait to resolve the promise.
+   */
+  constructor(opt_waitForResolve) {
+    super();
+
+    /**
+     * How many times the pause function was called.
+     * @type {number}
+     */
+    this.executedCount = 0;
+
+    /**
+     * How many times the pause function was called.
+     * @type {number}
+     */
+    this.pausedCount = 0;
+
+    /**
+     * How many times the reset function was called.
+     * @type {number}
+     */
+    this.resetCount = 0;
+
+    /**
+     * If the execute promise should wait to resolve. Saves the resolve function to `this.resolver`.
+     * @type {boolean}
+     */
+    this.waitForResolve = opt_waitForResolve || false;
+
+    /**
+     * Promise resolve function.
+     * @type {function()|undefined}
+     */
+    this.resolver = undefined;
+  }
 
   /**
-   * How many times the pause function was called.
-   * @type {number}
+   * @inheritDoc
    */
-  this.executedCount = 0;
+  execute() {
+    this.executedCount++;
+
+    return new goog.Promise((resolve, reject) => {
+      if (!this.waitForResolve) {
+        resolve();
+      } else {
+        this.resolver = resolve;
+      }
+    });
+  }
 
   /**
-   * How many times the pause function was called.
-   * @type {number}
+   * @inheritDoc
    */
-  this.pausedCount = 0;
+  pause() {
+    this.pausedCount++;
+    this.resolver = undefined;
+  }
 
   /**
-   * How many times the reset function was called.
-   * @type {number}
+   * @inheritDoc
    */
-  this.resetCount = 0;
+  reset() {
+    this.resetCount++;
+    this.resolver = undefined;
+  }
+}
 
-  /**
-   * If the execute promise should wait to resolve. Saves the resolve function to `this.resolver`.
-   * @type {boolean}
-   */
-  this.waitForResolve = opt_waitForResolve || false;
-
-  /**
-   * Promise resolve function.
-   * @type {function()|undefined}
-   */
-  this.resolver = undefined;
-};
-goog.inherits(plugin.file.kml.tour.MockTourPrimitive, plugin.file.kml.tour.AbstractTourPrimitive);
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.tour.MockTourPrimitive.prototype.execute = function() {
-  this.executedCount++;
-
-  return new goog.Promise(function(resolve, reject) {
-    if (!this.waitForResolve) {
-      resolve();
-    } else {
-      this.resolver = resolve;
-    }
-  }, this);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.tour.MockTourPrimitive.prototype.pause = function() {
-  this.pausedCount++;
-  this.resolver = undefined;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.file.kml.tour.MockTourPrimitive.prototype.reset = function() {
-  this.resetCount++;
-  this.resolver = undefined;
-};
+exports = MockTourPrimitive;

--- a/test/plugin/file/kml/tour/toursoundcue.test.js
+++ b/test/plugin/file/kml/tour/toursoundcue.test.js
@@ -1,6 +1,11 @@
+goog.require('goog.Promise');
+goog.require('os.audio.AudioManager');
 goog.require('plugin.file.kml.tour.SoundCue');
 
 describe('plugin.file.kml.tour.SoundCue', function() {
+  const Promise = goog.module.get('goog.Promise');
+  const AudioManager = goog.module.get('os.audio.AudioManager');
+  const SoundCue = goog.module.get('plugin.file.kml.tour.SoundCue');
   // default values for tests
   var href = 'https://test.com/test.mp3';
   var delayedStart = 4321;
@@ -19,7 +24,7 @@ describe('plugin.file.kml.tour.SoundCue', function() {
   it('initializes properly', function() {
     var delayedStarts = [undefined, -5000, 0, 5000];
     delayedStarts.forEach(function(delayedStart) {
-      var soundCue = new plugin.file.kml.tour.SoundCue(href, delayedStart);
+      var soundCue = new SoundCue(href, delayedStart);
       expect(soundCue.href_).toBe(href);
       expect(soundCue.duration_).toBe(delayedStart > 0 ? delayedStart : 0);
       expect(soundCue.remaining_).toBeUndefined();
@@ -29,7 +34,7 @@ describe('plugin.file.kml.tour.SoundCue', function() {
   });
 
   it('gets the correct interval', function() {
-    var soundCue = new plugin.file.kml.tour.SoundCue(href, delayedStart);
+    var soundCue = new SoundCue(href, delayedStart);
     expect(soundCue.getInterval()).toBe(soundCue.duration_);
 
     soundCue.remaining_ = 42;
@@ -43,7 +48,7 @@ describe('plugin.file.kml.tour.SoundCue', function() {
   });
 
   it('resolves execute promise immediately', function() {
-    var soundCue = new plugin.file.kml.tour.SoundCue(href, delayedStart);
+    var soundCue = new SoundCue(href, delayedStart);
     var fakeAudio = {
       playing: false,
       play: function() {
@@ -64,7 +69,7 @@ describe('plugin.file.kml.tour.SoundCue', function() {
 
     var beforeStart = Date.now() - 1;
     var soundCuePromise = soundCue.execute();
-    expect(soundCuePromise instanceof goog.Promise).toBe(true);
+    expect(soundCuePromise instanceof Promise).toBe(true);
 
     waitsFor(function() {
       return stFn !== undefined && stInterval !== undefined;
@@ -79,7 +84,7 @@ describe('plugin.file.kml.tour.SoundCue', function() {
       expect(stInterval).toBe(delayedStart);
 
       // promise is resolved
-      expect(soundCuePromise.state_).toBe(goog.Promise.State_.FULFILLED);
+      expect(soundCuePromise.state_).toBe(Promise.State_.FULFILLED);
 
       // this shouldn't be called until timeout fires
       expect(soundCue.playAudio_).not.toHaveBeenCalled();
@@ -99,7 +104,7 @@ describe('plugin.file.kml.tour.SoundCue', function() {
       expect(soundCue.timeoutId_).toBeUndefined();
 
       // respects global mute setting
-      var am = os.audio.AudioManager.getInstance();
+      var am = AudioManager.getInstance();
 
       am.setMute(true);
       expect(fakeAudio.muted).toBe(true);

--- a/test/plugin/file/kml/tour/tourwait.test.js
+++ b/test/plugin/file/kml/tour/tourwait.test.js
@@ -1,7 +1,10 @@
+goog.require('goog.Promise');
 goog.require('plugin.file.kml.tour.Wait');
 
 
 describe('plugin.file.kml.tour.Wait', function() {
+  const Promise = goog.module.get('goog.Promise');
+  const Wait = goog.module.get('plugin.file.kml.tour.Wait');
   // default values for tests
   var duration = 4321;
   var timeoutId = 1234;
@@ -19,7 +22,7 @@ describe('plugin.file.kml.tour.Wait', function() {
   it('initializes properly', function() {
     var durations = [-5000, 0, 5000, 10000];
     durations.forEach(function(duration) {
-      var wait = new plugin.file.kml.tour.Wait(duration);
+      var wait = new Wait(duration);
       expect(wait.duration_).toBe(duration > 0 ? duration : 0);
       expect(wait.remaining_).toBeUndefined();
       expect(wait.timeoutId_).toBeUndefined();
@@ -28,7 +31,7 @@ describe('plugin.file.kml.tour.Wait', function() {
   });
 
   it('gets the correct interval', function() {
-    var wait = new plugin.file.kml.tour.Wait(duration);
+    var wait = new Wait(duration);
     expect(wait.getInterval()).toBe(wait.duration_);
 
     wait.remaining_ = 42;
@@ -42,7 +45,7 @@ describe('plugin.file.kml.tour.Wait', function() {
   });
 
   it('resolves execute promise after the provided duration', function() {
-    var wait = new plugin.file.kml.tour.Wait(duration);
+    var wait = new Wait(duration);
 
     spyOn(window, 'setTimeout').andCallFake(fakeSetTimeout);
     spyOn(window, 'clearTimeout');
@@ -52,7 +55,7 @@ describe('plugin.file.kml.tour.Wait', function() {
 
     var beforeStart = Date.now() - 1;
     var waitPromise = wait.execute();
-    expect(waitPromise instanceof goog.Promise).toBe(true);
+    expect(waitPromise instanceof Promise).toBe(true);
 
     waitsFor(function() {
       return stFn !== undefined && stInterval !== undefined;
@@ -67,7 +70,7 @@ describe('plugin.file.kml.tour.Wait', function() {
       expect(stInterval).toBe(duration);
 
       // promise is in pending state
-      expect(waitPromise.state_).toBe(goog.Promise.State_.PENDING);
+      expect(waitPromise.state_).toBe(Promise.State_.PENDING);
 
       // these shouldn't be called until timeout fires
       expect(wait.onWaitComplete).not.toHaveBeenCalled();
@@ -79,14 +82,14 @@ describe('plugin.file.kml.tour.Wait', function() {
 
     waitsFor(function() {
       // wait for the promise to resolve
-      return waitPromise.state_ !== goog.Promise.State_.PENDING;
+      return waitPromise.state_ !== Promise.State_.PENDING;
     }, 'promise to resolve');
 
     runs(function() {
       // timeout callback should have been onWaitComplete, which should have reset and resolved the promise
       expect(wait.onWaitComplete).toHaveBeenCalled();
       expect(wait.reset).toHaveBeenCalled();
-      expect(waitPromise.state_).toBe(goog.Promise.State_.FULFILLED);
+      expect(waitPromise.state_).toBe(Promise.State_.FULFILLED);
 
       expect(window.clearTimeout).toHaveBeenCalledWith(timeoutId);
     });
@@ -97,7 +100,7 @@ describe('plugin.file.kml.tour.Wait', function() {
     var startTime = Date.now();
     var pauseTime = startTime + duration / 2;
 
-    var wait = new plugin.file.kml.tour.Wait(duration);
+    var wait = new Wait(duration);
 
     spyOn(window, 'setTimeout').andCallFake(fakeSetTimeout);
     spyOn(window, 'clearTimeout');
@@ -136,7 +139,7 @@ describe('plugin.file.kml.tour.Wait', function() {
   });
 
   it('does not create a timeout if no remaining time', function() {
-    var wait = new plugin.file.kml.tour.Wait(duration);
+    var wait = new Wait(duration);
 
     spyOn(window, 'setTimeout');
     spyOn(window, 'clearTimeout');
@@ -159,7 +162,7 @@ describe('plugin.file.kml.tour.Wait', function() {
   });
 
   it('resets during execution', function() {
-    var wait = new plugin.file.kml.tour.Wait(duration);
+    var wait = new Wait(duration);
     var startTime = Date.now();
 
     spyOn(window, 'setTimeout').andCallFake(fakeSetTimeout);

--- a/test/plugin/file/kml/ui/placemarkedit.test.js
+++ b/test/plugin/file/kml/ui/placemarkedit.test.js
@@ -1,15 +1,30 @@
+goog.require('ol');
+goog.require('ol.Feature');
+goog.require('os.annotation');
 goog.require('os.feature.DynamicFeature');
+goog.require('os.ui.datetime.AnyDateType');
 goog.require('plugin.file.kml.ui');
-goog.require('plugin.file.kml.ui.PlacemarkEditCtrl');
-goog.require('plugin.file.kml.ui.placemarkEditDirective');
+goog.require('plugin.file.kml.ui.KMLNode');
+goog.require('plugin.file.kml.ui.PlacemarkEditUI');
 goog.require('plugin.places.PlacesManager');
 
-
-
 describe('plugin.file.kml.ui.placemarkedit', function() {
-  var scope, element, rootFolder, folder1;
+  const {getUid} = goog.module.get('ol');
+  const Feature = goog.module.get('ol.Feature');
+  const osAnnotation = goog.module.get('os.annotation');
+  const DynamicFeature = goog.module.get('os.feature.DynamicFeature');
+  const AnyDateType = goog.module.get('os.ui.datetime.AnyDateType');
+  const kmlUI = goog.module.get('plugin.file.kml.ui');
+  const KMLNode = goog.module.get('plugin.file.kml.ui.KMLNode');
+  const PlacesManager = goog.module.get('plugin.places.PlacesManager');
+  const {Controller: PlacemarkEditController} = goog.module.get('plugin.file.kml.ui.PlacemarkEditUI');
 
-  // eslint-disable-next-line require-jsdoc
+  var scope;
+  var element;
+  var rootFolder;
+  var folder1;
+
+  // eslint-disable-next-line jsdoc/require-jsdoc
   function timeout(fn, delay, invokeApply) {
     // $window.setTimeout(fn,delay);
   }
@@ -28,25 +43,25 @@ describe('plugin.file.kml.ui.placemarkedit', function() {
       $compile(element)(scope);
     });
 
-    rootFolder = new plugin.file.kml.ui.KMLNode();
+    rootFolder = new KMLNode();
     rootFolder.canAddChildren = true;
     rootFolder.setLabel('Root folder');
 
-    folder1 = new plugin.file.kml.ui.KMLNode();
+    folder1 = new KMLNode();
     folder1.canAddChildren = true;
     folder1.setLabel('Folder 1');
     folder1.setParent(rootFolder);
 
-    spyOn(plugin.places.PlacesManager.prototype, 'getPlacesRoot').andCallFake(function() {
+    spyOn(PlacesManager.prototype, 'getPlacesRoot').andCallFake(function() {
       return rootFolder;
     });
-    spyOn(plugin.places.PlacesManager.prototype, 'reindexTimeModel_').andCallFake(function() {
+    spyOn(PlacesManager.prototype, 'reindexTimeModel_').andCallFake(function() {
       return;
     });
   });
 
   it('should init correctly', function() {
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
 
     expect(formCtrl['name']).toBe('New Place');
     expect(formCtrl['labelColumns'].length).toBe(16);
@@ -65,7 +80,7 @@ describe('plugin.file.kml.ui.placemarkedit', function() {
 
     scope['options'] = options;
 
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
     formCtrl['name'] = 'Test Name';
 
     expect(formCtrl['name']).toBe('Test Name');
@@ -74,7 +89,7 @@ describe('plugin.file.kml.ui.placemarkedit', function() {
   });
 
   it('should init with a dynamic feature', function() {
-    var feature = new os.feature.DynamicFeature();
+    var feature = new DynamicFeature();
     feature.setId('dynamicFeatureId');
     var options = {
       'feature': feature
@@ -82,7 +97,7 @@ describe('plugin.file.kml.ui.placemarkedit', function() {
 
     scope['options'] = options;
 
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
 
     expect(formCtrl['name']).toBe('New Place');
     expect(formCtrl['defaultExpandedOptionsId']).toBe('featureStyle' + formCtrl['uid']);
@@ -110,14 +125,14 @@ describe('plugin.file.kml.ui.placemarkedit', function() {
 
     scope['options'] = options;
 
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
 
     expect(formCtrl['name']).toBe('New Place');
     expect(formCtrl['startTime']).toBe(startDate);
     expect(formCtrl['endTime']).toBe(endDate);
     expect(formCtrl['startTimeISO']).toBe(startDate.toISOString());
     expect(formCtrl['endTimeISO']).toBe(endDate.toISOString());
-    expect(formCtrl['dateType']).toBe(os.ui.datetime.AnyDateType.RANGE);
+    expect(formCtrl['dateType']).toBe(AnyDateType.RANGE);
   });
 
   it('should init with time options reversed', function() {
@@ -140,18 +155,18 @@ describe('plugin.file.kml.ui.placemarkedit', function() {
 
     scope['options'] = options;
 
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
 
     expect(formCtrl['name']).toBe('New Place');
     expect(formCtrl['startTime']).toBe(endDate);
     expect(formCtrl['endTime']).toBe(startDate);
     expect(formCtrl['startTimeISO']).toBe(endDate.toISOString());
     expect(formCtrl['endTimeISO']).toBe(startDate.toISOString());
-    expect(formCtrl['dateType']).toBe(os.ui.datetime.AnyDateType.INSTANT);
+    expect(formCtrl['dateType']).toBe(AnyDateType.INSTANT);
   });
 
   it('should update a folder', function() {
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
 
     formCtrl['folder'] = folder1;
     formCtrl.updateFolder();
@@ -169,7 +184,7 @@ describe('plugin.file.kml.ui.placemarkedit', function() {
 
     scope['options'] = options;
 
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
 
     formCtrl.updateAnnotation();
 
@@ -177,7 +192,7 @@ describe('plugin.file.kml.ui.placemarkedit', function() {
   });
 
   it('should not update previewAnnotation', function() {
-    spyOn(os.annotation, 'hasOverlay').andReturn(true);
+    spyOn(osAnnotation, 'hasOverlay').andReturn(true);
     var annotation = {
       'show': true
     };
@@ -187,7 +202,7 @@ describe('plugin.file.kml.ui.placemarkedit', function() {
 
     scope['options'] = options;
 
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
 
     formCtrl.updateAnnotation();
 
@@ -195,7 +210,7 @@ describe('plugin.file.kml.ui.placemarkedit', function() {
   });
 
   it('should not update previewAnnotation with null previewFeature', function() {
-    spyOn(os.annotation, 'hasOverlay').andReturn(true);
+    spyOn(osAnnotation, 'hasOverlay').andReturn(true);
     var annotation = {
       'show': true
     };
@@ -205,7 +220,7 @@ describe('plugin.file.kml.ui.placemarkedit', function() {
 
     scope['options'] = options;
 
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
     formCtrl['previewFeature'] = null;
     formCtrl.updateAnnotation();
 
@@ -213,9 +228,9 @@ describe('plugin.file.kml.ui.placemarkedit', function() {
   });
 
   it('should load a feature', function() {
-    var feature = new ol.Feature();
+    var feature = new Feature();
 
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
 
     formCtrl.loadFromFeature(feature);
 
@@ -223,57 +238,62 @@ describe('plugin.file.kml.ui.placemarkedit', function() {
   });
 
   it('should load a feature with annotations already', function() {
-    var feature = new ol.Feature();
+    var options = {
+      cloneTest: true,
+      show: true,
+      editable: true
+    };
 
-    spyOn(feature, 'get').andCallFake(function(returnVal) {
-      if (returnVal == os.annotation.OPTIONS_FIELD) {
-        return os.annotation.OPTIONS_FIELD;
-      }
+    var feature = new Feature({
+      [osAnnotation.OPTIONS_FIELD]: options
     });
 
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
-
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
     formCtrl.loadFromFeature(feature);
-    expect(formCtrl['annotationOptions']).toBe(os.annotation.OPTIONS_FIELD);
+
+    expect(formCtrl['annotationOptions']).toBeDefined();
+    expect(formCtrl['annotationOptions'].cloneTest).toBe(true);
+    expect(formCtrl['annotationOptions'].show).toBe(true);
+    expect(formCtrl['annotationOptions'].editable).toBe(false);
   });
 
   it('should accept new feature', function() {
-    spyOn(plugin.file.kml.ui, 'updatePlacemark');
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
+    spyOn(kmlUI, 'updatePlacemark');
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
 
     formCtrl.accept();
 
     expect(formCtrl['annotationOptions'].editable).toBe(true);
-    expect(plugin.file.kml.ui.updatePlacemark).toHaveBeenCalled();
+    expect(kmlUI.updatePlacemark).toHaveBeenCalled();
   });
 
   it('should accept new feature with no labels', function() {
-    spyOn(plugin.file.kml.ui, 'updatePlacemark');
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
+    spyOn(kmlUI, 'updatePlacemark');
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
 
     formCtrl['labels'] = null;
     formCtrl.accept();
 
     expect(formCtrl['annotationOptions'].editable).toBe(true);
-    expect(plugin.file.kml.ui.updatePlacemark).toHaveBeenCalled();
+    expect(kmlUI.updatePlacemark).toHaveBeenCalled();
     expect(formCtrl['labels']).toBe(null);
   });
 
   it('should accept new feature with no labels', function() {
-    spyOn(plugin.file.kml.ui, 'updatePlacemark');
-    var feature = new ol.Feature();
-    feature.setId(ol.getUid(feature));
+    spyOn(kmlUI, 'updatePlacemark');
+    var feature = new Feature();
+    feature.setId(getUid(feature));
     var options = {
       'feature': feature
     };
 
     scope['options'] = options;
 
-    var formCtrl = new plugin.file.kml.ui.PlacemarkEditCtrl(scope, element, timeout);
+    var formCtrl = new PlacemarkEditController(scope, element, timeout);
 
     formCtrl.accept();
 
     expect(formCtrl['annotationOptions'].editable).toBe(true);
-    expect(plugin.file.kml.ui.updatePlacemark).toHaveBeenCalled();
+    expect(kmlUI.updatePlacemark).toHaveBeenCalled();
   });
 });

--- a/test/plugin/file/shp/mime.test.js
+++ b/test/plugin/file/shp/mime.test.js
@@ -1,29 +1,32 @@
 goog.require('os.file.File');
+goog.require('os.file.mime');
 goog.require('os.file.mime.mock');
 goog.require('plugin.file.shp.mime');
 
 describe('plugin.file.shp.mime', function() {
+  const osFileMime = goog.module.get('os.file.mime');
+  const mime = goog.module.get('plugin.file.shp.mime');
   it('should not detect files that are not shp files', function() {
-    os.file.mime.mock.testFiles([
+    osFileMime.mock.testFiles([
       '/base/test/resources/xml/namespaced-root-partial.xml',
       '/base/test/resources/xml/comment-with-embedded-xml.xml'],
-        os.file.mime.mock.testNo(plugin.file.shp.mime.TYPE));
+        osFileMime.mock.testNo(mime.TYPE));
   });
 
   it('should detect files that are shp files', function() {
-    os.file.mime.mock.testFiles([
+    osFileMime.mock.testFiles([
       '/base/test/resources/shp/example.shp',
       '/base/test/resources/shp/example.dbf'],
-        os.file.mime.mock.testYes(plugin.file.shp.mime.TYPE));
+        osFileMime.mock.testYes(mime.TYPE));
   });
 
   it('should register itself with mime detection', function() {
-    var chain = os.file.mime.getTypeChain('application/shapefile').join(', ');
+    var chain = osFileMime.getTypeChain('application/shapefile').join(', ');
     expect(chain).toBe('application/octet-stream, application/shapefile');
   });
 
   it('should detect files that are zipped shp files', function() {
-    os.file.mime.mock.testFiles(['/base/test/resources/shp/example.zip'],
-        os.file.mime.mock.testYes(plugin.file.shp.mime.ZIP_TYPE), Number.POSITIVE_INFINITY);
+    osFileMime.mock.testFiles(['/base/test/resources/shp/example.zip'],
+        osFileMime.mock.testYes(mime.ZIP_TYPE), Number.POSITIVE_INFINITY);
   });
 });

--- a/test/plugin/file/shp/shpexporter.test.js
+++ b/test/plugin/file/shp/shpexporter.test.js
@@ -1,15 +1,26 @@
+goog.require('goog.object');
+goog.require('ol.Feature');
+goog.require('ol.geom.LineString');
+goog.require('ol.geom.Point');
+goog.require('ol.geom.Polygon');
 goog.require('plugin.file.shp.SHPExporter');
 
 describe('plugin.file.shp.SHPExporter', function() {
-  var ex = new plugin.file.shp.SHPExporter();
+  const googObject = goog.module.get('goog.object');
+  const Feature = goog.module.get('ol.Feature');
+  const LineString = goog.module.get('ol.geom.LineString');
+  const Point = goog.module.get('ol.geom.Point');
+  const Polygon = goog.module.get('ol.geom.Polygon');
+  const SHPExporter = goog.module.get('plugin.file.shp.SHPExporter');
+  var ex = new SHPExporter();
   var lineFeature;
   var pointFeature;
   var polygonFeature;
 
   beforeEach(function() {
-    lineFeature = new ol.Feature(new ol.geom.LineString([[12, 34], [56, 78]]));
-    pointFeature = new ol.Feature(new ol.geom.Point([12, 34]));
-    polygonFeature = new ol.Feature(new ol.geom.Polygon([[[1, 2], [3, 4], [5, 6], [7, 8], [1, 2]]]));
+    lineFeature = new Feature(new LineString([[12, 34], [56, 78]]));
+    pointFeature = new Feature(new Point([12, 34]));
+    polygonFeature = new Feature(new Polygon([[[1, 2], [3, 4], [5, 6], [7, 8], [1, 2]]]));
 
     ex.reset();
   });
@@ -25,8 +36,8 @@ describe('plugin.file.shp.SHPExporter', function() {
       numKey: 5
     };
 
-    ex.setFields(goog.object.getKeys(props));
-    var result = ex.processItem(new ol.Feature(props));
+    ex.setFields(googObject.getKeys(props));
+    var result = ex.processItem(new Feature(props));
 
     expect(result).toBe(false);
   });
@@ -55,7 +66,7 @@ describe('plugin.file.shp.SHPExporter', function() {
         }
         if (file.getFileName().endsWith("prj")) {
             prjFound = true;
-            expect(file.getContent()).toBe(plugin.file.shp.SHPExporter.PRJ_WGS84);
+            expect(file.getContent()).toBe(SHPExporter.PRJ_WGS84);
         }
         if (file.getFileName().endsWith("cpg")) {
             cpgFound = true;
@@ -86,7 +97,7 @@ describe('plugin.file.shp.SHPExporter', function() {
   });
 
   it('should process features with multi-byte attributes', function() {
-    var feature = new ol.Feature(new ol.geom.Point([12, 34]));
+    var feature = new Feature(new Point([12, 34]));
     feature.set('name', '東京都');
     ex.setItems([feature]);
     ex.process();

--- a/test/plugin/file/zip/zipparser.test.js
+++ b/test/plugin/file/zip/zipparser.test.js
@@ -1,3 +1,4 @@
+goog.require('goog.events');
 goog.require('ol.geom.Point');
 goog.require('os.events.EventType');
 goog.require('os.file.File');
@@ -13,11 +14,15 @@ goog.require('plugin.file.zip.ZIPParserConfig');
 
 
 describe('plugin.file.zip.ZIPParser', function() {
+  const googEvents = goog.module.get('goog.events');
+  const EventType = goog.module.get('os.events.EventType');
+  const UrlMethod = goog.module.get('os.ui.file.method.UrlMethod');
+  const ZIPParser = goog.module.get('plugin.file.zip.ZIPParser');
   var testUrl = '/base/test/resources/zip/test-csv.zip';
-  var parser = new plugin.file.zip.ZIPParser();
+  var parser = new ZIPParser();
 
   it('parses zip file content', function() {
-    var urlMethod = new os.ui.file.method.UrlMethod();
+    var urlMethod = new UrlMethod();
     urlMethod.setUrl(testUrl);
 
     var methodComplete = false;
@@ -25,7 +30,7 @@ describe('plugin.file.zip.ZIPParser', function() {
       methodComplete = true;
     };
 
-    urlMethod.listenOnce(os.events.EventType.COMPLETE, onComplete);
+    urlMethod.listenOnce(EventType.COMPLETE, onComplete);
     urlMethod.loadFile();
 
     waitsFor(function() {
@@ -37,7 +42,7 @@ describe('plugin.file.zip.ZIPParser', function() {
       parseComplete = true;
     };
 
-    goog.events.listenOnce(parser, os.events.EventType.COMPLETE, onParseComplete);
+    googEvents.listenOnce(parser, EventType.COMPLETE, onParseComplete);
 
     runs(function( ){
       var file = urlMethod.getFile();


### PR DESCRIPTION
This PR converts all file plugins to use `goog.module`.

### Change Notes

- **[BREAKING]** The static `createFromConfig` functions on each file descriptor conflicted with the definition on their parent class, `FileDescriptor`. These methods weren't doing anything file-specific other than creating the correct descriptor type, so I removed them in favor of creating the descriptor and passing that + provider to the `FileDescriptor` method. `SHPDescriptor` has SHP-specific logic in its method, so I changed the function definition to match `FileDescriptor` and updated references accordingly.
- I had to use `goog.addSingletonGetter` for the providers because `DataManager` checks for a `getInstance` function. A static `getInstance` function differs from the function added by `addSingletonGetter` when compiled, which prevents the instance from being created/used properly. I tried creating an interface to resolve this, but static methods on interfaces do not seem to be allowed/handled by the compiler.
- There was a circular dependency between `kmlui.js` and `kmlnode.js` so I had to make some adjustments to the functions that create/update placemarks and folders. There is now a function to register the KML node class to avoid a hard dependency on `KMLNode` in `kmlui.js`.

### Testing

[OpenSphere](https://os-file-plugin-modules.surge.sh/)

Test the following for each supported file type (CSV, GeoJSON, GML, GPX, KML/KMZ, SHP):

- Files can be imported.
- Data can be exported as that file type (CSV, GeoJSON, KML/KMZ, SHP only).
- The file provider appears in Add Data when a file of each type is loaded.
- Files persist on refresh.
- Files can be removed from the application.