### PR TITLE
fix(kml): add missing require

### DIFF
--- a/src/os/ui/file/kml/abstractkmlexporter.js
+++ b/src/os/ui/file/kml/abstractkmlexporter.js
@@ -17,6 +17,7 @@ goog.require('os.time.TimeRange');
 goog.require('os.ui.file.kml');
 goog.require('os.ui.text.TuiEditor');
 goog.require('os.xml');
+goog.require('plugin.file.kml');
 goog.require('plugin.file.kml.JsonField');
 goog.require('plugin.file.kml.KMLField');
 


### PR DESCRIPTION
The `plugin.file.kml` module is referenced but not required.