### PR TITLE
refactor(file): move constants back to the class object

### DIFF
--- a/src/plugin/file/csv/csvplugin.js
+++ b/src/plugin/file/csv/csvplugin.js
@@ -25,7 +25,7 @@ class CSVPlugin extends AbstractPlugin {
    */
   constructor() {
     super();
-    this.id = ID;
+    this.id = CSVPlugin.ID;
   }
 
   /**
@@ -35,7 +35,7 @@ class CSVPlugin extends AbstractPlugin {
     var dm = DataManager.getInstance();
 
     // register csv provider type
-    dm.registerProviderType(new ProviderEntry(ID, CSVProvider, TYPE, TYPE));
+    dm.registerProviderType(new ProviderEntry(CSVPlugin.ID, CSVProvider, CSVPlugin.TYPE, CSVPlugin.TYPE));
 
     // register the csv descriptor type
     dm.registerDescriptorType(this.id, CSVDescriptor);
@@ -58,14 +58,16 @@ class CSVPlugin extends AbstractPlugin {
 
 /**
  * @type {string}
+ * @const
  */
-const ID = 'csv';
+CSVPlugin.ID = 'csv';
 
 
 /**
  * @type {string}
+ * @const
  */
-const TYPE = 'CSV Layers';
+CSVPlugin.TYPE = 'CSV Layers';
 
 
 exports = CSVPlugin;

--- a/src/plugin/file/geojson/geojsonplugin.js
+++ b/src/plugin/file/geojson/geojsonplugin.js
@@ -30,7 +30,7 @@ class GeoJSONPlugin extends AbstractPlugin {
    */
   constructor() {
     super();
-    this.id = ID;
+    this.id = GeoJSONPlugin.ID;
   }
 
   /**
@@ -40,7 +40,8 @@ class GeoJSONPlugin extends AbstractPlugin {
     var dm = DataManager.getInstance();
 
     // register geojson provider type
-    dm.registerProviderType(new ProviderEntry(ID, GeoJSONProvider, TYPE, TYPE));
+    dm.registerProviderType(new ProviderEntry(GeoJSONPlugin.ID, GeoJSONProvider, GeoJSONPlugin.TYPE,
+        GeoJSONPlugin.TYPE));
 
     // register the geojson descriptor type
     dm.registerDescriptorType(this.id, GeoJSONDescriptor);
@@ -64,14 +65,16 @@ class GeoJSONPlugin extends AbstractPlugin {
 
 /**
  * @type {string}
+ * @const
  */
-const ID = 'geojson';
+GeoJSONPlugin.ID = 'geojson';
 
 
 /**
  * @type {string}
+ * @const
  */
-const TYPE = 'GeoJSON Layers';
+GeoJSONPlugin.TYPE = 'GeoJSON Layers';
 
 
 exports = GeoJSONPlugin;

--- a/src/plugin/file/gpx/gpxplugin.js
+++ b/src/plugin/file/gpx/gpxplugin.js
@@ -23,7 +23,7 @@ class GPXPlugin extends AbstractPlugin {
    */
   constructor() {
     super();
-    this.id = ID;
+    this.id = GPXPlugin.ID;
   }
 
   /**
@@ -33,7 +33,7 @@ class GPXPlugin extends AbstractPlugin {
     var dm = DataManager.getInstance();
 
     // register kml provider type
-    dm.registerProviderType(new ProviderEntry(ID, GPXProvider, TYPE, TYPE));
+    dm.registerProviderType(new ProviderEntry(GPXPlugin.ID, GPXProvider, GPXPlugin.TYPE, GPXPlugin.TYPE));
 
     // register the kml descriptor type
     dm.registerDescriptorType(this.id, GPXDescriptor);
@@ -53,14 +53,16 @@ class GPXPlugin extends AbstractPlugin {
 
 /**
  * @type {string}
+ * @const
  */
-const ID = 'gpx';
+GPXPlugin.ID = 'gpx';
 
 
 /**
  * @type {string}
+ * @const
  */
-const TYPE = 'GPX Layers';
+GPXPlugin.TYPE = 'GPX Layers';
 
 
 exports = GPXPlugin;

--- a/src/plugin/file/shp/shpplugin.js
+++ b/src/plugin/file/shp/shpplugin.js
@@ -26,7 +26,7 @@ class SHPPlugin extends AbstractPlugin {
    */
   constructor() {
     super();
-    this.id = ID;
+    this.id = SHPPlugin.ID;
   }
 
   /**
@@ -36,7 +36,7 @@ class SHPPlugin extends AbstractPlugin {
     var dm = DataManager.getInstance();
 
     // register shp provider type
-    dm.registerProviderType(new ProviderEntry(ID, SHPProvider, TYPE, TYPE));
+    dm.registerProviderType(new ProviderEntry(SHPPlugin.ID, SHPProvider, SHPPlugin.TYPE, SHPPlugin.TYPE));
 
     // register the shp descriptor type
     dm.registerDescriptorType(this.id, SHPDescriptor);
@@ -60,14 +60,16 @@ class SHPPlugin extends AbstractPlugin {
 
 /**
  * @type {string}
+ * @const
  */
-const ID = 'shp';
+SHPPlugin.ID = 'shp';
 
 
 /**
  * @type {string}
+ * @const
  */
-const TYPE = 'SHP Layers';
+SHPPlugin.TYPE = 'SHP Layers';
 
 
 exports = SHPPlugin;

--- a/src/plugin/file/zip/zipplugin.js
+++ b/src/plugin/file/zip/zipplugin.js
@@ -17,7 +17,7 @@ class ZIPPlugin extends AbstractPlugin {
    */
   constructor() {
     super();
-    this.id = ID;
+    this.id = ZIPPlugin.ID;
   }
 
   /**
@@ -35,8 +35,9 @@ class ZIPPlugin extends AbstractPlugin {
 
 /**
  * @type {string}
+ * @const
  */
-const ID = 'zip';
+ZIPPlugin.ID = 'zip';
 
 
 exports = ZIPPlugin;


### PR DESCRIPTION
I got a little overzealous moving constants to the module scope, which impacted external projects. File plugin `ID` and `TYPE` have been moved back to a class constant to un-break the change.