### PR TITLE
fix(servers): use actual buttons to fix FA icon display issue

### DIFF
--- a/views/config/servers.html
+++ b/views/config/servers.html
@@ -24,12 +24,18 @@
               <i ng-if="item.loading" class="fa fa-fw fa-spin fa-spinner" title="Loading..."></i>
             </span>
             <span>
-              <i class="fa btn btn-secondary btn-sm" ng-class="item.edit ? 'fa-pencil' : 'fa-eye'" ng-if="item.hasView"
-                  ng-click="servers.edit(item.item)" title="{{item.edit ? 'Edit' : 'View'}} server"></i>
-              <i class="fa fa-close text-danger btn btn-secondary btn-sm" ng-if="item.edit" ng-click="servers.remove(item.item)"
-                  title="Delete server"></i>
-              <i class="fa fa-refresh btn btn-secondary btn-sm" ng-click="servers.refresh(item.item)"
-                  title="Refresh server"></i>
+              <button type="button" class="btn btn-secondary btn-sm" ng-if="item.hasView"
+                  ng-click="servers.edit(item.item)" title="{{item.edit ? 'Edit' : 'View'}} server">
+                <i class="fa fa-fw" ng-class="item.edit ? 'fa-pencil' : 'fa-eye'"></i>
+              </button>
+              <button type="button" class="btn btn-secondary btn-sm" title="Delete server" ng-if="item.edit"
+                  ng-click="servers.remove(item.item)" >
+                <i class="fa fa-fw fa-close text-danger"></i>
+              </button>
+              <button type="button" class="btn btn-secondary btn-sm" title="Refresh server"
+                  ng-click="servers.refresh(item.item)">
+                <i class="fa fa-fw fa-refresh"></i>
+              </button>
             </span>
           </td>
         </tr>


### PR DESCRIPTION
Some icons in the Servers UI did not display properly because they only have a solid icon in the free Font Awesome icon set. Those icons use font weight 800, and the `btn` class uses font weight 400. That prevented the icon from being displayed.

The use of `<i class="btn">` is not recommended (they should not be a click handler), so to resolve the issue I switched the UI to use `button` elements. I did not find any other UI's in OpenSphere that were doing this.