### PR TITLE
Transform ogc plugin to goog modules

### DIFF
--- a/src/plugin/ogc/geoserver.js
+++ b/src/plugin/ogc/geoserver.js
@@ -1,73 +1,70 @@
-goog.provide('plugin.ogc.GeoServer');
+goog.module('plugin.ogc.GeoServer');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.log');
-goog.require('goog.log.Logger');
-goog.require('goog.string.path');
-goog.require('os.data.IDataProvider');
-goog.require('os.ui.ogc.OGCServer');
-
+const log = goog.require('goog.log');
+const IDataProvider = goog.require('os.data.IDataProvider');
+const OGCServer = goog.require('os.ui.ogc.OGCServer');
+const Logger = goog.requireType('goog.log.Logger');
 
 
 /**
  * The GeoServer server provider.
  *
- * @implements {os.data.IDataProvider}
- * @extends {os.ui.ogc.OGCServer}
- * @constructor
+ * @implements {IDataProvider}
  */
-plugin.ogc.GeoServer = function() {
-  plugin.ogc.GeoServer.base(this, 'constructor');
-  this.log = plugin.ogc.GeoServer.LOGGER_;
-  this.providerType = plugin.ogc.GeoServer.TYPE;
-};
-goog.inherits(plugin.ogc.GeoServer, os.ui.ogc.OGCServer);
-os.implements(plugin.ogc.GeoServer, os.data.IDataProvider.ID);
+class GeoServer extends OGCServer {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.log = logger;
+    this.providerType = GeoServer.TYPE;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  configure(config) {
+    this.init();
+    this.setLabel(/** @type {string} */ (config['label']));
+    this.setEnabled(/** @type {boolean} */ (config['enabled']));
+    this.setEditable(/** @type {boolean} */ (config['editable']));
+
+    var url = /** @type {string} */ (config['url']);
+    this.setWmsUrl(url);
+    this.setOriginalWmsUrl(url);
+    this.setWfsUrl(url);
+    this.setOriginalWfsUrl(url);
+
+    this.setWmsTimeFormat(/** @type {string} */ (config['wmsTimeFormat']) || '{start}/{end}');
+    this.setWmsDateFormat(/** @type {string} */ (config['wmsDateFormat']) || 'YYYY-MM-DDTHH:mm:ss[Z]');
+
+    var wfsContentType = /** @type {string|undefined} */ (config['wfsContentType']);
+    if (wfsContentType) {
+      this.setWfsContentType(wfsContentType);
+    }
+  }
+}
+os.implements(GeoServer, IDataProvider.ID);
 
 /**
  * The GeoServer server type.
  * @type {string}
  * @const
  */
-plugin.ogc.GeoServer.TYPE = 'geoserver';
-
+GeoServer.TYPE = 'geoserver';
 
 /**
  * The logger.
- * @const
- * @type {goog.log.Logger}
- * @private
+ * @type {Logger}
  */
-plugin.ogc.GeoServer.LOGGER_ = goog.log.getLogger('plugin.ogc.GeoServer');
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.GeoServer.prototype.configure = function(config) {
-  this.init();
-  this.setLabel(/** @type {string} */ (config['label']));
-  this.setEnabled(/** @type {boolean} */ (config['enabled']));
-  this.setEditable(/** @type {boolean} */ (config['editable']));
-
-  var url = /** @type {string} */ (config['url']);
-  this.setWmsUrl(url);
-  this.setOriginalWmsUrl(url);
-  this.setWfsUrl(url);
-  this.setOriginalWfsUrl(url);
-
-  this.setWmsTimeFormat(/** @type {string} */ (config['wmsTimeFormat']) || '{start}/{end}');
-  this.setWmsDateFormat(/** @type {string} */ (config['wmsDateFormat']) || 'YYYY-MM-DDTHH:mm:ss[Z]');
-
-  var wfsContentType = /** @type {string|undefined} */ (config['wfsContentType']);
-  if (wfsContentType) {
-    this.setWfsContentType(wfsContentType);
-  }
-};
-
+const logger = log.getLogger('plugin.ogc.GeoServer');
 
 /**
  * @type {RegExp}
  * @const
  */
-plugin.ogc.GeoServer.URI_REGEXP = /\/(geoserver|.*?gs)(\/|(\/.*)?\/(ows|web)\/?)?([?#]|$)/i;
+GeoServer.URI_REGEXP = /\/(geoserver|.*?gs)(\/|(\/.*)?\/(ows|web)\/?)?([?#]|$)/i;
+
+exports = GeoServer;

--- a/src/plugin/ogc/geoserver.js
+++ b/src/plugin/ogc/geoserver.js
@@ -3,6 +3,7 @@ goog.module.declareLegacyNamespace();
 
 const log = goog.require('goog.log');
 const IDataProvider = goog.require('os.data.IDataProvider');
+const osImplements = goog.require('os.implements');
 const OGCServer = goog.require('os.ui.ogc.OGCServer');
 const Logger = goog.requireType('goog.log.Logger');
 
@@ -46,7 +47,7 @@ class GeoServer extends OGCServer {
     }
   }
 }
-os.implements(GeoServer, IDataProvider.ID);
+osImplements(GeoServer, IDataProvider.ID);
 
 /**
  * The GeoServer server type.

--- a/src/plugin/ogc/mime.js
+++ b/src/plugin/ogc/mime.js
@@ -1,29 +1,27 @@
-goog.provide('plugin.ogc.mime');
+goog.module('plugin.ogc.mime');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Promise');
-goog.require('os.file.mime');
-goog.require('os.file.mime.html');
-goog.require('os.file.mime.xml');
-goog.require('os.ogc');
-goog.require('plugin.ogc.GeoServer');
+const Promise = goog.require('goog.Promise');
+const mime = goog.require('os.file.mime');
+const html = goog.require('os.file.mime.html');
+const xml = goog.require('os.file.mime.xml');
+const ogc = goog.require('os.ogc');
+const GeoServer = goog.require('plugin.ogc.GeoServer');
 
-
-/**
- * @private
- */
-plugin.ogc.mime.capTest_ = os.file.mime.xml.createDetect(/^(W((MT_)?M|F)S_)?Capabilities$/i, null);
 
 /**
- * @private
  */
-plugin.ogc.mime.exTest_ = os.file.mime.xml.createDetect(/ExceptionReport$/, /\/(ows|ogc)(\/|$)/);
+const capTest_ = xml.createDetect(/^(W((MT_)?M|F)S_)?Capabilities$/i, null);
+
+/**
+ */
+const exTest_ = xml.createDetect(/ExceptionReport$/, /\/(ows|ogc)(\/|$)/);
 
 /**
  * @param {Array<*|undefined>} arr
  * @return {*|undefined}
- * @private
  */
-plugin.ogc.mime.or_ = function(arr) {
+const or_ = function(arr) {
   if (arr) {
     for (var i = 0, n = arr.length; i < n; i++) {
       if (arr[i]) {
@@ -33,42 +31,44 @@ plugin.ogc.mime.or_ = function(arr) {
   }
 };
 
-
 /**
  * @param {ArrayBuffer} buffer
  * @param {os.file.File} file
  * @param {*=} opt_context
- * @return {!goog.Promise<*|undefined>}
+ * @return {!Promise<*|undefined>}
  */
-plugin.ogc.mime.detectOGC = function(buffer, file, opt_context) {
-  return goog.Promise.all([
-    plugin.ogc.mime.capTest_(buffer, file, opt_context),
-    plugin.ogc.mime.exTest_(buffer, file, opt_context)]).then(plugin.ogc.mime.or_);
+const detectOGC = function(buffer, file, opt_context) {
+  return Promise.all([
+    capTest_(buffer, file, opt_context),
+    exTest_(buffer, file, opt_context)]).then(or_);
 };
 
-os.file.mime.register(os.ogc.ID, plugin.ogc.mime.detectOGC, 0, os.file.mime.xml.TYPE);
+mime.register(ogc.ID, detectOGC, 0, xml.TYPE);
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.ogc.mime.GEOSERVER_TYPE = 'geoserver';
-
+const GEOSERVER_TYPE = 'geoserver';
 
 /**
  * @param {ArrayBuffer} buffer
  * @param {os.file.File} file
  * @param {*=} opt_context
- * @return {!goog.Promise<*|undefined>}
+ * @return {!Promise<*|undefined>}
  */
-plugin.ogc.mime.detectGeoserver = function(buffer, file, opt_context) {
-  return /** @type {!goog.Promise<*|undefined>} */ (goog.Promise.resolve(
-      file && plugin.ogc.GeoServer.URI_REGEXP.test(file.getUrl())));
+const detectGeoserver = function(buffer, file, opt_context) {
+  return /** @type {!Promise<*|undefined>} */ (Promise.resolve(file && GeoServer.URI_REGEXP.test(file.getUrl())));
 };
 
-os.file.mime.register(plugin.ogc.mime.GEOSERVER_TYPE, plugin.ogc.mime.detectGeoserver, 0, os.ogc.ID);
+mime.register(GEOSERVER_TYPE, detectGeoserver, 0, ogc.ID);
 
 
 // we also allow users to paste the /geoserver/web url in
-os.file.mime.register(plugin.ogc.mime.GEOSERVER_TYPE, plugin.ogc.mime.detectGeoserver, 0, os.file.mime.html.TYPE);
+mime.register(GEOSERVER_TYPE, detectGeoserver, 0, html.TYPE);
+
+exports = {
+  detectOGC,
+  GEOSERVER_TYPE,
+  detectGeoserver
+};

--- a/src/plugin/ogc/ogclayerdescriptor.js
+++ b/src/plugin/ogc/ogclayerdescriptor.js
@@ -1,249 +1,1276 @@
-goog.provide('plugin.ogc.OGCLayerDescriptor');
+goog.module('plugin.ogc.OGCLayerDescriptor');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Uri.QueryData');
-goog.require('os.alert.AlertEventSeverity');
-goog.require('os.alert.AlertManager');
-goog.require('os.command.LayerAdd');
-goog.require('os.command.LayerRemove');
-goog.require('os.command.SequenceCommand');
-goog.require('os.data');
-goog.require('os.data.IAreaTest');
-goog.require('os.data.LayerSyncDescriptor');
-goog.require('os.events.LayerConfigEvent');
-goog.require('os.events.LayerConfigEventType');
-goog.require('os.events.LayerEvent');
-goog.require('os.events.LayerEventType');
-goog.require('os.events.PropertyChangeEvent');
-goog.require('os.filter.IFilterable');
-goog.require('os.implements');
-goog.require('os.layer.LayerType');
-goog.require('os.ogc.wfs.DescribeFeatureLoader');
-goog.require('os.ogc.wmts');
-goog.require('os.ui.ControlType');
-goog.require('os.ui.Icons');
-goog.require('os.ui.IconsSVG');
 goog.require('os.ui.filter.ui.filterableDescriptorNodeUIDirective');
-goog.require('os.ui.icons');
-goog.require('os.ui.ogc.IOGCDescriptor');
-goog.require('os.ui.query.BaseCombinatorCtrl');
-goog.require('os.ui.query.CombinatorCtrl');
-goog.require('os.ui.util.deprecated');
 
+const QueryData = goog.require('goog.Uri.QueryData');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const AlertManager = goog.require('os.alert.AlertManager');
+const Settings = goog.require('os.config.Settings');
+const data = goog.require('os.data');
+const IAreaTest = goog.require('os.data.IAreaTest');
+const LayerSyncDescriptor = goog.require('os.data.LayerSyncDescriptor');
+const PropertyChangeEvent = goog.require('os.events.PropertyChangeEvent');
+const IFilterable = goog.require('os.filter.IFilterable');
+const osImplements = goog.require('os.implements');
+const LayerType = goog.require('os.layer.LayerType');
+const DescribeFeatureLoader = goog.require('os.ogc.wfs.DescribeFeatureLoader');
+const wmts = goog.require('os.ogc.wmts');
+const ControlType = goog.require('os.ui.ControlType');
+const Icons = goog.require('os.ui.Icons');
+const IconsSVG = goog.require('os.ui.IconsSVG');
+const icons = goog.require('os.ui.icons');
+const IOGCDescriptor = goog.require('os.ui.ogc.IOGCDescriptor');
+const CombinatorCtrl = goog.require('os.ui.query.CombinatorCtrl');
+const deprecated = goog.require('os.ui.util.deprecated');
 
 
 /**
- * @extends {os.data.LayerSyncDescriptor}
- * @implements {os.ui.ogc.IOGCDescriptor}
- * @implements {os.filter.IFilterable}
- * @implements {os.data.IAreaTest}
- * @constructor
+ * @implements {IOGCDescriptor}
+ * @implements {IFilterable}
+ * @implements {IAreaTest}
  */
-plugin.ogc.OGCLayerDescriptor = function() {
-  plugin.ogc.OGCLayerDescriptor.base(this, 'constructor');
-
+class OGCLayerDescriptor extends LayerSyncDescriptor {
   /**
-   * @type {?string}
-   * @private
+   * Constructor.
    */
-  this.attribution_ = null;
+  constructor() {
+    super();
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.attribution_ = null;
+
+    /**
+     * @type {?ol.Extent}
+     * @private
+     */
+    this.bbox_ = null;
+
+    /**
+     * @type {?function()}
+     * @protected
+     */
+    this.describeCallback = null;
+
+    /**
+     * @type {?Object<string, string>}
+     * @private
+     */
+    this.dimensions_ = null;
+
+    /**
+     * @type {os.ogc.IFeatureType}
+     * @private
+     */
+    this.featureType_ = null;
+
+    /**
+     * @type {?Array<!string>}
+     * @private
+     */
+    this.legends_ = null;
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.opaque_ = false;
+
+    /**
+     * @type {?Array<osx.ogc.TileStyle>}
+     * @private
+     */
+    this.styles_ = null;
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.usePost_ = false;
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.wfsEnabled_ = false;
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.wfsName_ = null;
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.wfsNameSpace_ = null;
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.wfsUrl_ = null;
+
+    /**
+     * The WFS Content-Type request header.
+     * @type {string}
+     * @private
+     */
+    this.wfsContentType_ = 'text/xml';
+
+    /**
+     * @type {?Array<string>}
+     * @private
+     */
+    this.wfsFormats_ = null;
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.wmsEnabled_ = false;
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.wmsName_ = null;
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.wmsDateFormat_ = null;
+
+    /**
+     * @type {QueryData}
+     * @private
+     */
+    this.wmsParams_ = null;
+
+    /**
+     * @type {QueryData}
+     * @private
+     */
+    this.wfsParams_ = null;
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.wmsTimeFormat_ = null;
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.wmsUrl_ = null;
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.wmsVersion_ = null;
+
+    /**
+     * @type {?Array<!string>}
+     * @private
+     */
+    this.wmsSupportedCRS_ = null;
+
+    /**
+     * If WMTS is enabled for this descriptor.
+     * @type {boolean}
+     * @private
+     */
+    this.wmtsEnabled_ = false;
+
+    /**
+     * The WMTS date format.
+     * @type {?string}
+     * @private
+     */
+    this.wmtsDateFormat_ = null;
+
+    /**
+     * The WMTS options.
+     * @type {Array<olx.source.WMTSOptions>}
+     * @private
+     */
+    this.wmtsOptions_ = null;
+
+    /**
+     * The WMTS time format.
+     * @type {?string}
+     * @private
+     */
+    this.wmtsTimeFormat_ = null;
+
+    /**
+     * Marker for whether the layer is deprecated. If a layer is deprecated, it will pop up a notification to the user
+     * to stop using it when the descriptor is activated.
+     * @type {boolean}
+     * @private
+     */
+    this.deprecated_ = false;
+
+    /**
+     * Persisted settings to restore.
+     * @type {Object}
+     * @private
+     */
+    this.restoreSettings_ = null;
+
+    /**
+     * Regular expression to test for filterable types.
+     * @type {RegExp}
+     * @protected
+     */
+    this.filterableRegexp = OGCLayerDescriptor.FILTERABLE_RE;
+
+    this.descriptorType = os.ogc.ID;
+  }
 
   /**
-   * @type {?ol.Extent}
-   * @private
+   * @inheritDoc
    */
-  this.bbox_ = null;
+  getSearchType() {
+    return 'Layer';
+  }
 
   /**
-   * @type {?function()}
+   * @inheritDoc
+   */
+  getType() {
+    const hasTileLayer = this.wmsEnabled_ || this.wmtsEnabled_;
+    if (hasTileLayer && this.wfsEnabled_) {
+      return LayerType.GROUPS;
+    } else if (hasTileLayer) {
+      return LayerType.TILES;
+    } else if (this.wfsEnabled_) {
+      return LayerType.FEATURES;
+    }
+
+    return null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getIcons() {
+    var iconsSVG = this.getSVGSet();
+    var s = '';
+    var color = this.getColor() ? os.color.toRgbArray(this.getColor()) : [255, 255, 255, 1];
+
+    if (this.deprecated_) {
+      s += Icons.DEPRECATED;
+    }
+
+    s += icons.createIconSet(goog.string.getRandomString(), iconsSVG, [], color);
+
+    return s;
+  }
+
+  /**
+   * Gets the set of appropriate layer icons as SVG.
+   *
+   * @return {Array<string>}
+   */
+  getSVGSet() {
+    var iconsSVG = [];
+
+    if (this.wmsEnabled_ || this.wmtsEnabled_) {
+      iconsSVG.push(IconsSVG.TILES);
+    }
+
+    if (this.wfsEnabled_) {
+      iconsSVG.push(IconsSVG.FEATURES);
+    }
+
+    if (this.hasTimeExtent()) {
+      iconsSVG.push(IconsSVG.TIME);
+    }
+
+    return iconsSVG;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getAbstract() {
+    return this.getDescription();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setAbstract(value) {
+    this.setDescription(value);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getExplicitTitle() {
+    var title = '';
+
+    if (this.isWmsEnabled() || this.isWmtsEnabled()) {
+      title = 'Tiles';
+    }
+    if (this.isWfsEnabled()) {
+      title += title ? ' and Features' : 'Features';
+    }
+
+    return title;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getAliases() {
+    var aliases = [this.getId()];
+    if (this.wmsEnabled_ || this.wmtsEnabled_) {
+      aliases.push(this.getId() + os.ui.data.BaseProvider.ID_DELIMITER + 'tiles');
+    }
+    if (this.wfsEnabled_) {
+      aliases.push(this.getId() + os.ui.data.BaseProvider.ID_DELIMITER + 'features');
+    }
+
+    return aliases;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getAttribution() {
+    return this.attribution_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setAttribution(value) {
+    this.attribution_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getStyles() {
+    return this.styles_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setStyles(value) {
+    this.styles_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getOpaque() {
+    return this.opaque_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setOpaque(value) {
+    this.opaque_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getDimensions() {
+    return this.dimensions_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setDimensions(value) {
+    this.dimensions_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getBBox() {
+    return this.bbox_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setBBox(value) {
+    this.bbox_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getSupportedCRS() {
+    return this.wmsSupportedCRS_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setSupportedCRS(values) {
+    this.wmsSupportedCRS_ = values;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getKeywords() {
+    return this.getTags();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setKeywords(value) {
+    this.setTags(value);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLegends() {
+    return this.legends_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setLegends(value) {
+    this.legends_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getFeatureType() {
+    return this.featureType_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  isWfsEnabled() {
+    return this.wfsEnabled_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWfsEnabled(value) {
+    this.wfsEnabled_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWfsName() {
+    return this.wfsName_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWfsName(value) {
+    this.wfsName_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWfsNamespace() {
+    return this.wfsNameSpace_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWfsNamespace(value) {
+    this.wfsNameSpace_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  isFilterable() {
+    return this.isWfsEnabled();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWfsUrl() {
+    return this.wfsUrl_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWfsUrl(value) {
+    this.wfsUrl_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWfsContentType() {
+    return this.wfsContentType_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWfsContentType(value) {
+    this.wfsContentType_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWfsFormats() {
+    return this.wfsFormats_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWfsFormats(value) {
+    this.wfsFormats_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  isWmsEnabled() {
+    return this.wmsEnabled_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWmsEnabled(value) {
+    this.wmsEnabled_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWmsDateFormat() {
+    return this.wmsDateFormat_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWmsDateFormat(value) {
+    this.wmsDateFormat_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWmsParams() {
+    return this.wmsParams_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWmsParams(value) {
+    this.wmsParams_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWfsParams() {
+    return this.wfsParams_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWfsParams(value) {
+    this.wfsParams_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWmsName() {
+    return this.wmsName_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWmsName(value) {
+    this.wmsName_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWmsTimeFormat() {
+    return this.wmsTimeFormat_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWmsTimeFormat(value) {
+    this.wmsTimeFormat_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWmsUrl() {
+    return this.wmsUrl_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWmsUrl(value) {
+    this.wmsUrl_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWmsVersion() {
+    return this.wmsVersion_ || ol.DEFAULT_WMS_VERSION;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWmsVersion(value) {
+    this.wmsVersion_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  isWmtsEnabled() {
+    return this.wmtsEnabled_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWmtsEnabled(value) {
+    this.wmtsEnabled_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWmtsDateFormat() {
+    return this.wmtsDateFormat_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWmtsDateFormat(value) {
+    this.wmtsDateFormat_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWmtsOptions() {
+    return this.wmtsOptions_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWmtsOptions(value) {
+    this.wmtsOptions_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getWmtsTimeFormat() {
+    return this.wmtsTimeFormat_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setWmtsTimeFormat(value) {
+    this.wmtsTimeFormat_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getUsePost() {
+    return this.usePost_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setUsePost(value) {
+    this.usePost_ = value;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getUrlKey() {
+    return this.getFilterKey();
+  }
+
+  /**
+   * If the provider is available and has alternate URLs, replaces the URL with the next available URL from the server.
+   *
+   * @param {?string} url The URL to replace
+   * @return {?string}
    * @protected
    */
-  this.describeCallback = null;
+  replaceWithNextUrl(url) {
+    if (url && this.dataProvider instanceof os.ui.server.AbstractLoadingServer) {
+      var providerUrl = this.dataProvider.getUrl();
+      var nextUrl = this.dataProvider.getNextUrl();
+
+      if (providerUrl && nextUrl) {
+        url = url.replace(providerUrl, nextUrl);
+      }
+    }
+
+    return url;
+  }
 
   /**
-   * @type {?Object<string, string>}
-   * @private
+   * @inheritDoc
    */
-  this.dimensions_ = null;
+  getDeprecated() {
+    return this.deprecated_;
+  }
 
   /**
-   * @type {os.ogc.IFeatureType}
-   * @private
+   * @inheritDoc
    */
-  this.featureType_ = null;
+  setDeprecated(value) {
+    this.deprecated_ = value;
+  }
 
   /**
-   * @type {?Array<!string>}
-   * @private
+   * @inheritDoc
    */
-  this.legends_ = null;
+  addDimension(key, value) {
+    if (this.dimensions_ == null) {
+      this.dimensions_ = {};
+    }
+
+    this.dimensions_[key] = value;
+
+    if (key == 'time') {
+      var extents = value.split('/');
+      if (extents.length > 1) {
+        var n = new Date(extents[0]).getTime();
+        var m = new Date(extents[1]).getTime();
+
+        this.setMinDate(Math.min(m, n));
+        this.setMaxDate(Math.max(m, n));
+      } else {
+        this.setMinDate(NaN);
+        this.setMaxDate(NaN);
+      }
+    }
+  }
 
   /**
-   * @type {boolean}
-   * @private
+   * @inheritDoc
    */
-  this.opaque_ = false;
+  setActiveInternal() {
+    if (this.isActive()) {
+      // call this again when the feature type is ready, if necessary
+      this.describeCallback = this.setActiveInternal.bind(this);
+
+      // check if the feature type has been loaded
+      if (this.isFeatureTypeReady()) {
+        super.setActiveInternal();
+
+        // check for deprecated layers
+        if (this.getDeprecated()) {
+          deprecated.showDeprecatedWarning(this.getTitle());
+        }
+
+        // notify that the descriptor is ready since this may be async
+        this.onDescriptorReady();
+      }
+    } else {
+      return super.setActiveInternal();
+    }
+
+    // default to returning false so ready events aren't fired automatically
+    return false;
+  }
 
   /**
-   * @type {?Array<osx.ogc.TileStyle>}
-   * @private
+   * @inheritDoc
    */
-  this.styles_ = null;
+  isFeatureTypeReady() {
+    if (this.isWfsEnabled() && !this.featureType_) {
+      // lazy load the feature type
+      this.loadWFSDescribeFeature();
+      return false;
+    }
+
+    return true;
+  }
 
   /**
-   * @type {boolean}
-   * @private
+   * @inheritDoc
    */
-  this.usePost_ = false;
+  isFolder() {
+    return false;
+  }
 
   /**
-   * @type {boolean}
-   * @private
+   * @inheritDoc
    */
-  this.wfsEnabled_ = false;
+  isBaseLayer() {
+    return this.opaque_;
+  }
 
   /**
-   * @type {?string}
-   * @private
+   * @inheritDoc
    */
-  this.wfsName_ = null;
+  hasTimeExtent() {
+    if (this.isWmsEnabled()) {
+      return this.dimensions_ != null && 'time' in this.dimensions_;
+    }
+
+    if (this.isWmtsEnabled() && this.wmtsOptions_) {
+      return this.wmtsOptions_.some((options) => !!wmts.getTimeKey(options && options.dimensions || null));
+    }
+
+    if (this.featureType_ != null) {
+      return this.featureType_.getStartDateColumnName() !== null || this.featureType_.getEndDateColumnName() !== null;
+    }
+
+    return false;
+  }
 
   /**
-   * @type {?string}
-   * @private
+   * @inheritDoc
    */
-  this.wfsNameSpace_ = null;
+  updatedFromServer() {
+    this.setDeleteTime(NaN);
+    this.updateActiveFromTemp();
+    this.updateTags();
+  }
 
   /**
-   * @type {?string}
-   * @private
-   */
-  this.wfsUrl_ = null;
-
-  /**
-   * The WFS Content-Type request header.
-   * @type {string}
-   * @private
-   */
-  this.wfsContentType_ = 'text/xml';
-
-  /**
-   * @type {?Array<string>}
-   * @private
-   */
-  this.wfsFormats_ = null;
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  this.wmsEnabled_ = false;
-
-  /**
-   * @type {?string}
-   * @private
-   */
-  this.wmsName_ = null;
-
-  /**
-   * @type {?string}
-   * @private
-   */
-  this.wmsDateFormat_ = null;
-
-  /**
-   * @type {goog.Uri.QueryData}
-   * @private
-   */
-  this.wmsParams_ = null;
-
-  /**
-   * @type {goog.Uri.QueryData}
-   * @private
-   */
-  this.wfsParams_ = null;
-
-  /**
-   * @type {?string}
-   * @private
-   */
-  this.wmsTimeFormat_ = null;
-
-  /**
-   * @type {?string}
-   * @private
-   */
-  this.wmsUrl_ = null;
-
-  /**
-   * @type {?string}
-   * @private
-   */
-  this.wmsVersion_ = null;
-
-  /**
-   * @type {?Array<!string>}
-   * @private
-   */
-  this.wmsSupportedCRS_ = null;
-
-  /**
-   * If WMTS is enabled for this descriptor.
-   * @type {boolean}
-   * @private
-   */
-  this.wmtsEnabled_ = false;
-
-  /**
-   * The WMTS date format.
-   * @type {?string}
-   * @private
-   */
-  this.wmtsDateFormat_ = null;
-
-  /**
-   * The WMTS options.
-   * @type {Array<olx.source.WMTSOptions>}
-   * @private
-   */
-  this.wmtsOptions_ = null;
-
-  /**
-   * The WMTS time format.
-   * @type {?string}
-   * @private
-   */
-  this.wmtsTimeFormat_ = null;
-
-  /**
-   * Marker for whether the layer is deprecated. If a layer is deprecated, it will pop up a notification to the user
-   * to stop using it when the descriptor is activated.
-   * @type {boolean}
-   * @private
-   */
-  this.deprecated_ = false;
-
-  /**
-   * Regular expression to test for filterable types.
-   * @type {RegExp}
    * @protected
    */
-  this.filterableRegexp = plugin.ogc.OGCLayerDescriptor.FILTERABLE_RE;
+  updateTags() {
+    this.dispatchEvent(new PropertyChangeEvent('title'));
+  }
 
-  this.descriptorType = os.ogc.ID;
-};
-goog.inherits(plugin.ogc.OGCLayerDescriptor, os.data.LayerSyncDescriptor);
+  /**
+   *
+   * @inheritDoc
+   */
+  parseBBox(node, opt_forcedCrs) {
+    var forcedCrs = opt_forcedCrs || /** @type {string} */ (node['CRS']);
+
+    var minx = parseFloat(node['minx']);
+    var miny = parseFloat(node['miny']);
+    var maxx = parseFloat(node['maxx']);
+    var maxy = parseFloat(node['maxy']);
+
+    if (forcedCrs == os.proj.EPSG4326) {
+      this.bbox_ = [minx, miny, maxx, maxy];
+    } else {
+      this.bbox_ = [miny, minx, maxy, maxx];
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLayerOptions() {
+    var options = [];
+
+    if (this.isWmsEnabled()) {
+      options.push(this.getWmsOptions());
+    }
+
+    if (this.isWmtsEnabled()) {
+      options.push(this.getWmtsLayerOptions());
+    }
+
+    if (this.isWfsEnabled()) {
+      options.push(this.getWfsOptions());
+    }
+
+    return options;
+  }
+
+  /**
+   * @return {Object<string, *>}
+   * @protected
+   */
+  getWmsOptions() {
+    var options = {};
+    options['id'] = this.getId() + os.ui.data.BaseProvider.ID_DELIMITER + 'tiles';
+
+    var params = new QueryData();
+    params.set('LAYERS', this.getWmsName());
+    params.set('VERSION', this.getWmsVersion());
+
+    // merge custom WMS params
+    if (this.getWmsParams() != null) {
+      params.extend(this.getWmsParams());
+    }
+
+    options['baseColor'] = this.getColor();
+    options[ControlType.COLOR] = os.ui.ColorControlType.PICKER_RESET;
+
+    options['animate'] = this.hasTimeExtent();
+    options['dateFormat'] = this.getWmsDateFormat();
+    options['extent'] = this.getBBox();
+    options['layerType'] = this.getType();
+    options['legends'] = this.getLegends();
+    options['params'] = params;
+    options['provider'] = this.getProvider();
+    options['styles'] = this.getStyles();
+    options['tags'] = this.getTags();
+    options['timeFormat'] = this.getWmsTimeFormat();
+    options['title'] = this.getTitle();
+    options['type'] = 'WMS';
+    options['projections'] = this.getSupportedCRS();
+
+    var attribution = this.getAttribution();
+    if (attribution) {
+      options['attributions'] = [attribution];
+    }
+
+    var wmsUrl = this.getWmsUrl();
+    var urls = [wmsUrl];
+
+    if (this.dataProvider) {
+      var url = this.dataProvider.getUrl();
+      var alternateUrls = this.dataProvider.getAlternateUrls();
+
+      if (url && alternateUrls) {
+        for (var i = 0; i < alternateUrls.length; i++) {
+          urls.push(wmsUrl.replace(url, alternateUrls[i]));
+        }
+      }
+    }
+
+    options['urls'] = urls;
+
+    if (options['provider']) {
+      // check to see if the visibility is configured to false, if not visibility should be true
+      options['visible'] = Settings.getInstance().get(
+          [data.ProviderKey.ADMIN, this.getProvider().toLowerCase(), 'visible'], true);
+    }
+
+    return options;
+  }
+
+  /**
+   * Get the options object for the WMTS layer.
+   * @return {Object<string, *>}
+   * @protected
+   */
+  getWmtsLayerOptions() {
+    const id = this.getId() + os.ui.data.BaseProvider.ID_DELIMITER + 'tiles';
+    const wmtsOptions = this.getWmtsOptions();
+    const projections = wmtsOptions.map(wmts.optionsToProjection);
+
+    const options = {
+      'id': id,
+      'type': os.ogc.LayerType.WMTS,
+      'provider': this.getProvider(),
+      'title': this.getTitle(),
+      'extent': this.getBBox(),
+      'layerType': this.getType(),
+      'animate': this.hasTimeExtent(),
+      'dateFormat': this.getWmtsDateFormat(),
+      'timeFormat': this.getWmtsTimeFormat(),
+      'crossOrigin': wmtsOptions.crossOrigin,
+      'projections': projections,
+      'wmtsOptions': wmtsOptions
+    };
+
+    return options;
+  }
+
+  /**
+   * @return {Object<string, *>}
+   * @param {Object<string, *>=} opt_options
+   * @protected
+   */
+  getWfsOptions(opt_options) {
+    var options = opt_options || {};
+    options['id'] = this.getId() + os.ui.data.BaseProvider.ID_DELIMITER + 'features';
+
+    // color will change with user choices, baseColor maintains the original layer color for reset
+    options['baseColor'] = this.getColor();
+    options['color'] = this.getColor();
+    options[ControlType.COLOR] = os.ui.ColorControlType.PICKER_RESET;
+
+    options['animate'] = this.hasTimeExtent();
+    options['contentType'] = this.getWfsContentType();
+    options['exclusions'] = true;
+    options['featureType'] = this.featureType_;
+    options['filter'] = true;
+    options['layerType'] = this.getType();
+    options['load'] = true;
+    options['params'] = os.ogc.getWfsParams(this);
+    options['provider'] = this.getProvider();
+    options['spatial'] = true;
+    options['tags'] = this.getTags();
+    options['temporal'] = this.hasTimeExtent();
+    options['title'] = this.getTitle();
+    options['type'] = 'WFS';
+    options['url'] = this.replaceWithNextUrl(this.getWfsUrl());
+    options['usePost'] = this.getUsePost();
+    options['formats'] = this.getWfsFormats();
+
+    if (options['provider']) {
+      // check to see if the visibility is configured to false, if not visibility should be true
+      options['visible'] = Settings.getInstance().get(
+          [data.ProviderKey.ADMIN, this.getProvider().toLowerCase(), 'visible'], true);
+    }
+
+    return options;
+  }
+
+  /**
+   * @protected
+   */
+  loadWFSDescribeFeature() {
+    var loader = new DescribeFeatureLoader();
+    loader.setUrl(this.getWfsUrl());
+    loader.setTypename(this.getWfsName());
+    loader.listenOnce(goog.net.EventType.COMPLETE, this.onDescribeComplete_, false, this);
+    loader.load();
+  }
+
+  /**
+   * @param {goog.events.Event} event
+   * @private
+   */
+  onDescribeComplete_(event) {
+    var loader = /** @type {DescribeFeatureLoader} */ (event.target);
+    var featureType = loader.getFeatureType();
+    if (featureType) {
+      this.featureType_ = featureType;
+      // apply any persisted settings that may have been restored
+      if (this.restoreSettings_) {
+        this.featureType_.restore(this.restoreSettings_);
+        this.restoreSettings_ = null;
+        delete this.restoreSettings_;
+      }
+    } else {
+      this.onDescribeError();
+    }
+
+    if (this.describeCallback) {
+      this.describeCallback();
+      this.describeCallback = null;
+    }
+  }
+
+  /**
+   * Handle failure to load the feature type.
+   *
+   * @protected
+   */
+  onDescribeError() {
+    if (!this.online.refreshStatus()) {
+      // disable due to offline status
+      this.setActive(false);
+    } else {
+      // feature type could not be loaded, so disable WFS for the layer
+      this.setWfsEnabled(false);
+    }
+
+    var msg = this.getFeatureTypeErrorMsg();
+    AlertManager.getInstance().sendAlert(msg, AlertEventSeverity.ERROR);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setDescribeCallback(fn) {
+    this.describeCallback = fn;
+  }
+
+  /**
+   * Gets the error message to show when the DFT fails to load.
+   *
+   * @return {string}
+   */
+  getFeatureTypeErrorMsg() {
+    if (!this.online.refreshStatus()) {
+      return 'Network is disconnected. ' + this.getWfsName() + ' is unavailable.';
+    }
+
+    return 'Failed loading DescribeFeatureType for ' + this.getWfsName() +
+        '. Feature requests have been disabled for this layer.';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  launchFilterManager() {
+    this.describeCallback = this.launchFilterManager;
+
+    if (this.isFeatureTypeReady()) {
+      var id = this.getId() + os.ui.data.BaseProvider.ID_DELIMITER + 'features';
+      CombinatorCtrl.launchForLayer(id, this.getTitle() + ' Features');
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getFilterKey() {
+    return this.wfsUrl_ + os.ui.filter.FILTER_KEY_DELIMITER + this.wfsName_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLayerName() {
+    var name = this.wfsName_;
+    if (this.wfsName_) {
+      var idx = name.indexOf(':') + 1;
+      name = name.substring(idx);
+    }
+    return name;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getFilterColumns() {
+    return this.featureType_ ? this.featureType_.getColumns() : null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getNodeUI() {
+    var nodeUI = super.getNodeUI();
+    nodeUI += '<filterabledescriptornodeui></filterabledescriptornodeui>';
+    return nodeUI;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  persist(opt_obj) {
+    opt_obj = super.persist(opt_obj);
+    if (this.featureType_) {
+      opt_obj = this.featureType_.persist(opt_obj);
+    }
+    return opt_obj;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  restore(from) {
+    super.restore(from);
+    if (this.featureType_) {
+      this.featureType_.restore(from);
+    } else {
+      // The featureType has not been created yet, hold the restored
+      // settings and apply after featureType is set.
+      this.restoreSettings_ = from;
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getTestAreaKey(area) {
+    var key = [];
+
+    if (this.hasTimeExtent()) {
+      var tlc = os.time.TimelineController.getInstance();
+      key.push('' + tlc.getStart());
+      key.push('' + tlc.getEnd());
+    }
+
+    key.push(this.getId());
+    key.push(area.getId());
+
+    return key.join('|');
+  }
+
+  /**
+   * @inheritDoc
+   */
+  testArea(area) {
+    var result = false;
+
+    // simple bbox check
+    try {
+      var areaBox = area.getGeometry().getExtent();
+      var layerBox = this.getBBox();
+
+      if (areaBox && layerBox) {
+        result = ol.extent.intersects(areaBox, layerBox);
+      }
+    } catch (e) {
+    }
+
+    // TODO: if not result, return; otherwise, do more complex check
+    return result;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getFilterableTypes() {
+    return this.getAliases().filter(function(alias) {
+      return this.filterableRegexp.test(alias);
+    }, this);
+  }
+}
 
 
 /**
  * Class name
  * @type {string}
  */
-plugin.ogc.OGCLayerDescriptor.NAME = 'plugin.ogc.OGCLayerDescriptor';
-os.registerClass(plugin.ogc.OGCLayerDescriptor.NAME, plugin.ogc.OGCLayerDescriptor);
-os.implements(plugin.ogc.OGCLayerDescriptor, os.data.IAreaTest.ID);
-os.implements(plugin.ogc.OGCLayerDescriptor, os.filter.IFilterable.ID);
-os.implements(plugin.ogc.OGCLayerDescriptor, os.ui.ogc.IFeatureTypeDescriptor.ID);
-os.implements(plugin.ogc.OGCLayerDescriptor, os.ui.ogc.IOGCDescriptor.ID);
+OGCLayerDescriptor.NAME = 'plugin.ogc.OGCLayerDescriptor';
+os.registerClass(OGCLayerDescriptor.NAME, OGCLayerDescriptor);
+osImplements(OGCLayerDescriptor, IAreaTest.ID);
+osImplements(OGCLayerDescriptor, IFilterable.ID);
+osImplements(OGCLayerDescriptor, os.ui.ogc.IFeatureTypeDescriptor.ID);
+osImplements(OGCLayerDescriptor, IOGCDescriptor.ID);
 
 
 /**
@@ -251,1124 +1278,7 @@ os.implements(plugin.ogc.OGCLayerDescriptor, os.ui.ogc.IOGCDescriptor.ID);
  * @type {RegExp}
  * @const
  */
-plugin.ogc.OGCLayerDescriptor.FILTERABLE_RE = /#features/;
+OGCLayerDescriptor.FILTERABLE_RE = /#features/;
 
 
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getSearchType = function() {
-  return 'Layer';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getType = function() {
-  const hasTileLayer = this.wmsEnabled_ || this.wmtsEnabled_;
-  if (hasTileLayer && this.wfsEnabled_) {
-    return os.layer.LayerType.GROUPS;
-  } else if (hasTileLayer) {
-    return os.layer.LayerType.TILES;
-  } else if (this.wfsEnabled_) {
-    return os.layer.LayerType.FEATURES;
-  }
-
-  return null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getIcons = function() {
-  var iconsSVG = this.getSVGSet();
-  var s = '';
-  var color = this.getColor() ? os.color.toRgbArray(this.getColor()) : [255, 255, 255, 1];
-
-  if (this.deprecated_) {
-    s += os.ui.Icons.DEPRECATED;
-  }
-
-  s += os.ui.icons.createIconSet(goog.string.getRandomString(), iconsSVG, [], color);
-
-  return s;
-};
-
-
-/**
- * Gets the set of appropriate layer icons as SVG.
- *
- * @return {Array<string>}
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getSVGSet = function() {
-  var iconsSVG = [];
-
-  if (this.wmsEnabled_ || this.wmtsEnabled_) {
-    iconsSVG.push(os.ui.IconsSVG.TILES);
-  }
-
-  if (this.wfsEnabled_) {
-    iconsSVG.push(os.ui.IconsSVG.FEATURES);
-  }
-
-  if (this.hasTimeExtent()) {
-    iconsSVG.push(os.ui.IconsSVG.TIME);
-  }
-
-  return iconsSVG;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getAbstract = function() {
-  return this.getDescription();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setAbstract = function(value) {
-  this.setDescription(value);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getExplicitTitle = function() {
-  var title = '';
-
-  if (this.isWmsEnabled() || this.isWmtsEnabled()) {
-    title = 'Tiles';
-  }
-  if (this.isWfsEnabled()) {
-    title += title ? ' and Features' : 'Features';
-  }
-
-  return title;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getAliases = function() {
-  var aliases = [this.getId()];
-  if (this.wmsEnabled_ || this.wmtsEnabled_) {
-    aliases.push(this.getId() + os.ui.data.BaseProvider.ID_DELIMITER + 'tiles');
-  }
-  if (this.wfsEnabled_) {
-    aliases.push(this.getId() + os.ui.data.BaseProvider.ID_DELIMITER + 'features');
-  }
-
-  return aliases;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getAttribution = function() {
-  return this.attribution_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setAttribution = function(value) {
-  this.attribution_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getStyles = function() {
-  return this.styles_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setStyles = function(value) {
-  this.styles_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getOpaque = function() {
-  return this.opaque_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setOpaque = function(value) {
-  this.opaque_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getDimensions = function() {
-  return this.dimensions_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setDimensions = function(value) {
-  this.dimensions_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getBBox = function() {
-  return this.bbox_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setBBox = function(value) {
-  this.bbox_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getSupportedCRS = function() {
-  return this.wmsSupportedCRS_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setSupportedCRS = function(values) {
-  this.wmsSupportedCRS_ = values;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getKeywords = function() {
-  return this.getTags();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setKeywords = function(value) {
-  this.setTags(value);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getLegends = function() {
-  return this.legends_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setLegends = function(value) {
-  this.legends_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getFeatureType = function() {
-  return this.featureType_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.isWfsEnabled = function() {
-  return this.wfsEnabled_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWfsEnabled = function(value) {
-  this.wfsEnabled_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWfsName = function() {
-  return this.wfsName_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWfsName = function(value) {
-  this.wfsName_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWfsNamespace = function() {
-  return this.wfsNameSpace_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWfsNamespace = function(value) {
-  this.wfsNameSpace_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.isFilterable = function() {
-  return this.isWfsEnabled();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWfsUrl = function() {
-  return this.wfsUrl_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWfsUrl = function(value) {
-  this.wfsUrl_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWfsContentType = function() {
-  return this.wfsContentType_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWfsContentType = function(value) {
-  this.wfsContentType_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWfsFormats = function() {
-  return this.wfsFormats_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWfsFormats = function(value) {
-  this.wfsFormats_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.isWmsEnabled = function() {
-  return this.wmsEnabled_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWmsEnabled = function(value) {
-  this.wmsEnabled_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWmsDateFormat = function() {
-  return this.wmsDateFormat_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWmsDateFormat = function(value) {
-  this.wmsDateFormat_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWmsParams = function() {
-  return this.wmsParams_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWmsParams = function(value) {
-  this.wmsParams_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWfsParams = function() {
-  return this.wfsParams_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWfsParams = function(value) {
-  this.wfsParams_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWmsName = function() {
-  return this.wmsName_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWmsName = function(value) {
-  this.wmsName_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWmsTimeFormat = function() {
-  return this.wmsTimeFormat_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWmsTimeFormat = function(value) {
-  this.wmsTimeFormat_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWmsUrl = function() {
-  return this.wmsUrl_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWmsUrl = function(value) {
-  this.wmsUrl_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWmsVersion = function() {
-  return this.wmsVersion_ || ol.DEFAULT_WMS_VERSION;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWmsVersion = function(value) {
-  this.wmsVersion_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.isWmtsEnabled = function() {
-  return this.wmtsEnabled_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWmtsEnabled = function(value) {
-  this.wmtsEnabled_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWmtsDateFormat = function() {
-  return this.wmtsDateFormat_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWmtsDateFormat = function(value) {
-  this.wmtsDateFormat_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWmtsOptions = function() {
-  return this.wmtsOptions_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWmtsOptions = function(value) {
-  this.wmtsOptions_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWmtsTimeFormat = function() {
-  return this.wmtsTimeFormat_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setWmtsTimeFormat = function(value) {
-  this.wmtsTimeFormat_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getUsePost = function() {
-  return this.usePost_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setUsePost = function(value) {
-  this.usePost_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getUrlKey = function() {
-  return this.getFilterKey();
-};
-
-
-/**
- * If the provider is available and has alternate URLs, replaces the URL with the next available URL from the server.
- *
- * @param {?string} url The URL to replace
- * @return {?string}
- * @protected
- */
-plugin.ogc.OGCLayerDescriptor.prototype.replaceWithNextUrl = function(url) {
-  if (url && this.dataProvider instanceof os.ui.server.AbstractLoadingServer) {
-    var providerUrl = this.dataProvider.getUrl();
-    var nextUrl = this.dataProvider.getNextUrl();
-
-    if (providerUrl && nextUrl) {
-      url = url.replace(providerUrl, nextUrl);
-    }
-  }
-
-  return url;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getDeprecated = function() {
-  return this.deprecated_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setDeprecated = function(value) {
-  this.deprecated_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.addDimension = function(key, value) {
-  if (this.dimensions_ == null) {
-    this.dimensions_ = {};
-  }
-
-  this.dimensions_[key] = value;
-
-  if (key == 'time') {
-    var extents = value.split('/');
-    if (extents.length > 1) {
-      var n = new Date(extents[0]).getTime();
-      var m = new Date(extents[1]).getTime();
-
-      this.setMinDate(Math.min(m, n));
-      this.setMaxDate(Math.max(m, n));
-    } else {
-      this.setMinDate(NaN);
-      this.setMaxDate(NaN);
-    }
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setActiveInternal = function() {
-  if (this.isActive()) {
-    // call this again when the feature type is ready, if necessary
-    this.describeCallback = this.setActiveInternal.bind(this);
-
-    // check if the feature type has been loaded
-    if (this.isFeatureTypeReady()) {
-      plugin.ogc.OGCLayerDescriptor.base(this, 'setActiveInternal');
-
-      // check for deprecated layers
-      if (this.getDeprecated()) {
-        os.ui.util.deprecated.showDeprecatedWarning(this.getTitle());
-      }
-
-      // notify that the descriptor is ready since this may be async
-      this.onDescriptorReady();
-    }
-  } else {
-    return plugin.ogc.OGCLayerDescriptor.base(this, 'setActiveInternal');
-  }
-
-  // default to returning false so ready events aren't fired automatically
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.isFeatureTypeReady = function() {
-  if (this.isWfsEnabled() && !this.featureType_) {
-    // lazy load the feature type
-    this.loadWFSDescribeFeature();
-    return false;
-  }
-
-  return true;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.isFolder = function() {
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.isBaseLayer = function() {
-  return this.opaque_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.hasTimeExtent = function() {
-  if (this.isWmsEnabled()) {
-    return this.dimensions_ != null && 'time' in this.dimensions_;
-  }
-
-  if (this.isWmtsEnabled() && this.wmtsOptions_) {
-    return this.wmtsOptions_.some((options) => !!os.ogc.wmts.getTimeKey(options && options.dimensions || null));
-  }
-
-  if (this.featureType_ != null) {
-    return this.featureType_.getStartDateColumnName() !== null || this.featureType_.getEndDateColumnName() !== null;
-  }
-
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.updatedFromServer = function() {
-  this.setDeleteTime(NaN);
-  this.updateActiveFromTemp();
-  this.updateTags();
-};
-
-
-/**
- * @protected
- */
-plugin.ogc.OGCLayerDescriptor.prototype.updateTags = function() {
-  this.dispatchEvent(new os.events.PropertyChangeEvent('title'));
-};
-
-
-/**
- *
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.parseBBox = function(node, opt_forcedCrs) {
-  var forcedCrs = opt_forcedCrs || /** @type {string} */ (node['CRS']);
-
-  var minx = parseFloat(node['minx']);
-  var miny = parseFloat(node['miny']);
-  var maxx = parseFloat(node['maxx']);
-  var maxy = parseFloat(node['maxy']);
-
-  if (forcedCrs == os.proj.EPSG4326) {
-    this.bbox_ = [minx, miny, maxx, maxy];
-  } else {
-    this.bbox_ = [miny, minx, maxy, maxx];
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getLayerOptions = function() {
-  var options = [];
-
-  if (this.isWmsEnabled()) {
-    options.push(this.getWmsOptions());
-  }
-
-  if (this.isWmtsEnabled()) {
-    options.push(this.getWmtsLayerOptions());
-  }
-
-  if (this.isWfsEnabled()) {
-    options.push(this.getWfsOptions());
-  }
-
-  return options;
-};
-
-
-/**
- * @return {Object<string, *>}
- * @protected
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWmsOptions = function() {
-  var options = {};
-  options['id'] = this.getId() + os.ui.data.BaseProvider.ID_DELIMITER + 'tiles';
-
-  var params = new goog.Uri.QueryData();
-  params.set('LAYERS', this.getWmsName());
-  params.set('VERSION', this.getWmsVersion());
-
-  // merge custom WMS params
-  if (this.getWmsParams() != null) {
-    params.extend(this.getWmsParams());
-  }
-
-  options['baseColor'] = this.getColor();
-  options[os.ui.ControlType.COLOR] = os.ui.ColorControlType.PICKER_RESET;
-
-  options['animate'] = this.hasTimeExtent();
-  options['dateFormat'] = this.getWmsDateFormat();
-  options['extent'] = this.getBBox();
-  options['layerType'] = this.getType();
-  options['legends'] = this.getLegends();
-  options['params'] = params;
-  options['provider'] = this.getProvider();
-  options['styles'] = this.getStyles();
-  options['tags'] = this.getTags();
-  options['timeFormat'] = this.getWmsTimeFormat();
-  options['title'] = this.getTitle();
-  options['type'] = 'WMS';
-  options['projections'] = this.getSupportedCRS();
-
-  var attribution = this.getAttribution();
-  if (attribution) {
-    options['attributions'] = [attribution];
-  }
-
-  var wmsUrl = this.getWmsUrl();
-  var urls = [wmsUrl];
-
-  if (this.dataProvider) {
-    var url = this.dataProvider.getUrl();
-    var alternateUrls = this.dataProvider.getAlternateUrls();
-
-    if (url && alternateUrls) {
-      for (var i = 0; i < alternateUrls.length; i++) {
-        urls.push(wmsUrl.replace(url, alternateUrls[i]));
-      }
-    }
-  }
-
-  options['urls'] = urls;
-
-  if (options['provider']) {
-    // check to see if the visibility is configured to false, if not visibility should be true
-    options['visible'] = os.settings.get(
-        [os.data.ProviderKey.ADMIN, this.getProvider().toLowerCase(), 'visible'], true);
-  }
-
-  return options;
-};
-
-
-/**
- * Get the options object for the WMTS layer.
- * @return {Object<string, *>}
- * @protected
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWmtsLayerOptions = function() {
-  const id = this.getId() + os.ui.data.BaseProvider.ID_DELIMITER + 'tiles';
-  const wmtsOptions = this.getWmtsOptions();
-  const projections = wmtsOptions.map(os.ogc.wmts.optionsToProjection);
-
-  const options = {
-    'id': id,
-    'type': os.ogc.LayerType.WMTS,
-    'provider': this.getProvider(),
-    'title': this.getTitle(),
-    'extent': this.getBBox(),
-    'layerType': this.getType(),
-    'animate': this.hasTimeExtent(),
-    'dateFormat': this.getWmtsDateFormat(),
-    'timeFormat': this.getWmtsTimeFormat(),
-    'crossOrigin': wmtsOptions.crossOrigin,
-    'projections': projections,
-    'wmtsOptions': wmtsOptions
-  };
-
-  return options;
-};
-
-
-/**
- * @return {Object<string, *>}
- * @param {Object<string, *>=} opt_options
- * @protected
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getWfsOptions = function(opt_options) {
-  var options = opt_options || {};
-  options['id'] = this.getId() + os.ui.data.BaseProvider.ID_DELIMITER + 'features';
-
-  // color will change with user choices, baseColor maintains the original layer color for reset
-  options['baseColor'] = this.getColor();
-  options['color'] = this.getColor();
-  options[os.ui.ControlType.COLOR] = os.ui.ColorControlType.PICKER_RESET;
-
-  options['animate'] = this.hasTimeExtent();
-  options['contentType'] = this.getWfsContentType();
-  options['exclusions'] = true;
-  options['featureType'] = this.featureType_;
-  options['filter'] = true;
-  options['layerType'] = this.getType();
-  options['load'] = true;
-  options['params'] = os.ogc.getWfsParams(this);
-  options['provider'] = this.getProvider();
-  options['spatial'] = true;
-  options['tags'] = this.getTags();
-  options['temporal'] = this.hasTimeExtent();
-  options['title'] = this.getTitle();
-  options['type'] = 'WFS';
-  options['url'] = this.replaceWithNextUrl(this.getWfsUrl());
-  options['usePost'] = this.getUsePost();
-  options['formats'] = this.getWfsFormats();
-
-  if (options['provider']) {
-    // check to see if the visibility is configured to false, if not visibility should be true
-    options['visible'] = os.settings.get(
-        [os.data.ProviderKey.ADMIN, this.getProvider().toLowerCase(), 'visible'], true);
-  }
-
-  return options;
-};
-
-
-/**
- * @protected
- */
-plugin.ogc.OGCLayerDescriptor.prototype.loadWFSDescribeFeature = function() {
-  var loader = new os.ogc.wfs.DescribeFeatureLoader();
-  loader.setUrl(this.getWfsUrl());
-  loader.setTypename(this.getWfsName());
-  loader.listenOnce(goog.net.EventType.COMPLETE, this.onDescribeComplete_, false, this);
-  loader.load();
-};
-
-
-/**
- * @param {goog.events.Event} event
- * @private
- */
-plugin.ogc.OGCLayerDescriptor.prototype.onDescribeComplete_ = function(event) {
-  var loader = /** @type {os.ogc.wfs.DescribeFeatureLoader} */ (event.target);
-  var featureType = loader.getFeatureType();
-  if (featureType) {
-    this.featureType_ = featureType;
-    // apply any presisted settings that may have been restored
-    if (this.restoreSettings_) {
-      this.featureType_.restore(this.restoreSettings_);
-      this.restoreSettings_ = null;
-      delete this.restoreSettings_;
-    }
-  } else {
-    this.onDescribeError();
-  }
-
-  if (this.describeCallback) {
-    this.describeCallback();
-    this.describeCallback = null;
-  }
-};
-
-
-/**
- * Handle failure to load the feature type.
- *
- * @protected
- */
-plugin.ogc.OGCLayerDescriptor.prototype.onDescribeError = function() {
-  if (!this.online.refreshStatus()) {
-    // disable due to offline status
-    this.setActive(false);
-  } else {
-    // feature type could not be loaded, so disable WFS for the layer
-    this.setWfsEnabled(false);
-  }
-
-  var msg = this.getFeatureTypeErrorMsg();
-  os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.ERROR);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.setDescribeCallback = function(fn) {
-  this.describeCallback = fn;
-};
-
-
-/**
- * Gets the error message to show when the DFT fails to load.
- *
- * @return {string}
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getFeatureTypeErrorMsg = function() {
-  if (!this.online.refreshStatus()) {
-    return 'Network is disconnected. ' + this.getWfsName() + ' is unavailable.';
-  }
-
-  return 'Failed loading DescribeFeatureType for ' + this.getWfsName() +
-      '. Feature requests have been disabled for this layer.';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.launchFilterManager = function() {
-  this.describeCallback = this.launchFilterManager;
-
-  if (this.isFeatureTypeReady()) {
-    var id = this.getId() + os.ui.data.BaseProvider.ID_DELIMITER + 'features';
-    os.ui.query.CombinatorCtrl.launchForLayer(id, this.getTitle() + ' Features');
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getFilterKey = function() {
-  return this.wfsUrl_ + os.ui.filter.FILTER_KEY_DELIMITER + this.wfsName_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getLayerName = function() {
-  var name = this.wfsName_;
-  if (this.wfsName_) {
-    var idx = name.indexOf(':') + 1;
-    name = name.substring(idx);
-  }
-  return name;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getFilterColumns = function() {
-  return this.featureType_ ? this.featureType_.getColumns() : null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getNodeUI = function() {
-  var nodeUI = plugin.ogc.OGCLayerDescriptor.base(this, 'getNodeUI');
-  nodeUI += '<filterabledescriptornodeui></filterabledescriptornodeui>';
-  return nodeUI;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.persist = function(opt_obj) {
-  opt_obj = plugin.ogc.OGCLayerDescriptor.base(this, 'persist', opt_obj);
-  if (this.featureType_) {
-    opt_obj = this.featureType_.persist(opt_obj);
-  }
-  return opt_obj;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.restore = function(from) {
-  plugin.ogc.OGCLayerDescriptor.base(this, 'restore', from);
-  if (this.featureType_) {
-    this.featureType_.restore(from);
-  } else {
-    // The featureType has not been created yet, hold the restored
-    // settings and apply after featureType is set.
-    this.restoreSettings_ = from;
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getTestAreaKey = function(area) {
-  var key = [];
-
-  if (this.hasTimeExtent()) {
-    var tlc = os.time.TimelineController.getInstance();
-    key.push('' + tlc.getStart());
-    key.push('' + tlc.getEnd());
-  }
-
-  key.push(this.getId());
-  key.push(area.getId());
-
-  return key.join('|');
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.testArea = function(area) {
-  var result = false;
-
-  // simple bbox check
-  try {
-    var areaBox = area.getGeometry().getExtent();
-    var layerBox = this.getBBox();
-
-    if (areaBox && layerBox) {
-      result = ol.extent.intersects(areaBox, layerBox);
-    }
-  } catch (e) {
-  }
-
-  // TODO: if not result, return; otherwise, do more complex check
-  return result;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCLayerDescriptor.prototype.getFilterableTypes = function() {
-  return this.getAliases().filter(function(alias) {
-    return this.filterableRegexp.test(alias);
-  }, this);
-};
+exports = OGCLayerDescriptor;

--- a/src/plugin/ogc/ogcplugin.js
+++ b/src/plugin/ogc/ogcplugin.js
@@ -3,6 +3,8 @@ goog.module.declareLegacyNamespace();
 
 const DataManager = goog.require('os.data.DataManager');
 const ProviderEntry = goog.require('os.data.ProviderEntry');
+const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
+const net = goog.require('os.net');
 const osOgc = goog.require('os.ogc');
 const LayerType = goog.require('os.ogc.LayerType');
 const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
@@ -22,6 +24,7 @@ const QueryWFSLayerConfig = goog.require('plugin.ogc.wfs.QueryWFSLayerConfig');
 const WMSLayerConfig = goog.require('plugin.ogc.wms.WMSLayerConfig');
 const WMTSLayerConfig = goog.require('plugin.ogc.wmts.WMTSLayerConfig');
 const WMTSServer = goog.require('plugin.ogc.wmts.WMTSServer');
+
 
 /**
  * Provides WMS/WFS layer support, both separately and as a grouped layer combination.
@@ -58,11 +61,11 @@ class OGCPlugin extends AbstractPlugin {
     dm.registerDescriptorType(osOgc.ID, OGCLayerDescriptor);
 
     // register the layer configurations
-    var lcm = os.layer.config.LayerConfigManager.getInstance();
+    var lcm = LayerConfigManager.getInstance();
     lcm.registerLayerConfig(LayerType.WMS, WMSLayerConfig);
     lcm.registerLayerConfig(LayerType.WFS, QueryWFSLayerConfig);
     lcm.registerLayerConfig(LayerType.WMTS, WMTSLayerConfig);
-    lcm.registerDefaultLayerConfig(LayerType.WFS, plugin.ogc.getDefaultWfsOptions);
+    lcm.registerDefaultLayerConfig(LayerType.WFS, getDefaultWfsOptions);
 
     // register the server forms for adding/editing servers
     var im = ImportManager.getInstance();
@@ -82,17 +85,16 @@ class OGCPlugin extends AbstractPlugin {
       label: 'GeoServer'
     });
 
-    os.net.registerDefaultValidator(osOgc.getException);
+    net.registerDefaultValidator(osOgc.getException);
   }
 }
-
 
 /**
  * Get the default opensphere WFS layer options
  *
  * @return {!Object<string, *>}
  */
-plugin.ogc.getDefaultWfsOptions = function() {
+const getDefaultWfsOptions = function() {
   var options = osOgc.getDefaultWfsOptions();
 
   // opensphere handles this per-request based on the feature limit imposed by 2D/3D mode, so exclude it from the request
@@ -102,4 +104,5 @@ plugin.ogc.getDefaultWfsOptions = function() {
 
   return options;
 };
+
 exports = OGCPlugin;

--- a/src/plugin/ogc/ogcplugin.js
+++ b/src/plugin/ogc/ogcplugin.js
@@ -1,92 +1,90 @@
-goog.provide('plugin.ogc.OGCPlugin');
+goog.module('plugin.ogc.OGCPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.DataManager');
-goog.require('os.data.ProviderEntry');
-goog.require('os.ogc');
-goog.require('os.ogc.LayerType');
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.ui.ProviderImportUI');
-goog.require('os.ui.action.Action');
-goog.require('os.ui.im.ImportManager');
-goog.require('os.ui.ogc.OGCServer');
-goog.require('plugin.ogc.GeoServer');
-goog.require('plugin.ogc.OGCLayerDescriptor');
-goog.require('plugin.ogc.mime');
-goog.require('plugin.ogc.ui.GeoServerHelpUI');
-goog.require('plugin.ogc.ui.GeoserverImportForm');
-goog.require('plugin.ogc.ui.OgcServerHelpUI');
-goog.require('plugin.ogc.ui.OgcServerImportForm');
-goog.require('plugin.ogc.ui.geoserverDirective');
-goog.require('plugin.ogc.ui.ogcserverDirective');
-goog.require('plugin.ogc.wfs.QueryWFSLayerConfig');
-goog.require('plugin.ogc.wms.WMSLayerConfig');
-goog.require('plugin.ogc.wmts.WMTSLayerConfig');
-goog.require('plugin.ogc.wmts.WMTSServer');
-
-
+const DataManager = goog.require('os.data.DataManager');
+const ProviderEntry = goog.require('os.data.ProviderEntry');
+const osOgc = goog.require('os.ogc');
+const LayerType = goog.require('os.ogc.LayerType');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const ProviderImportUI = goog.require('os.ui.ProviderImportUI');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const OGCServer = goog.require('os.ui.ogc.OGCServer');
+const GeoServer = goog.require('plugin.ogc.GeoServer');
+const OGCLayerDescriptor = goog.require('plugin.ogc.OGCLayerDescriptor');
+const mime = goog.require('plugin.ogc.mime');
+const GeoServerHelpUI = goog.require('plugin.ogc.ui.GeoServerHelpUI');
+const GeoserverImportForm = goog.require('plugin.ogc.ui.GeoserverImportForm');
+const {directiveTag: geoserverImportUi} = goog.require('plugin.ogc.ui.GeoserverImportUI');
+const OgcServerHelpUI = goog.require('plugin.ogc.ui.OgcServerHelpUI');
+const OgcServerImportForm = goog.require('plugin.ogc.ui.OgcServerImportForm');
+const {directiveTag: ogcImportUi} = goog.require('plugin.ogc.ui.OgcServerImportUI');
+const QueryWFSLayerConfig = goog.require('plugin.ogc.wfs.QueryWFSLayerConfig');
+const WMSLayerConfig = goog.require('plugin.ogc.wms.WMSLayerConfig');
+const WMTSLayerConfig = goog.require('plugin.ogc.wmts.WMTSLayerConfig');
+const WMTSServer = goog.require('plugin.ogc.wmts.WMTSServer');
 
 /**
  * Provides WMS/WFS layer support, both separately and as a grouped layer combination.
- *
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.ogc.OGCPlugin = function() {
-  plugin.ogc.OGCPlugin.base(this, 'constructor');
-  this.id = os.ogc.ID;
-};
-goog.inherits(plugin.ogc.OGCPlugin, os.plugin.AbstractPlugin);
+class OGCPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = osOgc.ID;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  init() {
+    var dm = DataManager.getInstance();
 
-/**
- * @inheritDoc
- */
-plugin.ogc.OGCPlugin.prototype.init = function() {
-  var dm = os.dataManager;
+    var ogc = new ProviderEntry(osOgc.ID, OGCServer, 'OGC Server',
+        'OGC Servers provide raster imagery through WMS (Web Map Service) and vector features through WFS' +
+      ' (Web Feature Service) servers');
 
-  var ogc = new os.data.ProviderEntry(os.ogc.ID, os.ui.ogc.OGCServer, 'OGC Server',
-      'OGC Servers provide raster imagery through WMS (Web Map Service) and vector features through WFS' +
-    ' (Web Feature Service) servers');
+    var geo = new ProviderEntry(mime.GEOSERVER_TYPE, GeoServer, 'GeoServer', '');
 
-  var geo = new os.data.ProviderEntry(plugin.ogc.mime.GEOSERVER_TYPE, plugin.ogc.GeoServer, 'GeoServer', '');
+    var wmts = new ProviderEntry(WMTSServer.TYPE, WMTSServer, 'WMTS Server', '');
 
-  var wmts = new os.data.ProviderEntry(plugin.ogc.wmts.WMTSServer.TYPE, plugin.ogc.wmts.WMTSServer, 'WMTS Server', '');
+    // register the ogc provider types
+    dm.registerProviderType(ogc);
+    dm.registerProviderType(geo);
+    dm.registerProviderType(wmts);
 
-  // register the ogc provider types
-  dm.registerProviderType(ogc);
-  dm.registerProviderType(geo);
-  dm.registerProviderType(wmts);
+    // register the ogc descriptor types
+    dm.registerDescriptorType(osOgc.ID, OGCLayerDescriptor);
 
-  // register the ogc descriptor types
-  dm.registerDescriptorType(os.ogc.ID, plugin.ogc.OGCLayerDescriptor);
+    // register the layer configurations
+    var lcm = os.layer.config.LayerConfigManager.getInstance();
+    lcm.registerLayerConfig(LayerType.WMS, WMSLayerConfig);
+    lcm.registerLayerConfig(LayerType.WFS, QueryWFSLayerConfig);
+    lcm.registerLayerConfig(LayerType.WMTS, WMTSLayerConfig);
+    lcm.registerDefaultLayerConfig(LayerType.WFS, plugin.ogc.getDefaultWfsOptions);
 
-  // register the layer configurations
-  var lcm = os.layer.config.LayerConfigManager.getInstance();
-  lcm.registerLayerConfig(os.ogc.LayerType.WMS, plugin.ogc.wms.WMSLayerConfig);
-  lcm.registerLayerConfig(os.ogc.LayerType.WFS, plugin.ogc.wfs.QueryWFSLayerConfig);
-  lcm.registerLayerConfig(os.ogc.LayerType.WMTS, plugin.ogc.wmts.WMTSLayerConfig);
-  lcm.registerDefaultLayerConfig(os.ogc.LayerType.WFS, plugin.ogc.getDefaultWfsOptions);
+    // register the server forms for adding/editing servers
+    var im = ImportManager.getInstance();
+    im.registerImportUI(osOgc.ID, new ProviderImportUI(`<${ogcImportUi}></${ogcImportUi}>`));
+    im.registerServerType(osOgc.ID, {
+      type: 'ogc',
+      helpUi: OgcServerHelpUI.directiveTag,
+      formUi: OgcServerImportForm.directiveTag,
+      label: 'OGC Server'
+    });
+    im.registerImportUI(mime.GEOSERVER_TYPE,
+        new ProviderImportUI(`<${geoserverImportUi}></${geoserverImportUi}>`));
+    im.registerServerType(mime.GEOSERVER_TYPE, {
+      type: 'geoserver',
+      helpUi: GeoServerHelpUI.directiveTag,
+      formUi: GeoserverImportForm.directiveTag,
+      label: 'GeoServer'
+    });
 
-  // register the server forms for adding/editing servers
-  var im = os.ui.im.ImportManager.getInstance();
-  im.registerImportUI(os.ogc.ID, new os.ui.ProviderImportUI('<ogcserver></ogcserver>'));
-  im.registerServerType(os.ogc.ID, {
-    type: 'ogc',
-    helpUi: plugin.ogc.ui.OgcServerHelpUI.directiveTag,
-    formUi: plugin.ogc.ui.OgcServerImportForm.directiveTag,
-    label: 'OGC Server'
-  });
-  im.registerImportUI(plugin.ogc.mime.GEOSERVER_TYPE,
-      new os.ui.ProviderImportUI('<geoserver></geoserver>'));
-  im.registerServerType(plugin.ogc.mime.GEOSERVER_TYPE, {
-    type: 'geoserver',
-    helpUi: plugin.ogc.ui.GeoServerHelpUI.directiveTag,
-    formUi: plugin.ogc.ui.GeoserverImportForm.directiveTag,
-    label: 'GeoServer'
-  });
-
-  os.net.registerDefaultValidator(os.ogc.getException);
-};
+    os.net.registerDefaultValidator(osOgc.getException);
+  }
+}
 
 
 /**
@@ -95,7 +93,7 @@ plugin.ogc.OGCPlugin.prototype.init = function() {
  * @return {!Object<string, *>}
  */
 plugin.ogc.getDefaultWfsOptions = function() {
-  var options = os.ogc.getDefaultWfsOptions();
+  var options = osOgc.getDefaultWfsOptions();
 
   // opensphere handles this per-request based on the feature limit imposed by 2D/3D mode, so exclude it from the request
   // parameters
@@ -104,3 +102,4 @@ plugin.ogc.getDefaultWfsOptions = function() {
 
   return options;
 };
+exports = OGCPlugin;

--- a/src/plugin/ogc/query/filteridmodifier.js
+++ b/src/plugin/ogc/query/filteridmodifier.js
@@ -1,6 +1,7 @@
 goog.module('plugin.ogc.query.FilterIDModifier');
 goog.module.declareLegacyNamespace();
 
+const googString = goog.require('goog.string');
 const ParamModifier = goog.require('os.net.ParamModifier');
 const ModifierConstants = goog.require('os.ogc.filter.ModifierConstants');
 
@@ -28,7 +29,7 @@ class FilterIDModifier extends ParamModifier {
       for (var x = 0; x < columns.length; x++) {
         var propEquals = '<PropertyIsEqualTo><PropertyName>' + columns[x] + '</PropertyName><Literal>{{' + columns[x] +
             '}}</Literal></PropertyIsEqualTo>';
-        filterValue = goog.string.buildString(filterValue, propEquals.replace('{{' + columns[x] + '}}',
+        filterValue = googString.buildString(filterValue, propEquals.replace('{{' + columns[x] + '}}',
             columnValueMap[columns[x]][y]));
       }
       filterValue += '</And>';

--- a/src/plugin/ogc/query/filteridmodifier.js
+++ b/src/plugin/ogc/query/filteridmodifier.js
@@ -1,44 +1,47 @@
-goog.provide('plugin.ogc.query.FilterIDModifier');
-goog.require('os.net.ParamModifier');
-goog.require('os.ogc.filter.ModifierConstants');
+goog.module('plugin.ogc.query.FilterIDModifier');
+goog.module.declareLegacyNamespace();
 
+const ParamModifier = goog.require('os.net.ParamModifier');
+const ModifierConstants = goog.require('os.ogc.filter.ModifierConstants');
 
 
 /**
  * Modifier for adding WFS relation filters to OGC queries.
- *
- * @param {Object} columnValueMap
- * @extends {os.net.ParamModifier}
- * @constructor
  */
-plugin.ogc.query.FilterIDModifier = function(columnValueMap) {
-  var replacement = '<Or>';
-  var columns = [];
-  var valueLength = 0;
-  for (var columnId in columnValueMap) {
-    columns.push(columnId);
-    valueLength = columnValueMap[columnId].length;
-  }
-
-  // for all of the values, pair all of the column values together in an AND wrapped in one big OR
-  for (var y = 0; y < valueLength; y++) {
-    var filterValue = '<And>';
-    for (var x = 0; x < columns.length; x++) {
-      var propEquals = '<PropertyIsEqualTo><PropertyName>' + columns[x] + '</PropertyName><Literal>{{' + columns[x] +
-          '}}</Literal></PropertyIsEqualTo>';
-      filterValue = goog.string.buildString(filterValue, propEquals.replace('{{' + columns[x] + '}}',
-          columnValueMap[columns[x]][y]));
+class FilterIDModifier extends ParamModifier {
+  /**
+   * Constructor.
+   * @param {Object} columnValueMap
+   */
+  constructor(columnValueMap) {
+    var replacement = '<Or>';
+    var columns = [];
+    var valueLength = 0;
+    for (var columnId in columnValueMap) {
+      columns.push(columnId);
+      valueLength = columnValueMap[columnId].length;
     }
-    filterValue += '</And>';
 
-    if (replacement.indexOf(filterValue) < 0) { // no dupes
-      replacement += filterValue;
+    // for all of the values, pair all of the column values together in an AND wrapped in one big OR
+    for (var y = 0; y < valueLength; y++) {
+      var filterValue = '<And>';
+      for (var x = 0; x < columns.length; x++) {
+        var propEquals = '<PropertyIsEqualTo><PropertyName>' + columns[x] + '</PropertyName><Literal>{{' + columns[x] +
+            '}}</Literal></PropertyIsEqualTo>';
+        filterValue = goog.string.buildString(filterValue, propEquals.replace('{{' + columns[x] + '}}',
+            columnValueMap[columns[x]][y]));
+      }
+      filterValue += '</And>';
+
+      if (replacement.indexOf(filterValue) < 0) { // no dupes
+        replacement += filterValue;
+      }
     }
+
+    replacement += '</Or>';
+
+    super('relateLayer', 'filter', ModifierConstants.IDENTIFIERS, replacement);
   }
+}
 
-  replacement += '</Or>';
-
-  plugin.ogc.query.FilterIDModifier.base(this, 'constructor',
-      'relateLayer', 'filter', os.ogc.filter.ModifierConstants.IDENTIFIERS, replacement);
-};
-goog.inherits(plugin.ogc.query.FilterIDModifier, os.net.ParamModifier);
+exports = FilterIDModifier;

--- a/src/plugin/ogc/query/ogcexclusionformatter.js
+++ b/src/plugin/ogc/query/ogcexclusionformatter.js
@@ -1,28 +1,35 @@
-goog.provide('plugin.ogc.query.OGCExclusionFormatter');
-goog.require('os.ogc.filter.OGCExclusionFormatter');
+goog.module('plugin.ogc.query.OGCExclusionFormatter');
+goog.module.declareLegacyNamespace();
 
+const OSOGCExclusionFormatter = goog.require('os.ogc.filter.OGCExclusionFormatter');
 
-
-/**
- * @param {string=} opt_column
- * @extends {os.ogc.filter.OGCExclusionFormatter}
- * @constructor
- */
-plugin.ogc.query.OGCExclusionFormatter = function(opt_column) {
-  plugin.ogc.query.OGCExclusionFormatter.base(this, 'constructor', opt_column);
-};
-goog.inherits(plugin.ogc.query.OGCExclusionFormatter, os.ogc.filter.OGCExclusionFormatter);
+const Geometry = goog.requireType('ol.geom.Geometry');
 
 
 /**
- * @inheritDoc
+ * OGC exclusion formatter that converts the geometry to EPSG:4326.
  */
-plugin.ogc.query.OGCExclusionFormatter.prototype.getGeometry = function(feature) {
-  var geom = /** @type {ol.geom.Geometry} */ (feature.get(os.interpolate.ORIGINAL_GEOM_FIELD)) || feature.getGeometry();
-
-  if (geom) {
-    geom = geom.clone().toLonLat();
+class OGCExclusionFormatter extends OSOGCExclusionFormatter {
+  /**
+   * Constructor.
+   * @param {string=} opt_column
+   */
+  constructor(opt_column) {
+    super(opt_column);
   }
 
-  return geom;
-};
+  /**
+   * @inheritDoc
+   */
+  getGeometry(feature) {
+    var geom = /** @type {Geometry} */ (feature.get(os.interpolate.ORIGINAL_GEOM_FIELD)) || feature.getGeometry();
+
+    if (geom) {
+      geom = geom.clone().toLonLat();
+    }
+
+    return geom;
+  }
+}
+
+exports = OGCExclusionFormatter;

--- a/src/plugin/ogc/query/ogcexclusionformatter.js
+++ b/src/plugin/ogc/query/ogcexclusionformatter.js
@@ -1,6 +1,7 @@
 goog.module('plugin.ogc.query.OGCExclusionFormatter');
 goog.module.declareLegacyNamespace();
 
+const interpolate = goog.require('os.interpolate');
 const OSOGCExclusionFormatter = goog.require('os.ogc.filter.OGCExclusionFormatter');
 
 const Geometry = goog.requireType('ol.geom.Geometry');
@@ -22,7 +23,7 @@ class OGCExclusionFormatter extends OSOGCExclusionFormatter {
    * @inheritDoc
    */
   getGeometry(feature) {
-    var geom = /** @type {Geometry} */ (feature.get(os.interpolate.ORIGINAL_GEOM_FIELD)) || feature.getGeometry();
+    var geom = /** @type {Geometry} */ (feature.get(interpolate.ORIGINAL_GEOM_FIELD)) || feature.getGeometry();
 
     if (geom) {
       geom = geom.clone().toLonLat();

--- a/src/plugin/ogc/query/ogcqueryhandler.js
+++ b/src/plugin/ogc/query/ogcqueryhandler.js
@@ -1,27 +1,30 @@
-goog.provide('plugin.ogc.query.OGCQueryHandler');
+goog.module('plugin.ogc.query.OGCQueryHandler');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.net.ParamModifier');
-goog.require('os.ogc.filter.ModifierConstants');
-goog.require('os.ogc.filter.OGCFilterFormatter');
-goog.require('os.query.QueryHandler');
-goog.require('plugin.ogc.query.OGCExclusionFormatter');
-goog.require('plugin.ogc.query.OGCSpatialFormatter');
-
+const ParamModifier = goog.require('os.net.ParamModifier');
+const ModifierConstants = goog.require('os.ogc.filter.ModifierConstants');
+const OGCFilterFormatter = goog.require('os.ogc.filter.OGCFilterFormatter');
+const QueryHandler = goog.require('os.query.QueryHandler');
+const OGCExclusionFormatter = goog.require('plugin.ogc.query.OGCExclusionFormatter');
+const OGCSpatialFormatter = goog.require('plugin.ogc.query.OGCSpatialFormatter');
 
 
 /**
- * @param {string=} opt_geomColumn
- * @constructor
- * @extends {os.query.QueryHandler}
  */
-plugin.ogc.query.OGCQueryHandler = function(opt_geomColumn) {
-  plugin.ogc.query.OGCQueryHandler.base(this, 'constructor');
+class OGCQueryHandler extends QueryHandler {
+  /**
+   * Constructor.
+   * @param {string=} opt_geomColumn
+   */
+  constructor(opt_geomColumn) {
+    super();
 
-  this.setModifier(new os.net.ParamModifier('filter', 'filter', os.ogc.filter.ModifierConstants.FILTER, ''));
-  this.setAreaFormatter(new plugin.ogc.query.OGCSpatialFormatter(opt_geomColumn));
-  this.setExclusionFormatter(new plugin.ogc.query.OGCExclusionFormatter(opt_geomColumn));
-  this.setFilterFormatter(new os.ogc.filter.OGCFilterFormatter());
-  this.spatialRequired = true;
-};
-goog.inherits(plugin.ogc.query.OGCQueryHandler, os.query.QueryHandler);
+    this.setModifier(new ParamModifier('filter', 'filter', ModifierConstants.FILTER, ''));
+    this.setAreaFormatter(new OGCSpatialFormatter(opt_geomColumn));
+    this.setExclusionFormatter(new OGCExclusionFormatter(opt_geomColumn));
+    this.setFilterFormatter(new OGCFilterFormatter());
+    this.spatialRequired = true;
+  }
+}
 
+exports = OGCQueryHandler;

--- a/src/plugin/ogc/query/ogcspatialformatter.js
+++ b/src/plugin/ogc/query/ogcspatialformatter.js
@@ -1,28 +1,35 @@
-goog.provide('plugin.ogc.query.OGCSpatialFormatter');
-goog.require('os.ogc.filter.OGCSpatialFormatter');
+goog.module('plugin.ogc.query.OGCSpatialFormatter');
+goog.module.declareLegacyNamespace();
 
+const OSOGCSpatialFormatter = goog.require('os.ogc.filter.OGCSpatialFormatter');
 
-
-/**
- * @param {string=} opt_column
- * @extends {os.ogc.filter.OGCSpatialFormatter}
- * @constructor
- */
-plugin.ogc.query.OGCSpatialFormatter = function(opt_column) {
-  plugin.ogc.query.OGCSpatialFormatter.base(this, 'constructor', opt_column);
-};
-goog.inherits(plugin.ogc.query.OGCSpatialFormatter, os.ogc.filter.OGCSpatialFormatter);
+const Geometry = goog.requireType('ol.geom.Geometry');
 
 
 /**
- * @inheritDoc
+ * OGC spatial formatter that converts the geometry to EPSG:4326.
  */
-plugin.ogc.query.OGCSpatialFormatter.prototype.getGeometry = function(feature) {
-  var geom = /** @type {ol.geom.Geometry} */ (feature.get(os.interpolate.ORIGINAL_GEOM_FIELD)) || feature.getGeometry();
-
-  if (geom) {
-    geom = geom.clone().toLonLat();
+class OGCSpatialFormatter extends OSOGCSpatialFormatter {
+  /**
+   * Constructor.
+   * @param {string=} opt_column
+   */
+  constructor(opt_column) {
+    super(opt_column);
   }
 
-  return geom;
-};
+  /**
+   * @inheritDoc
+   */
+  getGeometry(feature) {
+    var geom = /** @type {Geometry} */ (feature.get(os.interpolate.ORIGINAL_GEOM_FIELD)) || feature.getGeometry();
+
+    if (geom) {
+      geom = geom.clone().toLonLat();
+    }
+
+    return geom;
+  }
+}
+
+exports = OGCSpatialFormatter;

--- a/src/plugin/ogc/query/ogcspatialformatter.js
+++ b/src/plugin/ogc/query/ogcspatialformatter.js
@@ -1,6 +1,7 @@
 goog.module('plugin.ogc.query.OGCSpatialFormatter');
 goog.module.declareLegacyNamespace();
 
+const interpolate = goog.require('os.interpolate');
 const OSOGCSpatialFormatter = goog.require('os.ogc.filter.OGCSpatialFormatter');
 
 const Geometry = goog.requireType('ol.geom.Geometry');
@@ -22,7 +23,7 @@ class OGCSpatialFormatter extends OSOGCSpatialFormatter {
    * @inheritDoc
    */
   getGeometry(feature) {
-    var geom = /** @type {Geometry} */ (feature.get(os.interpolate.ORIGINAL_GEOM_FIELD)) || feature.getGeometry();
+    var geom = /** @type {Geometry} */ (feature.get(interpolate.ORIGINAL_GEOM_FIELD)) || feature.getGeometry();
 
     if (geom) {
       geom = geom.clone().toLonLat();

--- a/src/plugin/ogc/ui/choosetimecolumn.js
+++ b/src/plugin/ogc/ui/choosetimecolumn.js
@@ -7,6 +7,9 @@ const Disposable = goog.require('goog.Disposable');
 const os = goog.require('os');
 const DataManager = goog.require('os.data.DataManager');
 const Module = goog.require('os.ui.Module');
+const WindowEventType = goog.require('os.ui.WindowEventType');
+const osWindow = goog.require('os.ui.window');
+
 const OGCLayerDescriptor = goog.requireType('plugin.ogc.OGCLayerDescriptor');
 
 
@@ -90,9 +93,9 @@ class Controller extends Disposable {
       this['end'] = this.featureType_.getEndDateColumnName();
       this['timeColumns'] = this.descriptor_.getFeatureType().getTimeColumns();
 
-      $scope.$emit(os.ui.WindowEventType.READY);
+      $scope.$emit(WindowEventType.READY);
     } else {
-      os.ui.window.close(this.element_);
+      osWindow.close(this.element_);
     }
   }
 
@@ -125,7 +128,7 @@ class Controller extends Disposable {
    * @export
    */
   close() {
-    os.ui.window.close(this.element_);
+    osWindow.close(this.element_);
     this.dispose();
   }
 
@@ -138,8 +141,8 @@ class Controller extends Disposable {
   static launch(layerId, opt_deferred) {
     var id = 'chooseTimeColumn';
 
-    if (os.ui.window.exists(id)) {
-      os.ui.window.bringToFront(id);
+    if (osWindow.exists(id)) {
+      osWindow.bringToFront(id);
     } else {
       var winOptions = {
         'id': id,
@@ -160,7 +163,7 @@ class Controller extends Disposable {
         'deferred': opt_deferred
       };
 
-      os.ui.window.create(winOptions, '<choose-time-column id="id" deferred="deferred"></choose-time-column>',
+      osWindow.create(winOptions, '<choose-time-column id="id" deferred="deferred"></choose-time-column>',
           undefined, undefined, undefined, scopeOptions);
     }
   }

--- a/src/plugin/ogc/ui/choosetimecolumn_shim.js
+++ b/src/plugin/ogc/ui/choosetimecolumn_shim.js
@@ -1,0 +1,13 @@
+goog.provide('plugin.ogc.ui.ChooseTimeColumnCtrl');
+goog.provide('plugin.ogc.ui.chooseTimeColumnDirective');
+goog.require('plugin.ogc.ui.ChooseTimeColumnUI');
+
+/**
+ * @deprecated Please use goog.require('plugin.ogc.ui.ChooseTimeColumnUI').Controller instead.
+ */
+plugin.ogc.ui.ChooseTimeColumnCtrl = plugin.ogc.ui.ChooseTimeColumnUI.Controller;
+
+/**
+ * @deprecated Please use goog.require('plugin.ogc.ui.ChooseTimeColumnUI').directive instead.
+ */
+plugin.ogc.ui.chooseTimeColumnDirective = plugin.ogc.ui.ChooseTimeColumnUI.directive;

--- a/src/plugin/ogc/ui/geoserverimport.js
+++ b/src/plugin/ogc/ui/geoserverimport.js
@@ -1,14 +1,13 @@
-goog.provide('plugin.ogc.ui.GeoserverImportCtrl');
-goog.provide('plugin.ogc.ui.geoserverDirective');
+goog.module('plugin.ogc.ui.GeoserverImportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os');
-goog.require('os.ui.Module');
-goog.require('os.ui.SingleUrlProviderImportCtrl');
-goog.require('os.ui.WindowEventType');
 goog.require('os.ui.singleUrlFormDirective');
-goog.require('os.ui.window');
-goog.require('plugin.ogc.GeoServer');
-goog.require('plugin.ogc.ui.GeoServerHelpUI');
+
+const os = goog.require('os');
+const Module = goog.require('os.ui.Module');
+const SingleUrlProviderImportCtrl = goog.require('os.ui.SingleUrlProviderImportCtrl');
+const GeoServer = goog.require('plugin.ogc.GeoServer');
+const GeoServerHelpUI = goog.require('plugin.ogc.ui.GeoServerHelpUI');
 
 
 /**
@@ -16,78 +15,87 @@ goog.require('plugin.ogc.ui.GeoServerHelpUI');
  *
  * @return {angular.Directive}
  */
-plugin.ogc.ui.geoserverDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    templateUrl: os.ROOT + 'views/forms/singleurl.html',
-    controller: plugin.ogc.ui.GeoserverImportCtrl,
-    controllerAs: 'ctrl'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  templateUrl: os.ROOT + 'views/forms/singleurl.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'geoserver';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('geoserver', [plugin.ogc.ui.geoserverDirective]);
+Module.directive('geoserver', [directive]);
 
 
 
 /**
  * Controller for the geoserver import dialog
- *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @extends {os.ui.SingleUrlProviderImportCtrl}
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.ogc.ui.GeoserverImportCtrl = function($scope, $element) {
-  plugin.ogc.ui.GeoserverImportCtrl.base(this, 'constructor', $scope, $element);
-  this['helpUi'] = plugin.ogc.ui.GeoServerHelpUI.directiveTag;
+class Controller extends SingleUrlProviderImportCtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    super($scope, $element);
+    this['helpUi'] = GeoServerHelpUI.directiveTag;
 
-  var file = /** @type {os.file.File} */ ($scope['config']['file']);
-  // regex handles URLs of the sort /geoserver(/stuff)/ows(/otherstuff), where it keeps (/stuff) intact, but removes
-  // (/otherstuff) at the end of the URL
-  $scope['config']['url'] = file ? file.getUrl().replace(/(\/geoserver|\/.*?gs)(\/.*)(web|ows)[#?\/].*$/, '/geoserver$1ows') :
-    this.getUrl();
-  $scope['config']['type'] = 'geoserver';
-  $scope['typeName'] = 'GeoServer';
-  $scope['urlExample'] = 'http://www.example.com/geoserver/ows';
+    var file = /** @type {os.file.File} */ ($scope['config']['file']);
+    // regex handles URLs of the sort /geoserver(/stuff)/ows(/otherstuff), where it keeps (/stuff) intact, but removes
+    // (/otherstuff) at the end of the URL
+    $scope['config']['url'] = file ? file.getUrl().replace(/(\/geoserver|\/.*?gs)(\/.*)(web|ows)[#?\/].*$/, '/geoserver$1ows') :
+      this.getUrl();
+    $scope['config']['type'] = 'geoserver';
+    $scope['typeName'] = 'GeoServer';
+    $scope['urlExample'] = 'http://www.example.com/geoserver/ows';
 
-  this.validateUrl();
-};
-goog.inherits(plugin.ogc.ui.GeoserverImportCtrl, os.ui.SingleUrlProviderImportCtrl);
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.ui.GeoserverImportCtrl.prototype.getDataProvider = function() {
-  var dp = new plugin.ogc.GeoServer();
-  dp.configure(this.scope['config']);
-  return dp;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.ui.GeoserverImportCtrl.prototype.getUrl = function() {
-  return this.dp ? /** @type {plugin.ogc.GeoServer} */ (this.dp).getOriginalWmsUrl() : '';
-};
-
-
-/**
- * @inheritDoc
- * @export
- */
-plugin.ogc.ui.GeoserverImportCtrl.prototype.validateUrl = function() {
-  if (/\/web\/?$/.test(this.scope['config']['url'])) {
-    this.scope['customUrlMessage'] = 'GeoServer URLs ending with \"/web\" are typically for the administration ' +
-    'interface. Consider replacing \"/web\" with \"/ows\" for the OGC service APIs.';
-  } else {
-    this.scope['customUrlMessage'] = undefined;
+    this.validateUrl();
   }
+
+  /**
+   * @inheritDoc
+   */
+  getDataProvider() {
+    var dp = new GeoServer();
+    dp.configure(this.scope['config']);
+    return dp;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getUrl() {
+    return this.dp ? /** @type {GeoServer} */ (this.dp).getOriginalWmsUrl() : '';
+  }
+
+  /**
+   * @inheritDoc
+   * @export
+   */
+  validateUrl() {
+    if (/\/web\/?$/.test(this.scope['config']['url'])) {
+      this.scope['customUrlMessage'] = 'GeoServer URLs ending with \"/web\" are typically for the administration ' +
+      'interface. Consider replacing \"/web\" with \"/ows\" for the OGC service APIs.';
+    } else {
+      this.scope['customUrlMessage'] = undefined;
+    }
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/ogc/ui/geoserverimport.js
+++ b/src/plugin/ogc/ui/geoserverimport.js
@@ -9,6 +9,8 @@ const SingleUrlProviderImportCtrl = goog.require('os.ui.SingleUrlProviderImportC
 const GeoServer = goog.require('plugin.ogc.GeoServer');
 const GeoServerHelpUI = goog.require('plugin.ogc.ui.GeoServerHelpUI');
 
+const OSFile = goog.requireType('os.file.File');
+
 
 /**
  * The geoserver import directive
@@ -36,7 +38,6 @@ const directiveTag = 'geoserver';
 Module.directive('geoserver', [directive]);
 
 
-
 /**
  * Controller for the geoserver import dialog
  * @unrestricted
@@ -52,7 +53,7 @@ class Controller extends SingleUrlProviderImportCtrl {
     super($scope, $element);
     this['helpUi'] = GeoServerHelpUI.directiveTag;
 
-    var file = /** @type {os.file.File} */ ($scope['config']['file']);
+    var file = /** @type {OSFile} */ ($scope['config']['file']);
     // regex handles URLs of the sort /geoserver(/stuff)/ows(/otherstuff), where it keeps (/stuff) intact, but removes
     // (/otherstuff) at the end of the URL
     $scope['config']['url'] = file ? file.getUrl().replace(/(\/geoserver|\/.*?gs)(\/.*)(web|ows)[#?\/].*$/, '/geoserver$1ows') :

--- a/src/plugin/ogc/ui/geoserverimport_shim.js
+++ b/src/plugin/ogc/ui/geoserverimport_shim.js
@@ -1,0 +1,13 @@
+goog.provide('plugin.ogc.ui.GeoserverImportCtrl');
+goog.provide('plugin.ogc.ui.geoserverDirective');
+goog.require('plugin.ogc.ui.GeoserverImportUI');
+
+/**
+ * @deprecated Please use goog.require('plugin.ogc.ui.GeoserverImportUI').Controller instead.
+ */
+plugin.ogc.ui.GeoserverImportCtrl = plugin.ogc.ui.GeoserverImportUI.Controller;
+
+/**
+ * @deprecated Please use goog.require('plugin.ogc.ui.GeoserverImportUI').directive instead.
+ */
+plugin.ogc.ui.geoserverDirective = plugin.ogc.ui.GeoserverImportUI.directive;

--- a/src/plugin/ogc/ui/geoserverimportform.js
+++ b/src/plugin/ogc/ui/geoserverimportform.js
@@ -1,9 +1,9 @@
 goog.module('plugin.ogc.ui.GeoserverImportForm');
 goog.module.declareLegacyNamespace();
 
+const {ROOT} = goog.require('os');
 const Module = goog.require('os.ui.Module');
 const geoserverDirective = goog.require('plugin.ogc.ui.geoserverDirective');
-const {ROOT} = goog.require('os');
 
 
 /**

--- a/src/plugin/ogc/ui/ogclayernodeui.js
+++ b/src/plugin/ogc/ui/ogclayernodeui.js
@@ -3,9 +3,11 @@ goog.module.declareLegacyNamespace();
 
 const Deferred = goog.require('goog.async.Deferred');
 const DataManager = goog.require('os.data.DataManager');
+const osImplements = goog.require('os.implements');
 const Module = goog.require('os.ui.Module');
 const DefaultLayerNodeUICtrl = goog.require('os.ui.node.DefaultLayerNodeUICtrl');
 const defaultLayerNodeUIDirective = goog.require('os.ui.node.defaultLayerNodeUIDirective');
+const IFeatureTypeDescriptor = goog.require('os.ui.ogc.IFeatureTypeDescriptor');
 const {Controller: ChooseTimeColumnController} = goog.require('plugin.ogc.ui.ChooseTimeColumnUI');
 
 
@@ -61,7 +63,7 @@ class Controller extends DefaultLayerNodeUICtrl {
 
     var chooseTime = false;
 
-    if (os.implements(this.descriptor_, os.ui.ogc.IFeatureTypeDescriptor.ID)) {
+    if (osImplements(this.descriptor_, IFeatureTypeDescriptor.ID)) {
       var featureType = this.descriptor_.getFeatureType();
       if (featureType) {
         chooseTime = (featureType.getStartDateColumnName() !== null || featureType.getEndDateColumnName() !== null) &&

--- a/src/plugin/ogc/ui/ogclayernodeui.js
+++ b/src/plugin/ogc/ui/ogclayernodeui.js
@@ -1,79 +1,93 @@
-goog.provide('plugin.ogc.ui.OGCLayerNodeUICtrl');
-goog.provide('plugin.ogc.ui.ogcLayerNodeUIDirective');
-goog.require('goog.async.Deferred');
-goog.require('goog.events.EventType');
-goog.require('os.ui.Module');
-goog.require('os.ui.node.DefaultLayerNodeUICtrl');
-goog.require('os.ui.node.defaultLayerNodeUIDirective');
-goog.require('plugin.ogc.ui.chooseTimeColumnDirective');
+goog.module('plugin.ogc.ui.OGCLayerNodeUI');
+goog.module.declareLegacyNamespace();
+
+const Deferred = goog.require('goog.async.Deferred');
+const DataManager = goog.require('os.data.DataManager');
+const Module = goog.require('os.ui.Module');
+const DefaultLayerNodeUICtrl = goog.require('os.ui.node.DefaultLayerNodeUICtrl');
+const defaultLayerNodeUIDirective = goog.require('os.ui.node.defaultLayerNodeUIDirective');
+const {Controller: ChooseTimeColumnController} = goog.require('plugin.ogc.ui.ChooseTimeColumnUI');
 
 
 /**
  * @type {string}
  */
-plugin.ogc.ui.OGCLayerNodeUITemplate = '<span ng-if="chooseTime" ng-click="nodeUi.chooseTime()">' +
+const template = '<span ng-if="chooseTime" ng-click="nodeUi.chooseTime()">' +
     '<i class="fa fa-clock-o fa-fw c-glyph" title="Choose Time Columns"></i></span>';
 
 
 /**
  * @return {angular.Directive}
  */
-plugin.ogc.ui.ogcLayerNodeUIDirective = function() {
-  var dir = os.ui.node.defaultLayerNodeUIDirective();
-  dir.template = dir.template.replace('>', '>' + plugin.ogc.ui.OGCLayerNodeUITemplate);
-  dir.controller = plugin.ogc.ui.OGCLayerNodeUICtrl;
+const directive = () => {
+  var dir = defaultLayerNodeUIDirective();
+  dir.template = dir.template.replace('>', '>' + template);
+  dir.controller = Controller;
   return dir;
 };
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'ogclayernodeui';
 
 
 /**
  * Add the directive tot he module
  */
-os.ui.Module.directive('ogclayernodeui', [plugin.ogc.ui.ogcLayerNodeUIDirective]);
-
+Module.directive('ogclayernodeui', [directive]);
 
 
 /**
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @constructor
- * @extends {os.ui.node.DefaultLayerNodeUICtrl}
- * @ngInject
+ * @unrestricted
  */
-plugin.ogc.ui.OGCLayerNodeUICtrl = function($scope, $element) {
-  plugin.ogc.ui.OGCLayerNodeUICtrl.base(this, 'constructor', $scope, $element);
+class Controller extends DefaultLayerNodeUICtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    super($scope, $element);
+
+    /**
+     * The descriptor for this layer
+     * @type {os.data.IDataDescriptor}
+     * @private
+     */
+    this.descriptor_ = DataManager.getInstance().getDescriptor(this.getLayerId());
+
+    var chooseTime = false;
+
+    if (os.implements(this.descriptor_, os.ui.ogc.IFeatureTypeDescriptor.ID)) {
+      var featureType = this.descriptor_.getFeatureType();
+      if (featureType) {
+        chooseTime = (featureType.getStartDateColumnName() !== null || featureType.getEndDateColumnName() !== null) &&
+          featureType.getTimeColumns().length >= 2;
+      }
+    }
+    $scope['chooseTime'] = chooseTime;
+  }
 
   /**
-   * The descriptor for this layer
-   * @type {os.data.IDataDescriptor}
-   * @private
+   * Launch the time column chooser for the layer
+   *
+   * @export
    */
-  this.descriptor_ = os.dataManager.getDescriptor(this.getLayerId());
-
-  var chooseTime = false;
-
-  if (os.implements(this.descriptor_, os.ui.ogc.IFeatureTypeDescriptor.ID)) {
-    var featureType = this.descriptor_.getFeatureType();
-    if (featureType) {
-      chooseTime = (featureType.getStartDateColumnName() !== null || featureType.getEndDateColumnName() !== null) &&
-        featureType.getTimeColumns().length >= 2;
-    }
+  chooseTime() {
+    var deferred = new Deferred();
+    deferred.addCallback(function() {
+      this.descriptor_.setActive(false);
+      this.descriptor_.setActive(true);
+    }, this);
+    ChooseTimeColumnController.launch(this.getLayerId(), deferred);
   }
-  $scope['chooseTime'] = chooseTime;
-};
-goog.inherits(plugin.ogc.ui.OGCLayerNodeUICtrl, os.ui.node.DefaultLayerNodeUICtrl);
+}
 
-
-/**
- * Launch the time column chooser for the layer
- *
- * @export
- */
-plugin.ogc.ui.OGCLayerNodeUICtrl.prototype.chooseTime = function() {
-  var deferred = new goog.async.Deferred();
-  deferred.addCallback(function() {
-    this.descriptor_.setActive(false);
-    this.descriptor_.setActive(true);
-  }, this);
-  plugin.ogc.ui.ChooseTimeColumnCtrl.launch(this.getLayerId(), deferred);
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/ogc/ui/ogclayernodeui_shim.js
+++ b/src/plugin/ogc/ui/ogclayernodeui_shim.js
@@ -1,0 +1,13 @@
+goog.provide('plugin.ogc.ui.OGCLayerNodeUICtrl');
+goog.provide('plugin.ogc.ui.ogcLayerNodeUIDirective');
+goog.require('plugin.ogc.ui.OGCLayerNodeUI');
+
+/**
+ * @deprecated Please use goog.require('plugin.ogc.ui.OGCLayerNodeUI').Controller instead.
+ */
+plugin.ogc.ui.OGCLayerNodeUICtrl = plugin.ogc.ui.OGCLayerNodeUI.Controller;
+
+/**
+ * @deprecated Please use goog.require('plugin.ogc.ui.OGCLayerNodeUI').directive instead.
+ */
+plugin.ogc.ui.ogcLayerNodeUIDirective = plugin.ogc.ui.OGCLayerNodeUI.directive;

--- a/src/plugin/ogc/ui/ogcserverimport.js
+++ b/src/plugin/ogc/ui/ogcserverimport.js
@@ -1,15 +1,14 @@
-goog.provide('plugin.ogc.ui.OgcServerImportCtrl');
-goog.provide('plugin.ogc.ui.ogcserverDirective');
+goog.module('plugin.ogc.ui.OgcServerImportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.dom.xml');
-goog.require('os');
-goog.require('os.ui.Module');
-goog.require('os.ui.ProviderImportCtrl');
-goog.require('os.ui.WindowEventType');
-goog.require('os.ui.ogc.OGCServer');
 goog.require('os.ui.singleUrlFormDirective');
-goog.require('os.ui.window');
-goog.require('plugin.ogc.ui.OgcServerHelpUI');
+
+const xml = goog.require('goog.dom.xml');
+const os = goog.require('os');
+const Module = goog.require('os.ui.Module');
+const ProviderImportCtrl = goog.require('os.ui.ProviderImportCtrl');
+const OGCServer = goog.require('os.ui.ogc.OGCServer');
+const OgcServerHelpUI = goog.require('plugin.ogc.ui.OgcServerHelpUI');
 
 
 /**
@@ -17,157 +16,162 @@ goog.require('plugin.ogc.ui.OgcServerHelpUI');
  *
  * @return {angular.Directive}
  */
-plugin.ogc.ui.ogcserverDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    templateUrl: os.ROOT + 'views/plugin/ogc/ui/ogcserverimport.html',
-    controller: plugin.ogc.ui.OgcServerImportCtrl,
-    controllerAs: 'ctrl'
-  };
-};
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  templateUrl: os.ROOT + 'views/plugin/ogc/ui/ogcserverimport.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'ogcserver';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('ogcserver', [plugin.ogc.ui.ogcserverDirective]);
+Module.directive('ogcserver', [directive]);
 
 
 
 /**
  * Controller for the ogcserver import dialog
- *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @extends {os.ui.ProviderImportCtrl}
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.ogc.ui.OgcServerImportCtrl = function($scope, $element) {
-  plugin.ogc.ui.OgcServerImportCtrl.base(this, 'constructor', $scope, $element);
-  this['helpUi'] = plugin.ogc.ui.OgcServerHelpUI.directiveTag;
+class Controller extends ProviderImportCtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    super($scope, $element);
+    this['helpUi'] = OgcServerHelpUI.directiveTag;
 
-  $scope['typeName'] = 'OGC Server';
+    $scope['typeName'] = 'OGC Server';
 
-  $scope['config']['type'] = 'ogc';
-  var file = /** @type {os.file.File} */ ($scope['config']['file']);
+    $scope['config']['type'] = 'ogc';
+    var file = /** @type {os.file.File} */ ($scope['config']['file']);
 
-  if (file) {
-    var content = file.getContent();
-    var url = file.getUrl();
+    if (file) {
+      var content = file.getContent();
+      var url = file.getUrl();
 
-    if (content && typeof content === 'string') {
-      var titles = content.match(/title>([^<]*)<\//i);
+      if (content && typeof content === 'string') {
+        var titles = content.match(/title>([^<]*)<\//i);
 
-      if (titles && titles.length > 1) {
-        $scope['config']['label'] = titles[1];
-      }
-
-      try {
-        const doc = goog.dom.xml.loadXml(content);
-        if (doc && doc.firstElementChild) {
-          const rootNodeName = doc.firstElementChild.nodeName;
-
-          if (os.ogc.GetCapsRootRegexp.WMS.test(rootNodeName) || /wms/i.test(url)) {
-            $scope['config']['wms'] = url;
-          } else if (os.ogc.GetCapsRootRegexp.WMTS.test(rootNodeName) || /wmts/i.test(url)) {
-            $scope['config']['wmts'] = url;
-          } else if (os.ogc.GetCapsRootRegexp.WFS.test(rootNodeName) || /wfs/i.test(url)) {
-            $scope['config']['wfs'] = url;
-          }
+        if (titles && titles.length > 1) {
+          $scope['config']['label'] = titles[1];
         }
-      } catch (e) {
 
+        try {
+          const doc = xml.loadXml(content);
+          if (doc && doc.firstElementChild) {
+            const rootNodeName = doc.firstElementChild.nodeName;
+
+            if (os.ogc.GetCapsRootRegexp.WMS.test(rootNodeName) || /wms/i.test(url)) {
+              $scope['config']['wms'] = url;
+            } else if (os.ogc.GetCapsRootRegexp.WMTS.test(rootNodeName) || /wmts/i.test(url)) {
+              $scope['config']['wmts'] = url;
+            } else if (os.ogc.GetCapsRootRegexp.WFS.test(rootNodeName) || /wfs/i.test(url)) {
+              $scope['config']['wfs'] = url;
+            }
+          }
+        } catch (e) {
+
+        }
+      }
+    } else if (this.dp) {
+      $scope['config']['label'] = this.dp.getLabel();
+
+      $scope['config']['wms'] = this.dp.getWmsUrl();
+      $scope['config']['wmts'] = this.dp.getWmtsUrl();
+      $scope['config']['wfs'] = this.dp.getWfsUrl();
+    }
+
+    // focus the form
+    this.element.find('input[name="title"]').focus();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getDataProvider() {
+    var dp = this.dp || new OGCServer();
+    dp.configure(this.scope['config']);
+    return dp;
+  }
+
+  /**
+   * @return {string}
+   */
+  getWmtsUrl() {
+    return this.dp ? /** @type {OGCServer} */ (this.dp).getOriginalWmtsUrl() : '';
+  }
+
+  /**
+   * @return {string}
+   */
+  getWmsUrl() {
+    return this.dp ? /** @type {OGCServer} */ (this.dp).getOriginalWmsUrl() : '';
+  }
+
+  /**
+   * @return {string}
+   */
+  getWfsUrl() {
+    return this.dp ? /** @type {OGCServer} */ (this.dp).getOriginalWfsUrl() : '';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getConfig() {
+    var conf = {};
+    var fields = ['label', 'enabled', 'type', 'wms', 'wmts', 'wfs'];
+    var original = this.scope['config'];
+
+    for (var key in original) {
+      if (fields.indexOf(key) > -1) {
+        conf[key] = original[key];
       }
     }
-  } else if (this.dp) {
-    $scope['config']['label'] = this.dp.getLabel();
 
-    $scope['config']['wms'] = this.dp.getWmsUrl();
-    $scope['config']['wmts'] = this.dp.getWmtsUrl();
-    $scope['config']['wfs'] = this.dp.getWfsUrl();
+    return conf;
   }
 
-  // focus the form
-  this.element.find('input[name="title"]').focus();
-};
-goog.inherits(plugin.ogc.ui.OgcServerImportCtrl, os.ui.ProviderImportCtrl);
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.ui.OgcServerImportCtrl.prototype.getDataProvider = function() {
-  var dp = this.dp || new os.ui.ogc.OGCServer();
-  dp.configure(this.scope['config']);
-  return dp;
-};
-
-
-/**
- * @return {string}
- */
-plugin.ogc.ui.OgcServerImportCtrl.prototype.getWmtsUrl = function() {
-  return this.dp ? /** @type {os.ui.ogc.OGCServer} */ (this.dp).getOriginalWmtsUrl() : '';
-};
-
-
-/**
- * @return {string}
- */
-plugin.ogc.ui.OgcServerImportCtrl.prototype.getWmsUrl = function() {
-  return this.dp ? /** @type {os.ui.ogc.OGCServer} */ (this.dp).getOriginalWmsUrl() : '';
-};
-
-
-/**
- * @return {string}
- */
-plugin.ogc.ui.OgcServerImportCtrl.prototype.getWfsUrl = function() {
-  return this.dp ? /** @type {os.ui.ogc.OGCServer} */ (this.dp).getOriginalWfsUrl() : '';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.ui.OgcServerImportCtrl.prototype.getConfig = function() {
-  var conf = {};
-  var fields = ['label', 'enabled', 'type', 'wms', 'wmts', 'wfs'];
-  var original = this.scope['config'];
-
-  for (var key in original) {
-    if (fields.indexOf(key) > -1) {
-      conf[key] = original[key];
-    }
+  /**
+   * @inheritDoc
+   */
+  formDiff() {
+    // If any of the urls change, re-test
+    return this.getWmtsUrl() !== this.scope['config']['wmts'] ||
+        this.getWmsUrl() !== this.scope['config']['wms'] ||
+        this.getWfsUrl() !== this.scope['config']['wfs'];
   }
 
-  return conf;
-};
+  /**
+   * @inheritDoc
+   */
+  saveAndClose() {
+    /** @type {os.structs.TreeNode} */ (this.dp).setLabel(this.scope['config']['label']);
+    this.dp.setWmtsUrl(this.scope['config']['wmts']);
+    this.dp.setWmsUrl(this.scope['config']['wms']);
+    this.dp.setWfsUrl(this.scope['config']['wfs']);
+    this.dp.setOriginalWmtsUrl(this.scope['config']['wmts']);
+    this.dp.setOriginalWmsUrl(this.scope['config']['wms']);
+    this.dp.setOriginalWfsUrl(this.scope['config']['wfs']);
+    super.saveAndClose();
+  }
+}
 
-
-/**
- * @inheritDoc
- */
-plugin.ogc.ui.OgcServerImportCtrl.prototype.formDiff = function() {
-  // If any of the urls change, re-test
-  return this.getWmtsUrl() !== this.scope['config']['wmts'] ||
-      this.getWmsUrl() !== this.scope['config']['wms'] ||
-      this.getWfsUrl() !== this.scope['config']['wfs'];
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.ui.OgcServerImportCtrl.prototype.saveAndClose = function() {
-  /** @type {os.structs.TreeNode} */ (this.dp).setLabel(this.scope['config']['label']);
-  this.dp.setWmtsUrl(this.scope['config']['wmts']);
-  this.dp.setWmsUrl(this.scope['config']['wms']);
-  this.dp.setWfsUrl(this.scope['config']['wfs']);
-  this.dp.setOriginalWmtsUrl(this.scope['config']['wmts']);
-  this.dp.setOriginalWmsUrl(this.scope['config']['wms']);
-  this.dp.setOriginalWfsUrl(this.scope['config']['wfs']);
-  plugin.ogc.ui.OgcServerImportCtrl.base(this, 'saveAndClose');
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/ogc/ui/ogcserverimport.js
+++ b/src/plugin/ogc/ui/ogcserverimport.js
@@ -5,10 +5,13 @@ goog.require('os.ui.singleUrlFormDirective');
 
 const xml = goog.require('goog.dom.xml');
 const os = goog.require('os');
+const ogc = goog.require('os.ogc');
 const Module = goog.require('os.ui.Module');
 const ProviderImportCtrl = goog.require('os.ui.ProviderImportCtrl');
 const OGCServer = goog.require('os.ui.ogc.OGCServer');
 const OgcServerHelpUI = goog.require('plugin.ogc.ui.OgcServerHelpUI');
+
+const OSFile = goog.requireType('os.file.File');
 
 
 /**
@@ -37,7 +40,6 @@ const directiveTag = 'ogcserver';
 Module.directive('ogcserver', [directive]);
 
 
-
 /**
  * Controller for the ogcserver import dialog
  * @unrestricted
@@ -56,7 +58,7 @@ class Controller extends ProviderImportCtrl {
     $scope['typeName'] = 'OGC Server';
 
     $scope['config']['type'] = 'ogc';
-    var file = /** @type {os.file.File} */ ($scope['config']['file']);
+    var file = /** @type {OSFile} */ ($scope['config']['file']);
 
     if (file) {
       var content = file.getContent();
@@ -74,11 +76,11 @@ class Controller extends ProviderImportCtrl {
           if (doc && doc.firstElementChild) {
             const rootNodeName = doc.firstElementChild.nodeName;
 
-            if (os.ogc.GetCapsRootRegexp.WMS.test(rootNodeName) || /wms/i.test(url)) {
+            if (ogc.GetCapsRootRegexp.WMS.test(rootNodeName) || /wms/i.test(url)) {
               $scope['config']['wms'] = url;
-            } else if (os.ogc.GetCapsRootRegexp.WMTS.test(rootNodeName) || /wmts/i.test(url)) {
+            } else if (ogc.GetCapsRootRegexp.WMTS.test(rootNodeName) || /wmts/i.test(url)) {
               $scope['config']['wmts'] = url;
-            } else if (os.ogc.GetCapsRootRegexp.WFS.test(rootNodeName) || /wfs/i.test(url)) {
+            } else if (ogc.GetCapsRootRegexp.WFS.test(rootNodeName) || /wfs/i.test(url)) {
               $scope['config']['wfs'] = url;
             }
           }

--- a/src/plugin/ogc/ui/ogcserverimport_shim.js
+++ b/src/plugin/ogc/ui/ogcserverimport_shim.js
@@ -1,0 +1,13 @@
+goog.provide('plugin.ogc.ui.OgcServerImportCtrl');
+goog.provide('plugin.ogc.ui.ogcserverDirective');
+goog.require('plugin.ogc.ui.OgcServerImportUI');
+
+/**
+ * @deprecated Please use goog.require('plugin.ogc.ui.OgcServerImportUI').Controller instead.
+ */
+plugin.ogc.ui.OgcServerImportCtrl = plugin.ogc.ui.OgcServerImportUI.Controller;
+
+/**
+ * @deprecated Please use goog.require('plugin.ogc.ui.OgcServerImportUI').directive instead.
+ */
+plugin.ogc.ui.ogcserverDirective = plugin.ogc.ui.OgcServerImportUI.directive;

--- a/src/plugin/ogc/ui/ogcserverimportform.js
+++ b/src/plugin/ogc/ui/ogcserverimportform.js
@@ -1,9 +1,9 @@
 goog.module('plugin.ogc.ui.OgcServerImportForm');
 goog.module.declareLegacyNamespace();
 
+const {ROOT} = goog.require('os');
 const Module = goog.require('os.ui.Module');
 const ogcserverDirective = goog.require('plugin.ogc.ui.ogcserverDirective');
-const {ROOT} = goog.require('os');
 
 
 /**

--- a/src/plugin/ogc/wfs/getfiltercolumns.js
+++ b/src/plugin/ogc/wfs/getfiltercolumns.js
@@ -1,6 +1,7 @@
 goog.module('plugin.ogc.wfs.getFilterColumns');
 goog.module.declareLegacyNamespace();
 
+
 /**
  * Get the filterable columns
  *

--- a/src/plugin/ogc/wfs/getfiltercolumns.js
+++ b/src/plugin/ogc/wfs/getfiltercolumns.js
@@ -1,0 +1,20 @@
+goog.module('plugin.ogc.wfs.getFilterColumns');
+goog.module.declareLegacyNamespace();
+
+/**
+ * Get the filterable columns
+ *
+ * @param {!os.layer.Vector} layer The layer
+ * @return {?Array<os.ogc.FeatureTypeColumn>} the columns
+ */
+exports = function(layer) {
+  var layerOptions = layer.getLayerOptions();
+  if (layerOptions && layerOptions['featureType']) {
+    var featureType = /** @type {os.ogc.IFeatureType} */ (layerOptions['featureType']);
+    if (featureType) {
+      return featureType.getColumns();
+    }
+  }
+
+  return null;
+};

--- a/src/plugin/ogc/wfs/launchfiltermanager.js
+++ b/src/plugin/ogc/wfs/launchfiltermanager.js
@@ -1,0 +1,11 @@
+goog.module('plugin.ogc.wfs.launchFilterManager');
+goog.module.declareLegacyNamespace();
+
+/**
+ * Launch the filter manager
+ *
+ * @param {!os.layer.Vector} layer The layer
+ */
+exports = function(layer) {
+  os.ui.query.CombinatorCtrl.launchForLayer(layer.getId());
+};

--- a/src/plugin/ogc/wfs/launchfiltermanager.js
+++ b/src/plugin/ogc/wfs/launchfiltermanager.js
@@ -1,11 +1,14 @@
 goog.module('plugin.ogc.wfs.launchFilterManager');
 goog.module.declareLegacyNamespace();
 
+const CombinatorCtrl = goog.require('os.ui.query.CombinatorCtrl');
+
+
 /**
  * Launch the filter manager
  *
  * @param {!os.layer.Vector} layer The layer
  */
 exports = function(layer) {
-  os.ui.query.CombinatorCtrl.launchForLayer(layer.getId());
+  CombinatorCtrl.launchForLayer(layer.getId());
 };

--- a/src/plugin/ogc/wfs/querywfslayerconfig.js
+++ b/src/plugin/ogc/wfs/querywfslayerconfig.js
@@ -2,6 +2,7 @@ goog.module('plugin.ogc.wfs.QueryWFSLayerConfig');
 goog.module.declareLegacyNamespace();
 
 const ParamModifier = goog.require('os.net.ParamModifier');
+const ModifierConstants = goog.require('os.ogc.filter.ModifierConstants');
 const OGCFilterModifier = goog.require('os.ogc.filter.OGCFilterModifier');
 const queryManager = goog.require('os.query.QueryManager');
 const TemporalHandler = goog.require('os.query.TemporalHandler');
@@ -93,7 +94,7 @@ class QueryWFSLayerConfig extends WFSLayerConfig {
           }
 
           var tqModifier = new ParamModifier('temporal', 'filter',
-              os.ogc.filter.ModifierConstants.TEMPORAL, '');
+              ModifierConstants.TEMPORAL, '');
 
           var tqHandler = new TemporalHandler();
           tqHandler.setFormatter(tqFormatter);

--- a/src/plugin/ogc/wfs/wfslayerconfig.js
+++ b/src/plugin/ogc/wfs/wfslayerconfig.js
@@ -2,6 +2,10 @@ goog.module('plugin.ogc.wfs.WFSLayerConfig');
 goog.module.declareLegacyNamespace();
 
 const Deferred = goog.require('goog.async.Deferred');
+const log = goog.require('goog.log');
+const EventType = goog.require('goog.net.EventType');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const AlertManager = goog.require('os.alert.AlertManager');
 const AltMapping = goog.require('os.im.mapping.AltMapping');
 const OrientationMapping = goog.require('os.im.mapping.OrientationMapping');
 const RadiusMapping = goog.require('os.im.mapping.RadiusMapping');
@@ -18,9 +22,10 @@ const DescribeFeatureLoader = goog.require('os.ogc.wfs.DescribeFeatureLoader');
 const WFSFormatter = goog.require('os.ogc.wfs.WFSFormatter');
 const ImportManager = goog.require('os.ui.im.ImportManager');
 const GeoJSONParser = goog.require('plugin.file.geojson.GeoJSONParser');
-const GMLParser = goog.requireType('plugin.file.gml.GMLParser');
 const {Controller: ChooseTimeColumnController} = goog.require('plugin.ogc.ui.ChooseTimeColumnUI');
 const {directiveTag: ogcLayerNodeUi} = goog.require('plugin.ogc.ui.OGCLayerNodeUI');
+
+const GMLParser = goog.requireType('plugin.file.gml.GMLParser');
 
 
 /**
@@ -125,7 +130,7 @@ class WFSLayerConfig extends AbstractDataSourceLayerConfig {
       var loader = new DescribeFeatureLoader();
       loader.setUrl(this.url);
       loader.setTypename(this.typename);
-      loader.listenOnce(goog.net.EventType.COMPLETE, this.onDescribeComplete_.bind(this, layer, options));
+      loader.listenOnce(EventType.COMPLETE, this.onDescribeComplete_.bind(this, layer, options));
       loader.load();
     }
   }
@@ -144,7 +149,7 @@ class WFSLayerConfig extends AbstractDataSourceLayerConfig {
       this.onFeatureTypeAvailable(layer, options);
     } else {
       var msg = 'Failed loading DescribeFeatureType for ' + this.typename + '. Feature layer will not be loaded.';
-      os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.ERROR);
+      AlertManager.getInstance().sendAlert(msg, AlertEventSeverity.ERROR);
     }
   }
 
@@ -450,7 +455,7 @@ class WFSLayerConfig extends AbstractDataSourceLayerConfig {
 /**
  * @type {goog.log.Logger}
  */
-const logger = goog.log.getLogger('plugin.ogc.wfs.WFSLayerConfig');
+const logger = log.getLogger('plugin.ogc.wfs.WFSLayerConfig');
 
 
 /**

--- a/src/plugin/ogc/wfs/wfslayerconfig.js
+++ b/src/plugin/ogc/wfs/wfslayerconfig.js
@@ -1,463 +1,463 @@
-goog.provide('plugin.ogc.wfs.WFSLayerConfig');
+goog.module('plugin.ogc.wfs.WFSLayerConfig');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.async.Deferred');
-goog.require('goog.string');
-goog.require('os.command.VectorLayerPreset');
-goog.require('os.im.mapping.AltMapping');
-goog.require('os.im.mapping.OrientationMapping');
-goog.require('os.im.mapping.RadiusMapping');
-goog.require('os.im.mapping.SemiMajorMapping');
-goog.require('os.im.mapping.SemiMinorMapping');
-goog.require('os.im.mapping.TimeFormat');
-goog.require('os.im.mapping.TimeType');
-goog.require('os.im.mapping.time.DateTimeMapping');
-goog.require('os.layer.Vector');
-goog.require('os.layer.config.AbstractDataSourceLayerConfig');
-goog.require('os.layer.preset.LayerPresetManager');
-goog.require('os.ogc');
-goog.require('os.ogc.filter.OGCFilterCleaner');
-goog.require('os.ogc.wfs.DescribeFeatureLoader');
-goog.require('os.ogc.wfs.WFSFormatter');
-goog.require('os.ui.im.ImportManager');
-goog.require('plugin.file.geojson.GeoJSONParser');
-goog.require('plugin.file.gml.GMLParser');
-goog.require('plugin.ogc.ui.chooseTimeColumnDirective');
-goog.require('plugin.ogc.ui.ogcLayerNodeUIDirective');
-
+const Deferred = goog.require('goog.async.Deferred');
+const AltMapping = goog.require('os.im.mapping.AltMapping');
+const OrientationMapping = goog.require('os.im.mapping.OrientationMapping');
+const RadiusMapping = goog.require('os.im.mapping.RadiusMapping');
+const SemiMajorMapping = goog.require('os.im.mapping.SemiMajorMapping');
+const SemiMinorMapping = goog.require('os.im.mapping.SemiMinorMapping');
+const TimeFormat = goog.require('os.im.mapping.TimeFormat');
+const TimeType = goog.require('os.im.mapping.TimeType');
+const DateTimeMapping = goog.require('os.im.mapping.time.DateTimeMapping');
+const VectorLayer = goog.require('os.layer.Vector');
+const AbstractDataSourceLayerConfig = goog.require('os.layer.config.AbstractDataSourceLayerConfig');
+const ogc = goog.require('os.ogc');
+const OGCFilterCleaner = goog.require('os.ogc.filter.OGCFilterCleaner');
+const DescribeFeatureLoader = goog.require('os.ogc.wfs.DescribeFeatureLoader');
+const WFSFormatter = goog.require('os.ogc.wfs.WFSFormatter');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const GeoJSONParser = goog.require('plugin.file.geojson.GeoJSONParser');
+const GMLParser = goog.requireType('plugin.file.gml.GMLParser');
+const {Controller: ChooseTimeColumnController} = goog.require('plugin.ogc.ui.ChooseTimeColumnUI');
+const {directiveTag: ogcLayerNodeUi} = goog.require('plugin.ogc.ui.OGCLayerNodeUI');
 
 
 /**
  * This is a plain WFS layer config that handles DescribeFeatureType, altitude and time mappings,
  * and outputformat detection for GeoJSON, GML3, or GML2.
- *
- * @extends {os.layer.config.AbstractDataSourceLayerConfig}
- * @constructor
  */
-plugin.ogc.wfs.WFSLayerConfig = function() {
-  plugin.ogc.wfs.WFSLayerConfig.base(this, 'constructor');
-  this.log = plugin.ogc.wfs.WFSLayerConfig.LOGGER_;
-
+class WFSLayerConfig extends AbstractDataSourceLayerConfig {
   /**
-   * @type {boolean}
-   * @protected
+   * Constructor.
    */
-  this.describeType = true;
+  constructor() {
+    super();
+    this.log = logger;
 
-  /**
-   * @type {os.ogc.IFeatureType}
-   */
-  this.featureType = null;
+    /**
+     * @type {boolean}
+     * @protected
+     */
+    this.describeType = true;
 
-  /**
-   * @type {?string}
-   * @protected
-   */
-  this.typename = null;
+    /**
+     * @type {ogc.IFeatureType}
+     */
+    this.featureType = null;
 
-  /**
-   * @type {boolean}
-   * @protected
-   */
-  this.lockable = true;
-};
-goog.inherits(plugin.ogc.wfs.WFSLayerConfig, os.layer.config.AbstractDataSourceLayerConfig);
+    /**
+     * @type {?string}
+     * @protected
+     */
+    this.typename = null;
 
-
-/**
- * @type {goog.log.Logger}
- * @private
- * @const
- */
-plugin.ogc.wfs.WFSLayerConfig.LOGGER_ = goog.log.getLogger('plugin.ogc.wfs.WFSLayerConfig');
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.wfs.WFSLayerConfig.prototype.initializeConfig = function(options) {
-  plugin.ogc.wfs.WFSLayerConfig.base(this, 'initializeConfig', options);
-
-  if (options['describeType'] !== undefined) {
-    this.describeType = options['describeType'];
+    /**
+     * @type {boolean}
+     * @protected
+     */
+    this.lockable = true;
   }
 
-  if (options['featureType'] !== undefined) {
-    this.featureType = options['featureType'];
-  }
+  /**
+   * @inheritDoc
+   */
+  initializeConfig(options) {
+    super.initializeConfig(options);
 
-  if (this.params) {
-    if (this.params.get('typename')) {
-      this.typename = /** @type {string} */ (this.params.get('typename'));
+    if (options['describeType'] !== undefined) {
+      this.describeType = options['describeType'];
     }
 
-    // this will set the outputformat in the params if it isn't already set
-    this.getBestType(options);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.wfs.WFSLayerConfig.prototype.createLayer = function(options) {
-  this.initializeConfig(options);
-
-  var source = this.getSource(options);
-  source.setId(this.id);
-  source.setRequest(this.getRequest(options));
-  source.setImporter(this.getImporter(options));
-  source.setTimeEnabled(this.animate !== undefined ? this.animate : false);
-  source.setTitle(this.title);
-
-  var layer = this.getLayer(source, options);
-  if (options) {
-    layer.restore(options);
-  }
-
-  if (this.describeType) {
-    if (this.featureType) {
-      this.onFeatureTypeAvailable(layer, options);
-    } else {
-      this.loadWFSDescribeFeature(layer, options);
-    }
-  } else if (options['load']) {
-    source = /** @type {os.source.ISource} */ (layer.getSource());
-    source.refresh();
-  }
-
-  return layer;
-};
-
-
-/**
- * @param {os.layer.Vector} layer
- * @param {Object.<string, *>} options
- * @protected
- */
-plugin.ogc.wfs.WFSLayerConfig.prototype.loadWFSDescribeFeature = function(layer, options) {
-  if (this.url && this.typename) {
-    var loader = new os.ogc.wfs.DescribeFeatureLoader();
-    loader.setUrl(this.url);
-    loader.setTypename(this.typename);
-    loader.listenOnce(goog.net.EventType.COMPLETE, this.onDescribeComplete_.bind(this, layer, options));
-    loader.load();
-  }
-};
-
-
-/**
- * @param {os.layer.Vector} layer
- * @param {Object.<string, *>} options
- * @param {goog.events.Event} event
- * @private
- */
-plugin.ogc.wfs.WFSLayerConfig.prototype.onDescribeComplete_ = function(layer, options, event) {
-  var loader = /** @type {os.ogc.wfs.DescribeFeatureLoader} */ (event.target);
-  var featureType = loader.getFeatureType();
-  if (featureType) {
-    this.featureType = featureType;
-    this.onFeatureTypeAvailable(layer, options);
-  } else {
-    var msg = 'Failed loading DescribeFeatureType for ' + this.typename + '. Feature layer will not be loaded.';
-    os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.ERROR);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.wfs.WFSLayerConfig.prototype.getRequest = function(options) {
-  var request = plugin.ogc.wfs.WFSLayerConfig.superClass_.getRequest.call(this, options);
-
-  var format = this.params.get('outputformat');
-  var regex = /json/i;
-
-  if (format && regex.test(format)) {
-    request.setHeader('Accept', 'application/json, text/plain, */*');
-  }
-
-  request.setValidator(os.ogc.getException);
-
-  if (options['postFormat'] !== 'kvp') {
-    var formatter = new os.ogc.wfs.WFSFormatter();
-    if (options['contentType']) {
-      formatter.contentType = /** @type {string} */ (options['contentType']);
+    if (options['featureType'] !== undefined) {
+      this.featureType = options['featureType'];
     }
 
-    request.setDataFormatter(formatter);
+    if (this.params) {
+      if (this.params.get('typename')) {
+        this.typename = /** @type {string} */ (this.params.get('typename'));
+      }
+
+      // this will set the outputformat in the params if it isn't already set
+      this.getBestType(options);
+    }
   }
 
-  const type = this.getBestType(options);
-  if (type && type.responseType != null) {
-    request.setResponseType(/** @type {goog.net.XhrIo.ResponseType} */ (type.responseType));
-  }
+  /**
+   * @inheritDoc
+   */
+  createLayer(options) {
+    this.initializeConfig(options);
 
-  return request;
-};
+    var source = this.getSource(options);
+    source.setId(this.id);
+    source.setRequest(this.getRequest(options));
+    source.setImporter(this.getImporter(options));
+    source.setTimeEnabled(this.animate !== undefined ? this.animate : false);
+    source.setTitle(this.title);
 
+    var layer = this.getLayer(source, options);
+    if (options) {
+      layer.restore(options);
+    }
 
-/**
- * @param {os.layer.Vector} layer
- * @param {Object.<string, *>} options
- * @protected
- */
-plugin.ogc.wfs.WFSLayerConfig.prototype.onFeatureTypeAvailable = function(layer, options) {
-  this.featureTypeAvailable(layer, options);
-};
-
-
-/**
- * @param {os.layer.Vector} layer
- * @param {Object.<string, *>} options
- * @protected
- */
-plugin.ogc.wfs.WFSLayerConfig.prototype.featureTypeAvailable = function(layer, options) {
-  var source = /** @type {os.source.Request} */ (layer.getSource());
-
-  var checkRefresh = function() {
-    if (source && !source.isDisposed() && options['load']) {
+    if (this.describeType) {
+      if (this.featureType) {
+        this.onFeatureTypeAvailable(layer, options);
+      } else {
+        this.loadWFSDescribeFeature(layer, options);
+      }
+    } else if (options['load']) {
+      source = /** @type {os.source.ISource} */ (layer.getSource());
       source.refresh();
     }
-  };
 
-  var setupRequest = function() {
-    if (source && !source.isDisposed()) {
-      var featureType = options['featureType'] = this.featureType;
-      if (featureType) {
-        this.fixFeatureTypeColumns(layer, options, featureType);
-      }
+    return layer;
+  }
 
-      this.addMappings(layer, options);
-
-      var request = source.getRequest();
-
-      if (request) {
-        request.addModifier(new os.ogc.filter.OGCFilterCleaner());
-      }
+  /**
+   * @param {VectorLayer} layer
+   * @param {Object.<string, *>} options
+   * @protected
+   */
+  loadWFSDescribeFeature(layer, options) {
+    if (this.url && this.typename) {
+      var loader = new DescribeFeatureLoader();
+      loader.setUrl(this.url);
+      loader.setTypename(this.typename);
+      loader.listenOnce(goog.net.EventType.COMPLETE, this.onDescribeComplete_.bind(this, layer, options));
+      loader.load();
     }
-  };
+  }
 
-  if (this.featureType) {
-    var deferred = new goog.async.Deferred();
-    deferred.addCallback(setupRequest, this);
-    deferred.addCallback(checkRefresh);
-
-    // If theres no start or end date picked. launch the gui
-    if (options['temporal'] && this.featureType.getTimeColumns().length >= 2 &&
-        (!this.featureType.getStartDateColumnName() || !this.featureType.getEndDateColumnName())) {
-      plugin.ogc.ui.ChooseTimeColumnCtrl.launch(this.id, deferred);
+  /**
+   * @param {VectorLayer} layer
+   * @param {Object.<string, *>} options
+   * @param {goog.events.Event} event
+   * @private
+   */
+  onDescribeComplete_(layer, options, event) {
+    var loader = /** @type {DescribeFeatureLoader} */ (event.target);
+    var featureType = loader.getFeatureType();
+    if (featureType) {
+      this.featureType = featureType;
+      this.onFeatureTypeAvailable(layer, options);
     } else {
-      deferred.callback();
+      var msg = 'Failed loading DescribeFeatureType for ' + this.typename + '. Feature layer will not be loaded.';
+      os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.ERROR);
     }
-  } else {
-    checkRefresh();
-  }
-};
-
-
-/**
- * Adds mappings
- *
- * @param {os.layer.Vector} layer
- * @param {Object.<string, *>} options
- * @protected
- */
-plugin.ogc.wfs.WFSLayerConfig.prototype.addMappings = function(layer, options) {
-  var animate = options['animate'] != null ? options['animate'] : false;
-  var source = /** @type {os.source.Request} */ (layer.getSource());
-  var importer = /** @type {os.im.Importer} */ (source.getImporter());
-  var execMappings = [];
-  var timeFields = options['timeFields'];
-
-  if (timeFields) {
-    if (!Array.isArray(timeFields)) {
-      timeFields = [timeFields];
-    }
-
-    this.featureType.setStartDateColumnName(timeFields[0]);
-    this.featureType.setEndDateColumnName(timeFields[1] || timeFields[0]);
   }
 
-  var startField = this.featureType.getStartDateColumnName();
-  var endField = this.featureType.getEndDateColumnName();
-  var columns = this.featureType.getColumns();
+  /**
+   * @inheritDoc
+   */
+  getRequest(options) {
+    var request = super.getRequest(options);
 
-  // do time autodetection
-  if (animate && startField) {
-    if (startField === 'validTime' && this.url.indexOf('/ogc/wfsServer') > -1) {
-      // validTime means that the feature type is dynamic, which means we need to find the actual start/end fields
-      // for the purposes of our mappings
-      for (var i = 0, ii = columns.length; i < ii; i++) {
-        var col = columns[i];
-        if (col['name'] === 'DATE_TIME') {
-          // if a DATE_TIME field is defined, then that's the field we need to use
-          startField = 'DATE_TIME';
-          endField = 'DATE_TIME';
-          break;
+    var format = this.params.get('outputformat');
+    var regex = /json/i;
+
+    if (format && regex.test(format)) {
+      request.setHeader('Accept', 'application/json, text/plain, */*');
+    }
+
+    request.setValidator(ogc.getException);
+
+    if (options['postFormat'] !== 'kvp') {
+      var formatter = new WFSFormatter();
+      if (options['contentType']) {
+        formatter.contentType = /** @type {string} */ (options['contentType']);
+      }
+
+      request.setDataFormatter(formatter);
+    }
+
+    const type = this.getBestType(options);
+    if (type && type.responseType != null) {
+      request.setResponseType(/** @type {goog.net.XhrIo.ResponseType} */ (type.responseType));
+    }
+
+    return request;
+  }
+
+  /**
+   * @param {VectorLayer} layer
+   * @param {Object.<string, *>} options
+   * @protected
+   */
+  onFeatureTypeAvailable(layer, options) {
+    this.featureTypeAvailable(layer, options);
+  }
+
+  /**
+   * @param {VectorLayer} layer
+   * @param {Object.<string, *>} options
+   * @protected
+   */
+  featureTypeAvailable(layer, options) {
+    var source = /** @type {os.source.Request} */ (layer.getSource());
+
+    var checkRefresh = function() {
+      if (source && !source.isDisposed() && options['load']) {
+        source.refresh();
+      }
+    };
+
+    var setupRequest = function() {
+      if (source && !source.isDisposed()) {
+        var featureType = options['featureType'] = this.featureType;
+        if (featureType) {
+          this.fixFeatureTypeColumns(layer, options, featureType);
         }
 
-        if (col['name'] === 'UP_DATE_TIME' || col['name'] === 'DOWN_DATE_TIME') {
-          // if UP_DATE_TIME or DOWN_TIME_TIME is defined, then those are the fields we need to use
-          startField = 'UP_DATE_TIME';
-          endField = 'DOWN_DATE_TIME';
-          break;
+        this.addMappings(layer, options);
+
+        var request = source.getRequest();
+
+        if (request) {
+          request.addModifier(new OGCFilterCleaner());
         }
       }
-    }
+    };
 
-    if (startField != endField) {
-      // add a start/end datetime mapping
-      // this mapping does not remove the original fields since it's mapping two fields to one, and the original
-      // fields may be wanted when exporting data
-      var mapping = new os.im.mapping.time.DateTimeMapping(os.im.mapping.TimeType.START);
-      mapping.field = startField;
-      mapping.setFormat(os.im.mapping.TimeFormat.ISO);
+    if (this.featureType) {
+      var deferred = new Deferred();
+      deferred.addCallback(setupRequest, this);
+      deferred.addCallback(checkRefresh);
 
-      execMappings.push(mapping);
-
-      mapping = new os.im.mapping.time.DateTimeMapping(os.im.mapping.TimeType.END);
-      mapping.field = endField;
-      mapping.setFormat(os.im.mapping.TimeFormat.ISO);
-
-      execMappings.push(mapping);
-    } else {
-      // add a datetime mapping
-      // this mapping removes the original field since we're replacing the original with our own
-      mapping = new os.im.mapping.time.DateTimeMapping(os.im.mapping.TimeType.INSTANT);
-      mapping.field = startField;
-      mapping.setFormat(os.im.mapping.TimeFormat.ISO);
-
-      execMappings.push(mapping);
-    }
-  }
-
-  // do the other autodetections
-  var columnObj = {};
-  columns.forEach(function(column) {
-    columnObj[column['name']] = column['type'];
-  });
-
-  var autodetects = [
-    new os.im.mapping.AltMapping(),
-    new os.im.mapping.RadiusMapping(),
-    new os.im.mapping.OrientationMapping(),
-    new os.im.mapping.SemiMajorMapping(),
-    new os.im.mapping.SemiMinorMapping()
-  ];
-
-  for (var i = 0, ii = autodetects.length; i < ii; i++) {
-    var mapping = autodetects[i];
-    var detected = mapping.autoDetect([columnObj]);
-
-    if (detected) {
-      execMappings.push(detected);
-    }
-  }
-
-  if (execMappings && execMappings.length > 0) {
-    importer.setExecMappings(execMappings);
-  }
-};
-
-
-/**
- * @param {Object<string, *>} options
- * @return {Object} The type config to use.
- * @protected
- */
-plugin.ogc.wfs.WFSLayerConfig.prototype.getBestType = function(options) {
-  var formats = /** @type {Array<string>|undefined} */ (options['formats']);
-  var format = /** @type {string} */ (this.params.get('outputformat'));
-  var preferred = plugin.ogc.wfs.WFSLayerConfig.TYPE_CONFIGS;
-
-  // see if the given format is one mutually supported by the layer and this plugin
-  if (format && (!formats || formats.includes(format))) {
-    for (var i = 0, n = preferred.length; i < n; i++) {
-      var pref = preferred[i];
-      if (pref.regex.test(format)) {
-        return pref;
+      // If theres no start or end date picked. launch the gui
+      if (options['temporal'] && this.featureType.getTimeColumns().length >= 2 &&
+          (!this.featureType.getStartDateColumnName() || !this.featureType.getEndDateColumnName())) {
+        ChooseTimeColumnController.launch(this.id, deferred);
+      } else {
+        deferred.callback();
       }
+    } else {
+      checkRefresh();
     }
   }
 
-  // otherwise, check the available formats for one we support and set that on the params
-  if (formats) {
-    for (var i = 0, n = preferred.length; i < n; i++) {
-      var pref = preferred[i];
+  /**
+   * Adds mappings
+   *
+   * @param {VectorLayer} layer
+   * @param {Object.<string, *>} options
+   * @protected
+   */
+  addMappings(layer, options) {
+    var animate = options['animate'] != null ? options['animate'] : false;
+    var source = /** @type {os.source.Request} */ (layer.getSource());
+    var importer = /** @type {os.im.Importer} */ (source.getImporter());
+    var execMappings = [];
+    var timeFields = options['timeFields'];
 
-      for (var j = 0, m = formats.length; j < m; j++) {
-        if (pref.regex.test(formats[j])) {
-          if (this.params) {
-            this.params.set('outputformat', formats[j]);
+    if (timeFields) {
+      if (!Array.isArray(timeFields)) {
+        timeFields = [timeFields];
+      }
+
+      this.featureType.setStartDateColumnName(timeFields[0]);
+      this.featureType.setEndDateColumnName(timeFields[1] || timeFields[0]);
+    }
+
+    var startField = this.featureType.getStartDateColumnName();
+    var endField = this.featureType.getEndDateColumnName();
+    var columns = this.featureType.getColumns();
+
+    // do time autodetection
+    if (animate && startField) {
+      if (startField === 'validTime' && this.url.indexOf('/ogc/wfsServer') > -1) {
+        // validTime means that the feature type is dynamic, which means we need to find the actual start/end fields
+        // for the purposes of our mappings
+        for (var i = 0, ii = columns.length; i < ii; i++) {
+          var col = columns[i];
+          if (col['name'] === 'DATE_TIME') {
+            // if a DATE_TIME field is defined, then that's the field we need to use
+            startField = 'DATE_TIME';
+            endField = 'DATE_TIME';
+            break;
           }
 
+          if (col['name'] === 'UP_DATE_TIME' || col['name'] === 'DOWN_DATE_TIME') {
+            // if UP_DATE_TIME or DOWN_TIME_TIME is defined, then those are the fields we need to use
+            startField = 'UP_DATE_TIME';
+            endField = 'DOWN_DATE_TIME';
+            break;
+          }
+        }
+      }
+
+      if (startField != endField) {
+        // add a start/end datetime mapping
+        // this mapping does not remove the original fields since it's mapping two fields to one, and the original
+        // fields may be wanted when exporting data
+        var mapping = new DateTimeMapping(TimeType.START);
+        mapping.field = startField;
+        mapping.setFormat(TimeFormat.ISO);
+
+        execMappings.push(mapping);
+
+        mapping = new DateTimeMapping(TimeType.END);
+        mapping.field = endField;
+        mapping.setFormat(TimeFormat.ISO);
+
+        execMappings.push(mapping);
+      } else {
+        // add a datetime mapping
+        // this mapping removes the original field since we're replacing the original with our own
+        mapping = new DateTimeMapping(TimeType.INSTANT);
+        mapping.field = startField;
+        mapping.setFormat(TimeFormat.ISO);
+
+        execMappings.push(mapping);
+      }
+    }
+
+    // do the other autodetections
+    var columnObj = {};
+    columns.forEach(function(column) {
+      columnObj[column['name']] = column['type'];
+    });
+
+    var autodetects = [
+      new AltMapping(),
+      new RadiusMapping(),
+      new OrientationMapping(),
+      new SemiMajorMapping(),
+      new SemiMinorMapping()
+    ];
+
+    for (var i = 0, ii = autodetects.length; i < ii; i++) {
+      var mapping = autodetects[i];
+      var detected = mapping.autoDetect([columnObj]);
+
+      if (detected) {
+        execMappings.push(detected);
+      }
+    }
+
+    if (execMappings && execMappings.length > 0) {
+      importer.setExecMappings(execMappings);
+    }
+  }
+
+  /**
+   * @param {Object<string, *>} options
+   * @return {Object} The type config to use.
+   * @protected
+   */
+  getBestType(options) {
+    var formats = /** @type {Array<string>|undefined} */ (options['formats']);
+    var format = /** @type {string} */ (this.params.get('outputformat'));
+    var preferred = WFSLayerConfig.TYPE_CONFIGS;
+
+    // see if the given format is one mutually supported by the layer and this plugin
+    if (format && (!formats || formats.includes(format))) {
+      for (var i = 0, n = preferred.length; i < n; i++) {
+        var pref = preferred[i];
+        if (pref.regex.test(format)) {
           return pref;
         }
       }
     }
-  }
 
-  this.params.remove('outputformat');
-  return plugin.ogc.wfs.WFSLayerConfig.GML3_CONFIG;
-};
+    // otherwise, check the available formats for one we support and set that on the params
+    if (formats) {
+      for (var i = 0, n = preferred.length; i < n; i++) {
+        var pref = preferred[i];
 
+        for (var j = 0, m = formats.length; j < m; j++) {
+          if (pref.regex.test(formats[j])) {
+            if (this.params) {
+              this.params.set('outputformat', formats[j]);
+            }
 
-/**
- * @inheritDoc
- */
-plugin.ogc.wfs.WFSLayerConfig.prototype.getParser = function(options) {
-  var typeConfig = this.getBestType(options);
-  var im = os.ui.im.ImportManager.getInstance();
-  var type = typeConfig.type;
-  var parser = im.getParser(typeConfig.parser, options);
-
-  // special case handling
-  if (type === 'geojson') {
-    // geojson needs a reference to the source for style merging purposes
-    if (!parser) {
-      parser = new plugin.file.geojson.GeoJSONParser();
+            return pref;
+          }
+        }
+      }
     }
 
-    parser.setSourceId(this.id);
-  } else if (type == 'gml2') {
-    // tell the parser to use it
-    /** @type {plugin.file.gml.GMLParser} */ (parser).useGML2Format(true);
+    this.params.remove('outputformat');
+    return WFSLayerConfig.GML3_CONFIG;
   }
 
-  return /** @type {!os.parse.IParser<ol.Feature>} */ (parser);
-};
+  /**
+   * @inheritDoc
+   */
+  getParser(options) {
+    var typeConfig = this.getBestType(options);
+    var im = ImportManager.getInstance();
+    var type = typeConfig.type;
+    var parser = im.getParser(typeConfig.parser, options);
+
+    // special case handling
+    if (type === 'geojson') {
+      // geojson needs a reference to the source for style merging purposes
+      if (!parser) {
+        parser = new GeoJSONParser();
+      }
+
+      parser.setSourceId(this.id);
+    } else if (type == 'gml2') {
+      // tell the parser to use it
+      /** @type {GMLParser} */ (parser).useGML2Format(true);
+    }
+
+    return /** @type {!os.parse.IParser<ol.Feature>} */ (parser);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLayer(source, options) {
+    var layer = new VectorLayer({
+      source: source
+    });
+
+    // set up the node ui when the layer node is hovered/selected
+    layer.setNodeUI(`<${ogcLayerNodeUi}></${ogcLayerNodeUi}>`);
+    return layer;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getSource(options) {
+    var source = super.getSource(options);
+    source.setLockable(this.lockable);
+    return source;
+  }
+
+  /**
+   * Register a type config object.
+   * @param {!ogc.WFSTypeConfig} config
+   * @protected
+   */
+  static registerType(config) {
+    const configs = WFSLayerConfig.TYPE_CONFIGS;
+
+    if (!configs.find((c) => c.type === config.type)) {
+      configs.push(config);
+    }
+
+    // sort them by priority, highest first
+    configs.sort((a, b) => b.priority - a.priority);
+  }
+}
 
 
 /**
- * @inheritDoc
+ * @type {goog.log.Logger}
  */
-plugin.ogc.wfs.WFSLayerConfig.prototype.getLayer = function(source, options) {
-  var layer = new os.layer.Vector({
-    source: source
-  });
-
-  // set up the node ui when the layer node is hovered/selected
-  layer.setNodeUI('<ogclayernodeui></ogclayernodeui>');
-  return layer;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.wfs.WFSLayerConfig.prototype.getSource = function(options) {
-  var source = plugin.ogc.wfs.WFSLayerConfig.base(this, 'getSource', options);
-  source.setLockable(this.lockable);
-  return source;
-};
+const logger = goog.log.getLogger('plugin.ogc.wfs.WFSLayerConfig');
 
 
 /**
  * Type config for GeoJSON parsing.
- * @type {os.ogc.WFSTypeConfig}
+ * @type {ogc.WFSTypeConfig}
  */
-plugin.ogc.wfs.WFSLayerConfig.GEOJSON_CONFIG = {
+WFSLayerConfig.GEOJSON_CONFIG = {
   regex: /^application\/json$/,
   parser: 'geojson',
   type: 'geojson',
@@ -467,9 +467,9 @@ plugin.ogc.wfs.WFSLayerConfig.GEOJSON_CONFIG = {
 
 /**
  * Type config for GML3 parsing.
- * @type {os.ogc.WFSTypeConfig}
+ * @type {ogc.WFSTypeConfig}
  */
-plugin.ogc.wfs.WFSLayerConfig.GML3_CONFIG = {
+WFSLayerConfig.GML3_CONFIG = {
   regex: /gml\/?3/i,
   parser: 'gml',
   type: 'gml3',
@@ -479,9 +479,9 @@ plugin.ogc.wfs.WFSLayerConfig.GML3_CONFIG = {
 
 /**
  * Type config for GML2 parsing.
- * @type {os.ogc.WFSTypeConfig}
+ * @type {ogc.WFSTypeConfig}
  */
-plugin.ogc.wfs.WFSLayerConfig.GML2_CONFIG = {
+WFSLayerConfig.GML2_CONFIG = {
   regex: /gml\/?2/i,
   parser: 'gml',
   type: 'gml2',
@@ -491,27 +491,13 @@ plugin.ogc.wfs.WFSLayerConfig.GML2_CONFIG = {
 
 /**
  * The available WFS type config objects. Plugins can add supported parser types to this.
- * @type {Array<os.ogc.WFSTypeConfig>}
+ * @type {Array<ogc.WFSTypeConfig>}
  */
-plugin.ogc.wfs.WFSLayerConfig.TYPE_CONFIGS = [
-  plugin.ogc.wfs.WFSLayerConfig.GEOJSON_CONFIG,
-  plugin.ogc.wfs.WFSLayerConfig.GML3_CONFIG,
-  plugin.ogc.wfs.WFSLayerConfig.GML2_CONFIG
+WFSLayerConfig.TYPE_CONFIGS = [
+  WFSLayerConfig.GEOJSON_CONFIG,
+  WFSLayerConfig.GML3_CONFIG,
+  WFSLayerConfig.GML2_CONFIG
 ];
 
 
-/**
- * Register a type config object.
- * @param {!os.ogc.WFSTypeConfig} config
- * @protected
- */
-plugin.ogc.wfs.WFSLayerConfig.registerType = function(config) {
-  const configs = plugin.ogc.wfs.WFSLayerConfig.TYPE_CONFIGS;
-
-  if (!configs.find((c) => c.type === config.type)) {
-    configs.push(config);
-  }
-
-  // sort them by priority, highest first
-  configs.sort((a, b) => b.priority - a.priority);
-};
+exports = WFSLayerConfig;

--- a/src/plugin/ogc/wms/tilewmssource.js
+++ b/src/plugin/ogc/wms/tilewmssource.js
@@ -1,64 +1,67 @@
-goog.provide('plugin.ogc.wms.TileWMSSource');
-goog.require('ol.source.TileWMS');
-goog.require('os.events.PropertyChangeEvent');
-goog.require('os.implements');
-goog.require('os.ol.source.ILoadingSource');
-goog.require('os.source.IFilterableTileSource');
-goog.require('os.source.IStyle');
-goog.require('os.tile.ColorableTile');
+goog.module('plugin.ogc.wms.TileWMSSource');
+goog.module.declareLegacyNamespace();
 
+const TileWMS = goog.require('ol.source.TileWMS');
+const PropertyChangeEvent = goog.require('os.events.PropertyChangeEvent');
+const osImplements = goog.require('os.implements');
+const IStyle = goog.require('os.source.IStyle');
+const ILoadingSource = goog.requireType('os.ol.source.ILoadingSource');
 
 
 /**
  * Layer source for tile data from WMS servers. This source fires a property change event when its
  * loading state changes based on how many tiles are currently in a loading state.
  *
- * @param {olx.source.TileWMSOptions=} opt_options Tile WMS options.
- * @implements {os.ol.source.ILoadingSource}
- * @implements {os.source.IStyle}
- * @extends {ol.source.TileWMS}
- * @constructor
+ * @implements {ILoadingSource}
+ * @implements {IStyle}
  */
-plugin.ogc.wms.TileWMSSource = function(opt_options) {
-  plugin.ogc.wms.TileWMSSource.base(this, 'constructor', opt_options);
-  this.refreshEnabled = true;
-};
-goog.inherits(plugin.ogc.wms.TileWMSSource, ol.source.TileWMS);
-os.implements(plugin.ogc.wms.TileWMSSource, os.source.IStyle.ID);
-
-
-/**
- * @return {?(string|osx.ogc.TileStyle)}
- * @override
- */
-plugin.ogc.wms.TileWMSSource.prototype.getStyle = function() {
-  var params = this.getParams();
-
-  if (params) {
-    var style = params['STYLES'] || '';
+class TileWMSSource extends TileWMS {
+  /**
+   * Constructor.
+   * @param {olx.source.TileWMSOptions=} opt_options Tile WMS options.
+   */
+  constructor(opt_options) {
+    super(opt_options);
+    this.refreshEnabled = true;
   }
 
-  return style;
-};
-
-
-/**
- * @param {?(string|osx.ogc.TileStyle)} value
- * @override
- */
-plugin.ogc.wms.TileWMSSource.prototype.setStyle = function(value) {
-  var style = typeof value == 'string' ? value : value != null ? value.data : '';
-
-  if (style != this.getStyle()) {
+  /**
+   * @return {?(string|osx.ogc.TileStyle)}
+   * @override
+   */
+  getStyle() {
     var params = this.getParams();
-    params['STYLES'] = style;
 
-    // clear the tile cache or tiles from the old style may be temporarily displayed while the new tiles are loaded
-    this.tileCache.clear();
+    if (params) {
+      var style = params['STYLES'] || '';
+    }
 
-    // update params, which will trigger a tile refresh
-    this.updateParams(params);
-
-    this.dispatchEvent(new os.events.PropertyChangeEvent(os.source.PropertyChange.STYLE));
+    return style;
   }
-};
+
+  /**
+   * @param {?(string|osx.ogc.TileStyle)} value
+   * @override
+   */
+  setStyle(value) {
+    var style = typeof value == 'string' ? value : value != null ? value.data : '';
+
+    if (style != this.getStyle()) {
+      var params = this.getParams();
+      params['STYLES'] = style;
+
+      // clear the tile cache or tiles from the old style may be temporarily displayed while the new tiles are loaded
+      this.tileCache.clear();
+
+      // update params, which will trigger a tile refresh
+      this.updateParams(params);
+
+      this.dispatchEvent(new PropertyChangeEvent(os.source.PropertyChange.STYLE));
+    }
+  }
+}
+
+osImplements(TileWMSSource, IStyle.ID);
+
+
+exports = TileWMSSource;

--- a/src/plugin/ogc/wms/tilewmssource.js
+++ b/src/plugin/ogc/wms/tilewmssource.js
@@ -5,6 +5,8 @@ const TileWMS = goog.require('ol.source.TileWMS');
 const PropertyChangeEvent = goog.require('os.events.PropertyChangeEvent');
 const osImplements = goog.require('os.implements');
 const IStyle = goog.require('os.source.IStyle');
+const PropertyChange = goog.require('os.source.PropertyChange');
+
 const ILoadingSource = goog.requireType('os.ol.source.ILoadingSource');
 
 
@@ -56,7 +58,7 @@ class TileWMSSource extends TileWMS {
       // update params, which will trigger a tile refresh
       this.updateParams(params);
 
-      this.dispatchEvent(new PropertyChangeEvent(os.source.PropertyChange.STYLE));
+      this.dispatchEvent(new PropertyChangeEvent(PropertyChange.STYLE));
     }
   }
 }

--- a/src/plugin/ogc/wms/wmslayerconfig.js
+++ b/src/plugin/ogc/wms/wmslayerconfig.js
@@ -1,9 +1,9 @@
-goog.provide('plugin.ogc.wms.WMSLayerConfig');
+goog.module('plugin.ogc.wms.WMSLayerConfig');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.layer.AnimatedTile');
-goog.require('os.layer.config.AbstractTileLayerConfig');
-goog.require('plugin.ogc.wms.TileWMSSource');
-
+const AnimatedTile = goog.require('os.layer.AnimatedTile');
+const AbstractTileLayerConfig = goog.require('os.layer.config.AbstractTileLayerConfig');
+const TileWMSSource = goog.require('plugin.ogc.wms.TileWMSSource');
 
 
 /**
@@ -58,115 +58,112 @@ goog.require('plugin.ogc.wms.TileWMSSource');
  * }
  *
  * This will produce a WMS layer which queries for TIME=&lt;formattedStartDate&gt;/&lt;formattedEndDate&gt;
- *
- * @extends {os.layer.config.AbstractTileLayerConfig}
- * @constructor
  */
-plugin.ogc.wms.WMSLayerConfig = function() {
-  plugin.ogc.wms.WMSLayerConfig.base(this, 'constructor');
+class WMSLayerConfig extends AbstractTileLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    /**
+     * @type {boolean}
+     * @protected
+     */
+    this.animate = false;
+  }
 
   /**
-   * @type {boolean}
-   * @protected
+   * @inheritDoc
    */
-  this.animate = false;
-};
-goog.inherits(plugin.ogc.wms.WMSLayerConfig, os.layer.config.AbstractTileLayerConfig);
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.wms.WMSLayerConfig.prototype.initializeConfig = function(options) {
-  plugin.ogc.wms.WMSLayerConfig.base(this, 'initializeConfig', options);
-  this.animate = !!options['animate'];
-  this.layerClass = this.animate ? os.layer.AnimatedTile : this.layerClass;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.wms.WMSLayerConfig.prototype.configureLayer = function(layer, options) {
-  plugin.ogc.wms.WMSLayerConfig.base(this, 'configureLayer', layer, options);
-
-  layer.setStyles(/** @type {?Array<osx.ogc.TileStyle>} */ (options['styles'] || null));
-
-  if (this.animate) {
-    if (layer instanceof os.layer.AnimatedTile) {
-      var animatedLayer = /** @type {os.layer.AnimatedTile} */ (layer);
-      animatedLayer.setTimeFunction(os.layer.AnimatedTile.updateParams);
-
-      if (options['dateFormat']) {
-        animatedLayer.setDateFormat(/** @type {string} */ (options['dateFormat']));
-      }
-
-      if (options['timeFormat']) {
-        animatedLayer.setTimeFormat(/** @type {string} */ (options['timeFormat']));
-      }
-    }
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.wms.WMSLayerConfig.prototype.getSource = function(options) {
-  var params = {'EXCEPTIONS': 'INIMAGE'};
-  if (this.params) {
-    var version = this.params.get('VERSION');
-    params['EXCEPTIONS'] = version === '1.1.1' ? 'application/vnd.ogc.se_inimage' : 'INIMAGE';
-    var keys = this.params.getKeys();
-    for (var i = 0, n = keys.length; i < n; i++) {
-      var key = keys[i];
-      params[options['caseSensitive'] ? key : key.toUpperCase()] = this.params.get(key);
-    }
+  initializeConfig(options) {
+    super.initializeConfig(options);
+    this.animate = !!options['animate'];
+    this.layerClass = this.animate ? AnimatedTile : this.layerClass;
   }
 
-  var wmsOptions = /** @type {olx.source.TileWMSOptions} */ ({
-    urls: this.urls,
-    params: params,
-    projection: this.projection,
-    tileGrid: this.tileGrid,
-    crossOrigin: this.crossOrigin,
-    wrapX: this.projection.isGlobal()
-  });
+  /**
+   * @inheritDoc
+   */
+  configureLayer(layer, options) {
+    super.configureLayer(layer, options);
 
-  return new plugin.ogc.wms.TileWMSSource(wmsOptions);
-};
+    layer.setStyles(/** @type {?Array<osx.ogc.TileStyle>} */ (options['styles'] || null));
 
+    if (this.animate) {
+      if (layer instanceof AnimatedTile) {
+        var animatedLayer = /** @type {AnimatedTile} */ (layer);
+        animatedLayer.setTimeFunction(AnimatedTile.updateParams);
 
-/**
- * @inheritDoc
- */
-plugin.ogc.wms.WMSLayerConfig.prototype.getTileWidth = function(options) {
-  if (this.params) {
-    var keys = this.params.getKeys();
-    for (var i = 0, n = keys.length; i < n; i++) {
-      if (keys[i].toUpperCase() == 'WIDTH') {
-        return parseInt(this.params.get(keys[i]), 10);
+        if (options['dateFormat']) {
+          animatedLayer.setDateFormat(/** @type {string} */ (options['dateFormat']));
+        }
+
+        if (options['timeFormat']) {
+          animatedLayer.setTimeFormat(/** @type {string} */ (options['timeFormat']));
+        }
       }
     }
   }
 
-  return plugin.ogc.wms.WMSLayerConfig.base(this, 'getTileWidth', options);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.ogc.wms.WMSLayerConfig.prototype.getTileHeight = function(options) {
-  if (this.params) {
-    var keys = this.params.getKeys();
-    for (var i = 0, n = keys.length; i < n; i++) {
-      if (keys[i].toUpperCase() == 'HEIGHT') {
-        return parseInt(this.params.get(keys[i]), 10);
+  /**
+   * @inheritDoc
+   */
+  getSource(options) {
+    var params = {'EXCEPTIONS': 'INIMAGE'};
+    if (this.params) {
+      var version = this.params.get('VERSION');
+      params['EXCEPTIONS'] = version === '1.1.1' ? 'application/vnd.ogc.se_inimage' : 'INIMAGE';
+      var keys = this.params.getKeys();
+      for (var i = 0, n = keys.length; i < n; i++) {
+        var key = keys[i];
+        params[options['caseSensitive'] ? key : key.toUpperCase()] = this.params.get(key);
       }
     }
+
+    var wmsOptions = /** @type {olx.source.TileWMSOptions} */ ({
+      urls: this.urls,
+      params: params,
+      projection: this.projection,
+      tileGrid: this.tileGrid,
+      crossOrigin: this.crossOrigin,
+      wrapX: this.projection.isGlobal()
+    });
+
+    return new TileWMSSource(wmsOptions);
   }
 
-  return plugin.ogc.wms.WMSLayerConfig.base(this, 'getTileHeight', options);
-};
+  /**
+   * @inheritDoc
+   */
+  getTileWidth(options) {
+    if (this.params) {
+      var keys = this.params.getKeys();
+      for (var i = 0, n = keys.length; i < n; i++) {
+        if (keys[i].toUpperCase() == 'WIDTH') {
+          return parseInt(this.params.get(keys[i]), 10);
+        }
+      }
+    }
 
+    return super.getTileWidth(options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getTileHeight(options) {
+    if (this.params) {
+      var keys = this.params.getKeys();
+      for (var i = 0, n = keys.length; i < n; i++) {
+        if (keys[i].toUpperCase() == 'HEIGHT') {
+          return parseInt(this.params.get(keys[i]), 10);
+        }
+      }
+    }
+
+    return super.getTileHeight(options);
+  }
+}
+
+exports = WMSLayerConfig;

--- a/src/plugin/ogc/wmts/wmtsserver.js
+++ b/src/plugin/ogc/wmts/wmtsserver.js
@@ -4,6 +4,7 @@ goog.module.declareLegacyNamespace();
 const QueryData = goog.require('goog.Uri.QueryData');
 const log = goog.require('goog.log');
 const IDataProvider = goog.require('os.data.IDataProvider');
+const osImplements = goog.require('os.implements');
 const OGCServer = goog.require('os.ui.ogc.OGCServer');
 
 const Logger = goog.requireType('goog.log.Logger');
@@ -61,6 +62,6 @@ class WMTSServer extends OGCServer {
     return 'wmts';
   }
 }
-os.implements(WMTSServer, IDataProvider.ID);
+osImplements(WMTSServer, IDataProvider.ID);
 
 exports = WMTSServer;

--- a/test/plugin/ogc/geoserver.test.js
+++ b/test/plugin/ogc/geoserver.test.js
@@ -4,6 +4,8 @@ goog.require('plugin.ogc.GeoServer');
 
 
 describe('plugin.ogc.GeoServer', function() {
+  const GeoServer = goog.module.get('plugin.ogc.GeoServer');
+
   var serverLabel = 'test-server';
   var serverUrl = 'http://im.a.test.server/wahoo/';
   var dateFormat = 'im-a-date';
@@ -25,7 +27,7 @@ describe('plugin.ogc.GeoServer', function() {
   };
 
   it('should initialize properly from config', function() {
-    var server = new plugin.ogc.GeoServer();
+    var server = new GeoServer();
     server.configure(serverConfig1);
 
     expect(server.getLabel()).toBe(serverLabel);

--- a/test/plugin/ogc/mime.test.js
+++ b/test/plugin/ogc/mime.test.js
@@ -1,28 +1,32 @@
+goog.require('os.file.mime');
 goog.require('os.file.mime.mock');
+goog.require('os.ogc');
 goog.require('plugin.ogc.mime');
 
 describe('plugin.ogc.mime', function() {
+  const mime = goog.module.get('os.file.mime');
+  const ogc = goog.module.get('os.ogc');
   it('should not detect files that are not OGC Server files', function() {
-    os.file.mime.mock.testFiles([
+    mime.mock.testFiles([
       '/base/test/plugin/file/kml/kml_test.xml',
       '/base/test/resources/bin/rand.bin',
       '/base/test/resources/json/partial_object.json'
-    ], os.file.mime.mock.testNo(os.ogc.ID));
+    ], mime.mock.testNo(ogc.ID));
   });
 
   it('should detect files that are OGC Server files', function() {
-    os.file.mime.mock.testFiles([
+    mime.mock.testFiles([
       '/base/test/resources/ogc/wms-130.xml',
       '/base/test/resources/ogc/wms-111.xml',
       '/base/test/resources/ogc/wmts-100.xml',
       '/base/test/resources/ogc/wfs-200.xml', // we don't support WFS 2.0.0 but we do detect it as an OGC server
       '/base/test/resources/ogc/wfs-110.xml',
       '/base/test/resources/ogc/exception-report.xml'
-    ], os.file.mime.mock.testYes(os.ogc.ID));
+    ], mime.mock.testYes(ogc.ID));
   });
 
   it('should register itself with mime detection', function() {
-    var chain = os.file.mime.getTypeChain(os.ogc.ID).join(', ');
-    expect(chain).toBe('application/octet-stream, text/plain, text/xml, ' + os.ogc.ID);
+    var chain = mime.getTypeChain(ogc.ID).join(', ');
+    expect(chain).toBe('application/octet-stream, text/plain, text/xml, ' + ogc.ID);
   });
 });

--- a/test/plugin/ogc/query/ogctemporalformatter.test.js
+++ b/test/plugin/ogc/query/ogctemporalformatter.test.js
@@ -1,12 +1,17 @@
 goog.require('goog.Uri');
+goog.require('os.time');
 goog.require('os.time.TimelineController');
 goog.require('plugin.ogc.query.OGCTemporalFormatter');
 
 describe('plugin.ogc.query.OGCTemporalFormatter', function() {
+  const time = goog.module.get('os.time');
+  const TimelineController = goog.module.get('os.time.TimelineController');
+  const OGCTemporalFormatter = goog.module.get('plugin.ogc.query.OGCTemporalFormatter');
+
   it('sets start/end columns with defaults', function() {
-    var formatter = new plugin.ogc.query.OGCTemporalFormatter();
-    expect(formatter.startColumn_).toBe(plugin.ogc.query.OGCTemporalFormatter.DEFAULT_COLUMN_);
-    expect(formatter.endColumn_).toBe(plugin.ogc.query.OGCTemporalFormatter.DEFAULT_COLUMN_);
+    var formatter = new OGCTemporalFormatter();
+    expect(formatter.startColumn_).toBe(OGCTemporalFormatter.DEFAULT_COLUMN_);
+    expect(formatter.endColumn_).toBe(OGCTemporalFormatter.DEFAULT_COLUMN_);
 
     var testStart = 'testStartColumn';
     var testEnd = 'testEndColumn';
@@ -17,23 +22,23 @@ describe('plugin.ogc.query.OGCTemporalFormatter', function() {
 
     formatter.setStartColumn('');
     formatter.setEndColumn('');
-    expect(formatter.startColumn_).toBe(plugin.ogc.query.OGCTemporalFormatter.DEFAULT_COLUMN_);
-    expect(formatter.endColumn_).toBe(plugin.ogc.query.OGCTemporalFormatter.DEFAULT_COLUMN_);
+    expect(formatter.startColumn_).toBe(OGCTemporalFormatter.DEFAULT_COLUMN_);
+    expect(formatter.endColumn_).toBe(OGCTemporalFormatter.DEFAULT_COLUMN_);
 
     formatter.setStartColumn(null);
     formatter.setEndColumn(null);
-    expect(formatter.startColumn_).toBe(plugin.ogc.query.OGCTemporalFormatter.DEFAULT_COLUMN_);
-    expect(formatter.endColumn_).toBe(plugin.ogc.query.OGCTemporalFormatter.DEFAULT_COLUMN_);
+    expect(formatter.startColumn_).toBe(OGCTemporalFormatter.DEFAULT_COLUMN_);
+    expect(formatter.endColumn_).toBe(OGCTemporalFormatter.DEFAULT_COLUMN_);
   });
 
   it('modifies a uri param', function() {
-    var formatter = new plugin.ogc.query.OGCTemporalFormatter();
+    var formatter = new OGCTemporalFormatter();
     var testStart = 'testStartColumn';
     var testEnd = 'testEndColumn';
     formatter.setStartColumn(testStart);
     formatter.setEndColumn(testEnd);
 
-    var controller = new os.time.TimelineController();
+    var controller = new TimelineController();
     var startTime = Date.now();
     var endTime = startTime + 5000;
     controller.setRange(controller.buildRange(startTime, endTime));
@@ -41,23 +46,23 @@ describe('plugin.ogc.query.OGCTemporalFormatter', function() {
     var result = formatter.format(controller);
     var expected = '<Or><And><PropertyIsGreaterThanOrEqualTo>' +
         '<PropertyName>' + testEnd + '</PropertyName>' +
-        '<Literal>' + os.time.format(new Date(startTime), undefined, false, true) + '</Literal>' +
+        '<Literal>' + time.format(new Date(startTime), undefined, false, true) + '</Literal>' +
         '</PropertyIsGreaterThanOrEqualTo>' +
         '<PropertyIsLessThan>' +
         '<PropertyName>' + testStart + '</PropertyName>' +
-        '<Literal>' + os.time.format(new Date(endTime), undefined, false, true) + '</Literal>' +
+        '<Literal>' + time.format(new Date(endTime), undefined, false, true) + '</Literal>' +
         '</PropertyIsLessThan></And></Or>';
     expect(result).toBe(expected);
   });
 
   it('handles multiple ranges, orders from oldest to newest', function() {
-    var formatter = new plugin.ogc.query.OGCTemporalFormatter();
+    var formatter = new OGCTemporalFormatter();
     var testStart = 'testStartColumn';
     var testEnd = 'testEndColumn';
     formatter.setStartColumn(testStart);
     formatter.setEndColumn(testEnd);
 
-    var controller = new os.time.TimelineController();
+    var controller = new TimelineController();
     var startTime = Date.now();
     var endTime = startTime + 5000;
     controller.setRange(controller.buildRange(startTime, endTime));
@@ -66,19 +71,19 @@ describe('plugin.ogc.query.OGCTemporalFormatter', function() {
     var result = formatter.format(controller);
     var expected = '<Or><And><PropertyIsGreaterThanOrEqualTo>' +
         '<PropertyName>' + testEnd + '</PropertyName>' +
-        '<Literal>' + os.time.format(new Date(startTime - 86400000), undefined, false, true) + '</Literal>' +
+        '<Literal>' + time.format(new Date(startTime - 86400000), undefined, false, true) + '</Literal>' +
         '</PropertyIsGreaterThanOrEqualTo>' +
         '<PropertyIsLessThan>' +
         '<PropertyName>' + testStart + '</PropertyName>' +
-        '<Literal>' + os.time.format(new Date(startTime - 86400000 + 50000), undefined, false, true) + '</Literal>' +
+        '<Literal>' + time.format(new Date(startTime - 86400000 + 50000), undefined, false, true) + '</Literal>' +
         '</PropertyIsLessThan></And>' +
         '<And><PropertyIsGreaterThanOrEqualTo>' +
         '<PropertyName>' + testEnd + '</PropertyName>' +
-        '<Literal>' + os.time.format(new Date(startTime), undefined, false, true) + '</Literal>' +
+        '<Literal>' + time.format(new Date(startTime), undefined, false, true) + '</Literal>' +
         '</PropertyIsGreaterThanOrEqualTo>' +
         '<PropertyIsLessThan>' +
         '<PropertyName>' + testStart + '</PropertyName>' +
-        '<Literal>' + os.time.format(new Date(endTime), undefined, false, true) + '</Literal>' +
+        '<Literal>' + time.format(new Date(endTime), undefined, false, true) + '</Literal>' +
         '</PropertyIsLessThan></And></Or>';
     expect(result).toBe(expected);
   });

--- a/test/plugin/ogc/state/v4/ogclayerstate.test.js
+++ b/test/plugin/ogc/state/v4/ogclayerstate.test.js
@@ -1,3 +1,5 @@
+goog.require('goog.Uri.QueryData');
+goog.require('os');
 goog.require('os.layer.Vector');
 goog.require('os.ogc.wfs.FeatureType');
 goog.require('os.state.StateManager');
@@ -8,10 +10,18 @@ goog.require('os.xml');
 goog.require('plugin.file.kml.KMLField');
 goog.require('plugin.ogc.OGCLayerDescriptor');
 goog.require('plugin.ogc.wfs.WFSLayerConfig');
-
-
+goog.require('plugin.ogc.wms.WMSLayerConfig');
 
 describe('OGC.v4.ArcLayerState', function() {
+  const QueryData = goog.module.get('goog.Uri.QueryData');
+  const os = goog.module.get('os');
+  const FeatureType = goog.module.get('os.ogc.wfs.FeatureType');
+  const StateManager = goog.module.get('os.state.StateManager');
+  const LayerState = goog.module.get('os.state.v4.LayerState');
+  const xml = goog.module.get('os.xml');
+  const OGCLayerDescriptor = goog.module.get('plugin.ogc.OGCLayerDescriptor');
+  const WMSLayerConfig = goog.module.get('plugin.ogc.wms.WMSLayerConfig');
+
   var stateManager = null;
 
   var expectPropertiesInAToBeSameInB = function(a, b, exclusions) {
@@ -41,13 +51,13 @@ describe('OGC.v4.ArcLayerState', function() {
   };
 
   beforeEach(function() {
-    os.stateManager = os.state.StateManager.getInstance();
-    stateManager = os.state.StateManager.getInstance();
+    os.stateManager = StateManager.getInstance();
+    stateManager = StateManager.getInstance();
     stateManager.setVersion('v4');
   });
 
   it('should exist', function() {
-    expect(os.state.v4.LayerState).not.toBe(undefined);
+    expect(LayerState).not.toBe(undefined);
   });
 
   it('OGC state validates against the state.xsd', function() {
@@ -172,8 +182,8 @@ describe('OGC.v4.ArcLayerState', function() {
     var resultSchemas = null;
 
     // These options are objects at runtime, converting them back.
-    defaultOptions.params = goog.Uri.QueryData.createFromMap(defaultOptions.params.keyMap_.map_);
-    defaultOptions.featureType = new os.ogc.wfs.FeatureType(defaultOptions.featureType,
+    defaultOptions.params = QueryData.createFromMap(defaultOptions.params.keyMap_.map_);
+    defaultOptions.featureType = new FeatureType(defaultOptions.featureType,
         defaultOptions.featureType.columns_, defaultOptions.featureType.isDynamic_);
 
     // Using jasman's async test, as we need to load the xsd files
@@ -197,7 +207,7 @@ describe('OGC.v4.ArcLayerState', function() {
       // creating an empty one in the hope that any new
       // layer options that may get added will get incorporated
       // and validated.
-      var descriptor = new plugin.ogc.OGCLayerDescriptor();
+      var descriptor = new OGCLayerDescriptor();
       descriptor.setWmsEnabled(true);
       descriptor.setWfsEnabled(true);
 
@@ -207,7 +217,7 @@ describe('OGC.v4.ArcLayerState', function() {
         title: 'test'
       };
 
-      var lc = new plugin.ogc.wms.WMSLayerConfig();
+      var lc = new WMSLayerConfig();
       var layer = lc.createLayer(createLayerOptions);
 
       var descriptorOptions = descriptor.getLayerOptions();
@@ -221,7 +231,7 @@ describe('OGC.v4.ArcLayerState', function() {
       // default option is added, good to have that present in case
       // it causes an issue.
       layer.setLayerOptions(options);
-      var layerState = new os.state.v4.LayerState();
+      var layerState = new LayerState();
       var xmlRootDocument = stateManager.createStateObject(function() {}, 'test state', 'desc', defaultOptions.tags);
       var stateOptions = stateManager.createStateOptions(function() {}, 'test state', 'desc', defaultOptions.tags);
       stateOptions.doc = xmlRootDocument;
@@ -229,7 +239,7 @@ describe('OGC.v4.ArcLayerState', function() {
       xmlRootDocument.firstElementChild.appendChild(rootObj);
       var result = layerState.layerToXML(layer, stateOptions);
       rootObj.appendChild(result);
-      var seralizedDoc = os.xml.serialize(stateOptions.doc);
+      var seralizedDoc = xml.serialize(stateOptions.doc);
       var xmlLintResult = xmllint.validateXML({
         xml: seralizedDoc,
         schema: resultSchemas
@@ -240,7 +250,7 @@ describe('OGC.v4.ArcLayerState', function() {
       var mapLayersNode = xmlRootDocument.firstElementChild.querySelector('dataLayers');
       var restoredOptions = layerState.xmlToOptions(mapLayersNode.firstElementChild);
       expect(restoredOptions).toBeDefined();
-      // method does a basic value comparision with expect(a?).toBe(b?) for most of the
+      // method does a basic value comparision with expect(a?).toBe(b?) for mos1t of the
       // values defined in the orginal default optons.
       expectPropertiesInAToBeSameInB(defaultOptions, restoredOptions,
           ['id', 'color', 'baseColor', 'params', 'map_', 'featureType']);

--- a/test/plugin/ogc/wfs/wfslayerconfig.test.js
+++ b/test/plugin/ogc/wfs/wfslayerconfig.test.js
@@ -1,20 +1,24 @@
 goog.require('goog.net.XhrIo');
+goog.require('goog.net.XhrIo.ResponseType');
 goog.require('plugin.ogc.wfs.WFSLayerConfig');
 
 
 describe('plugin.ogc.wfs.WFSLayerConfig', function() {
-  const preferredTypes = plugin.ogc.wfs.WFSLayerConfig.TYPE_CONFIGS;
+  const ResponseType = goog.module.get('goog.net.XhrIo.ResponseType');
+  const WFSLayerConfig = goog.module.get('plugin.ogc.wfs.WFSLayerConfig');
+
+  const preferredTypes = WFSLayerConfig.TYPE_CONFIGS;
   const avroConfig = {
     regex: /^avro\/binary$/,
     parser: 'avro',
     type: 'avro',
     priority: 500,
-    responseType: goog.net.XhrIo.ResponseType.ARRAY_BUFFER
+    responseType: ResponseType.ARRAY_BUFFER
   };
 
   it('should use provided outputformat given available supported server formats', function() {
     ['application/json', 'gml3', 'gml2'].forEach((format, i) => {
-      const wfs = new plugin.ogc.wfs.WFSLayerConfig();
+      const wfs = new WFSLayerConfig();
       const config = {
         'url': 'https://example.com/geoserver/ogc',
         'params': {
@@ -33,7 +37,7 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
 
   it('should use the provided outputformat if the application supports it', function() {
     ['application/json', 'gml3', 'gml2'].forEach((format, i) => {
-      const wfs = new plugin.ogc.wfs.WFSLayerConfig();
+      const wfs = new WFSLayerConfig();
       const config = {
         'url': 'https://example.com/geoserver/ogc',
         'params': {
@@ -50,7 +54,7 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
   });
 
   it('should default to formats supported by the application and the server', function() {
-    const wfs = new plugin.ogc.wfs.WFSLayerConfig();
+    const wfs = new WFSLayerConfig();
     const config = {
       'url': 'https://example.com/geoserver/ogc',
       'params': {
@@ -67,7 +71,7 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
   });
 
   it('should default to a format supported by the application', function() {
-    const wfs = new plugin.ogc.wfs.WFSLayerConfig();
+    const wfs = new WFSLayerConfig();
     const config = {
       'url': 'https://example.com/geoserver/ogc',
       'params': {
@@ -83,7 +87,7 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
   });
 
   it('should default to a format supported by both the application and the server', function() {
-    const wfs = new plugin.ogc.wfs.WFSLayerConfig();
+    const wfs = new WFSLayerConfig();
     const config = {
       'url': 'https://example.com/geoserver/ogc',
       'params': {
@@ -100,14 +104,14 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
   });
 
   it('should register new type configs and sort them by priority', function() {
-    plugin.ogc.wfs.WFSLayerConfig.registerType(avroConfig);
+    WFSLayerConfig.registerType(avroConfig);
 
     expect(preferredTypes.length).toBe(4);
     expect(preferredTypes[0]).toBe(avroConfig);
   });
 
   it('should select new type configs if they match a layer', function() {
-    const wfs = new plugin.ogc.wfs.WFSLayerConfig();
+    const wfs = new WFSLayerConfig();
     const config = {
       'url': 'https://example.com/geoserver/ogc',
       'params': {
@@ -124,7 +128,7 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
   });
 
   it('should respect the responseType defined on a type config', function() {
-    const wfs = new plugin.ogc.wfs.WFSLayerConfig();
+    const wfs = new WFSLayerConfig();
     const config = {
       'url': 'https://example.com/geoserver/ogc',
       'params': {
@@ -137,7 +141,7 @@ describe('plugin.ogc.wfs.WFSLayerConfig', function() {
 
     wfs.initializeConfig(config);
     const request = wfs.getRequest(config);
-    expect(request.getResponseType()).toBe(goog.net.XhrIo.ResponseType.ARRAY_BUFFER);
+    expect(request.getResponseType()).toBe(ResponseType.ARRAY_BUFFER);
 
     const formatter = request.getDataFormatter();
     expect(formatter).toBeDefined();

--- a/test/plugin/ogc/wms/wmslayerconfig.test.js
+++ b/test/plugin/ogc/wms/wmslayerconfig.test.js
@@ -1,9 +1,13 @@
-goog.require('os.net.ProxyHandler');
 goog.require('ol.proj');
+goog.require('os.net.ProxyHandler');
 goog.require('plugin.ogc.wms.WMSLayerConfig');
 
 
 describe('plugin.ogc.wms.WMSLayerConfig', function() {
+  const olProj = goog.module.get('ol.proj');
+  const ProxyHandler = goog.module.get('os.net.ProxyHandler');
+  const WMSLayerConfig = goog.module.get('plugin.ogc.wms.WMSLayerConfig');
+
   it('should proxy URLs properly', function() {
     var options = {
       url: 'http://www.example.com/wms',
@@ -11,7 +15,7 @@ describe('plugin.ogc.wms.WMSLayerConfig', function() {
       title: 'Test'
     };
 
-    var lc = new plugin.ogc.wms.WMSLayerConfig();
+    var lc = new WMSLayerConfig();
     var original = lc.createLayer(options);
 
     options['proxy'] = true;
@@ -22,11 +26,11 @@ describe('plugin.ogc.wms.WMSLayerConfig', function() {
 
     var tileCoord = [0, 0, 0];
     var pixelRatio = 1;
-    var proj = ol.proj.get('EPSG:4326');
+    var proj = olProj.get('EPSG:4326');
 
     var originalUrl = originalFunc(tileCoord, pixelRatio, proj);
     var proxyUrl = proxyFunc(tileCoord, pixelRatio, proj);
 
-    expect(proxyUrl).toBe(os.net.ProxyHandler.getProxyUri(originalUrl));
+    expect(proxyUrl).toBe(ProxyHandler.getProxyUri(originalUrl));
   });
 });

--- a/test/plugin/ogc/wmts/wmtsserver.test.js
+++ b/test/plugin/ogc/wmts/wmtsserver.test.js
@@ -1,6 +1,10 @@
+goog.require('os.data.DataManager');
+goog.require('os.data.DataProviderEventType');
 goog.require('plugin.ogc.wmts.WMTSServer');
 
 describe('plugin.ogc.wmts.WMTSServer', () => {
+  const DataManager = goog.module.get('os.data.DataManager');
+  const DataProviderEventType = goog.module.get('os.data.DataProviderEventType');
   const WMTSServer = goog.module.get('plugin.ogc.wmts.WMTSServer');
 
   const loadAndRun = function(server, config, func) {
@@ -11,7 +15,7 @@ describe('plugin.ogc.wmts.WMTSServer', () => {
       count++;
     };
 
-    server.listenOnce(os.data.DataProviderEventType.LOADED, listener);
+    server.listenOnce(DataProviderEventType.LOADED, listener);
 
     runs(function() {
       server.configure(config);
@@ -33,7 +37,7 @@ describe('plugin.ogc.wmts.WMTSServer', () => {
       expect(server.getId()).toBe('testogc');
       expect(server.getLabel()).toBe('Test WMTS');
 
-      var d = os.dataManager.getDescriptor('testogc#test-3857-1');
+      var d = DataManager.getInstance().getDescriptor('testogc#test-3857-1');
       expect(d).toBeTruthy();
 
       var wmtsOptions = d.getWmtsOptions();
@@ -43,7 +47,7 @@ describe('plugin.ogc.wmts.WMTSServer', () => {
       expect(wmtsOptions[0]['urls'][0]).toBe('https://wmts.example.com/ows?');
       expect(wmtsOptions[0]['projection'].getCode()).toBe('EPSG:3857');
 
-      var d = os.dataManager.getDescriptor('testogc#test-4326-1');
+      var d = DataManager.getInstance().getDescriptor('testogc#test-4326-1');
       expect(d).toBeTruthy();
 
       wmtsOptions = d.getWmtsOptions();


### PR DESCRIPTION
This PR converts the ogc plugin to use `goog.module`. UI shims were left in for backward compatibility in projects using OpenSphere as a library, and local references have been replaced. This set of transforms did not require any supplemental refactors.