### PR TITLE
Animation support for arbitrary layers/sources

### DIFF
--- a/src/os/data/histo/timelinehistmanager.js
+++ b/src/os/data/histo/timelinehistmanager.js
@@ -1,4 +1,5 @@
 goog.provide('os.data.histo.TimelineHistManager');
+
 goog.require('goog.async.Throttle');
 goog.require('goog.events.EventTarget');
 goog.require('goog.events.EventType');
@@ -10,6 +11,7 @@ goog.require('os.data.event.DataEvent');
 goog.require('os.data.event.DataEventType');
 goog.require('os.events.PropertyChangeEvent');
 goog.require('os.fn');
+goog.require('os.hist');
 goog.require('os.hist.HistogramData');
 goog.require('os.source.PropertyChange');
 goog.require('os.time.TimeRange');
@@ -160,19 +162,14 @@ os.data.histo.TimelineHistManager.prototype.getHistograms = function(options) {
 
   if (options.interval > 0) {
     var layers = os.MapContainer.getInstance().getLayers();
-    var sources = layers.map(os.fn.mapLayerToSource).filter(os.fn.filterFalsey);
+    histograms = layers.map((layer) => os.hist.mapLayerToHistogram(layer, options))
+        .filter(os.fn.filterFalsey);
 
-    if (!sources.length) {
-      sources = os.osDataManager.getSources();
+    if (!histograms.length) {
+      var sources = os.osDataManager.getSources();
+      histograms = sources.map((source) => os.hist.mapSourceToHistogram(source, options))
+          .filter(os.fn.filterFalsey);
     }
-
-    histograms = sources.map(function(source) {
-      if (os.implements(source, os.hist.IHistogramProvider.ID)) {
-        return /** @type {os.hist.IHistogramProvider} */ (source).getHistogram(options);
-      }
-
-      return null;
-    }).filter(os.fn.filterFalsey);
   }
 
   return histograms;

--- a/src/os/hist/hist.js
+++ b/src/os/hist/hist.js
@@ -2,7 +2,10 @@
  * Histogram utility functions.
  */
 goog.provide('os.hist');
+
 goog.require('os.hist.HistogramData');
+goog.require('os.hist.IHistogramProvider');
+goog.require('os.implements');
 
 
 /**
@@ -91,4 +94,46 @@ os.hist.getBinCounts = function(histograms, opt_combine, opt_skipCompare) {
   }
 
   return sortedCounts;
+};
+
+
+/**
+ * If an object is a histogram provider.
+ * @param {Object} obj The object.
+ * @return {boolean}
+ */
+os.hist.isHistogramProvider = (obj) => os.implements(obj, os.hist.IHistogramProvider.ID);
+
+
+/**
+ * Convenience function to map a layer or its source to a histogram.
+ * @param {ol.layer.Layer} layer The layer.
+ * @param {os.ui.timeline.TimelineScaleOptions} options The histogram options.
+ * @return {?os.hist.IHistogramData} The histogram, or null if unavailable. May be found on the layer or source.
+ */
+os.hist.mapLayerToHistogram = (layer, options) => {
+  if (layer) {
+    if (os.hist.isHistogramProvider(layer)) {
+      return /** @type {os.hist.IHistogramProvider} */ (layer).getHistogram(options);
+    } else {
+      return os.hist.mapSourceToHistogram(layer.getSource(), options);
+    }
+  }
+
+  return null;
+};
+
+
+/**
+ * Convenience function to map a source to a histogram.
+ * @param {ol.source.Source} source The source.
+ * @param {os.ui.timeline.TimelineScaleOptions} options The histogram options.
+ * @return {?os.hist.IHistogramData} The histogram, or null if unavailable.
+ */
+os.hist.mapSourceToHistogram = (source, options) => {
+  if (os.hist.isHistogramProvider(source)) {
+    return /** @type {os.hist.IHistogramProvider} */ (source).getHistogram(options);
+  }
+
+  return null;
 };

--- a/src/os/ianimationsupport.js
+++ b/src/os/ianimationsupport.js
@@ -1,0 +1,28 @@
+goog.module('os.IAnimationSupport');
+goog.module.declareLegacyNamespace();
+
+/**
+ * Interface for a layer or source that responds to timeline animation.
+ * @interface
+ */
+class IAnimationSupport {
+  /**
+   * If animation is enabled.
+   * @return {boolean}
+   */
+  getAnimationEnabled() {}
+
+  /**
+   * Set if animation is enabled.
+   * @param {boolean} value The value.
+   */
+  setAnimationEnabled(value) {}
+}
+
+/**
+ * ID for {@see os.implements}
+ * @type {string}
+ */
+IAnimationSupport.ID = 'os.IAnimationSupport';
+
+exports = IAnimationSupport;

--- a/src/os/layer/animatedtile.js
+++ b/src/os/layer/animatedtile.js
@@ -1,7 +1,9 @@
 goog.provide('os.layer.AnimatedTile');
 
 goog.require('goog.async.Delay');
+goog.require('os.IAnimationSupport');
 goog.require('os.events.PropertyChangeEvent');
+goog.require('os.implements');
 goog.require('os.layer.PropertyChange');
 goog.require('os.layer.Tile');
 goog.require('os.query.TemporalFormatter');
@@ -18,6 +20,7 @@ goog.requireType('ol.source.TileWMS');
 
 /**
  * @extends {os.layer.Tile}
+ * @implements {os.IAnimationSupport}
  * @param {olx.layer.TileOptions} options Tile layer options
  * @constructor
  */
@@ -76,6 +79,7 @@ os.layer.AnimatedTile = function(options) {
   this.timeFunction = null;
 };
 goog.inherits(os.layer.AnimatedTile, os.layer.Tile);
+os.implements(os.layer.AnimatedTile, os.IAnimationSupport.ID);
 
 
 /**
@@ -268,9 +272,7 @@ os.layer.AnimatedTile.prototype.setTimeFormat = function(format) {
 
 
 /**
- * If the layer has been enabled for animation.
- *
- * @return {boolean}
+ * @inheritDoc
  */
 os.layer.AnimatedTile.prototype.getAnimationEnabled = function() {
   return this.animationEnabled_;
@@ -278,9 +280,7 @@ os.layer.AnimatedTile.prototype.getAnimationEnabled = function() {
 
 
 /**
- * Marks the source as being in the animating state.
- *
- * @param {boolean} value
+ * @inheritDoc
  */
 os.layer.AnimatedTile.prototype.setAnimationEnabled = function(value) {
   if (this.animationEnabled_ !== value) {

--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -15,6 +15,7 @@ goog.require('ol.geom.Geometry');
 goog.require('ol.source.Vector');
 goog.require('os');
 goog.require('os.Fields');
+goog.require('os.IAnimationSupport');
 goog.require('os.alert.AlertEventSeverity');
 goog.require('os.alert.AlertManager');
 goog.require('os.data.ColumnDefinition');
@@ -57,6 +58,7 @@ goog.require('os.webgl');
 
 /**
  * @extends {ol.source.Vector}
+ * @implements {os.IAnimationSupport}
  * @implements {os.source.ISource}
  * @implements {os.hist.IHistogramProvider}
  * @implements {os.source.IModifiableSource}
@@ -432,6 +434,7 @@ os.source.Vector = function(opt_options) {
 goog.inherits(os.source.Vector, ol.source.Vector);
 os.implements(os.source.Vector, os.hist.IHistogramProvider.ID);
 os.implements(os.source.Vector, os.source.ISource.ID);
+os.implements(os.source.Vector, os.IAnimationSupport.ID);
 os.implements(os.source.Vector, os.source.IModifiableSource.ID);
 
 
@@ -1425,6 +1428,7 @@ os.source.Vector.prototype.setTitle = function(value) {
  * to the timeline controller and enable the animation overlay for faster feature rendering.
  *
  * @return {boolean}
+ * @override
  */
 os.source.Vector.prototype.getAnimationEnabled = function() {
   return this.animationEnabled_;
@@ -1435,6 +1439,7 @@ os.source.Vector.prototype.getAnimationEnabled = function() {
  * Marks the source as being in the animating state.
  *
  * @param {boolean} value
+ * @override
  */
 os.source.Vector.prototype.setAnimationEnabled = function(value) {
   if (this.animationEnabled_ !== value) {


### PR DESCRIPTION
Currently only `os.layer.AnimatedTile` and `os.source.Vector` support toggling the "timeline open" state via `setAnimationEnabled`. This would be useful for other layers/sources that need to behave differently depending on the state of the timeline. This PR makes a few changes to expand support for animation:

- Any layer/source may implement the new `os.IAnimationSupport` interface to have their animation state toggled when the timeline is opened or closed.
- Any layer/source may implement the existing `os.hist.IHistogramProvider` interface to provide a histogram to be rendered on the timeline.