### PR TITLE
Transform area/audio/config/descriptor plugins to goog.module

### DIFF
--- a/docs/cookbook/audionotification/index.rst
+++ b/docs/cookbook/audionotification/index.rst
@@ -15,7 +15,7 @@ Use the OpenSphere AudioManager. This is a singleton, and the `play()` function 
 .. literalinclude:: src/audioalertplugin.js
   :caption: AudioManager usage
   :linenos:
-  :lines: 30-31
+  :lines: 24-25
   :language: javascript
 
 There are three ways to provide the sound files - config settings, programmatically, or by user upload.
@@ -31,8 +31,11 @@ A programmatic approach is shown below:
 
 .. code-block:: javascript
 
-  var audioManager = os.audio.AudioManager.getInstance();
-  audioManager.addSound(os.ROOT + 'sounds/cowbell.wav', 'label');
+  const {ROOT} = goog.require('os');
+  const AudioManager = goog.require('os.audio.AudioManager');
+
+  const audioManager = AudioManager.getInstance();
+  audioManager.addSound(ROOT + 'sounds/cowbell.wav', 'label');
   audioManager.play('label');
 
 User upload uses the normal Import Data dialog. Note that it only works in a standard browser environment if the target is a HTTP or HTTPS URL (different rules apply in a "wrapped" environment like [Electron](https://electronjs.org/)).
@@ -41,14 +44,14 @@ User upload uses the normal Import Data dialog. Note that it only works in a sta
 Discussion
 ----------
 
-The level of audio support, including the file formats and associated codecs that are supported, depends on browser capabilities. 
+The level of audio support, including the file formats and associated codecs that are supported, depends on browser capabilities.
 
 In addition to the API shown earlier, AudioManager also supports muting the notifications. If your plugin makes use of audio notifications, we strongly suggest supporting global muting, as well as selective enable / disable of alerts.
 
 .. code-block:: javascript
 
   audioManager.setMute(true);
-  var mute = audioManager.getMute(); // true - muted
+  const mute = audioManager.getMute(); // true - muted
   audioManager.setMute(false); // now unmuted
 
 
@@ -57,5 +60,5 @@ Full code
 
 .. literalinclude:: src/audioalertplugin.js
   :caption: Audio Notification Cookbook example - Full code
-  :linenos: 
+  :linenos:
   :language: javascript

--- a/docs/cookbook/audionotification/src/audioalertplugin.js
+++ b/docs/cookbook/audionotification/src/audioalertplugin.js
@@ -1,35 +1,37 @@
-goog.provide('plugin.audioalert.AudioAlertPlugin');
+goog.module('plugin.audioalert.AudioAlertPlugin');
 
-goog.require('os.audio.AudioManager');
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.plugin.PluginManager');
-
+const AudioManager = goog.require('os.audio.AudioManager');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const PluginManager = goog.require('os.plugin.PluginManager');
 
 /**
  * Cookbook example for playing an audio alert.
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.audioalert.AudioAlertPlugin = function() {
-  plugin.audioalert.AudioAlertPlugin.base(this, 'constructor');
-  this.id = plugin.audioalert.ID;
-  this.errorMessage = null;
-};
-goog.inherits(plugin.audioalert.AudioAlertPlugin, os.plugin.AbstractPlugin);
+class AudioAlertPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = ID;
+    this.errorMessage = null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    const audioManager = AudioManager.getInstance();
+    audioManager.play('sound1');
+  }
+}
 
 /**
  * @type {string}
- * @const
  */
-plugin.audioalert.ID = 'audioalert';
-
-/**
- * @inheritDoc
- */
-plugin.audioalert.AudioAlertPlugin.prototype.init = function() {
-  var audioManager = os.audio.AudioManager.getInstance();
-  audioManager.play('sound1');
-};
+const ID = 'audioalert';
 
 // add the plugin to the application
-os.plugin.PluginManager.getInstance().addPlugin(new plugin.audioalert.AudioAlertPlugin());
+PluginManager.getInstance().addPlugin(new AudioAlertPlugin());
+
+exports = AudioAlertPlugin;

--- a/docs/guides/plugin_file_type_guide/time_support.rst
+++ b/docs/guides/plugin_file_type_guide/time_support.rst
@@ -6,8 +6,8 @@ You may have noticed that there is a little clock icon on the layer. The parent 
 .. literalinclude:: ../../../src/os/data/filedescriptor.js
   :linenos:
   :language: javascript
-  :lines: 85-101
-  :emphasize-lines: 5
+  :lines: 154-171
+  :emphasize-lines: 4
 
 That turns on time indexing on the layer. However, nothing is taking the time values from the ``<updated>`` tags in the GeoRSS entries and turning them into ``os.time.TimeInstant`` values in the proper place on the feature. Hence every feature is treated as "timeless" even though the source has time indexing enabled. This is where mappings come in.
 

--- a/src/os/audio/audiomanager.js
+++ b/src/os/audio/audiomanager.js
@@ -1,214 +1,227 @@
-goog.provide('os.audio.AudioManager');
-goog.provide('os.audio.AudioSetting');
+goog.module('os.audio.AudioManager');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.log');
-goog.require('goog.log.Logger');
-goog.require('goog.object');
-goog.require('os');
-goog.require('os.config.Settings');
-
-
-/**
- * Audio settings keys.
- * @enum {string}
- */
-os.audio.AudioSetting = {
-  MUTE: 'mute'
-};
-
+const log = goog.require('goog.log');
+const googObject = goog.require('goog.object');
+const {ROOT} = goog.require('os');
+const AudioSetting = goog.require('os.audio.AudioSetting');
+const Settings = goog.require('os.config.Settings');
+const Logger = goog.requireType('goog.log.Logger');
 
 
 /**
  * Manages audio sound effects for applications
- *
- * @constructor
  */
-os.audio.AudioManager = function() {
+class AudioManager {
   /**
-   * Whether or not we are muted
-   * @type {boolean}
-   * @private
+   * Constructor.
    */
-  this.mute_ = /** @type {boolean} */ (os.settings.get(os.audio.AudioSetting.MUTE, false));
+  constructor() {
+    /**
+     * Whether or not we are muted
+     * @type {boolean}
+     * @private
+     */
+    this.mute_ = /** @type {boolean} */ (Settings.getInstance().get(AudioSetting.MUTE, false));
+
+    /**
+     * Set of sounds
+     * @type {!Object<string, string>}
+     * @private
+     */
+    this.sounds_ = {};
+
+    /**
+     * Cache of audio objects
+     * @type {Object<string, HTMLAudioElement>}
+     * @private
+     */
+    this.cache_ = {};
+
+    /**
+     * Last played time
+     * @type {Object<string, number>}
+     * @private
+     */
+    this.lastPlayed_ = {};
+
+    /**
+     * The default sound played when a sound can not be found
+     * @type {?string}
+     * @private
+     */
+    this.default_ = null;
+
+    this.load();
+  }
 
   /**
-   * Set of sounds
-   * @type {!Object<string, string>}
-   * @private
+   * Gets the mute value
+   *
+   * @return {boolean} mute
    */
-  this.sounds_ = {};
+  getMute() {
+    return this.mute_;
+  }
 
   /**
-   * Cache of audio objects
-   * @type {Object<string, HTMLAudioElement>}
-   * @private
+   * Sets the mute value
+   *
+   * @param {boolean} mute
    */
-  this.cache_ = {};
+  setMute(mute) {
+    this.mute_ = mute;
+    Settings.getInstance().set(AudioSetting.MUTE, this.mute_);
+  }
 
   /**
-   * Last played time
-   * @type {Object<string, number>}
-   * @private
+   * Gets the sounds list
+   *
+   * @return {!Array<!string>} The list of sounds that can be played
    */
-  this.lastPlayed_ = {};
+  getSounds() {
+    return googObject.getKeys(this.sounds_);
+  }
 
   /**
-   * The default sound played when a sound can not be found
-   * @type {?string}
-   * @private
+   * Loads sounds from settings
+   *
+   * @protected
    */
-  this.default_ = null;
+  load() {
+    if (window.HTMLAudioElement) {
+      var sets = ['sounds', 'userSounds'];
 
-  this.load();
-};
-goog.addSingletonGetter(os.audio.AudioManager);
+      for (var s = 0, ss = sets.length; s < ss; s++) {
+        var set = /** @type {Object} */ (Settings.getInstance().get([sets[s]]));
 
+        for (var label in set) {
+          var url = /** @type {string} */ (set[label]);
 
-/**
- * @type {goog.log.Logger}
- * @const
- * @private
- */
-os.audio.AudioManager.LOGGER_ = goog.log.getLogger('os.audio.AudioManager');
+          if (url.indexOf('sounds/') === 0) {
+            url = ROOT + url;
+          }
 
+          if (label.toLowerCase() == 'default') {
+            this.default_ = label;
+          }
 
-/**
- * Gets the mute value
- *
- * @return {boolean} mute
- */
-os.audio.AudioManager.prototype.getMute = function() {
-  return this.mute_;
-};
-
-
-/**
- * Sets the mute value
- *
- * @param {boolean} mute
- */
-os.audio.AudioManager.prototype.setMute = function(mute) {
-  this.mute_ = mute;
-  os.settings.set(os.audio.AudioSetting.MUTE, this.mute_);
-};
-
-
-/**
- * Gets the sounds list
- *
- * @return {!Array<!string>} The list of sounds that can be played
- */
-os.audio.AudioManager.prototype.getSounds = function() {
-  return goog.object.getKeys(this.sounds_);
-};
-
-
-/**
- * Loads sounds from settings
- *
- * @protected
- */
-os.audio.AudioManager.prototype.load = function() {
-  if (window.HTMLAudioElement) {
-    var sets = ['sounds', 'userSounds'];
-
-    for (var s = 0, ss = sets.length; s < ss; s++) {
-      var set = /** @type {Object} */ (os.settings.get([sets[s]]));
-
-      for (var label in set) {
-        var url = /** @type {string} */ (set[label]);
-
-        if (url.indexOf('sounds/') === 0) {
-          url = os.ROOT + url;
+          this.sounds_[label] = url;
         }
+      }
+    } else {
+      log.warning(logger, 'This browser does not support audio');
+    }
+  }
 
-        if (label.toLowerCase() == 'default') {
-          this.default_ = label;
-        }
-
-        this.sounds_[label] = url;
+  /**
+   * Plays a given sound by label
+   *
+   * @param {string} label The sound to play
+   * @param {number=} opt_timeBetweenPlays An optional time which must ellapse between the last play and another
+   */
+  play(label, opt_timeBetweenPlays) {
+    if (!(label in this.sounds_)) {
+      if (this.default_) {
+        log.fine(logger,
+            'Could not find sound "' + label + '" in sound list, using the default instead.');
+        label = this.default_;
+      } else {
+        log.error(logger,
+            'Could not find "' + label + '" in sound list and no default sound was defined.');
+        return;
       }
     }
-  } else {
-    goog.log.warning(os.audio.AudioManager.LOGGER_, 'This browser does not support audio');
-  }
-};
 
+    var url = this.sounds_[label];
+    var audio = null;
+
+    if (url) {
+      if (url in this.cache_) {
+        audio = this.cache_[url];
+      } else {
+        audio = /** @type {HTMLAudioElement} */ (document.createElement('audio'));
+        audio.src = url;
+        this.cache_[url] = audio;
+      }
+
+      var lastPlayed = this.lastPlayed_[url] || 0;
+      var now = Date.now();
+
+      if (!this.mute_ && (opt_timeBetweenPlays === undefined || now - lastPlayed > opt_timeBetweenPlays)) {
+        log.fine(logger, 'Playing "' + label + '" from ' + url);
+        audio.play();
+        this.lastPlayed_[url] = now;
+      }
+    }
+  }
+
+  /**
+   * Adds a sound to the audio manager
+   *
+   * @param {!string} url
+   * @param {string=} opt_label
+   * @return {!string} The label that was used to add the sound
+   */
+  addSound(url, opt_label) {
+    if (!opt_label) {
+      // If a label wasn't provided, use the file name minus the extension. If we can't find that
+      // portion of the file name, then just use the whole URL as the label.
+      var x = url.lastIndexOf('.');
+      if (x < 0) {
+        x = url.length;
+      }
+
+      opt_label = url.substring(url.lastIndexOf('/') + 1, x);
+    }
+
+    // add to sounds
+    this.sounds_[opt_label] = url;
+
+    // remove cache and last played time
+    delete this.cache_[url];
+    delete this.lastPlayed_[url];
+
+    // add to user sounds
+    var userSounds = Settings.getInstance().get(['userSounds'], {});
+    userSounds[opt_label] = url;
+    Settings.getInstance().set(['userSounds'], userSounds);
+
+    log.info(logger, 'Added sound "' + opt_label + '" from ' + url);
+    return opt_label;
+  }
+
+  /**
+   * Get the global instance.
+   * @return {!AudioManager}
+   */
+  static getInstance() {
+    if (!instance) {
+      instance = new AudioManager();
+    }
+
+    return instance;
+  }
+
+  /**
+   * Set the global instance.
+   * @param {AudioManager} value
+   */
+  static setInstance(value) {
+    instance = value;
+  }
+}
 
 /**
- * Plays a given sound by label
- *
- * @param {string} label The sound to play
- * @param {number=} opt_timeBetweenPlays An optional time which must ellapse between the last play and another
+ * Global instance.
+ * @type {AudioManager|undefined}
  */
-os.audio.AudioManager.prototype.play = function(label, opt_timeBetweenPlays) {
-  if (!(label in this.sounds_)) {
-    if (this.default_) {
-      goog.log.fine(os.audio.AudioManager.LOGGER_,
-          'Could not find sound "' + label + '" in sound list, using the default instead.');
-      label = this.default_;
-    } else {
-      goog.log.error(os.audio.AudioManager.LOGGER_,
-          'Could not find "' + label + '" in sound list and no default sound was defined.');
-      return;
-    }
-  }
-
-  var url = this.sounds_[label];
-  var audio = null;
-
-  if (url) {
-    if (url in this.cache_) {
-      audio = this.cache_[url];
-    } else {
-      audio = /** @type {HTMLAudioElement} */ (document.createElement('audio'));
-      audio.src = url;
-      this.cache_[url] = audio;
-    }
-
-    var lastPlayed = this.lastPlayed_[url] || 0;
-    var now = Date.now();
-
-    if (!this.mute_ && (opt_timeBetweenPlays === undefined || now - lastPlayed > opt_timeBetweenPlays)) {
-      goog.log.fine(os.audio.AudioManager.LOGGER_, 'Playing "' + label + '" from ' + url);
-      audio.play();
-      this.lastPlayed_[url] = now;
-    }
-  }
-};
-
+let instance;
 
 /**
- * Adds a sound to the audio manager
- *
- * @param {!string} url
- * @param {string=} opt_label
- * @return {!string} The label that was used to add the sound
+ * @type {Logger}
  */
-os.audio.AudioManager.prototype.addSound = function(url, opt_label) {
-  if (!opt_label) {
-    // If a label wasn't provided, use the file name minus the extension. If we can't find that
-    // portion of the file name, then just use the whole URL as the label.
-    var x = url.lastIndexOf('.');
-    if (x < 0) {
-      x = url.length;
-    }
+const logger = log.getLogger('os.audio.AudioManager');
 
-    opt_label = url.substring(url.lastIndexOf('/') + 1, x);
-  }
 
-  // add to sounds
-  this.sounds_[opt_label] = url;
-
-  // remove cache and last played time
-  delete this.cache_[url];
-  delete this.lastPlayed_[url];
-
-  // add to user sounds
-  var userSounds = os.settings.get(['userSounds'], {});
-  userSounds[opt_label] = url;
-  os.settings.set(['userSounds'], userSounds);
-
-  goog.log.info(os.audio.AudioManager.LOGGER_, 'Added sound "' + opt_label + '" from ' + url);
-  return opt_label;
-};
+exports = AudioManager;

--- a/src/os/audio/audiosetting.js
+++ b/src/os/audio/audiosetting.js
@@ -1,0 +1,10 @@
+goog.module('os.audio.AudioSetting');
+goog.module.declareLegacyNamespace();
+
+/**
+ * Audio settings keys.
+ * @enum {string}
+ */
+exports = {
+  MUTE: 'mute'
+};

--- a/src/os/file/mime/text.js
+++ b/src/os/file/mime/text.js
@@ -15,6 +15,14 @@ os.file.mime.text.TYPE = 'text/plain';
 
 
 /**
+ * Priority for text detection.
+ * @type {number}
+ * @const
+ */
+os.file.mime.text.PRIORITY = 1000;
+
+
+/**
  * The Byte Order Marker (BOM) sequence.
  * @type {!Array<number>}
  * @const
@@ -121,7 +129,7 @@ os.file.mime.text.detectText = function(buffer, opt_file) {
   return goog.Promise.resolve(os.file.mime.text.getText(buffer, opt_file));
 };
 
-os.file.mime.register(os.file.mime.text.TYPE, os.file.mime.text.detectText, 1000);
+os.file.mime.register(os.file.mime.text.TYPE, os.file.mime.text.detectText, os.file.mime.text.PRIORITY);
 
 
 /**

--- a/src/os/ui/im/audioimportui.js
+++ b/src/os/ui/im/audioimportui.js
@@ -1,40 +1,41 @@
-goog.provide('os.ui.im.AudioImportUI');
+goog.module('os.ui.im.AudioImportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.alert.AlertEventSeverity');
-goog.require('os.alert.AlertManager');
-goog.require('os.audio.AudioManager');
-goog.require('os.file');
-goog.require('os.ui.im.AbstractImportUI');
-
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const AlertManager = goog.require('os.alert.AlertManager');
+const AudioManager = goog.require('os.audio.AudioManager');
+const osFile = goog.require('os.file');
+const AbstractImportUI = goog.require('os.ui.im.AbstractImportUI');
 
 
 /**
  * Used for importing sounds to the audio manager.
- *
- * @constructor
- * @extends {os.ui.im.AbstractImportUI}
- * @template T
  */
-os.ui.im.AudioImportUI = function() {
-  os.ui.im.AudioImportUI.base(this, 'constructor');
-};
-goog.inherits(os.ui.im.AudioImportUI, os.ui.im.AbstractImportUI);
-
-
-/**
- * @inheritDoc
- */
-os.ui.im.AudioImportUI.prototype.launchUI = function(file, opt_config) {
-  var url = file.getUrl();
-
-  var msg = null;
-  if (url && !os.file.isLocal(url) && (os.file.FILE_URL_ENABLED || !os.file.isFileSystem(url))) {
-    var label = os.audio.AudioManager.getInstance().addSound(url);
-
-    msg = 'Added new sound "' + label + '"';
-    os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.SUCCESS);
-  } else {
-    msg = 'The audio manager does not support local files. Only files from a URL can be played.';
-    os.alert.AlertManager.getInstance().sendAlert(msg, os.alert.AlertEventSeverity.ERROR);
+class AudioImportUI extends AbstractImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
-};
+
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    const url = file.getUrl();
+
+    let msg = null;
+    if (url && !osFile.isLocal(url) && (osFile.FILE_URL_ENABLED || !osFile.isFileSystem(url))) {
+      const label = AudioManager.getInstance().addSound(url);
+
+      msg = 'Added new sound "' + label + '"';
+      AlertManager.getInstance().sendAlert(msg, AlertEventSeverity.SUCCESS);
+    } else {
+      msg = 'The audio manager does not support local files. Only files from a URL can be played.';
+      AlertManager.getInstance().sendAlert(msg, AlertEventSeverity.ERROR);
+    }
+  }
+}
+
+exports = AudioImportUI;

--- a/src/plugin/area/area.js
+++ b/src/plugin/area/area.js
@@ -1,65 +1,66 @@
-goog.provide('plugin.area');
+goog.module('plugin.area');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.Feature');
-goog.require('ol.array');
-goog.require('os.data.RecordField');
-goog.require('os.fn');
-goog.require('os.geo.jsts');
+const Feature = goog.require('ol.Feature');
+const olArray = goog.require('ol.array');
+const AlertManager = goog.require('os.alert.AlertManager');
+const RecordField = goog.require('os.data.RecordField');
+const fn = goog.require('os.fn');
+const jsts = goog.require('os.geo.jsts');
+const areaManager = goog.require('os.query.AreaManager');
 
 
 /**
  * Process imported features.
  *
- * @param {Array<ol.Feature>} features
+ * @param {Array<Feature>} features
  * @param {Object} config
  */
-plugin.area.processFeatures = function(features, config) {
+const processFeatures = function(features, config) {
   // filter only valid features
-  features = os.ui.areaManager.filterFeatures(features);
+  features = areaManager.getInstance().filterFeatures(features);
 
   if (features && features.length > 0) {
     var mappings = os.ui.query.createMappingsFromConfig(config);
-    var geometries = features.map(os.fn.mapFeatureToGeometry).filter(os.fn.filterFalsey);
+    var geometries = features.map(fn.mapFeatureToGeometry).filter(fn.filterFalsey);
 
     if (config['merge'] && geometries.length > 1) {
-      var merged = os.geo.jsts.merge(geometries);
+      var merged = jsts.merge(geometries);
       if (merged) {
-        var feature = new ol.Feature(merged);
-        plugin.area.processFeature_(feature, config, mappings);
-        os.ui.areaManager.add(feature);
+        var feature = new Feature(merged);
+        processFeature_(feature, config, mappings);
+        areaManager.getInstance().add(feature);
       } else {
-        os.alertManager.sendAlert('Failed merging areas', os.alert.AlertEventSeverity.ERROR);
+        AlertManager.getInstance().sendAlert('Failed merging areas', os.alert.AlertEventSeverity.ERROR);
       }
     } else {
       features.forEach(function(feature) {
-        if (feature && !os.ui.areaManager.get(feature)) {
-          plugin.area.processFeature_(feature, config, mappings);
+        if (feature && !areaManager.getInstance().get(feature)) {
+          processFeature_(feature, config, mappings);
         }
       });
 
-      os.ui.areaManager.bulkAdd(features, true);
+      areaManager.getInstance().bulkAdd(features, true);
     }
   } else {
-    os.alertManager.sendAlert('No Areas Found', os.alert.AlertEventSeverity.WARNING);
+    AlertManager.getInstance().sendAlert('No Areas Found', os.alert.AlertEventSeverity.WARNING);
   }
 };
-
 
 /**
  * Process an imported feature.
  *
- * @param {!ol.Feature} feature
+ * @param {!Feature} feature
  * @param {Object} config
  * @param {!Array<!os.im.mapping.IMapping>} mappings
- * @private
  */
-plugin.area.processFeature_ = function(feature, config, mappings) {
+const processFeature_ = function(feature, config, mappings) {
   // apply mappings to the feature
   os.ui.query.applyMappings(feature, mappings);
 
   // Strip out unnecessary feature values (kml style was breaking the refresh)
   feature.getKeys().forEach(function(value) {
-    var found = ol.array.find(os.ui.query.featureKeys, function(key) {
+    var found = olArray.find(os.ui.query.featureKeys, function(key) {
       return key.toLowerCase() == value.toLowerCase();
     });
     if (!found) {
@@ -70,5 +71,9 @@ plugin.area.processFeature_ = function(feature, config, mappings) {
     }
   });
 
-  feature.set(os.data.RecordField.SOURCE_NAME, config[os.data.RecordField.SOURCE_NAME], true);
+  feature.set(RecordField.SOURCE_NAME, config[RecordField.SOURCE_NAME], true);
+};
+
+exports = {
+  processFeatures
 };

--- a/src/plugin/area/area.js
+++ b/src/plugin/area/area.js
@@ -3,11 +3,13 @@ goog.module.declareLegacyNamespace();
 
 const Feature = goog.require('ol.Feature');
 const olArray = goog.require('ol.array');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
 const AlertManager = goog.require('os.alert.AlertManager');
 const RecordField = goog.require('os.data.RecordField');
 const fn = goog.require('os.fn');
 const jsts = goog.require('os.geo.jsts');
 const areaManager = goog.require('os.query.AreaManager');
+const query = goog.require('os.ui.query');
 
 
 /**
@@ -21,7 +23,7 @@ const processFeatures = function(features, config) {
   features = areaManager.getInstance().filterFeatures(features);
 
   if (features && features.length > 0) {
-    var mappings = os.ui.query.createMappingsFromConfig(config);
+    var mappings = query.createMappingsFromConfig(config);
     var geometries = features.map(fn.mapFeatureToGeometry).filter(fn.filterFalsey);
 
     if (config['merge'] && geometries.length > 1) {
@@ -31,7 +33,7 @@ const processFeatures = function(features, config) {
         processFeature_(feature, config, mappings);
         areaManager.getInstance().add(feature);
       } else {
-        AlertManager.getInstance().sendAlert('Failed merging areas', os.alert.AlertEventSeverity.ERROR);
+        AlertManager.getInstance().sendAlert('Failed merging areas', AlertEventSeverity.ERROR);
       }
     } else {
       features.forEach(function(feature) {
@@ -43,7 +45,7 @@ const processFeatures = function(features, config) {
       areaManager.getInstance().bulkAdd(features, true);
     }
   } else {
-    AlertManager.getInstance().sendAlert('No Areas Found', os.alert.AlertEventSeverity.WARNING);
+    AlertManager.getInstance().sendAlert('No Areas Found', AlertEventSeverity.WARNING);
   }
 };
 
@@ -56,11 +58,11 @@ const processFeatures = function(features, config) {
  */
 const processFeature_ = function(feature, config, mappings) {
   // apply mappings to the feature
-  os.ui.query.applyMappings(feature, mappings);
+  query.applyMappings(feature, mappings);
 
   // Strip out unnecessary feature values (kml style was breaking the refresh)
   feature.getKeys().forEach(function(value) {
-    var found = olArray.find(os.ui.query.featureKeys, function(key) {
+    var found = olArray.find(query.featureKeys, function(key) {
       return key.toLowerCase() == value.toLowerCase();
     });
     if (!found) {

--- a/src/plugin/area/areaimportctrl.js
+++ b/src/plugin/area/areaimportctrl.js
@@ -1,6 +1,7 @@
 goog.module('plugin.area.AreaImportCtrl');
 goog.module.declareLegacyNamespace();
 
+const RecordField = goog.require('os.data.RecordField');
 const AreaImportCtrl = goog.require('os.ui.query.AreaImportCtrl');
 const area = goog.require('plugin.area');
 
@@ -40,7 +41,7 @@ class Controller extends AreaImportCtrl {
    * @protected
    */
   processFeatures(features) {
-    this.config[os.data.RecordField.SOURCE_NAME] = this.getFileName();
+    this.config[RecordField.SOURCE_NAME] = this.getFileName();
     area.processFeatures(features, this.config);
   }
 }

--- a/src/plugin/area/areaimportctrl.js
+++ b/src/plugin/area/areaimportctrl.js
@@ -1,45 +1,48 @@
-goog.provide('plugin.area.AreaImportCtrl');
+goog.module('plugin.area.AreaImportCtrl');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.ui.query.AreaImportCtrl');
-goog.require('plugin.area');
-
+const AreaImportCtrl = goog.require('os.ui.query.AreaImportCtrl');
+const area = goog.require('plugin.area');
 
 
 /**
  * Abstract controller for importing areas from a file.
  *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout The Angular $timeout service.
- * @extends {os.ui.query.AreaImportCtrl}
- * @constructor
- * @ngInject
  * @template T
+ * @unrestricted
  */
-plugin.area.AreaImportCtrl = function($scope, $element, $timeout) {
-  plugin.area.AreaImportCtrl.base(this, 'constructor', $scope, $element, $timeout);
-};
-goog.inherits(plugin.area.AreaImportCtrl, os.ui.query.AreaImportCtrl);
+class Controller extends AreaImportCtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @param {!angular.$timeout} $timeout The Angular $timeout service.
+   * @ngInject
+   */
+  constructor($scope, $element, $timeout) {
+    super($scope, $element, $timeout);
+  }
 
+  /**
+   * Get the filename for the source file.
+   *
+   * @return {string|undefined}
+   * @protected
+   */
+  getFileName() {
+    return this.config && this.config['title'] || undefined;
+  }
 
-/**
- * Get the filename for the source file.
- *
- * @return {string|undefined}
- * @protected
- */
-plugin.area.AreaImportCtrl.prototype.getFileName = function() {
-  return this.config && this.config['title'] || undefined;
-};
+  /**
+   * Process imported features.
+   *
+   * @param {Array<ol.Feature>} features
+   * @protected
+   */
+  processFeatures(features) {
+    this.config[os.data.RecordField.SOURCE_NAME] = this.getFileName();
+    area.processFeatures(features, this.config);
+  }
+}
 
-
-/**
- * Process imported features.
- *
- * @param {Array<ol.Feature>} features
- * @protected
- */
-plugin.area.AreaImportCtrl.prototype.processFeatures = function(features) {
-  this.config[os.data.RecordField.SOURCE_NAME] = this.getFileName();
-  plugin.area.processFeatures(features, this.config);
-};
+exports = Controller;

--- a/src/plugin/area/areaplugin.js
+++ b/src/plugin/area/areaplugin.js
@@ -1,6 +1,7 @@
 goog.module('plugin.area.AreaPlugin');
 goog.module.declareLegacyNamespace();
 
+const os = goog.require('os');
 const csv = goog.require('os.file.mime.csv');
 const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
 const ImportMethod = goog.require('os.ui.file.method.ImportMethod');

--- a/src/plugin/area/areaplugin.js
+++ b/src/plugin/area/areaplugin.js
@@ -1,66 +1,67 @@
-goog.provide('plugin.area.AreaPlugin');
+goog.module('plugin.area.AreaPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.file.FileManager');
-goog.require('os.file.mime.csv');
-goog.require('os.mixin.object');
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.ui.file.method.ImportMethod');
-goog.require('os.ui.im.ImportManager');
-goog.require('plugin.area.CSVAreaImportUI');
-goog.require('plugin.area.GeoJSONAreaImportUI');
-goog.require('plugin.area.KMLAreaImportUI');
-goog.require('plugin.area.SHPAreaImportUI');
-goog.require('plugin.file.geojson.mime');
-goog.require('plugin.file.kml.mime');
-goog.require('plugin.file.shp.mime');
-
+const csv = goog.require('os.file.mime.csv');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const ImportMethod = goog.require('os.ui.file.method.ImportMethod');
+const CSVAreaImportUI = goog.require('plugin.area.CSVAreaImportUI');
+const GeoJSONAreaImportUI = goog.require('plugin.area.GeoJSONAreaImportUI');
+const KMLAreaImportUI = goog.require('plugin.area.KMLAreaImportUI');
+const SHPAreaImportUI = goog.require('plugin.area.SHPAreaImportUI');
+const pluginFileGeojsonMime = goog.require('plugin.file.geojson.mime');
+const pluginFileKmlMime = goog.require('plugin.file.kml.mime');
+const mime = goog.require('plugin.file.shp.mime');
 
 
 /**
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.area.AreaPlugin = function() {
-  plugin.area.AreaPlugin.base(this, 'constructor');
-  this.id = plugin.area.AreaPlugin.ID;
-  this.errorMessage = null;
-};
-goog.inherits(plugin.area.AreaPlugin, os.plugin.AbstractPlugin);
+class AreaPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = AreaPlugin.ID;
+    this.errorMessage = null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    // initialize managers used by the area plugin
+    var aim = os.areaImportManager;
+    var afm = os.areaFileManager;
+
+    // register file import method
+    afm.registerFileMethod(new ImportMethod(false));
+
+    // csv
+    aim.registerImportUI(csv.TYPE, new CSVAreaImportUI());
+    aim.registerImportDetails('CSV', true);
+
+    // geojson
+    aim.registerImportUI(pluginFileGeojsonMime.TYPE, new GeoJSONAreaImportUI());
+    aim.registerImportDetails('GeoJSON', true);
+
+    // kml
+    aim.registerImportUI(pluginFileKmlMime.TYPE, new KMLAreaImportUI());
+    aim.registerImportUI(pluginFileKmlMime.KMZ_TYPE, new KMLAreaImportUI());
+    aim.registerImportDetails('KML/KMZ', true);
+
+    // shp
+    aim.registerImportUI(mime.TYPE, new SHPAreaImportUI());
+    aim.registerImportUI(mime.ZIP_TYPE, new SHPAreaImportUI());
+    aim.registerImportDetails('Shapefile (SHP/DBF or ZIP)', true);
+  }
+}
 
 
 /**
  * @type {string}
  * @const
  */
-plugin.area.AreaPlugin.ID = 'areas';
+AreaPlugin.ID = 'areas';
 
 
-/**
- * @inheritDoc
- */
-plugin.area.AreaPlugin.prototype.init = function() {
-  // initialize managers used by the area plugin
-  var aim = os.areaImportManager;
-  var afm = os.areaFileManager;
-
-  // register file import method
-  afm.registerFileMethod(new os.ui.file.method.ImportMethod(false));
-
-  // csv
-  aim.registerImportUI(os.file.mime.csv.TYPE, new plugin.area.CSVAreaImportUI());
-  aim.registerImportDetails('CSV', true);
-
-  // geojson
-  aim.registerImportUI(plugin.file.geojson.mime.TYPE, new plugin.area.GeoJSONAreaImportUI());
-  aim.registerImportDetails('GeoJSON', true);
-
-  // kml
-  aim.registerImportUI(plugin.file.kml.mime.TYPE, new plugin.area.KMLAreaImportUI());
-  aim.registerImportUI(plugin.file.kml.mime.KMZ_TYPE, new plugin.area.KMLAreaImportUI());
-  aim.registerImportDetails('KML/KMZ', true);
-
-  // shp
-  aim.registerImportUI(plugin.file.shp.mime.TYPE, new plugin.area.SHPAreaImportUI());
-  aim.registerImportUI(plugin.file.shp.mime.ZIP_TYPE, new plugin.area.SHPAreaImportUI());
-  aim.registerImportDetails('Shapefile (SHP/DBF or ZIP)', true);
-};
+exports = AreaPlugin;

--- a/src/plugin/area/csvareaimport.js
+++ b/src/plugin/area/csvareaimport.js
@@ -1,9 +1,11 @@
 goog.module('plugin.area.CSVAreaImport');
 goog.module.declareLegacyNamespace();
 
+const RecordField = goog.require('os.data.RecordField');
 const EventType = goog.require('os.events.EventType');
 const Importer = goog.require('os.im.Importer');
 const Module = goog.require('os.ui.Module');
+const osWindow = goog.require('os.ui.window');
 const WizardCtrl = goog.require('os.ui.wiz.WizardCtrl');
 const wizardDirective = goog.require('os.ui.wiz.wizardDirective');
 const area = goog.require('plugin.area');
@@ -55,11 +57,11 @@ class Controller extends WizardCtrl {
     importer.dispose();
 
     if (features && features.length > 0) {
-      this.scope['config'][os.data.RecordField.SOURCE_NAME] = this.scope['config']['file'].getFileName();
+      this.scope['config'][RecordField.SOURCE_NAME] = this.scope['config']['file'].getFileName();
       area.processFeatures(features, this.scope['config']);
     }
 
-    os.ui.window.close(this.element);
+    osWindow.close(this.element);
   }
 }
 

--- a/src/plugin/area/csvareaimport.js
+++ b/src/plugin/area/csvareaimport.js
@@ -1,81 +1,93 @@
-goog.provide('plugin.area.CSVAreaImportCtrl');
-goog.provide('plugin.area.csvAreaImportDirective');
+goog.module('plugin.area.CSVAreaImport');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.events.EventType');
-goog.require('os.im.Importer');
-goog.require('os.ui.Module');
-goog.require('os.ui.wiz.WizardCtrl');
-goog.require('os.ui.wiz.wizardDirective');
-goog.require('plugin.area');
-goog.require('plugin.file.csv.CSVParser');
-
+const EventType = goog.require('os.events.EventType');
+const Importer = goog.require('os.im.Importer');
+const Module = goog.require('os.ui.Module');
+const WizardCtrl = goog.require('os.ui.wiz.WizardCtrl');
+const wizardDirective = goog.require('os.ui.wiz.wizardDirective');
+const area = goog.require('plugin.area');
+const CSVParser = goog.require('plugin.file.csv.CSVParser');
 
 
 /**
  * Controller for the CSV import wizard window
  *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout
- * @param {!Object<string, string>} $attrs
- * @extends {os.ui.wiz.WizardCtrl<T>}
- * @constructor
- * @ngInject
+ * @extends {WizardCtrl<T>}
  * @template T,S
+ * @unrestricted
  */
-plugin.area.CSVAreaImportCtrl = function($scope, $element, $timeout, $attrs) {
-  plugin.area.CSVAreaImportCtrl.base(this, 'constructor', $scope, $element, $timeout, $attrs);
-};
-goog.inherits(plugin.area.CSVAreaImportCtrl, os.ui.wiz.WizardCtrl);
-
-
-/**
- * @inheritDoc
- */
-plugin.area.CSVAreaImportCtrl.prototype.finish = function() {
-  this['loading'] = true;
-
-  var parser = new plugin.file.csv.CSVParser(this.scope['config']);
-  var importer = new os.im.Importer(parser);
-  importer.setMappings(this.scope['config']['mappings']);
-  importer.listenOnce(os.events.EventType.COMPLETE, this.onImportComplete_, false, this);
-  importer.startImport(this.scope['config']['file'].getContent());
-};
-
-
-/**
- * Success callback for importing data. Adds the areas to Area Manager
- *
- * @param {goog.events.Event} event
- * @private
- */
-plugin.area.CSVAreaImportCtrl.prototype.onImportComplete_ = function(event) {
-  var importer = /** @type {os.im.Importer} */ (event.target);
-  var features = /** @type {!Array<ol.Feature>} */ (importer.getData());
-  importer.dispose();
-
-  if (features && features.length > 0) {
-    this.scope['config'][os.data.RecordField.SOURCE_NAME] = this.scope['config']['file'].getFileName();
-    plugin.area.processFeatures(features, this.scope['config']);
+class Controller extends WizardCtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @param {!angular.$timeout} $timeout
+   * @param {!Object<string, string>} $attrs
+   * @ngInject
+   */
+  constructor($scope, $element, $timeout, $attrs) {
+    super($scope, $element, $timeout, $attrs);
   }
 
-  os.ui.window.close(this.element);
-};
+  /**
+   * @inheritDoc
+   */
+  finish() {
+    this['loading'] = true;
 
+    var parser = new CSVParser(this.scope['config']);
+    var importer = new Importer(parser);
+    importer.setMappings(this.scope['config']['mappings']);
+    importer.listenOnce(EventType.COMPLETE, this.onImportComplete_, false, this);
+    importer.startImport(this.scope['config']['file'].getContent());
+  }
+
+  /**
+   * Success callback for importing data. Adds the areas to Area Manager
+   *
+   * @param {goog.events.Event} event
+   * @private
+   */
+  onImportComplete_(event) {
+    var importer = /** @type {Importer} */ (event.target);
+    var features = /** @type {!Array<ol.Feature>} */ (importer.getData());
+    importer.dispose();
+
+    if (features && features.length > 0) {
+      this.scope['config'][os.data.RecordField.SOURCE_NAME] = this.scope['config']['file'].getFileName();
+      area.processFeatures(features, this.scope['config']);
+    }
+
+    os.ui.window.close(this.element);
+  }
+}
 
 /**
  * The CSV import wizard directive.
  *
  * @return {angular.Directive}
  */
-plugin.area.csvAreaImportDirective = function() {
-  var dir = os.ui.wiz.wizardDirective();
-  dir.controller = plugin.area.CSVAreaImportCtrl;
+const directive = () => {
+  var dir = wizardDirective();
+  dir.controller = Controller;
   return dir;
 };
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'csvareaimport';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('csvareaimport', [plugin.area.csvAreaImportDirective]);
+Module.directive('csvareaimport', [directive]);
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
+};

--- a/src/plugin/area/csvareaimport_shim.js
+++ b/src/plugin/area/csvareaimport_shim.js
@@ -1,0 +1,13 @@
+goog.provide('plugin.area.CSVAreaImportCtrl');
+goog.provide('plugin.area.csvAreaImportDirective');
+goog.require('plugin.area.CSVAreaImportUI');
+
+/**
+ * @deprecated Please use goog.require('plugin.area.CSVAreaImportUI').Controller instead.
+ */
+plugin.area.CSVAreaImportCtrl = plugin.area.CSVAreaImportUI.Controller;
+
+/**
+ * @deprecated Please use goog.require('plugin.area.CSVAreaImportUI').directive instead.
+ */
+plugin.area.csvAreaImportDirective = plugin.area.CSVAreaImportUI.directive;

--- a/src/plugin/area/csvareaimportui.js
+++ b/src/plugin/area/csvareaimportui.js
@@ -1,71 +1,75 @@
-goog.provide('plugin.area.CSVAreaImportUI');
+goog.module('plugin.area.CSVAreaImportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.query.ui.AreaOptionsStep');
-goog.require('os.ui.file.ui.csv.ConfigStep');
-goog.require('os.ui.im.FileImportUI');
-goog.require('os.ui.window');
-goog.require('os.ui.wiz.GeometryStep');
-goog.require('plugin.area.csvAreaImportDirective');
-goog.require('plugin.file.csv.CSVParserConfig');
-
-
-
-/**
- * @extends {os.ui.im.FileImportUI.<plugin.file.csv.CSVParserConfig>}
- * @constructor
- */
-plugin.area.CSVAreaImportUI = function() {
-  plugin.area.CSVAreaImportUI.base(this, 'constructor');
-
-  // file contents are only used in memory, not loaded from storage
-  this.requiresStorage = false;
-};
-goog.inherits(plugin.area.CSVAreaImportUI, os.ui.im.FileImportUI);
+const AreaOptionsStep = goog.require('os.query.ui.AreaOptionsStep');
+const ConfigStep = goog.require('os.ui.file.ui.csv.ConfigStep');
+const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const osWindow = goog.require('os.ui.window');
+const windowSelector = goog.require('os.ui.windowSelector');
+const GeometryStep = goog.require('os.ui.wiz.GeometryStep');
+const {directiveTag: areaImportUi} = goog.require('plugin.area.CSVAreaImport');
+const CSVParserConfig = goog.require('plugin.file.csv.CSVParserConfig');
 
 
 /**
- * @inheritDoc
+ * @extends {FileImportUI<CSVParserConfig>}
  */
-plugin.area.CSVAreaImportUI.prototype.getTitle = function() {
-  return 'Area Import - CSV';
-};
+class CSVAreaImportUI extends FileImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
 
+    // file contents are only used in memory, not loaded from storage
+    this.requiresStorage = false;
+  }
 
-/**
- * @inheritDoc
- */
-plugin.area.CSVAreaImportUI.prototype.launchUI = function(file, opt_config) {
-  plugin.area.CSVAreaImportUI.base(this, 'launchUI', file, opt_config);
+  /**
+   * @inheritDoc
+   */
+  getTitle() {
+    return 'Area Import - CSV';
+  }
 
-  var steps = [
-    new os.ui.file.ui.csv.ConfigStep(),
-    new os.ui.wiz.GeometryStep(),
-    new os.query.ui.AreaOptionsStep()
-  ];
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    super.launchUI(file, opt_config);
 
-  var config = new plugin.file.csv.CSVParserConfig();
-  config['file'] = file;
-  config['title'] = file.getFileName();
-  config.updateLinePreview();
+    var steps = [
+      new ConfigStep(),
+      new GeometryStep(),
+      new AreaOptionsStep()
+    ];
 
-  var scopeOptions = {
-    'config': config,
-    'steps': steps
-  };
-  var windowOptions = {
-    'label': 'CSV Area Import',
-    'icon': 'fa fa-sign-in',
-    'x': 'center',
-    'y': 'center',
-    'width': '850',
-    'min-width': '500',
-    'max-width': '1200',
-    'height': '650',
-    'min-height': '300',
-    'max-height': '1000',
-    'modal': 'true',
-    'show-close': 'true'
-  };
-  var template = '<csvareaimport resize-with="' + os.ui.windowSelector.WINDOW + '"></csvareaimport>';
-  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
-};
+    var config = new CSVParserConfig();
+    config['file'] = file;
+    config['title'] = file.getFileName();
+    config.updateLinePreview();
+
+    var scopeOptions = {
+      'config': config,
+      'steps': steps
+    };
+    var windowOptions = {
+      'label': 'CSV Area Import',
+      'icon': 'fa fa-sign-in',
+      'x': 'center',
+      'y': 'center',
+      'width': '850',
+      'min-width': '500',
+      'max-width': '1200',
+      'height': '650',
+      'min-height': '300',
+      'max-height': '1000',
+      'modal': 'true',
+      'show-close': 'true'
+    };
+    var template = `<${areaImportUi} resize-with="${windowSelector.WINDOW}"></${areaImportUi}>`;
+    osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+  }
+}
+
+exports = CSVAreaImportUI;

--- a/src/plugin/area/geojsonareaimport.js
+++ b/src/plugin/area/geojsonareaimport.js
@@ -1,9 +1,11 @@
 goog.module('plugin.area.GeoJSONAreaImport');
 goog.module.declareLegacyNamespace();
 
+const RecordField = goog.require('os.data.RecordField');
 const EventType = goog.require('os.events.EventType');
 const Importer = goog.require('os.im.Importer');
 const Module = goog.require('os.ui.Module');
+const osWindow = goog.require('os.ui.window');
 const WizardCtrl = goog.require('os.ui.wiz.WizardCtrl');
 const wizardDirective = goog.require('os.ui.wiz.wizardDirective');
 const area = goog.require('plugin.area');
@@ -55,11 +57,11 @@ class Controller extends WizardCtrl {
     importer.dispose();
 
     if (features && features.length > 0) {
-      this.scope['config'][os.data.RecordField.SOURCE_NAME] = this.scope['config']['file'].getFileName();
+      this.scope['config'][RecordField.SOURCE_NAME] = this.scope['config']['file'].getFileName();
       area.processFeatures(features, this.scope['config']);
     }
 
-    os.ui.window.close(this.element);
+    osWindow.close(this.element);
   }
 }
 

--- a/src/plugin/area/geojsonareaimport.js
+++ b/src/plugin/area/geojsonareaimport.js
@@ -1,81 +1,93 @@
-goog.provide('plugin.area.GeoJSONAreaImportCtrl');
-goog.provide('plugin.area.geojsonAreaImportDirective');
+goog.module('plugin.area.GeoJSONAreaImport');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.events.EventType');
-goog.require('os.im.Importer');
-goog.require('os.ui.Module');
-goog.require('os.ui.wiz.WizardCtrl');
-goog.require('os.ui.wiz.wizardDirective');
-goog.require('plugin.area');
-goog.require('plugin.file.geojson.GeoJSONParser');
-
+const EventType = goog.require('os.events.EventType');
+const Importer = goog.require('os.im.Importer');
+const Module = goog.require('os.ui.Module');
+const WizardCtrl = goog.require('os.ui.wiz.WizardCtrl');
+const wizardDirective = goog.require('os.ui.wiz.wizardDirective');
+const area = goog.require('plugin.area');
+const GeoJSONParser = goog.require('plugin.file.geojson.GeoJSONParser');
 
 
 /**
  * Controller for the GeoJSON import wizard window
  *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout
- * @param {!Object.<string, string>} $attrs
- * @extends {os.ui.wiz.WizardCtrl<T>}
- * @constructor
- * @ngInject
+ * @extends {WizardCtrl<T>}
  * @template T,S
+ * @unrestricted
  */
-plugin.area.GeoJSONAreaImportCtrl = function($scope, $element, $timeout, $attrs) {
-  plugin.area.GeoJSONAreaImportCtrl.base(this, 'constructor', $scope, $element, $timeout, $attrs);
-};
-goog.inherits(plugin.area.GeoJSONAreaImportCtrl, os.ui.wiz.WizardCtrl);
-
-
-/**
- * @inheritDoc
- */
-plugin.area.GeoJSONAreaImportCtrl.prototype.finish = function() {
-  this['loading'] = true;
-
-  var parser = new plugin.file.geojson.GeoJSONParser();
-  var importer = new os.im.Importer(parser);
-  importer.setMappings(this.scope['config']['mappings']);
-  importer.listenOnce(os.events.EventType.COMPLETE, this.onImportComplete_, false, this);
-  importer.startImport(this.scope['config']['file'].getContent());
-};
-
-
-/**
- * Success callback for importing data. Adds the areas to Area Manager
- *
- * @param {goog.events.Event} event
- * @private
- */
-plugin.area.GeoJSONAreaImportCtrl.prototype.onImportComplete_ = function(event) {
-  var importer = /** @type {os.im.Importer} */ (event.target);
-  var features = /** @type {!Array<ol.Feature>} */ (importer.getData());
-  importer.dispose();
-
-  if (features && features.length > 0) {
-    this.scope['config'][os.data.RecordField.SOURCE_NAME] = this.scope['config']['file'].getFileName();
-    plugin.area.processFeatures(features, this.scope['config']);
+class Controller extends WizardCtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @param {!angular.$timeout} $timeout
+   * @param {!Object.<string, string>} $attrs
+   * @ngInject
+   */
+  constructor($scope, $element, $timeout, $attrs) {
+    super($scope, $element, $timeout, $attrs);
   }
 
-  os.ui.window.close(this.element);
-};
+  /**
+   * @inheritDoc
+   */
+  finish() {
+    this['loading'] = true;
 
+    var parser = new GeoJSONParser();
+    var importer = new Importer(parser);
+    importer.setMappings(this.scope['config']['mappings']);
+    importer.listenOnce(EventType.COMPLETE, this.onImportComplete_, false, this);
+    importer.startImport(this.scope['config']['file'].getContent());
+  }
+
+  /**
+   * Success callback for importing data. Adds the areas to Area Manager
+   *
+   * @param {goog.events.Event} event
+   * @private
+   */
+  onImportComplete_(event) {
+    var importer = /** @type {Importer} */ (event.target);
+    var features = /** @type {!Array<ol.Feature>} */ (importer.getData());
+    importer.dispose();
+
+    if (features && features.length > 0) {
+      this.scope['config'][os.data.RecordField.SOURCE_NAME] = this.scope['config']['file'].getFileName();
+      area.processFeatures(features, this.scope['config']);
+    }
+
+    os.ui.window.close(this.element);
+  }
+}
 
 /**
  * The geojson import wizard directive.
  *
  * @return {angular.Directive}
  */
-plugin.area.geojsonAreaImportDirective = function() {
-  var dir = os.ui.wiz.wizardDirective();
-  dir.controller = plugin.area.GeoJSONAreaImportCtrl;
+const directive = () => {
+  var dir = wizardDirective();
+  dir.controller = Controller;
   return dir;
 };
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'geojsonareaimport';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('geojsonareaimport', [plugin.area.geojsonAreaImportDirective]);
+Module.directive('geojsonareaimport', [directive]);
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
+};

--- a/src/plugin/area/geojsonareaimport_shim.js
+++ b/src/plugin/area/geojsonareaimport_shim.js
@@ -1,0 +1,13 @@
+goog.provide('plugin.area.GeoJSONAreaImportCtrl');
+goog.provide('plugin.area.geojsonAreaImportDirective');
+goog.require('plugin.area.GeoJSONAreaImportUI');
+
+/**
+ * @deprecated Please use goog.require('plugin.area.GeoJSONAreaImportUI').Controller instead.
+ */
+plugin.area.GeoJSONAreaImportCtrl = plugin.area.GeoJSONAreaImportUI.Controller;
+
+/**
+ * @deprecated Please use goog.require('plugin.area.GeoJSONAreaImportUI').directive instead.
+ */
+plugin.area.geojsonAreaImportDirective = plugin.area.GeoJSONAreaImportUI.directive;

--- a/src/plugin/area/geojsonareaimportui.js
+++ b/src/plugin/area/geojsonareaimportui.js
@@ -1,71 +1,75 @@
-goog.provide('plugin.area.GeoJSONAreaImportUI');
+goog.module('plugin.area.GeoJSONAreaImportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.query.ui.AreaOptionsStep');
-goog.require('os.ui.im.FileImportUI');
-goog.require('os.ui.window');
-goog.require('plugin.area.geojsonAreaImportDirective');
-goog.require('plugin.file.geojson.GeoJSONParserConfig');
-
-
-
-/**
- * @extends {os.ui.im.FileImportUI.<plugin.file.geojson.GeoJSONParserConfig>}
- * @constructor
- */
-plugin.area.GeoJSONAreaImportUI = function() {
-  plugin.area.GeoJSONAreaImportUI.base(this, 'constructor');
-
-  // file contents are only used in memory, not loaded from storage
-  this.requiresStorage = false;
-};
-goog.inherits(plugin.area.GeoJSONAreaImportUI, os.ui.im.FileImportUI);
+const AreaOptionsStep = goog.require('os.query.ui.AreaOptionsStep');
+const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const osWindow = goog.require('os.ui.window');
+const windowSelector = goog.require('os.ui.windowSelector');
+const {directiveTag: areaImportUi} = goog.require('plugin.area.GeoJSONAreaImport');
+const GeoJSONParserConfig = goog.require('plugin.file.geojson.GeoJSONParserConfig');
 
 
 /**
- * @inheritDoc
+ * @extends {FileImportUI<GeoJSONParserConfig>}
  */
-plugin.area.GeoJSONAreaImportUI.prototype.getTitle = function() {
-  return 'Area Import - GeoJSON';
-};
+class GeoJSONAreaImportUI extends FileImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
 
-
-/**
- * @inheritDoc
- */
-plugin.area.GeoJSONAreaImportUI.prototype.launchUI = function(file, opt_config) {
-  plugin.area.GeoJSONAreaImportUI.base(this, 'launchUI', file, opt_config);
-  var steps = [
-    new os.query.ui.AreaOptionsStep()
-  ];
-
-  var config = new plugin.file.geojson.GeoJSONParserConfig();
-
-  // if a configuration was provided, merge it in
-  if (opt_config) {
-    this.mergeConfig(opt_config, config);
+    // file contents are only used in memory, not loaded from storage
+    this.requiresStorage = false;
   }
 
-  config['file'] = file;
-  config['title'] = file.getFileName();
+  /**
+   * @inheritDoc
+   */
+  getTitle() {
+    return 'Area Import - GeoJSON';
+  }
 
-  var scopeOptions = {
-    'config': config,
-    'steps': steps
-  };
-  var windowOptions = {
-    'label': 'GeoJSON Area Import',
-    'icon': 'fa fa-sign-in',
-    'x': 'center',
-    'y': 'center',
-    'width': '850',
-    'min-width': '500',
-    'max-width': '1200',
-    'height': '650',
-    'min-height': '300',
-    'max-height': '1000',
-    'modal': 'true',
-    'show-close': 'true'
-  };
-  var template = '<geojsonareaimport resize-with="' + os.ui.windowSelector.WINDOW + '"></geojsonareaimport>';
-  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
-};
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    super.launchUI(file, opt_config);
+    var steps = [
+      new AreaOptionsStep()
+    ];
+
+    var config = new GeoJSONParserConfig();
+
+    // if a configuration was provided, merge it in
+    if (opt_config) {
+      this.mergeConfig(opt_config, config);
+    }
+
+    config['file'] = file;
+    config['title'] = file.getFileName();
+
+    var scopeOptions = {
+      'config': config,
+      'steps': steps
+    };
+    var windowOptions = {
+      'label': 'GeoJSON Area Import',
+      'icon': 'fa fa-sign-in',
+      'x': 'center',
+      'y': 'center',
+      'width': '850',
+      'min-width': '500',
+      'max-width': '1200',
+      'height': '650',
+      'min-height': '300',
+      'max-height': '1000',
+      'modal': 'true',
+      'show-close': 'true'
+    };
+    var template = `<${areaImportUi} resize-with="${windowSelector.WINDOW}"></${areaImportUi}>`;
+    osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+  }
+}
+
+exports = GeoJSONAreaImportUI;

--- a/src/plugin/area/kmlareaimportui.js
+++ b/src/plugin/area/kmlareaimportui.js
@@ -1,8 +1,11 @@
 goog.module('plugin.area.KMLAreaImportUI');
 goog.module.declareLegacyNamespace();
 
+const dispose = goog.require('goog.dispose');
+const EventType = goog.require('os.events.EventType');
 const FileParserConfig = goog.require('os.parse.FileParserConfig');
 const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const osWindow = goog.require('os.ui.window');
 const KMLAreaParser = goog.require('plugin.area.KMLAreaParser');
 const {directiveTag: areaImportUi} = goog.require('plugin.area.KMLAreaUI');
 
@@ -45,8 +48,8 @@ class KMLAreaImportUI extends FileImportUI {
 
     var callback = goog.partial(this.onPreviewReady_, config);
     var parser = new KMLAreaParser();
-    parser.listenOnce(os.events.EventType.COMPLETE, callback, false, this);
-    parser.listenOnce(os.events.EventType.ERROR, callback, false, this);
+    parser.listenOnce(EventType.COMPLETE, callback, false, this);
+    parser.listenOnce(EventType.ERROR, callback, false, this);
     parser.setSource(file.getContent());
   }
 
@@ -59,7 +62,7 @@ class KMLAreaImportUI extends FileImportUI {
     var parser = /** @type {KMLAreaParser} */ (event.target);
     var preview = parser.parseNext();
     var columns = parser.getColumns() || [];
-    goog.dispose(parser);
+    dispose(parser);
 
     config['columns'] = columns;
     config['preview'] = preview;
@@ -80,7 +83,7 @@ class KMLAreaImportUI extends FileImportUI {
       'show-close': 'true'
     };
     var template = `<${areaImportUi}></${areaImportUi}>`;
-    os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+    osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
   }
 }
 

--- a/src/plugin/area/kmlareaimportui.js
+++ b/src/plugin/area/kmlareaimportui.js
@@ -1,169 +1,87 @@
-goog.provide('plugin.area.KMLAreaCtrl');
-goog.provide('plugin.area.KMLAreaImportUI');
+goog.module('plugin.area.KMLAreaImportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os');
-goog.require('os.im.Importer');
-goog.require('os.im.mapping.RenameMapping');
-goog.require('os.parse.FileParserConfig');
-goog.require('os.ui.im.FileImportUI');
-goog.require('os.ui.query');
-goog.require('os.ui.query.cmd.AreaAdd');
-goog.require('plugin.area.AreaImportCtrl');
-goog.require('plugin.area.KMLAreaParser');
-
+const FileParserConfig = goog.require('os.parse.FileParserConfig');
+const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const KMLAreaParser = goog.require('plugin.area.KMLAreaParser');
+const {directiveTag: areaImportUi} = goog.require('plugin.area.KMLAreaUI');
 
 
 /**
- * @extends {os.ui.im.FileImportUI}
- * @constructor
  */
-plugin.area.KMLAreaImportUI = function() {
-  plugin.area.KMLAreaImportUI.base(this, 'constructor');
+class KMLAreaImportUI extends FileImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
 
-  // file contents are only used in memory, not loaded from storage
-  this.requiresStorage = false;
+    // file contents are only used in memory, not loaded from storage
+    this.requiresStorage = false;
+
+    /**
+     * @type {?string}
+     * @protected
+     */
+    this.fileName = '';
+  }
 
   /**
-   * @type {?string}
-   * @protected
+   * @inheritDoc
    */
-  this.fileName = '';
-};
-goog.inherits(plugin.area.KMLAreaImportUI, os.ui.im.FileImportUI);
+  getTitle() {
+    return 'Area Import - KML';
+  }
 
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    super.launchUI(file, opt_config);
 
-/**
- * @inheritDoc
- */
-plugin.area.KMLAreaImportUI.prototype.getTitle = function() {
-  return 'Area Import - KML';
-};
+    var config = new FileParserConfig();
+    config['file'] = file;
+    config['title'] = file.getFileName() || '';
 
+    var callback = goog.partial(this.onPreviewReady_, config);
+    var parser = new KMLAreaParser();
+    parser.listenOnce(os.events.EventType.COMPLETE, callback, false, this);
+    parser.listenOnce(os.events.EventType.ERROR, callback, false, this);
+    parser.setSource(file.getContent());
+  }
 
-/**
- * @inheritDoc
- */
-plugin.area.KMLAreaImportUI.prototype.launchUI = function(file, opt_config) {
-  plugin.area.KMLAreaImportUI.base(this, 'launchUI', file, opt_config);
+  /**
+   * @param {FileParserConfig} config
+   * @param {goog.events.Event} event
+   * @private
+   */
+  onPreviewReady_(config, event) {
+    var parser = /** @type {KMLAreaParser} */ (event.target);
+    var preview = parser.parseNext();
+    var columns = parser.getColumns() || [];
+    goog.dispose(parser);
 
-  var config = new os.parse.FileParserConfig();
-  config['file'] = file;
-  config['title'] = file.getFileName() || '';
+    config['columns'] = columns;
+    config['preview'] = preview;
 
-  var callback = goog.partial(this.onPreviewReady_, config);
-  var parser = new plugin.area.KMLAreaParser();
-  parser.listenOnce(os.events.EventType.COMPLETE, callback, false, this);
-  parser.listenOnce(os.events.EventType.ERROR, callback, false, this);
-  parser.setSource(file.getContent());
-};
+    var scopeOptions = {
+      'config': config
+    };
+    var windowOptions = {
+      'label': 'KML Area Import',
+      'icon': 'fa fa-sign-in',
+      'x': 'center',
+      'y': 'center',
+      'width': '450',
+      'min-width': '300',
+      'max-width': '800',
+      'height': 'auto',
+      'modal': 'true',
+      'show-close': 'true'
+    };
+    var template = `<${areaImportUi}></${areaImportUi}>`;
+    os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+  }
+}
 
-
-/**
- * @param {os.parse.FileParserConfig} config
- * @param {goog.events.Event} event
- * @private
- */
-plugin.area.KMLAreaImportUI.prototype.onPreviewReady_ = function(config, event) {
-  var parser = /** @type {plugin.area.KMLAreaParser} */ (event.target);
-  var preview = parser.parseNext();
-  var columns = parser.getColumns() || [];
-  goog.dispose(parser);
-
-  config['columns'] = columns;
-  config['preview'] = preview;
-
-  var scopeOptions = {
-    'config': config
-  };
-  var windowOptions = {
-    'label': 'KML Area Import',
-    'icon': 'fa fa-sign-in',
-    'x': 'center',
-    'y': 'center',
-    'width': '450',
-    'min-width': '300',
-    'max-width': '800',
-    'height': 'auto',
-    'modal': 'true',
-    'show-close': 'true'
-  };
-  var template = '<kmlarea></kmlarea>';
-  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
-};
-
-
-/**
- * The KML area import directive
- *
- * @return {angular.Directive}
- */
-plugin.area.kmlAreaDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    templateUrl: os.ROOT + 'views/plugin/kml/kmlarea.html',
-    controller: plugin.area.KMLAreaCtrl,
-    controllerAs: 'areaFiles'
-  };
-};
-
-
-/**
- * Add the directive to the module
- */
-os.ui.Module.directive('kmlarea', [plugin.area.kmlAreaDirective]);
-
-
-
-/**
- * Controller for the SHP import file selection step
- *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout The Angular $timeout service.
- * @extends {plugin.area.AreaImportCtrl<os.parse.FileParserConfig>}
- * @constructor
- * @ngInject
- */
-plugin.area.KMLAreaCtrl = function($scope, $element, $timeout) {
-  plugin.area.KMLAreaCtrl.base(this, 'constructor', $scope, $element, $timeout);
-};
-goog.inherits(plugin.area.KMLAreaCtrl, plugin.area.AreaImportCtrl);
-
-
-/**
- * @inheritDoc
- * @export
- */
-plugin.area.KMLAreaCtrl.prototype.finish = function() {
-  plugin.area.KMLAreaCtrl.base(this, 'finish');
-
-  var parser = new plugin.area.KMLAreaParser();
-  var importer = new os.im.Importer(parser);
-  importer.listenOnce(os.events.EventType.COMPLETE, this.onImportComplete_, false, this);
-  importer.startImport(this.config['file'].getContent());
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.area.KMLAreaCtrl.prototype.getFileName = function() {
-  return this.config['file'] && this.config['file'].getFileName() || undefined;
-};
-
-
-/**
- * Success callback for importing data. Adds the areas to Area Manager
- *
- * @param {goog.events.Event} event
- * @private
- */
-plugin.area.KMLAreaCtrl.prototype.onImportComplete_ = function(event) {
-  var importer = /** @type {os.im.Importer} */ (event.target);
-  var features = /** @type {!Array<ol.Feature>} */ (importer.getData() || []);
-  importer.dispose();
-
-  this.processFeatures(features);
-  this.close();
-};
+exports = KMLAreaImportUI;

--- a/src/plugin/area/kmlareaparser.js
+++ b/src/plugin/area/kmlareaparser.js
@@ -1,275 +1,269 @@
-goog.provide('plugin.area.KMLAreaParser');
-goog.require('ol.format.KML');
-goog.require('ol.xml');
-goog.require('os.data.ColumnDefinition');
-goog.require('os.file.mime.text');
-goog.require('os.file.mime.zip');
-goog.require('os.parse.AsyncZipParser');
-goog.require('os.parse.IParser');
-goog.require('os.ui.im.mergeAreaOptionDirective');
+goog.module('plugin.area.KMLAreaParser');
+goog.module.declareLegacyNamespace();
 
+const KML = goog.require('ol.format.KML');
+const xml = goog.require('ol.xml');
+const ColumnDefinition = goog.require('os.data.ColumnDefinition');
+const text = goog.require('os.file.mime.text');
+const mimeZip = goog.require('os.file.mime.zip');
+const AsyncZipParser = goog.require('os.parse.AsyncZipParser');
+const IParser = goog.requireType('os.parse.IParser');
 
 
 /**
  * Simple KML parser that extracts areas from a KML. Has asynchronous support for KMZ files.
  *
- * @implements {os.parse.IParser.<ol.Feature>}
- * @extends {os.parse.AsyncZipParser}
+ * @implements {IParser.<ol.Feature>}
  * @template T
- * @constructor
  */
-plugin.area.KMLAreaParser = function() {
-  plugin.area.KMLAreaParser.base(this, 'constructor');
+class KMLAreaParser extends AsyncZipParser {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    /**
+     * @type {KML}
+     * @private
+     */
+    this.format_ = new KML({
+      showPointNames: false
+    });
+
+    /**
+     * @type {?Document}
+     * @private
+     */
+    this.document_ = null;
+
+    /**
+     * @type {Object<string, !zip.Entry>} entries
+     * @private
+     */
+    this.kmlEntries_ = {};
+
+    /**
+     * @type {Array<ColumnDefinition>}
+     * @protected
+     */
+    this.columns = null;
+
+    /**
+     * @type {goog.log.Logger}
+     * @private
+     */
+    this.log_ = logger;
+  }
 
   /**
-   * @type {ol.format.KML}
+   * @inheritDoc
+   */
+  setSource(source) {
+    this.cleanup();
+
+    if (xml.isDocument(source)) {
+      this.document_ = /** @type {Document} */ (source);
+    } else if (typeof source === 'string') {
+      this.document_ = goog.dom.xml.loadXml(source);
+    } else if (source instanceof ArrayBuffer) {
+      if (mimeZip.isZip(source)) {
+        this.createZipReader(source);
+        return;
+      } else {
+        var s = text.getText(source);
+        if (s) {
+          this.document_ = goog.dom.xml.loadXml(s);
+        } else {
+          goog.log.error(this.log_, 'The buffer source does not appear to be text');
+          this.onError();
+        }
+      }
+    } else if (source instanceof Blob) {
+      goog.fs.FileReader.readAsArrayBuffer(source).addCallback(this.setSource, this);
+      return;
+    }
+
+    if (this.document_) {
+      var rootEl = goog.dom.getFirstElementChild(this.document_);
+      if (rootEl && rootEl.localName.toLowerCase() !== 'kml') {
+        // Sometimes people are dumb and create documents without a root <kml> tag.
+        // This is technically invalid KML and even invalid XML.  Because Google Earth
+        // accepts this crap, add a special case to put the proper root tag.
+        var newRoot = os.xml.createElement('kml', this.document_);
+        newRoot.appendChild(rootEl);
+        this.document_.appendChild(newRoot);
+        rootEl = newRoot;
+      }
+
+      if (rootEl) {
+        this.onReady();
+      } else {
+        goog.log.error(this.log_, 'No KML content to parse!');
+        this.onError();
+      }
+    } else {
+      goog.log.error(this.log_, 'Content must be a valid KML document!');
+      this.onError();
+    }
+  }
+
+  /**
+   * HACK ALERT! zip.js has a zip.TextWriter() class that directly turns the zip entry into the string we want.
+   * Unfortunately, it doesn't work in FF24 for some reason, but luckily, the BlobWriter does. Here, we read
+   * the zip as a Blob, then feed it to a FileReader in the next callback in order to extract the text.
+   *
+   * @inheritDoc
+   */
+  handleZipEntries(entries) {
+    var mainEntry = null;
+    var firstEntry = null;
+    var mainKml = /(doc|index)\.kml$/i;
+    var anyKml = /\.kml$/i;
+
+    for (var i = 0, n = entries.length; i < n; i++) {
+      // if we have multiple entries, try to find one titled either doc.kml or index.kml as these
+      // are generally the most important ones
+      var entry = entries[i];
+      if (!mainEntry && mainKml.test(entry.filename)) {
+        mainEntry = entry;
+      } else if (anyKml.test(entry.filename)) {
+        if (!firstEntry) {
+          firstEntry = entry;
+        }
+
+        this.kmlEntries_[entry.filename] = entry;
+      }
+    }
+
+    mainEntry = mainEntry || firstEntry;
+
+    if (mainEntry) {
+      this.processMainEntry_(mainEntry);
+    } else {
+      goog.log.error(this.log_, 'No KML found in the ZIP!');
+      this.onError();
+    }
+  }
+
+  /**
+   * Parse the main kml file
+   *
+   * @param {zip.Entry} mainEntry
    * @private
    */
-  this.format_ = new ol.format.KML({
-    showPointNames: false
-  });
+  processMainEntry_(mainEntry) {
+    mainEntry.getData(new zip.BlobWriter(), this.processZIPEntry_.bind(this, mainEntry.filename));
+  }
 
   /**
-   * @type {?Document}
+   * Unzips the main entry.
+   *
+   * @param {string} filename
+   * @param {*} content
    * @private
    */
-  this.document_ = null;
+  processZIPEntry_(filename, content) {
+    if (content && content instanceof Blob) {
+      var reader = new FileReader();
+      reader.onload = this.handleZIPText_.bind(this, filename);
+      reader.readAsText(content);
+    } else {
+      goog.log.error(this.log_, 'There was a problem unzipping the KMZ!');
+      this.onError();
+    }
+  }
 
   /**
-   * @type {Object<string, !zip.Entry>} entries
+   * @param {string} filename
+   * @param {Event} event
    * @private
    */
-  this.kmlEntries_ = {};
+  handleZIPText_(filename, event) {
+    var content = event.target.result;
+
+    if (content && typeof content === 'string') {
+      if (!this.document_) {
+        this.setSource(content);
+      }
+    } else {
+      goog.log.error(this.log_, 'There was a problem reading the ZIP content!');
+      this.onError();
+    }
+  }
 
   /**
-   * @type {Array<os.data.ColumnDefinition>}
-   * @protected
+   * @inheritDoc
    */
-  this.columns = null;
+  cleanup() {
+    this.document_ = null;
+
+    this.zipReaders.forEach(function(reader) {
+      reader.close();
+    });
+
+    this.zipReaders.length = 0;
+  }
 
   /**
-   * @type {goog.log.Logger}
-   * @private
+   * @inheritDoc
    */
-  this.log_ = plugin.area.KMLAreaParser.LOGGER_;
-};
-goog.inherits(plugin.area.KMLAreaParser, os.parse.AsyncZipParser);
+  hasNext() {
+    return this.document_ != null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  parseNext() {
+    var features = null;
+    if (this.document_) {
+      // make sure the document reference is cleared so errors don't result in hasNext continuing to return true. the
+      // importer will catch and report the error so we don't do it here.
+      var doc = this.document_;
+      this.document_ = null;
+      features = this.format_.readFeatures(doc, {
+        featureProjection: os.map.PROJECTION
+      });
+    }
+
+    if (features) {
+      this.columns = [];
+      var columnMap = {};
+      features.forEach(function(feature) {
+        var values = feature.getProperties();
+        if (values) {
+          for (var key in values) {
+            columnMap[key] = true;
+          }
+        }
+      });
+
+      for (var key in columnMap) {
+        var definition = new ColumnDefinition(key);
+        this.columns.push(definition);
+      }
+    }
+
+    this.cleanup();
+    return features;
+  }
+
+  /**
+   * Get the columns.
+   *
+   * @return {?Array<ColumnDefinition>} The definitions
+   */
+  getColumns() {
+    return this.columns;
+  }
+}
 
 
 /**
  * @type {goog.log.Logger}
- * @private
- * @const
  */
-plugin.area.KMLAreaParser.LOGGER_ = goog.log.getLogger('plugin.area.KMLAreaParser');
+const logger = goog.log.getLogger('plugin.area.KMLAreaParser');
 
 
-/**
- * @inheritDoc
- */
-plugin.area.KMLAreaParser.prototype.setSource = function(source) {
-  this.cleanup();
-
-  if (ol.xml.isDocument(source)) {
-    this.document_ = /** @type {Document} */ (source);
-  } else if (typeof source === 'string') {
-    this.document_ = goog.dom.xml.loadXml(source);
-  } else if (source instanceof ArrayBuffer) {
-    if (os.file.mime.zip.isZip(source)) {
-      this.createZipReader(source);
-      return;
-    } else {
-      var s = os.file.mime.text.getText(source);
-      if (s) {
-        this.document_ = goog.dom.xml.loadXml(s);
-      } else {
-        goog.log.error(this.log_, 'The buffer source does not appear to be text');
-        this.onError();
-      }
-    }
-  } else if (source instanceof Blob) {
-    goog.fs.FileReader.readAsArrayBuffer(source).addCallback(this.setSource, this);
-    return;
-  }
-
-  if (this.document_) {
-    var rootEl = goog.dom.getFirstElementChild(this.document_);
-    if (rootEl && rootEl.localName.toLowerCase() !== 'kml') {
-      // Sometimes people are dumb and create documents without a root <kml> tag.
-      // This is technically invalid KML and even invalid XML.  Because Google Earth
-      // accepts this crap, add a special case to put the proper root tag.
-      var newRoot = os.xml.createElement('kml', this.document_);
-      newRoot.appendChild(rootEl);
-      this.document_.appendChild(newRoot);
-      rootEl = newRoot;
-    }
-
-    if (rootEl) {
-      this.onReady();
-    } else {
-      goog.log.error(this.log_, 'No KML content to parse!');
-      this.onError();
-    }
-  } else {
-    goog.log.error(this.log_, 'Content must be a valid KML document!');
-    this.onError();
-  }
-};
-
-
-/**
- * HACK ALERT! zip.js has a zip.TextWriter() class that directly turns the zip entry into the string we want.
- * Unfortunately, it doesn't work in FF24 for some reason, but luckily, the BlobWriter does. Here, we read
- * the zip as a Blob, then feed it to a FileReader in the next callback in order to extract the text.
- *
- * @inheritDoc
- */
-plugin.area.KMLAreaParser.prototype.handleZipEntries = function(entries) {
-  var mainEntry = null;
-  var firstEntry = null;
-  var mainKml = /(doc|index)\.kml$/i;
-  var anyKml = /\.kml$/i;
-
-  for (var i = 0, n = entries.length; i < n; i++) {
-    // if we have multiple entries, try to find one titled either doc.kml or index.kml as these
-    // are generally the most important ones
-    var entry = entries[i];
-    if (!mainEntry && mainKml.test(entry.filename)) {
-      mainEntry = entry;
-    } else if (anyKml.test(entry.filename)) {
-      if (!firstEntry) {
-        firstEntry = entry;
-      }
-
-      this.kmlEntries_[entry.filename] = entry;
-    }
-  }
-
-  mainEntry = mainEntry || firstEntry;
-
-  if (mainEntry) {
-    this.processMainEntry_(mainEntry);
-  } else {
-    goog.log.error(this.log_, 'No KML found in the ZIP!');
-    this.onError();
-  }
-};
-
-
-/**
- * Parse the main kml file
- *
- * @param {zip.Entry} mainEntry
- * @private
- */
-plugin.area.KMLAreaParser.prototype.processMainEntry_ = function(mainEntry) {
-  mainEntry.getData(new zip.BlobWriter(), this.processZIPEntry_.bind(this, mainEntry.filename));
-};
-
-
-/**
- * Unzips the main entry.
- *
- * @param {string} filename
- * @param {*} content
- * @private
- */
-plugin.area.KMLAreaParser.prototype.processZIPEntry_ = function(filename, content) {
-  if (content && content instanceof Blob) {
-    var reader = new FileReader();
-    reader.onload = this.handleZIPText_.bind(this, filename);
-    reader.readAsText(content);
-  } else {
-    goog.log.error(this.log_, 'There was a problem unzipping the KMZ!');
-    this.onError();
-  }
-};
-
-
-/**
- * @param {string} filename
- * @param {Event} event
- * @private
- */
-plugin.area.KMLAreaParser.prototype.handleZIPText_ = function(filename, event) {
-  var content = event.target.result;
-
-  if (content && typeof content === 'string') {
-    if (!this.document_) {
-      this.setSource(content);
-    }
-  } else {
-    goog.log.error(this.log_, 'There was a problem reading the ZIP content!');
-    this.onError();
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.area.KMLAreaParser.prototype.cleanup = function() {
-  this.document_ = null;
-
-  this.zipReaders.forEach(function(reader) {
-    reader.close();
-  });
-
-  this.zipReaders.length = 0;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.area.KMLAreaParser.prototype.hasNext = function() {
-  return this.document_ != null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.area.KMLAreaParser.prototype.parseNext = function() {
-  var features = null;
-  if (this.document_) {
-    // make sure the document reference is cleared so errors don't result in hasNext continuing to return true. the
-    // importer will catch and report the error so we don't do it here.
-    var doc = this.document_;
-    this.document_ = null;
-    features = this.format_.readFeatures(doc, {
-      featureProjection: os.map.PROJECTION
-    });
-  }
-
-  if (features) {
-    this.columns = [];
-    var columnMap = {};
-    features.forEach(function(feature) {
-      var values = feature.getProperties();
-      if (values) {
-        for (var key in values) {
-          columnMap[key] = true;
-        }
-      }
-    });
-
-    for (var key in columnMap) {
-      var definition = new os.data.ColumnDefinition(key);
-      this.columns.push(definition);
-    }
-  }
-
-  this.cleanup();
-  return features;
-};
-
-
-/**
- * Get the columns.
- *
- * @return {?Array<os.data.ColumnDefinition>} The definitions
- */
-plugin.area.KMLAreaParser.prototype.getColumns = function() {
-  return this.columns;
-};
+exports = KMLAreaParser;

--- a/src/plugin/area/kmlareaui.js
+++ b/src/plugin/area/kmlareaui.js
@@ -4,7 +4,9 @@ goog.module.declareLegacyNamespace();
 goog.require('os.ui.im.mergeAreaOptionDirective');
 
 const {ROOT} = goog.require('os');
+const EventType = goog.require('os.events.EventType');
 const Importer = goog.require('os.im.Importer');
+const Module = goog.require('os.ui.Module');
 const AreaImportCtrl = goog.require('plugin.area.AreaImportCtrl');
 const KMLAreaParser = goog.require('plugin.area.KMLAreaParser');
 
@@ -35,7 +37,7 @@ const directiveTag = 'kmlarea';
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('kmlarea', [directive]);
+Module.directive('kmlarea', [directive]);
 
 
 
@@ -66,7 +68,7 @@ class Controller extends AreaImportCtrl {
 
     var parser = new KMLAreaParser();
     var importer = new Importer(parser);
-    importer.listenOnce(os.events.EventType.COMPLETE, this.onImportComplete_, false, this);
+    importer.listenOnce(EventType.COMPLETE, this.onImportComplete_, false, this);
     importer.startImport(this.config['file'].getContent());
   }
 

--- a/src/plugin/area/kmlareaui.js
+++ b/src/plugin/area/kmlareaui.js
@@ -1,0 +1,100 @@
+goog.module('plugin.area.KMLAreaUI');
+goog.module.declareLegacyNamespace();
+
+goog.require('os.ui.im.mergeAreaOptionDirective');
+
+const {ROOT} = goog.require('os');
+const Importer = goog.require('os.im.Importer');
+const AreaImportCtrl = goog.require('plugin.area.AreaImportCtrl');
+const KMLAreaParser = goog.require('plugin.area.KMLAreaParser');
+
+const FileParserConfig = goog.requireType('os.parse.FileParserConfig');
+
+
+/**
+ * The KML area import directive
+ *
+ * @return {angular.Directive}
+ */
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  templateUrl: ROOT + 'views/plugin/kml/kmlarea.html',
+  controller: Controller,
+  controllerAs: 'areaFiles'
+});
+
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'kmlarea';
+
+
+/**
+ * Add the directive to the module
+ */
+os.ui.Module.directive('kmlarea', [directive]);
+
+
+
+/**
+ * Controller for the SHP import file selection step
+ *
+ * @extends {AreaImportCtrl<FileParserConfig>}
+ * @unrestricted
+ */
+class Controller extends AreaImportCtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @param {!angular.$timeout} $timeout The Angular $timeout service.
+   * @ngInject
+   */
+  constructor($scope, $element, $timeout) {
+    super($scope, $element, $timeout);
+  }
+
+  /**
+   * @inheritDoc
+   * @export
+   */
+  finish() {
+    super.finish();
+
+    var parser = new KMLAreaParser();
+    var importer = new Importer(parser);
+    importer.listenOnce(os.events.EventType.COMPLETE, this.onImportComplete_, false, this);
+    importer.startImport(this.config['file'].getContent());
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getFileName() {
+    return this.config['file'] && this.config['file'].getFileName() || undefined;
+  }
+
+  /**
+   * Success callback for importing data. Adds the areas to Area Manager
+   *
+   * @param {goog.events.Event} event
+   * @private
+   */
+  onImportComplete_(event) {
+    var importer = /** @type {Importer} */ (event.target);
+    var features = /** @type {!Array<ol.Feature>} */ (importer.getData() || []);
+    importer.dispose();
+
+    this.processFeatures(features);
+    this.close();
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
+};

--- a/src/plugin/area/shpareaimportui.js
+++ b/src/plugin/area/shpareaimportui.js
@@ -1,188 +1,73 @@
-goog.provide('plugin.area.SHPAreaCtrl');
-goog.provide('plugin.area.SHPAreaImportUI');
-goog.provide('plugin.area.shpAreaDirective');
+goog.module('plugin.area.SHPAreaImportUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os');
-goog.require('os.im.Importer');
-goog.require('os.ui.im.FileImportUI');
-goog.require('os.ui.query');
-goog.require('os.ui.windowSelector');
-goog.require('os.ui.wiz.step.WizardStepEvent');
-goog.require('plugin.area.AreaImportCtrl');
-goog.require('plugin.file.shp.SHPParser');
-goog.require('plugin.file.shp.SHPParserConfig');
-goog.require('plugin.file.shp.mime');
-goog.require('plugin.file.shp.ui.SHPFilesStep');
-
+const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const windowSelector = goog.require('os.ui.windowSelector');
+const SHPParserConfig = goog.require('plugin.file.shp.SHPParserConfig');
+const {directiveTag: areaImportUi} = goog.require('plugin.area.SHPAreaUI');
+const mime = goog.require('plugin.file.shp.mime');
 
 
 /**
- * @extends {os.ui.im.FileImportUI.<plugin.file.shp.SHPParserConfig>}
- * @constructor
+ * @extends {FileImportUI<SHPParserConfig>}
  */
-plugin.area.SHPAreaImportUI = function() {
-  plugin.area.SHPAreaImportUI.base(this, 'constructor');
+class SHPAreaImportUI extends FileImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
 
-  // file contents are only used in memory, not loaded from storage
-  this.requiresStorage = false;
-};
-goog.inherits(plugin.area.SHPAreaImportUI, os.ui.im.FileImportUI);
-
-
-/**
- * @inheritDoc
- */
-plugin.area.SHPAreaImportUI.prototype.getTitle = function() {
-  return 'Area Import - SHP';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.area.SHPAreaImportUI.prototype.launchUI = function(file, opt_config) {
-  plugin.area.SHPAreaImportUI.base(this, 'launchUI', file, opt_config);
-
-  var config = new plugin.file.shp.SHPParserConfig();
-
-  // determine if the initial file is the DBF or SHP file
-  var name = file.getFileName();
-  if (plugin.file.shp.mime.SHP_EXT_REGEXP.test(name)) {
-    config['file'] = file;
-    config['title'] = name;
-  } else if (plugin.file.shp.mime.DBF_EXT_REGEXP.test(name)) {
-    config['file2'] = file;
-    config['title'] = name.split(plugin.file.shp.mime.DBF_EXT_REGEXP)[0] + '.shp';
-  } else {
-    config['zipFile'] = file;
-    config['title'] = name;
+    // file contents are only used in memory, not loaded from storage
+    this.requiresStorage = false;
   }
 
-  var scopeOptions = {
-    'config': config
-  };
-  var windowOptions = {
-    'label': 'SHP Area Import',
-    'icon': 'fa fa-sign-in',
-    'x': 'center',
-    'y': 'center',
-    'width': '450',
-    'min-width': '300',
-    'max-width': '800',
-    'height': 'auto',
-    'modal': 'true',
-    'show-close': 'true'
-  };
-  var template = '<shparea resize-with="' + os.ui.windowSelector.WINDOW + '"></shparea>';
-  os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
-};
-
-
-/**
- * The SHP import file selection area directive
- *
- * @return {angular.Directive}
- */
-plugin.area.shpAreaDirective = function() {
-  return {
-    restrict: 'E',
-    replace: true,
-    templateUrl: os.ROOT + 'views/plugin/shp/shparea.html',
-    controller: plugin.area.SHPAreaCtrl,
-    controllerAs: 'areaFiles'
-  };
-};
-
-
-/**
- * Add the directive to the module
- */
-os.ui.Module.directive('shparea', [plugin.area.shpAreaDirective]);
-
-
-
-/**
- * Controller for the SHP import file selection step
- *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout The Angular $timeout service.
- * @extends {plugin.area.AreaImportCtrl<plugin.file.shp.SHPParserConfig>}
- * @constructor
- * @ngInject
- */
-plugin.area.SHPAreaCtrl = function($scope, $element, $timeout) {
-  plugin.area.SHPAreaCtrl.base(this, 'constructor', $scope, $element, $timeout);
-
-  this.scope.$on(os.ui.wiz.step.WizardStepEvent.VALIDATE, this.onFileChange_.bind(this));
-
-  // If this is the zip file, run the preview
-  if (this.config['zipFile']) {
-    this.config.updateZipPreview(os.ui.apply.bind(this, this.scope));
+  /**
+   * @inheritDoc
+   */
+  getTitle() {
+    return 'Area Import - SHP';
   }
-};
-goog.inherits(plugin.area.SHPAreaCtrl, plugin.area.AreaImportCtrl);
 
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    super.launchUI(file, opt_config);
 
-/**
- * Update Title/Description
- *
- * @param {angular.Scope.Event} event The Angular event
- * @param {boolean} valid
- * @private
- */
-plugin.area.SHPAreaCtrl.prototype.onFileChange_ = function(event, valid) {
-  this.config.updatePreview();
-  os.ui.apply(this.scope);
-};
+    var config = new SHPParserConfig();
 
+    // determine if the initial file is the DBF or SHP file
+    var name = file.getFileName();
+    if (mime.SHP_EXT_REGEXP.test(name)) {
+      config['file'] = file;
+      config['title'] = name;
+    } else if (mime.DBF_EXT_REGEXP.test(name)) {
+      config['file2'] = file;
+      config['title'] = name.split(mime.DBF_EXT_REGEXP)[0] + '.shp';
+    } else {
+      config['zipFile'] = file;
+      config['title'] = name;
+    }
 
-/**
- * Validate the done button
- *
- * @return {boolean} if the form is valid
- * @export
- */
-plugin.area.SHPAreaCtrl.prototype.invalid = function() {
-  var config = this.config;
-  if (config['zipFile']) {
-    return !config['columns'] || config['columns'].length == 0 || (!config['title'] && !config['titleColumn']);
-  } else {
-    return !config['file'] || !config['file2'] || (!config['title'] && !config['titleColumn']);
+    var scopeOptions = {
+      'config': config
+    };
+    var windowOptions = {
+      'label': 'SHP Area Import',
+      'icon': 'fa fa-sign-in',
+      'x': 'center',
+      'y': 'center',
+      'width': '450',
+      'min-width': '300',
+      'max-width': '800',
+      'height': 'auto',
+      'modal': 'true',
+      'show-close': 'true'
+    };
+    var template = `<${areaImportUi} resize-with="${windowSelector.WINDOW}"></${areaImportUi}>`;
+    os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
   }
-};
+}
 
-
-/**
- * @inheritDoc
- * @export
- */
-plugin.area.SHPAreaCtrl.prototype.finish = function() {
-  plugin.area.SHPAreaCtrl.base(this, 'finish');
-
-  var parser = new plugin.file.shp.SHPParser(this.config);
-  var importer = new os.im.Importer(parser);
-  importer.listenOnce(os.events.EventType.COMPLETE, this.onImportComplete_, false, this);
-
-  if (this.config['zipFile']) {
-    importer.startImport(this.config['zipFile'].getContent());
-  } else {
-    importer.startImport([this.config['file'].getContent(), this.config['file2'].getContent()]);
-  }
-};
-
-
-/**
- * Success callback for importing data. Adds the areas to Area Manager
- *
- * @param {goog.events.Event} event
- * @private
- */
-plugin.area.SHPAreaCtrl.prototype.onImportComplete_ = function(event) {
-  var importer = /** @type {os.im.Importer} */ (event.target);
-  var features = /** @type {!Array<ol.Feature>} */ (importer.getData() || []);
-  importer.dispose();
-
-  this.processFeatures(features);
-  this.close();
-};
+exports = SHPAreaImportUI;

--- a/src/plugin/area/shpareaimportui.js
+++ b/src/plugin/area/shpareaimportui.js
@@ -2,9 +2,10 @@ goog.module('plugin.area.SHPAreaImportUI');
 goog.module.declareLegacyNamespace();
 
 const FileImportUI = goog.require('os.ui.im.FileImportUI');
+const osWindow = goog.require('os.ui.window');
 const windowSelector = goog.require('os.ui.windowSelector');
-const SHPParserConfig = goog.require('plugin.file.shp.SHPParserConfig');
 const {directiveTag: areaImportUi} = goog.require('plugin.area.SHPAreaUI');
+const SHPParserConfig = goog.require('plugin.file.shp.SHPParserConfig');
 const mime = goog.require('plugin.file.shp.mime');
 
 
@@ -66,7 +67,7 @@ class SHPAreaImportUI extends FileImportUI {
       'show-close': 'true'
     };
     var template = `<${areaImportUi} resize-with="${windowSelector.WINDOW}"></${areaImportUi}>`;
-    os.ui.window.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
+    osWindow.create(windowOptions, template, undefined, undefined, undefined, scopeOptions);
   }
 }
 

--- a/src/plugin/area/shpareaimportui_shim.js
+++ b/src/plugin/area/shpareaimportui_shim.js
@@ -1,0 +1,13 @@
+goog.provide('plugin.area.SHPAreaCtrl');
+goog.provide('plugin.area.shpAreaDirective');
+goog.require('plugin.area.SHPAreaUI');
+
+/**
+ * @deprecated Please use goog.require('plugin.area.SHPAreaUI').Controller instead.
+ */
+plugin.area.SHPAreaCtrl = plugin.area.SHPAreaUI.Controller;
+
+/**
+ * @deprecated Please use goog.require('plugin.area.SHPAreaUI').directive instead.
+ */
+plugin.area.shpAreaDirective = plugin.area.SHPAreaUI.directive;

--- a/src/plugin/area/shpareaui.js
+++ b/src/plugin/area/shpareaui.js
@@ -4,7 +4,10 @@ goog.module.declareLegacyNamespace();
 goog.require('os.ui.im.mergeAreaOptionDirective');
 
 const {ROOT} = goog.require('os');
+const EventType = goog.require('os.events.EventType');
 const Importer = goog.require('os.im.Importer');
+const ui = goog.require('os.ui');
+const Module = goog.require('os.ui.Module');
 const WizardStepEvent = goog.require('os.ui.wiz.step.WizardStepEvent');
 const AreaImportCtrl = goog.require('plugin.area.AreaImportCtrl');
 const SHPParser = goog.require('plugin.file.shp.SHPParser');
@@ -35,7 +38,7 @@ const directiveTag = 'shparea';
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('shparea', [directive]);
+Module.directive('shparea', [directive]);
 
 
 /**
@@ -59,7 +62,7 @@ class Controller extends AreaImportCtrl {
 
     // If this is the zip file, run the preview
     if (this.config['zipFile']) {
-      this.config.updateZipPreview(os.ui.apply.bind(this, this.scope));
+      this.config.updateZipPreview(ui.apply.bind(this, this.scope));
     }
   }
 
@@ -72,7 +75,7 @@ class Controller extends AreaImportCtrl {
    */
   onFileChange_(event, valid) {
     this.config.updatePreview();
-    os.ui.apply(this.scope);
+    ui.apply(this.scope);
   }
 
   /**
@@ -99,7 +102,7 @@ class Controller extends AreaImportCtrl {
 
     var parser = new SHPParser(this.config);
     var importer = new Importer(parser);
-    importer.listenOnce(os.events.EventType.COMPLETE, this.onImportComplete_, false, this);
+    importer.listenOnce(EventType.COMPLETE, this.onImportComplete_, false, this);
 
     if (this.config['zipFile']) {
       importer.startImport(this.config['zipFile'].getContent());

--- a/src/plugin/area/shpareaui.js
+++ b/src/plugin/area/shpareaui.js
@@ -1,0 +1,131 @@
+goog.module('plugin.area.SHPAreaUI');
+goog.module.declareLegacyNamespace();
+
+goog.require('os.ui.im.mergeAreaOptionDirective');
+
+const {ROOT} = goog.require('os');
+const Importer = goog.require('os.im.Importer');
+const WizardStepEvent = goog.require('os.ui.wiz.step.WizardStepEvent');
+const AreaImportCtrl = goog.require('plugin.area.AreaImportCtrl');
+const SHPParser = goog.require('plugin.file.shp.SHPParser');
+
+const SHPParserConfig = goog.requireType('plugin.file.shp.SHPParserConfig');
+
+
+/**
+ * The SHP import file selection area directive
+ *
+ * @return {angular.Directive}
+ */
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  templateUrl: ROOT + 'views/plugin/shp/shparea.html',
+  controller: Controller,
+  controllerAs: 'areaFiles'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'shparea';
+
+
+/**
+ * Add the directive to the module
+ */
+os.ui.Module.directive('shparea', [directive]);
+
+
+/**
+ * Controller for the SHP import file selection step
+ *
+ * @extends {AreaImportCtrl<SHPParserConfig>}
+ * @unrestricted
+ */
+class Controller extends AreaImportCtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @param {!angular.$timeout} $timeout The Angular $timeout service.
+   * @ngInject
+   */
+  constructor($scope, $element, $timeout) {
+    super($scope, $element, $timeout);
+
+    this.scope.$on(WizardStepEvent.VALIDATE, this.onFileChange_.bind(this));
+
+    // If this is the zip file, run the preview
+    if (this.config['zipFile']) {
+      this.config.updateZipPreview(os.ui.apply.bind(this, this.scope));
+    }
+  }
+
+  /**
+   * Update Title/Description
+   *
+   * @param {angular.Scope.Event} event The Angular event
+   * @param {boolean} valid
+   * @private
+   */
+  onFileChange_(event, valid) {
+    this.config.updatePreview();
+    os.ui.apply(this.scope);
+  }
+
+  /**
+   * Validate the done button
+   *
+   * @return {boolean} if the form is valid
+   * @export
+   */
+  invalid() {
+    var config = this.config;
+    if (config['zipFile']) {
+      return !config['columns'] || config['columns'].length == 0 || (!config['title'] && !config['titleColumn']);
+    } else {
+      return !config['file'] || !config['file2'] || (!config['title'] && !config['titleColumn']);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   * @export
+   */
+  finish() {
+    super.finish();
+
+    var parser = new SHPParser(this.config);
+    var importer = new Importer(parser);
+    importer.listenOnce(os.events.EventType.COMPLETE, this.onImportComplete_, false, this);
+
+    if (this.config['zipFile']) {
+      importer.startImport(this.config['zipFile'].getContent());
+    } else {
+      importer.startImport([this.config['file'].getContent(), this.config['file2'].getContent()]);
+    }
+  }
+
+  /**
+   * Success callback for importing data. Adds the areas to Area Manager
+   *
+   * @param {goog.events.Event} event
+   * @private
+   */
+  onImportComplete_(event) {
+    var importer = /** @type {Importer} */ (event.target);
+    var features = /** @type {!Array<ol.Feature>} */ (importer.getData() || []);
+    importer.dispose();
+
+    this.processFeatures(features);
+    this.close();
+  }
+}
+
+exports = {
+  Controller,
+  directive,
+  directiveTag
+};

--- a/src/plugin/audio/audioplugin.js
+++ b/src/plugin/audio/audioplugin.js
@@ -1,29 +1,33 @@
-goog.provide('plugin.audio.AudioPlugin');
+goog.module('plugin.audio.AudioPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.ui.im.AudioImportUI');
-goog.require('os.ui.im.ImportManager');
-goog.require('plugin.audio.mime');
-
-
-
-/**
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
- */
-plugin.audio.AudioPlugin = function() {
-  plugin.audio.AudioPlugin.base(this, 'constructor');
-  this.id = 'audio';
-};
-goog.inherits(plugin.audio.AudioPlugin, os.plugin.AbstractPlugin);
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const AudioImportUI = goog.require('os.ui.im.AudioImportUI');
+const ImportManager = goog.require('os.ui.im.ImportManager');
+const mime = goog.require('plugin.audio.mime');
 
 
 /**
- * @inheritDoc
+ * Plugin to allow importing audio files.
  */
-plugin.audio.AudioPlugin.prototype.init = function() {
-  // register the audio import UI
-  var im = os.ui.im.ImportManager.getInstance();
-  im.registerImportDetails('Audio files for application sounds.');
-  im.registerImportUI(plugin.audio.mime.TYPE, new os.ui.im.AudioImportUI());
-};
+class AudioPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = 'audio';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    // register the audio import UI
+    const im = ImportManager.getInstance();
+    im.registerImportDetails('Audio files for application sounds.');
+    im.registerImportUI(mime.TYPE, new AudioImportUI());
+  }
+}
+
+exports = AudioPlugin;

--- a/src/plugin/audio/mime.js
+++ b/src/plugin/audio/mime.js
@@ -3,10 +3,18 @@ goog.module.declareLegacyNamespace();
 
 const Promise = goog.require('goog.Promise');
 const mime = goog.require('os.file.mime');
+const mimeText = goog.require('os.file.mime.text');
 
 const OSFile = goog.requireType('os.file.File');
 
 /**
+ * Priority for audio file detection. Some audio formats (like .wav) may be detected as text, so this has to run first.
+ * @type {number}
+ */
+const PRIORITY = mimeText.PRIORITY - 1;
+
+/**
+ * MIME type for audio files.
  * @type {string}
  */
 const TYPE = 'application/audio';
@@ -21,9 +29,11 @@ const detect = function(buffer, opt_file) {
     Promise.resolve(opt_file && /\.(mp3|wav|ogg|m4a)$/i.test(opt_file.getFileName())));
 };
 
-mime.register(TYPE, detect, 10000);
+// Some audio formats (like .wav) may be detected as text, so this has to run first.
+mime.register(TYPE, detect, PRIORITY);
 
 exports = {
+  PRIORITY,
   TYPE,
   detect
 };

--- a/src/plugin/audio/mime.js
+++ b/src/plugin/audio/mime.js
@@ -1,25 +1,29 @@
-goog.provide('plugin.audio.mime');
+goog.module('plugin.audio.mime');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Promise');
-goog.require('os.file.mime');
+const Promise = goog.require('goog.Promise');
+const mime = goog.require('os.file.mime');
 
+const OSFile = goog.requireType('os.file.File');
 
 /**
  * @type {string}
- * @const
  */
-plugin.audio.mime.TYPE = 'application/audio';
-
+const TYPE = 'application/audio';
 
 /**
  * @param {ArrayBuffer} buffer
- * @param {os.file.File=} opt_file
- * @return {!goog.Promise<*|undefined>}
+ * @param {OSFile=} opt_file
+ * @return {!Promise<*|undefined>}
  */
-plugin.audio.mime.detect = function(buffer, opt_file) {
-  return /** @type {!goog.Promise<*|undefined>} */ (
-    goog.Promise.resolve(opt_file && /\.(mp3|wav|ogg|m4a)$/i.test(opt_file.getFileName())));
+const detect = function(buffer, opt_file) {
+  return /** @type {!Promise<*|undefined>} */ (
+    Promise.resolve(opt_file && /\.(mp3|wav|ogg|m4a)$/i.test(opt_file.getFileName())));
 };
 
+mime.register(TYPE, detect, 10000);
 
-os.file.mime.register(plugin.audio.mime.TYPE, plugin.audio.mime.detect, 10000);
+exports = {
+  TYPE,
+  detect
+};

--- a/src/plugin/config/config.js
+++ b/src/plugin/config/config.js
@@ -1,8 +1,11 @@
-goog.provide('plugin.config');
-
+goog.module('plugin.config');
+goog.module.declareLegacyNamespace();
 
 /**
  * @type {string}
- * @const
  */
-plugin.config.ID = 'config';
+const ID = 'config';
+
+exports = {
+  ID
+};

--- a/src/plugin/config/configplugin.js
+++ b/src/plugin/config/configplugin.js
@@ -1,36 +1,64 @@
-goog.provide('plugin.config.Plugin');
+goog.module('plugin.config.Plugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.data.ConfigDescriptor');
-goog.require('os.data.DataManager');
-goog.require('os.data.ProviderEntry');
-goog.require('os.plugin.AbstractPlugin');
-goog.require('plugin.config');
-goog.require('plugin.config.Provider');
+const ConfigDescriptor = goog.require('os.data.ConfigDescriptor');
+const DataManager = goog.require('os.data.DataManager');
+const ProviderEntry = goog.require('os.data.ProviderEntry');
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const config = goog.require('plugin.config');
+const Provider = goog.require('plugin.config.Provider');
 
 
 /**
  * Provides config support
- *
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.config.Plugin = function() {
-  plugin.config.Plugin.base(this, 'constructor');
-  this.id = plugin.config.ID;
-};
-goog.inherits(plugin.config.Plugin, os.plugin.AbstractPlugin);
-goog.addSingletonGetter(plugin.config.Plugin);
+class Plugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = config.ID;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  init() {
+    const dm = DataManager.getInstance();
+
+    dm.registerProviderType(new ProviderEntry(
+        config.ID, Provider, 'config Provider',
+        'config servers provide layers through layer configs'));
+
+    dm.registerDescriptorType(ConfigDescriptor.ID, ConfigDescriptor);
+  }
+
+  /**
+   * Get the global instance.
+   * @return {!Plugin}
+   */
+  static getInstance() {
+    if (!instance) {
+      instance = new Plugin();
+    }
+
+    return instance;
+  }
+
+  /**
+   * Set the global instance.
+   * @param {Plugin} value
+   */
+  static setInstance(value) {
+    instance = value;
+  }
+}
 
 /**
- * @inheritDoc
+ * Global instance.
+ * @type {Plugin|undefined}
  */
-plugin.config.Plugin.prototype.init = function() {
-  var dm = os.dataManager;
+let instance;
 
-  dm.registerProviderType(new os.data.ProviderEntry(
-      plugin.config.ID, plugin.config.Provider, 'config Provider',
-      'config servers provide layers through layer configs'));
-
-  dm.registerDescriptorType(os.data.ConfigDescriptor.ID, os.data.ConfigDescriptor);
-};
+exports = Plugin;

--- a/src/plugin/config/configprovider.js
+++ b/src/plugin/config/configprovider.js
@@ -1,229 +1,226 @@
-goog.provide('plugin.config.Provider');
+goog.module('plugin.config.Provider');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.log');
-goog.require('goog.log.Logger');
-goog.require('os.data');
-goog.require('os.data.BaseDescriptor');
-goog.require('os.data.ConfigDescriptor');
-goog.require('os.data.DataManager');
-goog.require('os.data.DataProviderEvent');
-goog.require('os.data.DataProviderEventType');
-goog.require('os.data.IDataProvider');
-goog.require('os.ui.data.DescriptorNode');
-goog.require('os.ui.data.DescriptorProvider');
+const log = goog.require('goog.log');
+const Settings = goog.require('os.config.Settings');
+const {ProviderKey} = goog.require('os.data');
+const BaseDescriptor = goog.require('os.data.BaseDescriptor');
+const ConfigDescriptor = goog.require('os.data.ConfigDescriptor');
+const DataManager = goog.require('os.data.DataManager');
+const DataProviderEvent = goog.require('os.data.DataProviderEvent');
+const DataProviderEventType = goog.require('os.data.DataProviderEventType');
+const IDataProvider = goog.require('os.data.IDataProvider');
+const DescriptorProvider = goog.require('os.ui.data.DescriptorProvider');
+const {ID} = goog.require('plugin.config');
+
+const Logger = goog.requireType('goog.log.Logger');
+const IDataDescriptor = goog.requireType('os.data.IDataDescriptor');
+
 
 /**
  * The configuration provider provides access to configuration sources.
  *
- * @implements {os.data.IDataProvider}
- * @extends {os.ui.data.DescriptorProvider}
- * @constructor
+ * @implements {IDataProvider}
  */
-plugin.config.Provider = function() {
-  plugin.config.Provider.base(this, 'constructor');
+class Provider extends DescriptorProvider {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
 
-  this.log = plugin.config.Provider.LOGGER_;
-  this.setId(plugin.config.ID);
+    this.log = logger;
+    this.setId(ID);
+
+    /**
+     * Map of layer group ID to the layer configs.
+     * @type {!Object<string, (Array<Object>|Object)>}
+     * @private
+     */
+    this.layers_ = {};
+
+    /**
+     * The base provider key for settings.
+     * @type {ProviderKey}
+     * @private
+     */
+    this.providerKey_ = ProviderKey.USER;
+  }
 
   /**
-   * Map of layer group ID to the layer configs.
-   * @type {!Object<string, (Array<Object>|Object)>}
-   * @private
+   * @inheritDoc
    */
-  this.layers_ = {};
+  configure(config) {
+    super.configure(config);
+    this.setToolTip(/** @type {?string} */ (config['tooltip'] || config['description']));
+    this.layers_ = /** @type {Object} */ (config['layers']) || {};
+    this.providerKey_ = /** @type {ProviderKey} */ (config['providerKey']) || ProviderKey.USER;
+  }
 
   /**
-   * The base provider key for settings.
-   * @type {os.data.ProviderKey}
-   * @private
+   * @inheritDoc
    */
-  this.providerKey_ = os.data.ProviderKey.USER;
-};
-goog.inherits(plugin.config.Provider, os.ui.data.DescriptorProvider);
-os.implements(plugin.config.Provider, os.data.IDataProvider.ID);
+  load(ping) {
+    this.dispatchEvent(new DataProviderEvent(DataProviderEventType.LOADING, this));
+    this.setChildren(null);
 
+    for (var id in this.layers_) {
+      this.loadConfig(id, this.layers_[id]);
+    }
+
+    this.dispatchEvent(new DataProviderEvent(DataProviderEventType.LOADED, this));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  removeDescriptor(descriptor, opt_clear) {
+    var result = super.removeDescriptor(descriptor, opt_clear);
+
+    var id = descriptor.getId();
+    var configId = id.replace(this.getId() + BaseDescriptor.ID_DELIMITER, '');
+    if (configId && configId in this.layers_) {
+      delete this.layers_[configId];
+
+      var settingsKey = this.getSettingsKey() + '.layers';
+      Settings.getInstance().set(settingsKey, this.layers_);
+    }
+
+    return result;
+  }
+
+  /**
+   * Load a layer config.
+   * @param {string} id The layer id.
+   * @param {Object|Array<Object>} config The layer config(s) to load.
+   * @return {IDataDescriptor} The descriptor, or null if one could not be found/created.
+   * @protected
+   */
+  loadConfig(id, config) {
+    var descriptor = null;
+
+    try {
+      var descriptorId = this.getId() + BaseDescriptor.ID_DELIMITER + id;
+      descriptor = /** @type {ConfigDescriptor} */ (DataManager.getInstance().getDescriptor(descriptorId));
+
+      if (!descriptor) {
+        descriptor = new ConfigDescriptor();
+        descriptor.setId(descriptorId);
+      }
+
+      this.fixId(descriptorId, config);
+
+      descriptor.setBaseConfig(config);
+      DataManager.getInstance().addDescriptor(descriptor);
+      this.addDescriptor(descriptor, false, false);
+    } catch (e) {
+      log.error(this.log, 'There was an error processing the configuration', e);
+    }
+
+    return descriptor;
+  }
+
+  /**
+   * Ensure layer config id's are prefixed with the descriptor id.
+   * @param {string} id The descriptor id.
+   * @param {Array<Object>|Object} config The layer config(s).
+   * @protected
+   */
+  fixId(id, config) {
+    if (Array.isArray(config)) {
+      config.forEach(this.fixId.bind(this, id));
+    } else if (config) {
+      if (!('id' in config)) {
+        throw new Error('Config for "' + id + '" does not contain the "id" field!');
+      }
+      if (!config['id'].startsWith(id)) {
+        config['id'] = id + BaseDescriptor.ID_DELIMITER + config['id'];
+      }
+    }
+  }
+
+  /**
+   * Get the settings key for the provider.
+   * @return {string} The key.
+   * @protected
+   */
+  getSettingsKey() {
+    return this.providerKey_ + '.' + this.getId();
+  }
+
+  /**
+   * Add a layer group to the provider and create a descriptor.
+   * @param {string} id The layer group id.
+   * @param {Array<Object>|Object} config The layer config(s) to add to the group.
+   * @return {IDataDescriptor} The descriptor. If `id` is already registered with the provider, the existing
+   *                                   descriptor will be returned.
+   */
+  addLayerGroup(id, config) {
+    var descriptor = null;
+
+    if (config) {
+      if (!(id in this.layers_)) {
+        this.layers_[id] = config;
+
+        var layersKey = this.getSettingsKey() + '.layers';
+        Settings.getInstance().set(layersKey, this.layers_);
+
+        descriptor = this.loadConfig(id, config);
+      } else {
+        var descriptorId = [this.getId(), id].join(BaseDescriptor.ID_DELIMITER);
+        descriptor = DataManager.getInstance().getDescriptor(descriptorId);
+      }
+    }
+
+    return descriptor;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getErrorMessage() {
+    return null;
+  }
+
+  /**
+   * Create a new config provider, or return it if it already exists.
+   * @param {string} id The provider id.
+   * @param {Object} config The provider config.
+   * @return {Provider} The provider.
+   */
+  static create(id, config) {
+    var provider = null;
+
+    if (id && config) {
+      provider = /** @type {Provider} */ (DataManager.getInstance().getProvider(id));
+
+      if (!provider) {
+        // ensure the type is set properly, and layers are defined
+        config['type'] = ID;
+
+        if (!config['layers']) {
+          config['layers'] = {};
+        }
+
+        provider = new Provider();
+        provider.setId(id);
+        provider.configure(config);
+        provider.load();
+
+        Settings.getInstance().set(provider.getSettingsKey(), config);
+        DataManager.getInstance().addProvider(provider);
+      }
+    }
+
+    return provider;
+  }
+}
+os.implements(Provider, IDataProvider.ID);
 
 /**
  * The logger.
- * @const
- * @type {goog.log.Logger}
- * @private
+ * @type {Logger}
  */
-plugin.config.Provider.LOGGER_ = goog.log.getLogger('plugin.config.Provider');
+const logger = log.getLogger('plugin.config.Provider');
 
-
-/**
- * @inheritDoc
- */
-plugin.config.Provider.prototype.configure = function(config) {
-  plugin.config.Provider.base(this, 'configure', config);
-  this.setToolTip(/** @type {?string} */ (config['tooltip'] || config['description']));
-  this.layers_ = /** @type {Object} */ (config['layers']) || {};
-  this.providerKey_ = /** @type {os.data.ProviderKey} */ (config['providerKey']) || os.data.ProviderKey.USER;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.config.Provider.prototype.load = function(ping) {
-  this.dispatchEvent(new os.data.DataProviderEvent(os.data.DataProviderEventType.LOADING, this));
-  this.setChildren(null);
-
-  for (var id in this.layers_) {
-    this.loadConfig(id, this.layers_[id]);
-  }
-
-  this.dispatchEvent(new os.data.DataProviderEvent(os.data.DataProviderEventType.LOADED, this));
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.config.Provider.prototype.removeDescriptor = function(descriptor, opt_clear) {
-  var result = plugin.config.Provider.base(this, 'removeDescriptor', descriptor, opt_clear);
-
-  var id = descriptor.getId();
-  var configId = id.replace(this.getId() + os.data.BaseDescriptor.ID_DELIMITER, '');
-  if (configId && configId in this.layers_) {
-    delete this.layers_[configId];
-
-    var settingsKey = this.getSettingsKey() + '.layers';
-    os.settings.set(settingsKey, this.layers_);
-  }
-
-  return result;
-};
-
-
-/**
- * Load a layer config.
- * @param {string} id The layer id.
- * @param {Object|Array<Object>} config The layer config(s) to load.
- * @return {os.data.IDataDescriptor} The descriptor, or null if one could not be found/created.
- * @protected
- */
-plugin.config.Provider.prototype.loadConfig = function(id, config) {
-  var descriptor = null;
-
-  try {
-    var descriptorId = this.getId() + os.data.BaseDescriptor.ID_DELIMITER + id;
-    descriptor = /** @type {os.data.ConfigDescriptor} */ (os.dataManager.getDescriptor(descriptorId));
-
-    if (!descriptor) {
-      descriptor = new os.data.ConfigDescriptor();
-      descriptor.setId(descriptorId);
-    }
-
-    this.fixId(descriptorId, config);
-
-    descriptor.setBaseConfig(config);
-    os.dataManager.addDescriptor(descriptor);
-    this.addDescriptor(descriptor, false, false);
-  } catch (e) {
-    goog.log.error(this.log, 'There was an error processing the configuration', e);
-  }
-
-  return descriptor;
-};
-
-
-/**
- * Ensure layer config id's are prefixed with the descriptor id.
- * @param {string} id The descriptor id.
- * @param {Array<Object>|Object} config The layer config(s).
- * @protected
- */
-plugin.config.Provider.prototype.fixId = function(id, config) {
-  if (Array.isArray(config)) {
-    config.forEach(this.fixId.bind(this, id));
-  } else if (config) {
-    if (!('id' in config)) {
-      throw new Error('Config for "' + id + '" does not contain the "id" field!');
-    }
-    if (!config['id'].startsWith(id)) {
-      config['id'] = id + os.data.BaseDescriptor.ID_DELIMITER + config['id'];
-    }
-  }
-};
-
-
-/**
- * Get the settings key for the provider.
- * @return {string} The key.
- * @protected
- */
-plugin.config.Provider.prototype.getSettingsKey = function() {
-  return this.providerKey_ + '.' + this.getId();
-};
-
-
-/**
- * Add a layer group to the provider and create a descriptor.
- * @param {string} id The layer group id.
- * @param {Array<Object>|Object} config The layer config(s) to add to the group.
- * @return {os.data.IDataDescriptor} The descriptor. If `id` is already registered with the provider, the existing
- *                                   descriptor will be returned.
- */
-plugin.config.Provider.prototype.addLayerGroup = function(id, config) {
-  var descriptor = null;
-
-  if (config) {
-    if (!(id in this.layers_)) {
-      this.layers_[id] = config;
-
-      var layersKey = this.getSettingsKey() + '.layers';
-      os.settings.set(layersKey, this.layers_);
-
-      descriptor = this.loadConfig(id, config);
-    } else {
-      var descriptorId = [this.getId(), id].join(os.data.BaseDescriptor.ID_DELIMITER);
-      descriptor = os.dataManager.getDescriptor(descriptorId);
-    }
-  }
-
-  return descriptor;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.config.Provider.prototype.getErrorMessage = function() {
-  return null;
-};
-
-
-/**
- * Create a new config provider, or return it if it already exists.
- * @param {string} id The provider id.
- * @param {Object} config The provider config.
- * @return {plugin.config.Provider} The provider.
- */
-plugin.config.Provider.create = function(id, config) {
-  var provider = null;
-
-  if (id && config) {
-    provider = /** @type {plugin.config.Provider} */ (os.dataManager.getProvider(id));
-
-    if (!provider) {
-      // ensure the type is set properly, and layers are defined
-      config['type'] = plugin.config.ID;
-
-      if (!config['layers']) {
-        config['layers'] = {};
-      }
-
-      provider = new plugin.config.Provider();
-      provider.setId(id);
-      provider.configure(config);
-      provider.load();
-
-      os.settings.set(provider.getSettingsKey(), config);
-      os.dataManager.addProvider(provider);
-    }
-  }
-
-  return provider;
-};
+exports = Provider;

--- a/src/plugin/descriptor/descriptorresult.js
+++ b/src/plugin/descriptor/descriptorresult.js
@@ -1,39 +1,46 @@
-goog.provide('plugin.descriptor.DescriptorResult');
-goog.require('os.search.AbstractSearchResult');
-goog.require('plugin.descriptor.descriptorResultCardDirective');
+goog.module('plugin.descriptor.DescriptorResult');
+goog.module.declareLegacyNamespace();
 
+const AbstractSearchResult = goog.require('os.search.AbstractSearchResult');
+const {directiveTag: cardUi} = goog.require('plugin.descriptor.ResultCardUI');
+
+const IDataDescriptor = goog.requireType('os.data.IDataDescriptor');
 
 
 /**
- * @param {!os.data.IDataDescriptor} result
- * @param {number} score
- * @param {number=} opt_count The number of features available in the layer.
- * @extends {os.search.AbstractSearchResult<!os.data.IDataDescriptor>}
- * @constructor
+ * Descriptor search result.
+ * @extends {AbstractSearchResult<!IDataDescriptor>}
  */
-plugin.descriptor.DescriptorResult = function(result, score, opt_count) {
-  plugin.descriptor.DescriptorResult.base(this, 'constructor', result, score);
+class DescriptorResult extends AbstractSearchResult {
+  /**
+   * Constructor.
+   * @param {!IDataDescriptor} result The descriptor.
+   * @param {number} score The search score.
+   * @param {number=} opt_count The number of features available in the layer.
+   */
+  constructor(result, score, opt_count) {
+    super(result, score);
+
+    /**
+     * The feature count from elastic.
+     * @type {number|undefined}
+     */
+    this.featureCount = opt_count;
+  }
 
   /**
-   * The feature count from elastic.
-   * @type {number|undefined}
+   * @inheritDoc
    */
-  this.featureCount = opt_count;
-};
-goog.inherits(plugin.descriptor.DescriptorResult, os.search.AbstractSearchResult);
+  getSearchUI() {
+    return `<${cardUi} result="result"></${cardUi}>`;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  performAction() {
+    return false;
+  }
+}
 
-/**
- * @inheritDoc
- */
-plugin.descriptor.DescriptorResult.prototype.getSearchUI = function() {
-  return '<descriptorresultcard result="result"></descriptorresultcard>';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.descriptor.DescriptorResult.prototype.performAction = function() {
-  return false;
-};
+exports = DescriptorResult;

--- a/src/plugin/descriptor/descriptorresultcard.js
+++ b/src/plugin/descriptor/descriptorresultcard.js
@@ -1,9 +1,10 @@
 goog.module('plugin.descriptor.ResultCardUI');
 goog.module.declareLegacyNamespace();
 
-const os = goog.require('os');
+const {ROOT} = goog.require('os');
 const dispatcher = goog.require('os.Dispatcher');
 const DescriptorEvent = goog.require('os.data.DescriptorEvent');
+const DescriptorEventType = goog.require('os.data.DescriptorEventType');
 const Module = goog.require('os.ui.Module');
 
 
@@ -13,7 +14,7 @@ const Module = goog.require('os.ui.Module');
 const directive = () => ({
   restrict: 'E',
   replace: true,
-  templateUrl: os.ROOT + 'views/plugin/descriptor/resultcard.html',
+  templateUrl: ROOT + 'views/plugin/descriptor/resultcard.html',
   controller: Controller,
   controllerAs: 'ctrl'
 });
@@ -145,7 +146,7 @@ class Controller {
       d.setActive(!d.isActive());
 
       if (d.isActive()) {
-        dispatcher.getInstance().dispatchEvent(new DescriptorEvent(os.data.DescriptorEventType.USER_TOGGLED, d));
+        dispatcher.getInstance().dispatchEvent(new DescriptorEvent(DescriptorEventType.USER_TOGGLED, d));
       }
     }
   }

--- a/src/plugin/descriptor/descriptorresultcard_shim.js
+++ b/src/plugin/descriptor/descriptorresultcard_shim.js
@@ -1,0 +1,13 @@
+goog.provide('plugin.descriptor.ResultCardCtrl');
+goog.provide('plugin.descriptor.descriptorResultCardDirective');
+goog.require('plugin.descriptor.ResultCardUI');
+
+/**
+ * @deprecated Please use goog.require('plugin.descriptor.ResultCardUI').Controller instead.
+ */
+plugin.descriptor.ResultCardCtrl = plugin.descriptor.ResultCardUI.Controller;
+
+/**
+ * @deprecated Please use goog.require('plugin.descriptor.ResultCardUI').directive instead.
+ */
+plugin.descriptor.descriptorResultCardDirective = plugin.descriptor.ResultCardUI.directive;

--- a/src/plugin/descriptor/descriptorsearch.js
+++ b/src/plugin/descriptor/descriptorsearch.js
@@ -5,6 +5,8 @@ const Promise = goog.require('goog.Promise');
 const googArray = goog.require('goog.array');
 const log = goog.require('goog.log');
 const DataManager = goog.require('os.data.DataManager');
+const osImplements = goog.require('os.implements');
+const search = goog.require('os.search');
 const AbstractSearch = goog.require('os.search.AbstractSearch');
 const IFacetedSearch = goog.require('os.search.IFacetedSearch');
 const SearchEvent = goog.require('os.search.SearchEvent');
@@ -153,11 +155,11 @@ class DescriptorSearch extends AbstractSearch {
       var self = this;
       Promise.all(promises).then(function(value) {
         self.dispatchEvent(new SearchEvent(SearchEventType.SUCCESS,
-            self.term, os.search.pageResults(results, opt_start, opt_pageSize), results.length));
+            self.term, search.pageResults(results, opt_start, opt_pageSize), results.length));
       });
     } else {
       this.dispatchEvent(new SearchEvent(SearchEventType.SUCCESS,
-          this.term, os.search.pageResults(results, opt_start, opt_pageSize), results.length));
+          this.term, search.pageResults(results, opt_start, opt_pageSize), results.length));
     }
 
     return true;
@@ -308,7 +310,7 @@ class DescriptorSearch extends AbstractSearch {
     }
   }
 }
-os.implements(DescriptorSearch, IFacetedSearch.ID);
+osImplements(DescriptorSearch, IFacetedSearch.ID);
 
 
 /**

--- a/src/plugin/descriptor/descriptorsearch.js
+++ b/src/plugin/descriptor/descriptorsearch.js
@@ -1,89 +1,314 @@
-goog.provide('plugin.descriptor.DescriptorSearch');
+goog.module('plugin.descriptor.DescriptorSearch');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.Promise');
-goog.require('goog.array');
-goog.require('goog.events.EventTarget');
-goog.require('goog.log');
-goog.require('os.search.AbstractSearch');
-goog.require('os.search.IFacetedSearch');
-goog.require('os.search.SearchEvent');
-goog.require('os.search.SearchEventType');
-goog.require('plugin.descriptor.DescriptorResult');
-goog.require('plugin.descriptor.facet.Area');
-goog.require('plugin.descriptor.facet.SearchTerm');
-goog.require('plugin.descriptor.facet.Source');
-goog.require('plugin.descriptor.facet.Tag');
-goog.require('plugin.descriptor.facet.TagSplit');
-goog.require('plugin.descriptor.facet.Type');
-
+const Promise = goog.require('goog.Promise');
+const googArray = goog.require('goog.array');
+const log = goog.require('goog.log');
+const DataManager = goog.require('os.data.DataManager');
+const AbstractSearch = goog.require('os.search.AbstractSearch');
+const IFacetedSearch = goog.require('os.search.IFacetedSearch');
+const SearchEvent = goog.require('os.search.SearchEvent');
+const SearchEventType = goog.require('os.search.SearchEventType');
+const DescriptorResult = goog.require('plugin.descriptor.DescriptorResult');
+const SearchTerm = goog.require('plugin.descriptor.facet.SearchTerm');
+const Source = goog.require('plugin.descriptor.facet.Source');
+const Tag = goog.require('plugin.descriptor.facet.Tag');
+const TagSplit = goog.require('plugin.descriptor.facet.TagSplit');
+const Type = goog.require('plugin.descriptor.facet.Type');
 
 
 /**
  * Searches descriptors
  *
- * @param {string} name
- * @extends {os.search.AbstractSearch}
- * @implements {os.search.IFacetedSearch}
- * @constructor
+ * @implements {IFacetedSearch}
  */
-plugin.descriptor.DescriptorSearch = function(name) {
-  plugin.descriptor.DescriptorSearch.base(this, 'constructor', plugin.descriptor.DescriptorSearch.ID, name);
-  this.log = plugin.descriptor.DescriptorSearch.LOGGER_;
-  this.priority = 90;
-  this.type = plugin.descriptor.DescriptorSearch.ID;
+class DescriptorSearch extends AbstractSearch {
+  /**
+   * Constructor.
+   * @param {string} name
+   */
+  constructor(name) {
+    super(DescriptorSearch.ID, name);
+    this.log = logger;
+    this.priority = 90;
+    this.type = DescriptorSearch.ID;
+
+    /**
+     * @type {Array<DescriptorResult>}
+     * @private
+     */
+    this.results_ = [];
+
+    /**
+     * @type {os.search.FacetSet}
+     * @private
+     */
+    this.availableFacets_ = {};
+
+    /**
+     * @type {?os.search.AppliedFacets}
+     * @private
+     */
+    this.appliedFacets_ = null;
+
+    /**
+     * @type {SearchTerm}
+     * @private
+     */
+    this.searchTermFacet_ = new SearchTerm();
+
+    /**
+     * @type {!Array<!os.search.BaseFacet<!os.data.IDataDescriptor>>}
+     * @private
+     */
+    this.facets_ = [];
+    this.initFacets_();
+  }
 
   /**
-   * @type {Array<plugin.descriptor.DescriptorResult>}
    * @private
    */
-  this.results_ = [];
+  initFacets_() {
+    this.facets_ = [
+      // The current method of bbox testing is not accurate enough, and 3D's method is too slow.
+      // To properly enable this, see the corresponding comment in browsedata.js:~52 and ~69
+      // new plugin.descriptor.facet.Area(),
+      new TagSplit(),
+      new Source(),
+      new Type(),
+      // commenting out because the tag facet is utter nonsense at this point. If you are looking
+      // for something specific, just type it in as a keyword search.
+      new Tag(),
+      this.searchTermFacet_
+    ];
+  }
 
   /**
-   * @type {os.search.FacetSet}
-   * @private
+   * @inheritDoc
    */
-  this.availableFacets_ = {};
+  cancel() {
+    // synchronous, so this is empty
+  }
 
   /**
-   * @type {?os.search.AppliedFacets}
-   * @private
+   * @return {!Array<!os.data.IDataDescriptor>}
    */
-  this.appliedFacets_ = null;
+  getDescriptors() {
+    return DataManager.getInstance().getDescriptors();
+  }
 
   /**
-   * @type {plugin.descriptor.facet.SearchTerm}
-   * @private
+   * @inheritDoc
    */
-  this.searchTermFacet_ = new plugin.descriptor.facet.SearchTerm();
+  autocomplete(term, opt_maxResults) {
+    this.term = term;
+    this.dispatchEvent(new SearchEvent(SearchEventType.AUTOCOMPLETED, this.term, []));
+  }
 
   /**
-   * @type {!Array<!os.search.BaseFacet<!os.data.IDataDescriptor>>}
-   * @private
+   * @inheritDoc
    */
-  this.facets_ = [];
-  this.initFacets_();
-};
-goog.inherits(plugin.descriptor.DescriptorSearch, os.search.AbstractSearch);
-os.implements(plugin.descriptor.DescriptorSearch, os.search.IFacetedSearch.ID);
+  searchTerm(term, opt_start, opt_pageSize) {
+    this.term = term;
+    this.results_.length = 0;
+    this.searchTermFacet_.setTerm(term);
 
+    var descriptors = this.getDescriptors();
+    var promises = [];
+    var results = this.results_;
+    var priority = this.getPriority();
 
-/**
- * @private
- */
-plugin.descriptor.DescriptorSearch.prototype.initFacets_ = function() {
-  this.facets_ = [
-    // The current method of bbox testing is not accurate enough, and 3D's method is too slow.
-    // To properly enable this, see the corresponding comment in browsedata.js:~52 and ~69
-    // new plugin.descriptor.facet.Area(),
-    new plugin.descriptor.facet.TagSplit(),
-    new plugin.descriptor.facet.Source(),
-    new plugin.descriptor.facet.Type(),
-    // commenting out because the tag facet is utter nonsense at this point. If you are looking
-    // for something specific, just type it in as a keyword search.
-    new plugin.descriptor.facet.Tag(),
-    this.searchTermFacet_
-  ];
-};
+    if (descriptors) {
+      for (var i = 0, n = descriptors.length; i < n; i++) {
+        var d = descriptors[i];
+
+        // ensure the provider is enabled
+        var provider = d.getDataProvider();
+        if (provider && !provider.getEnabled()) {
+          continue;
+        }
+
+        var result = this.testFacets(d);
+        var onResult = function(score) {
+          if (score) {
+            // add result
+            score = priority + score / 100;
+            results.push(new DescriptorResult(d, score));
+          }
+        };
+
+        if (result instanceof Promise) {
+          promises.push(result.then(onResult));
+        } else {
+          onResult(result);
+        }
+      }
+    }
+
+    googArray.sort(results, function(a, b) {
+      return googArray.defaultCompare(b.getScore(), a.getScore());
+    });
+
+    if (promises.length) {
+      var self = this;
+      Promise.all(promises).then(function(value) {
+        self.dispatchEvent(new SearchEvent(SearchEventType.SUCCESS,
+            self.term, os.search.pageResults(results, opt_start, opt_pageSize), results.length));
+      });
+    } else {
+      this.dispatchEvent(new SearchEvent(SearchEventType.SUCCESS,
+          this.term, os.search.pageResults(results, opt_start, opt_pageSize), results.length));
+    }
+
+    return true;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  loadFacets() {
+    var applied = this.appliedFacets_ || {};
+    var available = this.availableFacets_ = {};
+    var descriptors = this.getDescriptors();
+    var promises = [];
+
+    if (descriptors) {
+      var facets = this.facets_;
+
+      for (var i = 0, n = descriptors.length; i < n; i++) {
+        var d = descriptors[i];
+        var counts = {};
+        var tests = {};
+
+        var childPromises = [];
+
+        for (var j = 0, m = facets.length; j < m; j++) {
+          var promise = facets[j].load(d, counts);
+          if (promise) {
+            childPromises.push(promise);
+          }
+
+          promise = facets[j].test(d, applied, tests);
+          if (promise) {
+            childPromises.push(promise);
+          }
+        }
+
+        var computeCounts = function() {
+          for (var cat in counts) {
+            var matches = true;
+            for (var cat2 in tests) {
+              if (cat !== cat2 && !tests[cat2]) {
+                matches = false;
+              }
+            }
+
+            for (var value in counts[cat]) {
+              if (!available[cat]) {
+                available[cat] = {};
+              }
+
+              if (!available[cat][value]) {
+                available[cat][value] = 0;
+              }
+
+              available[cat][value] += matches ? 1 : 0;
+            }
+          }
+        };
+
+        if (childPromises.length) {
+          promises.push(Promise.all(childPromises).then(computeCounts));
+        } else {
+          computeCounts();
+        }
+      }
+    }
+
+    if (promises.length) {
+      var thing = this;
+      Promise.all(promises).then(function(value) {
+        thing.dispatchEvent(SearchEventType.FACETLOAD);
+      });
+    } else {
+      this.dispatchEvent(SearchEventType.FACETLOAD);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getFacets() {
+    return this.availableFacets_;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  applyFacets(facets) {
+    this.appliedFacets_ = facets;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getLabel(category, value) {
+    for (var i = 0, n = this.facets_.length; i < n; i++) {
+      if (this.facets_[i].transformsValue(category)) {
+        return this.facets_[i].valueToLabel(value);
+      }
+    }
+
+    return value;
+  }
+
+  /**
+   * @param {!os.data.IDataDescriptor} descriptor
+   * @return {number|Promise} the score or a promise which resolves to the score
+   * @protected
+   */
+  testFacets(descriptor) {
+    var applied = this.appliedFacets_ || {};
+    var results = {};
+    var facets = this.facets_;
+
+    var promises = [];
+
+    for (var i = 0, n = facets.length; i < n; i++) {
+      var promise = facets[i].test(descriptor, applied, results);
+      if (promise) {
+        promises.push(promise);
+      }
+    }
+
+    var onResults = function() {
+      // if any of the result categories has a 0, then that facet wasn't matched
+      var score = 0;
+      for (var cat in results) {
+        var val = results[cat];
+
+        if (!val) {
+          return 0;
+        }
+
+        score += val;
+      }
+
+      return score;
+    };
+
+    if (promises.length) {
+      return new Promise(function(resolve) {
+        Promise.all(promises).then(function() {
+          resolve(onResults());
+        });
+      });
+    } else {
+      return onResults();
+    }
+  }
+}
+os.implements(DescriptorSearch, IFacetedSearch.ID);
 
 
 /**
@@ -91,247 +316,14 @@ plugin.descriptor.DescriptorSearch.prototype.initFacets_ = function() {
  * @type {string}
  * @const
  */
-plugin.descriptor.DescriptorSearch.ID = 'descriptor';
+DescriptorSearch.ID = 'descriptor';
 
 
 /**
  * Logger for plugin.descriptor.DescriptorSearch
- * @type {goog.log.Logger}
- * @private
- * @const
+ * @type {log.Logger}
  */
-plugin.descriptor.DescriptorSearch.LOGGER_ = goog.log.getLogger('plugin.descriptor.DescriptorSearch');
+const logger = log.getLogger('plugin.descriptor.DescriptorSearch');
 
 
-/**
- * @inheritDoc
- */
-plugin.descriptor.DescriptorSearch.prototype.cancel = function() {
-  // synchronous, so this is empty
-};
-
-
-/**
- * @return {!Array<!os.data.IDataDescriptor>}
- */
-plugin.descriptor.DescriptorSearch.prototype.getDescriptors = function() {
-  return os.dataManager.getDescriptors();
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.descriptor.DescriptorSearch.prototype.autocomplete = function(term, opt_maxResults) {
-  this.term = term;
-  this.dispatchEvent(new os.search.SearchEvent(os.search.SearchEventType.AUTOCOMPLETED, this.term, []));
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.descriptor.DescriptorSearch.prototype.searchTerm = function(term, opt_start, opt_pageSize) {
-  this.term = term;
-  this.results_.length = 0;
-  this.searchTermFacet_.setTerm(term);
-
-  var descriptors = this.getDescriptors();
-  var promises = [];
-  var results = this.results_;
-  var priority = this.getPriority();
-
-  if (descriptors) {
-    for (var i = 0, n = descriptors.length; i < n; i++) {
-      var d = descriptors[i];
-
-      // ensure the provider is enabled
-      var provider = d.getDataProvider();
-      if (provider && !provider.getEnabled()) {
-        continue;
-      }
-
-      var result = this.testFacets(d);
-      var onResult = function(score) {
-        if (score) {
-          // add result
-          score = priority + score / 100;
-          results.push(new plugin.descriptor.DescriptorResult(d, score));
-        }
-      };
-
-      if (result instanceof goog.Promise) {
-        promises.push(result.then(onResult));
-      } else {
-        onResult(result);
-      }
-    }
-  }
-
-  goog.array.sort(results, function(a, b) {
-    return goog.array.defaultCompare(b.getScore(), a.getScore());
-  });
-
-  if (promises.length) {
-    var self = this;
-    goog.Promise.all(promises).then(function(value) {
-      self.dispatchEvent(new os.search.SearchEvent(os.search.SearchEventType.SUCCESS,
-          self.term, os.search.pageResults(results, opt_start, opt_pageSize), results.length));
-    });
-  } else {
-    this.dispatchEvent(new os.search.SearchEvent(os.search.SearchEventType.SUCCESS,
-        this.term, os.search.pageResults(results, opt_start, opt_pageSize), results.length));
-  }
-
-  return true;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.descriptor.DescriptorSearch.prototype.loadFacets = function() {
-  var applied = this.appliedFacets_ || {};
-  var available = this.availableFacets_ = {};
-  var descriptors = this.getDescriptors();
-  var promises = [];
-
-  if (descriptors) {
-    var facets = this.facets_;
-
-    for (var i = 0, n = descriptors.length; i < n; i++) {
-      var d = descriptors[i];
-      var counts = {};
-      var tests = {};
-
-      var childPromises = [];
-
-      for (var j = 0, m = facets.length; j < m; j++) {
-        var promise = facets[j].load(d, counts);
-        if (promise) {
-          childPromises.push(promise);
-        }
-
-        promise = facets[j].test(d, applied, tests);
-        if (promise) {
-          childPromises.push(promise);
-        }
-      }
-
-      var computeCounts = function() {
-        for (var cat in counts) {
-          var matches = true;
-          for (var cat2 in tests) {
-            if (cat !== cat2 && !tests[cat2]) {
-              matches = false;
-            }
-          }
-
-          for (var value in counts[cat]) {
-            if (!available[cat]) {
-              available[cat] = {};
-            }
-
-            if (!available[cat][value]) {
-              available[cat][value] = 0;
-            }
-
-            available[cat][value] += matches ? 1 : 0;
-          }
-        }
-      };
-
-      if (childPromises.length) {
-        promises.push(goog.Promise.all(childPromises).then(computeCounts));
-      } else {
-        computeCounts();
-      }
-    }
-  }
-
-  if (promises.length) {
-    var thing = this;
-    goog.Promise.all(promises).then(function(value) {
-      thing.dispatchEvent(os.search.SearchEventType.FACETLOAD);
-    });
-  } else {
-    this.dispatchEvent(os.search.SearchEventType.FACETLOAD);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.descriptor.DescriptorSearch.prototype.getFacets = function() {
-  return this.availableFacets_;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.descriptor.DescriptorSearch.prototype.applyFacets = function(facets) {
-  this.appliedFacets_ = facets;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.descriptor.DescriptorSearch.prototype.getLabel = function(category, value) {
-  for (var i = 0, n = this.facets_.length; i < n; i++) {
-    if (this.facets_[i].transformsValue(category)) {
-      return this.facets_[i].valueToLabel(value);
-    }
-  }
-
-  return value;
-};
-
-
-/**
- * @param {!os.data.IDataDescriptor} descriptor
- * @return {number|goog.Promise} the score or a promise which resolves to the score
- * @protected
- */
-plugin.descriptor.DescriptorSearch.prototype.testFacets = function(descriptor) {
-  var applied = this.appliedFacets_ || {};
-  var results = {};
-  var facets = this.facets_;
-
-  var promises = [];
-
-  for (var i = 0, n = facets.length; i < n; i++) {
-    var promise = facets[i].test(descriptor, applied, results);
-    if (promise) {
-      promises.push(promise);
-    }
-  }
-
-  var onResults = function() {
-    // if any of the result categories has a 0, then that facet wasn't matched
-    var score = 0;
-    for (var cat in results) {
-      var val = results[cat];
-
-      if (!val) {
-        return 0;
-      }
-
-      score += val;
-    }
-
-    return score;
-  };
-
-  if (promises.length) {
-    return new goog.Promise(function(resolve) {
-      goog.Promise.all(promises).then(function() {
-        resolve(onResults());
-      });
-    });
-  } else {
-    return onResults();
-  }
-};
+exports = DescriptorSearch;

--- a/src/plugin/descriptor/facet/areafacet.js
+++ b/src/plugin/descriptor/facet/areafacet.js
@@ -1,12 +1,18 @@
 goog.module('plugin.descriptor.facet.Area');
 goog.module.declareLegacyNamespace();
 
+const Promise = goog.require('goog.Promise');
+
 const IAreaTest = goog.require('os.data.IAreaTest');
+const osImplements = goog.require('os.implements');
+const AreaManager = goog.require('os.query.AreaManager');
 const BaseFacet = goog.require('os.search.BaseFacet');
+
+const IDataDescriptor = goog.requireType('os.data.IDataDescriptor');
 
 
 /**
- * @extends {BaseFacet<!os.data.IDataDescriptor>}
+ * @extends {BaseFacet<!IDataDescriptor>}
  */
 class Area extends BaseFacet {
   /**
@@ -27,7 +33,7 @@ class Area extends BaseFacet {
    * @inheritDoc
    */
   valueToLabel(value) {
-    var area = os.query.AreaManager.getInstance().get(value);
+    var area = AreaManager.getInstance().get(value);
 
     if (area) {
       return /** @type {string} */ (area.get('title'));
@@ -42,7 +48,7 @@ class Area extends BaseFacet {
   load(item, facets) {
     return this.updateCache_(
         item,
-        os.query.AreaManager.getInstance().getAll(),
+        AreaManager.getInstance().getAll(),
         function(areaId) {
           BaseFacet.update('Area', areaId, facets);
         });
@@ -57,7 +63,7 @@ class Area extends BaseFacet {
     if (areaIds) {
       BaseFacet.updateResults('Area', results);
 
-      var areas = os.query.AreaManager.getInstance().getAll();
+      var areas = AreaManager.getInstance().getAll();
       if (areas) {
         areas = areas.filter(function(area) {
           return areaIds.indexOf(/** @type {string} */ (area.getId())) > -1;
@@ -76,7 +82,7 @@ class Area extends BaseFacet {
   /**
    * This is where the magic happens.
    *
-   * @param {os.data.IDataDescriptor} descriptor
+   * @param {IDataDescriptor} descriptor
    * @param {Array<!ol.Feature>} areas
    * @param {Function} updateFunc
    * @return {goog.Promise|undefined}
@@ -85,7 +91,7 @@ class Area extends BaseFacet {
   updateCache_(descriptor, areas, updateFunc) {
     var promises = [];
     if (areas) {
-      if (os.implements(descriptor, IAreaTest.ID)) {
+      if (osImplements(descriptor, IAreaTest.ID)) {
         var cache = Area.cache_;
         var item = /** @type {IAreaTest} */ (descriptor);
 
@@ -114,7 +120,7 @@ class Area extends BaseFacet {
 
               var result = item.testArea(area);
 
-              if (result instanceof goog.Promise) {
+              if (result instanceof Promise) {
                 result.then(onResult);
                 promises.push(result);
               } else {
@@ -126,7 +132,7 @@ class Area extends BaseFacet {
       }
     }
 
-    return promises.length ? goog.Promise.all(promises) : undefined;
+    return promises.length ? Promise.all(promises) : undefined;
   }
 }
 

--- a/src/plugin/descriptor/facet/searchtermfacet.js
+++ b/src/plugin/descriptor/facet/searchtermfacet.js
@@ -1,68 +1,70 @@
-goog.provide('plugin.descriptor.facet.SearchTerm');
+goog.module('plugin.descriptor.facet.SearchTerm');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.search.SearchTermFacet');
-
+const SearchTermFacet = goog.require('os.search.SearchTermFacet');
 
 
 /**
- * @constructor
- * @extends {os.search.SearchTermFacet<!os.data.IDataDescriptor>}
+ * @extends {SearchTermFacet<!os.data.IDataDescriptor>}
  */
-plugin.descriptor.facet.SearchTerm = function() {
-  plugin.descriptor.facet.SearchTerm.base(this, 'constructor');
+class SearchTerm extends SearchTermFacet {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    /**
+     * @type {number}
+     * @private
+     */
+    this.dateThreshold_ = -1;
+  }
 
   /**
-   * @type {number}
-   * @private
+   * @inheritDoc
    */
-  this.dateThreshold_ = -1;
-};
-goog.inherits(plugin.descriptor.facet.SearchTerm, os.search.SearchTermFacet);
+  setTerm(term) {
+    super.setTerm(term);
+    this.dateThreshold_ = -1;
+
+    if (term) {
+      var now = Date.now();
+      this.dateThreshold_ = now - duration;
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  testInternal(item) {
+    var score = super.testInternal(item);
+    if (score) {
+      // items that the user has recently activated should be higher in the list
+      var lastActive = item.getLastActive();
+      var duration = duration;
+
+      if (!isNaN(lastActive)) {
+        score += 5 * (Math.max(0, lastActive - this.dateThreshold_) / duration);
+      }
+    }
+
+    return score;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getTexts(item) {
+    return [item.getSearchText(), item.getTitle()];
+  }
+}
 
 
 /**
  * @type {number}
- * @private
  */
-plugin.descriptor.facet.SearchTerm.DURATION_ = 2 * 7 * 24 * 60 * 60 * 1000;
+const duration = 2 * 7 * 24 * 60 * 60 * 1000;
 
 
-/**
- * @inheritDoc
- */
-plugin.descriptor.facet.SearchTerm.prototype.setTerm = function(term) {
-  plugin.descriptor.facet.SearchTerm.base(this, 'setTerm', term);
-  this.dateThreshold_ = -1;
-
-  if (term) {
-    var now = Date.now();
-    this.dateThreshold_ = now - plugin.descriptor.facet.SearchTerm.DURATION_;
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.descriptor.facet.SearchTerm.prototype.testInternal = function(item) {
-  var score = plugin.descriptor.facet.SearchTerm.base(this, 'testInternal', item);
-  if (score) {
-    // items that the user has recently activated should be higher in the list
-    var lastActive = item.getLastActive();
-    var duration = plugin.descriptor.facet.SearchTerm.DURATION_;
-
-    if (!isNaN(lastActive)) {
-      score += 5 * (Math.max(0, lastActive - this.dateThreshold_) / duration);
-    }
-  }
-
-  return score;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.descriptor.facet.SearchTerm.prototype.getTexts = function(item) {
-  return [item.getSearchText(), item.getTitle()];
-};
+exports = SearchTerm;

--- a/src/plugin/descriptor/facet/searchtermfacet.js
+++ b/src/plugin/descriptor/facet/searchtermfacet.js
@@ -3,9 +3,11 @@ goog.module.declareLegacyNamespace();
 
 const SearchTermFacet = goog.require('os.search.SearchTermFacet');
 
+const IDataDescriptor = goog.requireType('os.data.IDataDescriptor');
+
 
 /**
- * @extends {SearchTermFacet<!os.data.IDataDescriptor>}
+ * @extends {SearchTermFacet<!IDataDescriptor>}
  */
 class SearchTerm extends SearchTermFacet {
   /**

--- a/src/plugin/descriptor/facet/sourcefacet.js
+++ b/src/plugin/descriptor/facet/sourcefacet.js
@@ -1,39 +1,43 @@
-goog.provide('plugin.descriptor.facet.Source');
-goog.require('os.search.BaseFacet');
+goog.module('plugin.descriptor.facet.Source');
+goog.module.declareLegacyNamespace();
 
-
-
-/**
- * @constructor
- * @extends {os.search.BaseFacet<!os.data.IDataDescriptor>}
- */
-plugin.descriptor.facet.Source = function() {
-  plugin.descriptor.facet.Source.base(this, 'constructor');
-};
-goog.inherits(plugin.descriptor.facet.Source, os.search.BaseFacet);
+const BaseFacet = goog.require('os.search.BaseFacet');
 
 
 /**
- * @inheritDoc
+ * @extends {BaseFacet<!os.data.IDataDescriptor>}
  */
-plugin.descriptor.facet.Source.prototype.load = function(item, facets) {
-  var source = item.getProvider();
-
-  if (source) {
-    os.search.BaseFacet.update('Source', source, facets);
+class Source extends BaseFacet {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  load(item, facets) {
+    var source = item.getProvider();
 
-/**
- * @inheritDoc
- */
-plugin.descriptor.facet.Source.prototype.test = function(item, facets, results) {
-  var values = facets['Source'];
-
-  if (values) {
-    var p = item.getProvider();
-    var x = p ? values.indexOf(p) : -1;
-    os.search.BaseFacet.updateResults('Source', results, x > -1 ? 1 : 0);
+    if (source) {
+      BaseFacet.update('Source', source, facets);
+    }
   }
-};
+
+  /**
+   * @inheritDoc
+   */
+  test(item, facets, results) {
+    var values = facets['Source'];
+
+    if (values) {
+      var p = item.getProvider();
+      var x = p ? values.indexOf(p) : -1;
+      BaseFacet.updateResults('Source', results, x > -1 ? 1 : 0);
+    }
+  }
+}
+
+exports = Source;

--- a/src/plugin/descriptor/facet/sourcefacet.js
+++ b/src/plugin/descriptor/facet/sourcefacet.js
@@ -3,9 +3,11 @@ goog.module.declareLegacyNamespace();
 
 const BaseFacet = goog.require('os.search.BaseFacet');
 
+const IDataDescriptor = goog.requireType('os.data.IDataDescriptor');
+
 
 /**
- * @extends {BaseFacet<!os.data.IDataDescriptor>}
+ * @extends {BaseFacet<!IDataDescriptor>}
  */
 class Source extends BaseFacet {
   /**

--- a/src/plugin/descriptor/facet/tagfacet.js
+++ b/src/plugin/descriptor/facet/tagfacet.js
@@ -1,50 +1,54 @@
-goog.provide('plugin.descriptor.facet.Tag');
-goog.require('os.search.BaseFacet');
+goog.module('plugin.descriptor.facet.Tag');
+goog.module.declareLegacyNamespace();
 
-
-
-/**
- * @constructor
- * @extends {os.search.BaseFacet<!os.data.IDataDescriptor>}
- */
-plugin.descriptor.facet.Tag = function() {
-  plugin.descriptor.facet.Tag.base(this, 'constructor');
-};
-goog.inherits(plugin.descriptor.facet.Tag, os.search.BaseFacet);
+const BaseFacet = goog.require('os.search.BaseFacet');
 
 
 /**
- * @inheritDoc
+ * @extends {BaseFacet<!os.data.IDataDescriptor>}
  */
-plugin.descriptor.facet.Tag.prototype.load = function(item, facets) {
-  var tags = item.getTags();
-
-  if (tags) {
-    for (var i = 0, n = tags.length; i < n; i++) {
-      var tag = tags[i];
-
-      if (tag) {
-        os.search.BaseFacet.update('Tag', tag, facets);
-      }
-    }
+class Tag extends BaseFacet {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
   }
-};
 
-
-/**
- * @inheritDoc
- */
-plugin.descriptor.facet.Tag.prototype.test = function(item, facets, results) {
-  var values = facets['Tag'];
-
-  if (values) {
-    os.search.BaseFacet.updateResults('Tag', results);
-
+  /**
+   * @inheritDoc
+   */
+  load(item, facets) {
     var tags = item.getTags();
+
     if (tags) {
-      for (var i = 0, n = values.length; i < n; i++) {
-        os.search.BaseFacet.updateResults('Tag', results, tags.indexOf(values[i]) > -1 ? 1 : 0);
+      for (var i = 0, n = tags.length; i < n; i++) {
+        var tag = tags[i];
+
+        if (tag) {
+          BaseFacet.update('Tag', tag, facets);
+        }
       }
     }
   }
-};
+
+  /**
+   * @inheritDoc
+   */
+  test(item, facets, results) {
+    var values = facets['Tag'];
+
+    if (values) {
+      BaseFacet.updateResults('Tag', results);
+
+      var tags = item.getTags();
+      if (tags) {
+        for (var i = 0, n = values.length; i < n; i++) {
+          BaseFacet.updateResults('Tag', results, tags.indexOf(values[i]) > -1 ? 1 : 0);
+        }
+      }
+    }
+  }
+}
+
+exports = Tag;

--- a/src/plugin/descriptor/facet/tagfacet.js
+++ b/src/plugin/descriptor/facet/tagfacet.js
@@ -3,9 +3,11 @@ goog.module.declareLegacyNamespace();
 
 const BaseFacet = goog.require('os.search.BaseFacet');
 
+const IDataDescriptor = goog.requireType('os.data.IDataDescriptor');
+
 
 /**
- * @extends {BaseFacet<!os.data.IDataDescriptor>}
+ * @extends {BaseFacet<!IDataDescriptor>}
  */
 class Tag extends BaseFacet {
   /**

--- a/src/plugin/descriptor/facet/tagsplitfacet.js
+++ b/src/plugin/descriptor/facet/tagsplitfacet.js
@@ -1,56 +1,60 @@
-goog.provide('plugin.descriptor.facet.TagSplit');
-goog.require('os.search.BaseFacet');
+goog.module('plugin.descriptor.facet.TagSplit');
+goog.module.declareLegacyNamespace();
 
-
-
-/**
- * @constructor
- * @extends {os.search.BaseFacet<!os.data.IDataDescriptor>}
- */
-plugin.descriptor.facet.TagSplit = function() {
-  plugin.descriptor.facet.TagSplit.base(this, 'constructor');
-};
-goog.inherits(plugin.descriptor.facet.TagSplit, os.search.BaseFacet);
+const BaseFacet = goog.require('os.search.BaseFacet');
 
 
 /**
- * @inheritDoc
+ * @extends {BaseFacet<!os.data.IDataDescriptor>}
  */
-plugin.descriptor.facet.TagSplit.prototype.load = function(item, facets) {
-  var tags = item.getTags();
+class TagSplit extends BaseFacet {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
 
-  if (tags) {
-    for (var i = 0, n = tags.length; i < n; i++) {
-      var tag = tags[i];
+  /**
+   * @inheritDoc
+   */
+  load(item, facets) {
+    var tags = item.getTags();
 
-      if (tag) {
-        var split = tag.split(/:/);
+    if (tags) {
+      for (var i = 0, n = tags.length; i < n; i++) {
+        var tag = tags[i];
 
-        if (split && split.length === 2) {
-          os.search.BaseFacet.update(split[0], split[1], facets);
+        if (tag) {
+          var split = tag.split(/:/);
+
+          if (split && split.length === 2) {
+            BaseFacet.update(split[0], split[1], facets);
+          }
         }
       }
     }
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  test(item, facets, results) {
+    var tags = item.getTags();
 
-/**
- * @inheritDoc
- */
-plugin.descriptor.facet.TagSplit.prototype.test = function(item, facets, results) {
-  var tags = item.getTags();
+    for (var cat in facets) {
+      var values = facets[cat];
+      BaseFacet.updateResults(cat, results);
 
-  for (var cat in facets) {
-    var values = facets[cat];
-    os.search.BaseFacet.updateResults(cat, results);
+      for (var i = 0, n = values.length; i < n; i++) {
+        var value = cat + ':' + values[i];
 
-    for (var i = 0, n = values.length; i < n; i++) {
-      var value = cat + ':' + values[i];
-
-      if (tags && tags.indexOf(value) > -1) {
-        os.search.BaseFacet.updateResults(cat, results, 1);
+        if (tags && tags.indexOf(value) > -1) {
+          BaseFacet.updateResults(cat, results, 1);
+        }
       }
     }
   }
-};
+}
+
+exports = TagSplit;

--- a/src/plugin/descriptor/facet/tagsplitfacet.js
+++ b/src/plugin/descriptor/facet/tagsplitfacet.js
@@ -3,9 +3,11 @@ goog.module.declareLegacyNamespace();
 
 const BaseFacet = goog.require('os.search.BaseFacet');
 
+const IDataDescriptor = goog.requireType('os.data.IDataDescriptor');
+
 
 /**
- * @extends {BaseFacet<!os.data.IDataDescriptor>}
+ * @extends {BaseFacet<!IDataDescriptor>}
  */
 class TagSplit extends BaseFacet {
   /**

--- a/src/plugin/descriptor/facet/typefacet.js
+++ b/src/plugin/descriptor/facet/typefacet.js
@@ -1,33 +1,37 @@
-goog.provide('plugin.descriptor.facet.Type');
+goog.module('plugin.descriptor.facet.Type');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.search.ValueFacet');
-
-
-/**
- * @constructor
- * @extends {os.search.ValueFacet<!os.data.IDataDescriptor>}
- */
-plugin.descriptor.facet.Type = function() {
-  plugin.descriptor.facet.Type.base(this, 'constructor', 'Type');
-};
-goog.inherits(plugin.descriptor.facet.Type, os.search.ValueFacet);
+const ValueFacet = goog.require('os.search.ValueFacet');
 
 
 /**
- * @inheritDoc
+ * @extends {ValueFacet<!os.data.IDataDescriptor>}
  */
-plugin.descriptor.facet.Type.prototype.getValue = function(item) {
-  return item ? item.getType() : null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.descriptor.facet.Type.prototype.valueToLabel = function(value) {
-  if (goog.string.endsWith(value, 's') && !goog.string.endsWith(value, 'es')) {
-    return value.substring(0, value.length - 1);
+class Type extends ValueFacet {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super('Type');
   }
 
-  return value;
-};
+  /**
+   * @inheritDoc
+   */
+  getValue(item) {
+    return item ? item.getType() : null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  valueToLabel(value) {
+    if (goog.string.endsWith(value, 's') && !goog.string.endsWith(value, 'es')) {
+      return value.substring(0, value.length - 1);
+    }
+
+    return value;
+  }
+}
+
+exports = Type;

--- a/src/plugin/descriptor/facet/typefacet.js
+++ b/src/plugin/descriptor/facet/typefacet.js
@@ -1,11 +1,14 @@
 goog.module('plugin.descriptor.facet.Type');
 goog.module.declareLegacyNamespace();
 
+const googString = goog.require('goog.string');
 const ValueFacet = goog.require('os.search.ValueFacet');
+
+const IDataDescriptor = goog.requireType('os.data.IDataDescriptor');
 
 
 /**
- * @extends {ValueFacet<!os.data.IDataDescriptor>}
+ * @extends {ValueFacet<!IDataDescriptor>}
  */
 class Type extends ValueFacet {
   /**
@@ -26,7 +29,7 @@ class Type extends ValueFacet {
    * @inheritDoc
    */
   valueToLabel(value) {
-    if (goog.string.endsWith(value, 's') && !goog.string.endsWith(value, 'es')) {
+    if (googString.endsWith(value, 's') && !googString.endsWith(value, 'es')) {
       return value.substring(0, value.length - 1);
     }
 

--- a/src/plugin/descriptor/searchplugin.js
+++ b/src/plugin/descriptor/searchplugin.js
@@ -1,35 +1,39 @@
-goog.provide('plugin.descriptor.SearchPlugin');
+goog.module('plugin.descriptor.SearchPlugin');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.plugin.AbstractPlugin');
-goog.require('os.ui.search.FacetedSearchCtrl');
-goog.require('plugin.descriptor.DescriptorSearch');
-
+const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const FacetedSearchCtrl = goog.require('os.ui.search.FacetedSearchCtrl');
+const DescriptorSearch = goog.require('plugin.descriptor.DescriptorSearch');
 
 
 /**
- * @extends {os.plugin.AbstractPlugin}
- * @constructor
  */
-plugin.descriptor.SearchPlugin = function() {
-  plugin.descriptor.SearchPlugin.base(this, 'constructor');
-  this.id = plugin.descriptor.SearchPlugin.ID;
-};
-goog.inherits(plugin.descriptor.SearchPlugin, os.plugin.AbstractPlugin);
+class SearchPlugin extends AbstractPlugin {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.id = SearchPlugin.ID;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  init() {
+    if (!FacetedSearchCtrl.provider) {
+      os.search.SearchManager.getInstance().registerSearch(new DescriptorSearch('Layers'));
+      FacetedSearchCtrl.provider = new DescriptorSearch('Layers');
+    }
+  }
+}
 
 
 /**
  * @type {string}
  * @const
  */
-plugin.descriptor.SearchPlugin.ID = 'descriptorsearch';
+SearchPlugin.ID = 'descriptorsearch';
 
 
-/**
- * @inheritDoc
- */
-plugin.descriptor.SearchPlugin.prototype.init = function() {
-  if (!os.ui.search.FacetedSearchCtrl.provider) {
-    os.search.SearchManager.getInstance().registerSearch(new plugin.descriptor.DescriptorSearch('Layers'));
-    os.ui.search.FacetedSearchCtrl.provider = new plugin.descriptor.DescriptorSearch('Layers');
-  }
-};
+exports = SearchPlugin;

--- a/src/plugin/descriptor/searchplugin.js
+++ b/src/plugin/descriptor/searchplugin.js
@@ -2,6 +2,7 @@ goog.module('plugin.descriptor.SearchPlugin');
 goog.module.declareLegacyNamespace();
 
 const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
+const SearchManager = goog.require('os.search.SearchManager');
 const FacetedSearchCtrl = goog.require('os.ui.search.FacetedSearchCtrl');
 const DescriptorSearch = goog.require('plugin.descriptor.DescriptorSearch');
 
@@ -22,7 +23,7 @@ class SearchPlugin extends AbstractPlugin {
    */
   init() {
     if (!FacetedSearchCtrl.provider) {
-      os.search.SearchManager.getInstance().registerSearch(new DescriptorSearch('Layers'));
+      SearchManager.getInstance().registerSearch(new DescriptorSearch('Layers'));
       FacetedSearchCtrl.provider = new DescriptorSearch('Layers');
     }
   }

--- a/test/plugin/descriptor/descriptorsearch.test.js
+++ b/test/plugin/descriptor/descriptorsearch.test.js
@@ -4,6 +4,9 @@ goog.require('test.os.config.SettingsUtil');
 
 
 describe('plugin.descriptor.DescriptorSearch', function() {
+  const Settings = goog.module.get('os.config.Settings');
+  const DescriptorSearch = goog.module.get('plugin.descriptor.DescriptorSearch');
+
   var mockDescriptor = function() {
     this.id = 'A';
     this.type = 'Type A';
@@ -36,11 +39,11 @@ describe('plugin.descriptor.DescriptorSearch', function() {
   var list = [d1, d2, d3, d4];
 
   it('should init properly', function() {
-    var settings = new os.config.Settings();
+    var settings = new Settings();
     test.os.config.SettingsUtil.initAndLoad(settings);
 
     runs(function() {
-      ds = new plugin.descriptor.DescriptorSearch('Layers');
+      ds = new DescriptorSearch('Layers');
     });
   });
 

--- a/test/plugin/descriptor/facet/tagsplitfacet.test.js
+++ b/test/plugin/descriptor/facet/tagsplitfacet.test.js
@@ -2,6 +2,8 @@ goog.require('plugin.descriptor.facet.TagSplit');
 
 
 describe('plugin.descriptor.facet.TagSplit', function() {
+  const TagSplit = goog.module.get('plugin.descriptor.facet.TagSplit');
+
   var mockDescriptor = function() {
     this.tags = null;
   };
@@ -12,7 +14,7 @@ describe('plugin.descriptor.facet.TagSplit', function() {
 
   it('should handle empty tags on load', function() {
     var d = new mockDescriptor();
-    var f = new plugin.descriptor.facet.TagSplit();
+    var f = new TagSplit();
 
     var loaded = {};
     f.load(d, loaded);
@@ -27,7 +29,7 @@ describe('plugin.descriptor.facet.TagSplit', function() {
 
   it('should handle empty tags on test', function() {
     var d = new mockDescriptor();
-    var f = new plugin.descriptor.facet.TagSplit();
+    var f = new TagSplit();
     var results = {};
     f.test(d, {}, results);
     var count = 0;
@@ -49,7 +51,7 @@ describe('plugin.descriptor.facet.TagSplit', function() {
     var list = [d, d1, d2];
 
     var loaded = {};
-    var f = new plugin.descriptor.facet.TagSplit();
+    var f = new TagSplit();
 
     for (var i = 0; i < list.length; i++) {
       f.load(list[i], loaded);
@@ -74,7 +76,7 @@ describe('plugin.descriptor.facet.TagSplit', function() {
       yer: ['mom']
     };
 
-    var f = new plugin.descriptor.facet.TagSplit();
+    var f = new TagSplit();
     var results = {};
     f.test(d2, applied, results);
     expect(results['yer']).toBe(1);
@@ -88,5 +90,3 @@ describe('plugin.descriptor.facet.TagSplit', function() {
     expect(results['yer']).toBe(0);
   });
 });
-
-


### PR DESCRIPTION
No significant changes were necessary in the transform. I did notice the audio MIME detection was not working because it was prioritized after text detection. Audio files were being incorrectly detected as text, so I adjusted the audio MIME priority to be `<text priority> - 1`. You should be able to import audio files by URL again.