### PR TITLE
Transform basemap plugin to goog.module

### DIFF
--- a/src/plugin/basemap/basemap.js
+++ b/src/plugin/basemap/basemap.js
@@ -1,47 +1,49 @@
-goog.provide('plugin.basemap');
-goog.require('os.layer.Tile');
+goog.module('plugin.basemap');
+goog.module.declareLegacyNamespace();
+
+const Tile = goog.require('os.layer.Tile');
+
+const Layer = goog.requireType('ol.layer.Layer');
 
 
 /**
  * @type {string}
- * @const
  */
-plugin.basemap.ID = 'basemap';
-
+const ID = 'basemap';
 
 /**
  * @type {string}
- * @const
  */
-plugin.basemap.TERRAIN_ID = 'terrain';
-
+const TERRAIN_ID = 'terrain';
 
 /**
  * @type {string}
- * @const
  */
-plugin.basemap.LAYER_TYPE = 'Map Layers';
-
+const LAYER_TYPE = 'Map Layers';
 
 /**
  * @type {string}
- * @const
  */
-plugin.basemap.TYPE = 'basemap';
-
+const TYPE = 'basemap';
 
 /**
  * @type {string}
- * @const
  */
-plugin.basemap.TERRAIN_TYPE = 'terrain';
-
+const TERRAIN_TYPE = 'terrain';
 
 /**
- * @param {!ol.layer.Layer} layer
+ * @param {!Layer} layer
  * @return {boolean} Whether or not the layer belongs in the base map group
  */
-plugin.basemap.isBaseMap = function(layer) {
-  return layer instanceof os.layer.Tile &&
-  /** @type {os.layer.Tile} */ (layer).getOSType() == plugin.basemap.LAYER_TYPE;
+const isBaseMap = function(layer) {
+  return layer instanceof Tile && /** @type {Tile} */ (layer).getOSType() == LAYER_TYPE;
+};
+
+exports = {
+  ID,
+  TERRAIN_ID,
+  LAYER_TYPE,
+  TYPE,
+  TERRAIN_TYPE,
+  isBaseMap
 };

--- a/src/plugin/basemap/basemapconfig.js
+++ b/src/plugin/basemap/basemapconfig.js
@@ -1,16 +1,17 @@
-goog.provide('plugin.basemap.BaseMapConfig');
+goog.module('plugin.basemap.BaseMapConfig');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
-goog.require('goog.object');
-goog.require('os.layer.config.AbstractLayerConfig');
-goog.require('plugin.basemap.layer.BaseMap');
-
+const asserts = goog.require('goog.asserts');
+const googObject = goog.require('goog.object');
+const AbstractLayerConfig = goog.require('os.layer.config.AbstractLayerConfig');
+const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
+const BaseMap = goog.require('plugin.basemap.layer.BaseMap');
 
 
 /**
  * Creates a tiled map layer. Map layers are typically opaque and belong under all data overlays.
  *
- * Note that this configuration forces the <code>layerClass</code> option to be {@link plugin.basemap.layer.BaseMap}.
+ * Note that this configuration forces the <code>layerClass</code> option to be {@link BaseMap}.
  *
  * @example <caption>Example map layer config</caption>
  * "example": {
@@ -31,28 +32,30 @@ goog.require('plugin.basemap.layer.BaseMap');
  *   ... The rest of the properties should configure that specific type
  * }
  *
- * @extends {os.layer.config.AbstractLayerConfig}
  * @see {@link plugin.ogc.wms.WMSLayerConfig} for configuring WMS map layers
  * @see {@link plugin.xyz.XYZLayerConfig} for configuring XYZ map layers (also best for ArcGIS map layers)
- * @constructor
  */
-plugin.basemap.BaseMapConfig = function() {
-  plugin.basemap.BaseMapConfig.base(this, 'constructor');
-};
-goog.inherits(plugin.basemap.BaseMapConfig, os.layer.config.AbstractLayerConfig);
+class BaseMapConfig extends AbstractLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
 
+  /**
+   * @inheritDoc
+   */
+  createLayer(options) {
+    var clonedOptions = googObject.clone(options);
+    clonedOptions['layerClass'] = BaseMap;
 
-/**
- * @inheritDoc
- */
-plugin.basemap.BaseMapConfig.prototype.createLayer = function(options) {
-  var clonedOptions = goog.object.clone(options);
-  clonedOptions['layerClass'] = plugin.basemap.layer.BaseMap;
+    var layerType = /** @type {string} */ (clonedOptions['baseType']);
+    var layerConfig = LayerConfigManager.getInstance().getLayerConfig(layerType);
+    asserts.assert(layerConfig !== undefined);
 
-  var layerType = /** @type {string} */ (clonedOptions['baseType']);
-  var layerConfig = os.layer.config.LayerConfigManager.getInstance().getLayerConfig(layerType);
-  goog.asserts.assert(layerConfig !== undefined);
+    return layerConfig.createLayer(clonedOptions);
+  }
+}
 
-  return layerConfig.createLayer(clonedOptions);
-};
-
+exports = BaseMapConfig;

--- a/src/plugin/basemap/basemapdescriptor.js
+++ b/src/plugin/basemap/basemapdescriptor.js
@@ -1,166 +1,157 @@
-goog.provide('plugin.basemap.BaseMapDescriptor');
-goog.require('goog.object');
-goog.require('os.data.LayerSyncDescriptor');
-goog.require('os.events.LayerConfigEvent');
-goog.require('os.events.LayerEvent');
-goog.require('os.events.LayerEventType');
-goog.require('os.map');
-goog.require('os.object');
-goog.require('os.ui.Icons');
-goog.require('plugin.basemap');
+goog.module('plugin.basemap.BaseMapDescriptor');
+goog.module.declareLegacyNamespace();
 
+const googObject = goog.require('goog.object');
+const LayerSyncDescriptor = goog.require('os.data.LayerSyncDescriptor');
+const osMap = goog.require('os.map');
+const Icons = goog.require('os.ui.Icons');
+const basemap = goog.require('plugin.basemap');
 
 
 /**
  * A descriptor for a base map (or "Map Layer")
  *
- * @extends {os.data.LayerSyncDescriptor}
- * @constructor
- * @see {@link plugin.basemap.BaseMapPlugin} for configuration instructions
+ * @see {@link basemap.BaseMapPlugin} for configuration instructions
  */
-plugin.basemap.BaseMapDescriptor = function() {
-  plugin.basemap.BaseMapDescriptor.base(this, 'constructor');
+class BaseMapDescriptor extends LayerSyncDescriptor {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.canDelete_ = true;
+
+    /**
+     * @type {Object.<string, *>}
+     * @private
+     */
+    this.origConf_ = null;
+
+    this.setTags(['GEOINT']);
+    this.setType(basemap.LAYER_TYPE);
+    this.descriptorType = basemap.ID;
+  }
 
   /**
-   * @type {boolean}
-   * @private
+   * @param {!Object.<string, *>} value
    */
-  this.canDelete_ = true;
+  setConfig(value) {
+    this.origConf_ = value;
+
+    // Layer type override from the base map config
+    if (value['layerType']) {
+      this.setType(/** @type {string} */ (value['layerType']));
+    }
+  }
 
   /**
-   * @type {Object.<string, *>}
-   * @private
+   * @inheritDoc
    */
-  this.origConf_ = null;
-
-  this.setTags(['GEOINT']);
-  this.setType(plugin.basemap.LAYER_TYPE);
-  this.descriptorType = plugin.basemap.ID;
-};
-goog.inherits(plugin.basemap.BaseMapDescriptor, os.data.LayerSyncDescriptor);
-
-
-/**
- * @param {!Object.<string, *>} value
- */
-plugin.basemap.BaseMapDescriptor.prototype.setConfig = function(value) {
-  this.origConf_ = value;
-
-  // Layer type override from the base map config
-  if (value['layerType']) {
-    this.setType(/** @type {string} */ (value['layerType']));
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.BaseMapDescriptor.prototype.getIcons = function() {
-  return os.ui.Icons.TILES;
-};
-
-
-/**
- * Whether or not this map layer descriptor can be deleted by the user
- *
- * @return {boolean}
- */
-plugin.basemap.BaseMapDescriptor.prototype.canDelete = function() {
-  return this.canDelete_;
-};
-
-
-/**
- * Sets whether the user can delete this map layer or not
- *
- * @param {boolean} value The value
- */
-plugin.basemap.BaseMapDescriptor.prototype.setCanDelete = function(value) {
-  this.canDelete_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.BaseMapDescriptor.prototype.getSearchType = function() {
-  return 'Map Layer';
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.BaseMapDescriptor.prototype.getLayerOptions = function() {
-  var options = goog.object.clone(this.origConf_);
-
-  options['id'] = this.getId();
-  options['provider'] = this.getProvider();
-  options['animate'] = false;
-  options['title'] = this.getTitle();
-  options['layerType'] = this.getType();
-  options['tags'] = this.getTags();
-  options['noClear'] = true;
-
-  return options;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.BaseMapDescriptor.prototype.getProvider = function() {
-  if (this.origConf_ && 'provider' in this.origConf_) {
-    return /** @type {?string} */ (this.origConf_['provider']);
+  getIcons() {
+    return Icons.TILES;
   }
 
-  return plugin.basemap.BaseMapDescriptor.base(this, 'getProvider');
-};
-
-
-/**
- * Basemaps need to be more careful about their initial restoration. It's possible for a basemap to have been active in
- * a different projection from the one the application is currently in, causing the application to  immediately
- * try to switch projections upon loading. This works around that problem.
- *
- * @override
- */
-plugin.basemap.BaseMapDescriptor.prototype.updateActiveFromTemp = function() {
-  if (this.getLayerOptions()['projection'] === os.map.PROJECTION.getCode() && this.tempActive === true) {
-    this.setActive(this.tempActive);
+  /**
+   * Whether or not this map layer descriptor can be deleted by the user
+   *
+   * @return {boolean}
+   */
+  canDelete() {
+    return this.canDelete_;
   }
 
-  // unset temp active. It should only run once at load.
-  this.tempActive = undefined;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.BaseMapDescriptor.prototype.persist = function(opt_obj) {
-  if (!opt_obj) {
-    opt_obj = {};
+  /**
+   * Sets whether the user can delete this map layer or not
+   *
+   * @param {boolean} value The value
+   */
+  setCanDelete(value) {
+    this.canDelete_ = value;
   }
 
-  opt_obj['canDelete'] = this.canDelete();
-  opt_obj['origConf'] = this.origConf_;
-
-  return plugin.basemap.BaseMapDescriptor.superClass_.persist.call(this, opt_obj);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.BaseMapDescriptor.prototype.restore = function(from) {
-  plugin.basemap.BaseMapDescriptor.superClass_.restore.call(this, from);
-
-  this.origConf_ = from['origConf'];
-  this.setCanDelete(from['canDelete']);
-
-  if (!this.canDelete_ && isNaN(this.getDeleteTime())) {
-    this.setDeleteTime(Date.now() + 24 * 60 * 60 * 1000);
+  /**
+   * @inheritDoc
+   */
+  getSearchType() {
+    return 'Map Layer';
   }
-};
+
+  /**
+   * @inheritDoc
+   */
+  getLayerOptions() {
+    var options = googObject.clone(this.origConf_);
+
+    options['id'] = this.getId();
+    options['provider'] = this.getProvider();
+    options['animate'] = false;
+    options['title'] = this.getTitle();
+    options['layerType'] = this.getType();
+    options['tags'] = this.getTags();
+    options['noClear'] = true;
+
+    return options;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getProvider() {
+    if (this.origConf_ && 'provider' in this.origConf_) {
+      return /** @type {?string} */ (this.origConf_['provider']);
+    }
+
+    return super.getProvider();
+  }
+
+  /**
+   * Basemaps need to be more careful about their initial restoration. It's possible for a basemap to have been active in
+   * a different projection from the one the application is currently in, causing the application to  immediately
+   * try to switch projections upon loading. This works around that problem.
+   *
+   * @override
+   */
+  updateActiveFromTemp() {
+    if (this.getLayerOptions()['projection'] === osMap.PROJECTION.getCode() && this.tempActive === true) {
+      this.setActive(this.tempActive);
+    }
+
+    // unset temp active. It should only run once at load.
+    this.tempActive = undefined;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  persist(opt_obj) {
+    if (!opt_obj) {
+      opt_obj = {};
+    }
+
+    opt_obj['canDelete'] = this.canDelete();
+    opt_obj['origConf'] = this.origConf_;
+
+    return super.persist(opt_obj);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  restore(from) {
+    super.restore(from);
+
+    this.origConf_ = from['origConf'];
+    this.setCanDelete(from['canDelete']);
+
+    if (!this.canDelete_ && isNaN(this.getDeleteTime())) {
+      this.setDeleteTime(Date.now() + 24 * 60 * 60 * 1000);
+    }
+  }
+}
+
+exports = BaseMapDescriptor;

--- a/src/plugin/basemap/basemapgroup.js
+++ b/src/plugin/basemap/basemapgroup.js
@@ -1,19 +1,25 @@
-goog.provide('plugin.basemap.Group');
-goog.require('os.data.ZOrderEventType');
-goog.require('os.layer.Group');
+goog.module('plugin.basemap.Group');
+goog.module.declareLegacyNamespace();
 
+const LayerGroup = goog.require('os.layer.Group');
+const basemap = goog.require('plugin.basemap');
 
 
 /**
- * @extends {os.layer.Group}
- * @param {olx.layer.GroupOptions=} opt_options
- * @constructor
+ * Basemap layer group.
  */
-plugin.basemap.Group = function(opt_options) {
-  plugin.basemap.Group.base(this, 'constructor', opt_options);
+class Group extends LayerGroup {
+  /**
+   * Constructor.
+   * @param {olx.layer.GroupOptions=} opt_options
+   */
+  constructor(opt_options) {
+    super(opt_options);
 
-  this.setPriority(-1000);
-  this.setCheckFunc(plugin.basemap.isBaseMap);
-  this.setOSType(plugin.basemap.LAYER_TYPE);
-};
-goog.inherits(plugin.basemap.Group, os.layer.Group);
+    this.setPriority(-1000);
+    this.setCheckFunc(basemap.isBaseMap);
+    this.setOSType(basemap.LAYER_TYPE);
+  }
+}
+
+exports = Group;

--- a/src/plugin/basemap/basemapplugin.js
+++ b/src/plugin/basemap/basemapplugin.js
@@ -4,8 +4,10 @@ goog.module.declareLegacyNamespace();
 const MapContainer = goog.require('os.MapContainer');
 const DataManager = goog.require('os.data.DataManager');
 const ProviderEntry = goog.require('os.data.ProviderEntry');
+const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
 const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
 const StateManager = goog.require('os.state.StateManager');
+const Versions = goog.require('os.state.Versions');
 const LayersCtrl = goog.require('os.ui.LayersCtrl');
 const basemap = goog.require('plugin.basemap');
 const BaseMapConfig = goog.require('plugin.basemap.BaseMapConfig');
@@ -86,13 +88,12 @@ class BaseMapPlugin extends AbstractPlugin {
     MapContainer.getInstance().addGroup(new Group());
 
     // register the layer config
-    os.layer.config.LayerConfigManager.getInstance().registerLayerConfig(
-        basemap.TYPE, BaseMapConfig);
+    LayerConfigManager.getInstance().registerLayerConfig(basemap.TYPE, BaseMapConfig);
 
     // register the state
     var sm = StateManager.getInstance();
-    sm.addStateImplementation(os.state.Versions.V3, pluginBasemapV3BaseMapState);
-    sm.addStateImplementation(os.state.Versions.V4, BaseMapState);
+    sm.addStateImplementation(Versions.V3, pluginBasemapV3BaseMapState);
+    sm.addStateImplementation(Versions.V4, BaseMapState);
 
     // do not toggle the base maps on and off
     LayersCtrl.SKIP_TOGGLE_FUNCS.push(basemap.isBaseMap);

--- a/src/plugin/basemap/basemapprovider.js
+++ b/src/plugin/basemap/basemapprovider.js
@@ -1,13 +1,16 @@
 goog.module('plugin.basemap.BaseMapProvider');
 goog.module.declareLegacyNamespace();
 
+const dispose = goog.require('goog.dispose');
 const dispatcher = goog.require('os.Dispatcher');
+const MapContainer = goog.require('os.MapContainer');
 const MapEvent = goog.require('os.MapEvent');
 const BaseDescriptor = goog.require('os.data.BaseDescriptor');
 const DataManager = goog.require('os.data.DataManager');
 const DataProviderEvent = goog.require('os.data.DataProviderEvent');
 const DataProviderEventType = goog.require('os.data.DataProviderEventType');
 const IDataProvider = goog.require('os.data.IDataProvider');
+const osImplements = goog.require('os.implements');
 const osMap = goog.require('os.map');
 const osProjSwitch = goog.require('os.proj.switch');
 const DescriptorProvider = goog.require('os.ui.data.DescriptorProvider');
@@ -214,7 +217,7 @@ class BaseMapProvider extends DescriptorProvider {
    * @protected
    */
   onSwitchProjectionBins(evt) {
-    var layers = os.MapContainer.getInstance().getLayers();
+    var layers = MapContainer.getInstance().getLayers();
     var bins = evt.layers;
     var numBaseMaps = 0;
     var map = {};
@@ -279,7 +282,7 @@ class BaseMapProvider extends DescriptorProvider {
       // remove the descriptor from the data manager
       DataManager.getInstance().removeDescriptor(descriptor);
       this.removeDescriptor(descriptor);
-      goog.dispose(descriptor);
+      dispose(descriptor);
     }
   }
 
@@ -290,6 +293,6 @@ class BaseMapProvider extends DescriptorProvider {
     return null;
   }
 }
-os.implements(BaseMapProvider, IDataProvider.ID);
+osImplements(BaseMapProvider, IDataProvider.ID);
 
 exports = BaseMapProvider;

--- a/src/plugin/basemap/layer/basemaplayer.js
+++ b/src/plugin/basemap/layer/basemaplayer.js
@@ -1,50 +1,54 @@
-goog.provide('plugin.basemap.layer.BaseMap');
+goog.module('plugin.basemap.layer.BaseMap');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.fn');
-goog.require('os.layer.Tile');
-goog.require('plugin.basemap.ui.baseMapLayerUIDirective');
-
-
-
-/**
- * @extends {os.layer.Tile}
- * @param {olx.layer.TileOptions} options Tile layer options
- * @constructor
- */
-plugin.basemap.layer.BaseMap = function(options) {
-  plugin.basemap.layer.BaseMap.base(this, 'constructor', options);
-
-  // omit base maps from the legend by default
-  this.renderLegend = os.fn.noop;
-};
-goog.inherits(plugin.basemap.layer.BaseMap, os.layer.Tile);
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.layer.BaseMap.prototype.getLayerUI = function() {
-  return 'basemaplayerui';
-};
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const AlertManager = goog.require('os.alert.AlertManager');
+const fn = goog.require('os.fn');
+const Tile = goog.require('os.layer.Tile');
+const {directiveTag: basemapLayerUi} = goog.require('plugin.basemap.ui.BaseMapLayerUI');
 
 
 /**
  * @type {boolean}
- * @private
  */
-plugin.basemap.layer.BaseMap.warningShown_ = false;
+let warningShown = false;
 
 
 /**
- * @inheritDoc
  */
-plugin.basemap.layer.BaseMap.prototype.setLoading = function(value) {
-  plugin.basemap.layer.BaseMap.base(this, 'setLoading', value);
+class BaseMap extends Tile {
+  /**
+   * Constructor.
+   * @param {olx.layer.TileOptions} options Tile layer options
+   */
+  constructor(options) {
+    super(options);
 
-  if (this.getError() && !plugin.basemap.layer.BaseMap.warningShown_) {
-    os.alertManager.sendAlert('One or more Map Layers are having issues reaching the remote server. Please try ' +
-        'adding another Map Layer or [click here to add a working one|basemapAddFailover].',
-    os.alert.AlertEventSeverity.WARNING);
-    plugin.basemap.layer.BaseMap.warningShown_ = true;
+    // omit base maps from the legend by default
+    this.renderLegend = fn.noop;
   }
-};
+
+  /**
+   * @inheritDoc
+   */
+  getLayerUI() {
+    return basemapLayerUi;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setLoading(value) {
+    super.setLoading(value);
+
+    if (this.getError() && !warningShown) {
+      AlertManager.getInstance().sendAlert(
+          'One or more Map Layers are having issues reaching the remote server. Please try adding another Map Layer ' +
+          'or [click here to add a working one|basemapAddFailover].',
+          AlertEventSeverity.WARNING);
+      warningShown = true;
+    }
+  }
+}
+
+exports = BaseMap;

--- a/src/plugin/basemap/terraindescriptor.js
+++ b/src/plugin/basemap/terraindescriptor.js
@@ -4,6 +4,7 @@ goog.module.declareLegacyNamespace();
 const DisplaySetting = goog.require('os.config.DisplaySetting');
 const Settings = goog.require('os.config.Settings');
 const BaseDescriptor = goog.require('os.data.BaseDescriptor');
+const Icons = goog.require('os.ui.Icons');
 const basemap = goog.require('plugin.basemap');
 
 
@@ -38,7 +39,7 @@ class TerrainDescriptor extends BaseDescriptor {
    * @inheritDoc
    */
   getIcons() {
-    return os.ui.Icons.TERRAIN;
+    return Icons.TERRAIN;
   }
 
   /**

--- a/src/plugin/basemap/terraindescriptor.js
+++ b/src/plugin/basemap/terraindescriptor.js
@@ -1,28 +1,76 @@
-goog.provide('plugin.basemap.TerrainDescriptor');
-goog.require('os.config.DisplaySetting');
-goog.require('os.data.BaseDescriptor');
-goog.require('plugin.basemap');
+goog.module('plugin.basemap.TerrainDescriptor');
+goog.module.declareLegacyNamespace();
 
+const DisplaySetting = goog.require('os.config.DisplaySetting');
+const Settings = goog.require('os.config.Settings');
+const BaseDescriptor = goog.require('os.data.BaseDescriptor');
+const basemap = goog.require('plugin.basemap');
 
 
 /**
  * Descriptor to activate/deactivate terrain from the Add Data window.
- *
- * @extends {os.data.BaseDescriptor}
- * @constructor
  */
-plugin.basemap.TerrainDescriptor = function() {
-  plugin.basemap.TerrainDescriptor.base(this, 'constructor');
-  this.setDescription(plugin.basemap.TerrainDescriptor.DESCRIPTION);
-  this.setProvider(null);
-  this.setTags(['GEOINT', 'Terrain', 'Elevation']);
-  this.setTitle('Terrain');
-  this.setType(null);
-  this.descriptorType = plugin.basemap.TERRAIN_ID;
+class TerrainDescriptor extends BaseDescriptor {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.setDescription(TerrainDescriptor.DESCRIPTION);
+    this.setProvider(null);
+    this.setTags(['GEOINT', 'Terrain', 'Elevation']);
+    this.setTitle('Terrain');
+    this.setType(null);
+    this.descriptorType = basemap.TERRAIN_ID;
 
-  os.settings.listen(os.config.DisplaySetting.ENABLE_TERRAIN, this.onTerrainChange_, false, this);
-};
-goog.inherits(plugin.basemap.TerrainDescriptor, os.data.BaseDescriptor);
+    Settings.getInstance().listen(DisplaySetting.ENABLE_TERRAIN, this.onTerrainChange_, false, this);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
+    Settings.getInstance().unlisten(DisplaySetting.ENABLE_TERRAIN, this.onTerrainChange_, false, this);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getIcons() {
+    return os.ui.Icons.TERRAIN;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setActiveInternal() {
+    Settings.getInstance().set(DisplaySetting.ENABLE_TERRAIN, this.isActive());
+
+    return super.setActiveInternal();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  restore(from) {
+    super.restore(from);
+    this.tempActive = /** @type {boolean} */ (Settings.getInstance().get(DisplaySetting.ENABLE_TERRAIN, false));
+    this.updateActiveFromTemp();
+  }
+
+  /**
+   * Handle changes to the terrain enabled setting.
+   *
+   * @param {os.events.SettingChangeEvent} event
+   * @private
+   */
+  onTerrainChange_(event) {
+    if (event.newVal !== this.isActive()) {
+      this.setActive(/** @type {boolean} */ (event.newVal));
+    }
+  }
+}
 
 
 /**
@@ -30,53 +78,7 @@ goog.inherits(plugin.basemap.TerrainDescriptor, os.data.BaseDescriptor);
  * @type {string}
  * @const
  */
-plugin.basemap.TerrainDescriptor.DESCRIPTION = 'Show terrain on the 3D globe.';
+TerrainDescriptor.DESCRIPTION = 'Show terrain on the 3D globe.';
 
 
-/**
- * @inheritDoc
- */
-plugin.basemap.TerrainDescriptor.prototype.disposeInternal = function() {
-  plugin.basemap.TerrainDescriptor.base(this, 'disposeInternal');
-  os.settings.unlisten(os.config.DisplaySetting.ENABLE_TERRAIN, this.onTerrainChange_, false, this);
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.TerrainDescriptor.prototype.getIcons = function() {
-  return os.ui.Icons.TERRAIN;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.TerrainDescriptor.prototype.setActiveInternal = function() {
-  os.settings.set(os.config.DisplaySetting.ENABLE_TERRAIN, this.isActive());
-
-  return plugin.basemap.TerrainDescriptor.base(this, 'setActiveInternal');
-};
-
-/**
- * @inheritDoc
- */
-plugin.basemap.TerrainDescriptor.prototype.restore = function(from) {
-  plugin.basemap.TerrainDescriptor.base(this, 'restore', from);
-  this.tempActive = /** @type {boolean} */ (os.settings.get(os.config.DisplaySetting.ENABLE_TERRAIN, false));
-  this.updateActiveFromTemp();
-};
-
-
-/**
- * Handle changes to the terrain enabled setting.
- *
- * @param {os.events.SettingChangeEvent} event
- * @private
- */
-plugin.basemap.TerrainDescriptor.prototype.onTerrainChange_ = function(event) {
-  if (event.newVal !== this.isActive()) {
-    this.setActive(/** @type {boolean} */ (event.newVal));
-  }
-};
+exports = TerrainDescriptor;

--- a/src/plugin/basemap/terrainlayernodeui.js
+++ b/src/plugin/basemap/terrainlayernodeui.js
@@ -1,14 +1,16 @@
-goog.provide('plugin.basemap.TerrainNodeUICtrl');
-goog.provide('plugin.basemap.terrainNodeUIDirective');
+goog.module('plugin.basemap.TerrainNodeUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.ui.Module');
-goog.require('os.ui.node.DefaultLayerNodeUICtrl');
+const DisplaySetting = goog.require('os.config.DisplaySetting');
+const Settings = goog.require('os.config.Settings');
+const Module = goog.require('os.ui.Module');
+const DefaultLayerNodeUICtrl = goog.require('os.ui.node.DefaultLayerNodeUICtrl');
 
 
 /**
  * @type {string}
  */
-plugin.basemap.TerrainNodeUITemplate =
+const template =
   '<span ng-if="nodeUi.show()" class="d-flex flex-shrink-0">' +
     '<span ng-if="nodeUi.isRemovable()" ng-click="nodeUi.remove()">' +
       '<i class="fa fa-times fa-fw c-glyph" title="Remove the terrain layer"></i></span>' +
@@ -21,46 +23,57 @@ plugin.basemap.TerrainNodeUITemplate =
  *
  * @return {angular.Directive}
  */
-plugin.basemap.terrainNodeUIDirective = function() {
-  return {
-    restrict: 'AE',
-    replace: true,
-    template: plugin.basemap.TerrainNodeUITemplate,
-    controller: plugin.basemap.TerrainNodeUICtrl,
-    controllerAs: 'nodeUi'
-  };
-};
+const directive = () => ({
+  restrict: 'AE',
+  replace: true,
+  template: template,
+  controller: Controller,
+  controllerAs: 'nodeUi'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'terrainnodeui';
 
 
 /**
  * Add the directive to the module.
  */
-os.ui.Module.directive('terrainnodeui', [plugin.basemap.terrainNodeUIDirective]);
+Module.directive('terrainnodeui', [directive]);
 
 
 
 /**
  * Controller for the terrain layer node UI.
- *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @extends {os.ui.node.DefaultLayerNodeUICtrl}
- * @constructor
- * @ngInject
+ * @unrestricted
  */
-plugin.basemap.TerrainNodeUICtrl = function($scope, $element) {
-  plugin.basemap.TerrainNodeUICtrl.base(this, 'constructor', $scope, $element);
-};
-goog.inherits(plugin.basemap.TerrainNodeUICtrl, os.ui.node.DefaultLayerNodeUICtrl);
+class Controller extends DefaultLayerNodeUICtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    super($scope, $element);
+  }
 
+  /**
+   * Remove the terrain layer.
+   *
+   * @override
+   * @export
+   */
+  remove() {
+    // remove the layer via setting change
+    Settings.getInstance().set(DisplaySetting.ENABLE_TERRAIN, false);
+  }
+}
 
-/**
- * Remove the terrain layer.
- *
- * @override
- * @export
- */
-plugin.basemap.TerrainNodeUICtrl.prototype.remove = function() {
-  // remove the layer via setting change
-  os.settings.set(os.config.DisplaySetting.ENABLE_TERRAIN, false);
+exports = {
+  Controller,
+  directive,
+  directiveTag
 };

--- a/src/plugin/basemap/terrainlayernodeui_shim.js
+++ b/src/plugin/basemap/terrainlayernodeui_shim.js
@@ -1,0 +1,13 @@
+goog.provide('plugin.basemap.TerrainNodeUICtrl');
+goog.provide('plugin.basemap.terrainNodeUIDirective');
+goog.require('plugin.basemap.TerrainNodeUI');
+
+/**
+ * @deprecated Please use goog.require('plugin.basemap.TerrainNodeUI').Controller instead.
+ */
+plugin.basemap.TerrainNodeUICtrl = plugin.basemap.TerrainNodeUI.Controller;
+
+/**
+ * @deprecated Please use goog.require('plugin.basemap.TerrainNodeUI').directive instead.
+ */
+plugin.basemap.terrainNodeUIDirective = plugin.basemap.TerrainNodeUI.directive;

--- a/src/plugin/basemap/ui/basemaplayerui.js
+++ b/src/plugin/basemap/ui/basemaplayerui.js
@@ -1,13 +1,14 @@
-goog.provide('plugin.basemap.ui.BaseMapLayerUICtrl');
-goog.provide('plugin.basemap.ui.baseMapLayerUIDirective');
+goog.module('plugin.basemap.ui.BaseMapLayerUI');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.async.Delay');
-goog.require('os');
-goog.require('os.MapContainer');
-goog.require('os.map');
-goog.require('os.ui.Module');
-goog.require('os.ui.layer.TileLayerUICtrl');
 goog.require('os.ui.spinnerDirective');
+
+const Delay = goog.require('goog.async.Delay');
+const os = goog.require('os');
+const MapContainer = goog.require('os.MapContainer');
+const osMap = goog.require('os.map');
+const Module = goog.require('os.ui.Module');
+const TileLayerUICtrl = goog.require('os.ui.layer.TileLayerUICtrl');
 
 
 /**
@@ -15,212 +16,216 @@ goog.require('os.ui.spinnerDirective');
  *
  * @return {!angular.Directive}
  */
-plugin.basemap.ui.baseMapLayerUIDirective = function() {
-  return {
-    restrict: 'AE',
-    replace: true,
-    templateUrl: os.ROOT + 'views/plugin/basemap/basemaplayerui.html',
-    controller: plugin.basemap.ui.BaseMapLayerUICtrl,
-    controllerAs: 'basemap'
-  };
-};
+const directive = () => ({
+  restrict: 'AE',
+  replace: true,
+  templateUrl: os.ROOT + 'views/plugin/basemap/basemaplayerui.html',
+  controller: Controller,
+  controllerAs: 'basemap'
+});
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'basemaplayerui';
 
 
 /**
  * Add the directive to the module
  */
-os.ui.Module.directive('basemaplayerui', [plugin.basemap.ui.baseMapLayerUIDirective]);
+Module.directive('basemaplayerui', [directive]);
 
 
 
 /**
  * Controller for the base map layer UI
- *
- * @param {!angular.Scope} $scope
- * @param {!angular.JQLite} $element
- * @param {!angular.$timeout} $timeout
- * @constructor
- * @extends {os.ui.layer.TileLayerUICtrl}
- * @ngInject
+ * @unrestricted
  */
-plugin.basemap.ui.BaseMapLayerUICtrl = function($scope, $element, $timeout) {
-  plugin.basemap.ui.BaseMapLayerUICtrl.base(this, 'constructor', $scope, $element, $timeout);
+class Controller extends TileLayerUICtrl {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope
+   * @param {!angular.JQLite} $element
+   * @param {!angular.$timeout} $timeout
+   * @ngInject
+   */
+  constructor($scope, $element, $timeout) {
+    super($scope, $element, $timeout);
 
-  $scope.$on('minZoom.spin', this.onMinZoomChange.bind(this));
-  $scope.$on('minZoom.spinchange', this.onMinZoomChange.bind(this));
-  $scope.$on('maxZoom.spin', this.onMaxZoomChange.bind(this));
-  $scope.$on('maxZoom.spinchange', this.onMaxZoomChange.bind(this));
+    $scope.$on('minZoom.spin', this.onMinZoomChange.bind(this));
+    $scope.$on('minZoom.spinchange', this.onMinZoomChange.bind(this));
+    $scope.$on('maxZoom.spin', this.onMaxZoomChange.bind(this));
+    $scope.$on('maxZoom.spinchange', this.onMaxZoomChange.bind(this));
 
-  this['mapMinZoom'] = os.map.MIN_ZOOM;
-  this['mapMaxZoom'] = os.map.MAX_ZOOM;
+    this['mapMinZoom'] = osMap.MIN_ZOOM;
+    this['mapMaxZoom'] = osMap.MAX_ZOOM;
 
-  this.refreshDelay = new goog.async.Delay(this.onRefresh, 1000, this);
-};
-goog.inherits(plugin.basemap.ui.BaseMapLayerUICtrl, os.ui.layer.TileLayerUICtrl);
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.ui.BaseMapLayerUICtrl.prototype.initUI = function() {
-  plugin.basemap.ui.BaseMapLayerUICtrl.base(this, 'initUI');
-
-  if (this.scope) {
-    this.scope['minZoom'] = this.getMinZoom_();
-    this.scope['maxZoom'] = this.getMaxZoom_();
+    this.refreshDelay = new Delay(this.onRefresh, 1000, this);
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  initUI() {
+    super.initUI();
 
-/**
- * Handles changes to min zoom
- *
- * @param {?angular.Scope.Event} event
- * @param {number} value
- * @protected
- */
-plugin.basemap.ui.BaseMapLayerUICtrl.prototype.onMinZoomChange = function(event, value) {
-  var items = /** @type {Array.<!os.data.LayerNode>} */ (this.scope['items']);
+    if (this.scope) {
+      this.scope['minZoom'] = this.getMinZoom_();
+      this.scope['maxZoom'] = this.getMaxZoom_();
+    }
+  }
 
-  if (items) {
-    var resolution = os.MapContainer.getInstance().zoomToResolution(value);
+  /**
+   * Handles changes to min zoom
+   *
+   * @param {?angular.Scope.Event} event
+   * @param {number} value
+   * @protected
+   */
+  onMinZoomChange(event, value) {
+    var items = /** @type {Array.<!os.data.LayerNode>} */ (this.scope['items']);
 
-    for (var i = 0, n = items.length; i < n; i++) {
-      try {
-        /** @type {ol.layer.Layer} */ (items[i].getLayer()).setMaxResolution(resolution);
-        this.refreshDelay.start();
-      } catch (e) {
+    if (items) {
+      var resolution = MapContainer.getInstance().zoomToResolution(value);
+
+      for (var i = 0, n = items.length; i < n; i++) {
+        try {
+          /** @type {ol.layer.Layer} */ (items[i].getLayer()).setMaxResolution(resolution);
+          this.refreshDelay.start();
+        } catch (e) {
+        }
       }
     }
   }
-};
 
+  /**
+   * Handles changes to max zoom
+   *
+   * @param {?angular.Scope.Event} event
+   * @param {number} value
+   * @protected
+   */
+  onMaxZoomChange(event, value) {
+    var items = /** @type {Array.<!os.data.LayerNode>} */ (this.scope['items']);
 
-/**
- * Handles changes to max zoom
- *
- * @param {?angular.Scope.Event} event
- * @param {number} value
- * @protected
- */
-plugin.basemap.ui.BaseMapLayerUICtrl.prototype.onMaxZoomChange = function(event, value) {
-  var items = /** @type {Array.<!os.data.LayerNode>} */ (this.scope['items']);
+    if (items) {
+      var resolution = MapContainer.getInstance().zoomToResolution(value);
 
-  if (items) {
-    var resolution = os.MapContainer.getInstance().zoomToResolution(value);
-
-    for (var i = 0, n = items.length; i < n; i++) {
-      try {
-        /** @type {ol.layer.Layer} */ (items[i].getLayer()).setMinResolution(resolution);
-        this.refreshDelay.start();
-      } catch (e) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        try {
+          /** @type {ol.layer.Layer} */ (items[i].getLayer()).setMinResolution(resolution);
+          this.refreshDelay.start();
+        } catch (e) {
+        }
       }
     }
   }
-};
 
+  /**
+   * @protected
+   */
+  onRefresh() {
+    // Changing the min/max zoom in Cesium affects the tile cache, so refresh
+    if (MapContainer.getInstance().is3DEnabled()) {
+      var items = /** @type {Array.<!os.data.LayerNode>} */ (this.scope['items']);
 
-/**
- * @protected
- */
-plugin.basemap.ui.BaseMapLayerUICtrl.prototype.onRefresh = function() {
-  // Changing the min/max zoom in Cesium affects the tile cache, so refresh
-  if (os.MapContainer.getInstance().is3DEnabled()) {
+      if (items) {
+        for (var i = 0, n = items.length; i < n; i++) {
+          var layer = items[i].getLayer();
+
+          if (layer && /** @type {ol.layer.Layer} */ (layer).getSource()) {
+            /** @type {ol.layer.Layer} */ (layer).getSource().refresh();
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Gets the min zoom
+   *
+   * @return {number} zoom
+   * @private
+   */
+  getMinZoom_() {
     var items = /** @type {Array.<!os.data.LayerNode>} */ (this.scope['items']);
 
     if (items) {
       for (var i = 0, n = items.length; i < n; i++) {
-        var layer = items[i].getLayer();
+        try {
+          var layer = /** @type {ol.layer.Layer} */ (items[i].getLayer());
 
-        if (layer && /** @type {ol.layer.Layer} */ (layer).getSource()) {
-          /** @type {ol.layer.Layer} */ (layer).getSource().refresh();
+          if (layer) {
+            return Math.round(MapContainer.getInstance().resolutionToZoom(layer.getMaxResolution()));
+          }
+        } catch (e) {
         }
       }
     }
+
+    return osMap.MIN_ZOOM;
   }
-};
 
+  /**
+   * Gets the max zoom
+   *
+   * @return {number}
+   * @private
+   */
+  getMaxZoom_() {
+    var items = /** @type {Array.<!os.data.LayerNode>} */ (this.scope['items']);
 
-/**
- * Gets the min zoom
- *
- * @return {number} zoom
- * @private
- */
-plugin.basemap.ui.BaseMapLayerUICtrl.prototype.getMinZoom_ = function() {
-  var items = /** @type {Array.<!os.data.LayerNode>} */ (this.scope['items']);
+    if (items) {
+      for (var i = 0, n = items.length; i < n; i++) {
+        try {
+          var layer = /** @type {ol.layer.Layer} */ (items[i].getLayer());
 
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      try {
-        var layer = /** @type {ol.layer.Layer} */ (items[i].getLayer());
-
-        if (layer) {
-          return Math.round(os.MapContainer.getInstance().resolutionToZoom(layer.getMaxResolution()));
+          if (layer) {
+            return Math.round(MapContainer.getInstance().resolutionToZoom(layer.getMinResolution()));
+          }
+        } catch (e) {
         }
-      } catch (e) {
       }
     }
+
+    return osMap.MAX_ZOOM;
   }
 
-  return os.map.MIN_ZOOM;
-};
+  /**
+   * @param {string} key The scope value to set
+   * @export
+   */
+  setCurrent(key) {
+    var map = MapContainer.getInstance();
+    var resolution;
 
-
-/**
- * Gets the max zoom
- *
- * @return {number}
- * @private
- */
-plugin.basemap.ui.BaseMapLayerUICtrl.prototype.getMaxZoom_ = function() {
-  var items = /** @type {Array.<!os.data.LayerNode>} */ (this.scope['items']);
-
-  if (items) {
-    for (var i = 0, n = items.length; i < n; i++) {
-      try {
-        var layer = /** @type {ol.layer.Layer} */ (items[i].getLayer());
-
-        if (layer) {
-          return Math.round(os.MapContainer.getInstance().resolutionToZoom(layer.getMinResolution()));
-        }
-      } catch (e) {
+    if (map.is3DEnabled()) {
+      // in 3D mode, the resolution should be determined based on the camera height adjusted to the equator. this will
+      // prevent the 2D projection from interfering with the relative zoom
+      var camera = map.getWebGLCamera();
+      if (camera) {
+        resolution = camera.calcResolutionForDistance(camera.getAltitude(), 0);
       }
-    }
-  }
-
-  return os.map.MAX_ZOOM;
-};
-
-
-/**
- * @param {string} key The scope value to set
- * @export
- */
-plugin.basemap.ui.BaseMapLayerUICtrl.prototype.setCurrent = function(key) {
-  var map = os.MapContainer.getInstance();
-  var resolution;
-
-  if (map.is3DEnabled()) {
-    // in 3D mode, the resolution should be determined based on the camera height adjusted to the equator. this will
-    // prevent the 2D projection from interfering with the relative zoom
-    var camera = map.getWebGLCamera();
-    if (camera) {
-      resolution = camera.calcResolutionForDistance(camera.getAltitude(), 0);
-    }
-  } else {
-    resolution = map.getMap().getView().getResolution();
-  }
-
-  if (resolution != null) {
-    // zoom level should be an integer inclusive of the current level
-    this.scope[key] = Math.floor(map.resolutionToZoom(resolution));
-
-    if (key == 'minZoom') {
-      this.onMinZoomChange(null, this.scope[key]);
     } else {
-      this.onMaxZoomChange(null, this.scope[key]);
+      resolution = map.getMap().getView().getResolution();
+    }
+
+    if (resolution != null) {
+      // zoom level should be an integer inclusive of the current level
+      this.scope[key] = Math.floor(map.resolutionToZoom(resolution));
+
+      if (key == 'minZoom') {
+        this.onMinZoomChange(null, this.scope[key]);
+      } else {
+        this.onMaxZoomChange(null, this.scope[key]);
+      }
     }
   }
-};
+}
 
+exports = {
+  Controller,
+  directive,
+  directiveTag
+};

--- a/src/plugin/basemap/ui/basemaplayerui_shim.js
+++ b/src/plugin/basemap/ui/basemaplayerui_shim.js
@@ -1,0 +1,13 @@
+goog.provide('plugin.basemap.ui.BaseMapLayerUICtrl');
+goog.provide('plugin.basemap.ui.baseMapLayerUIDirective');
+goog.require('plugin.basemap.ui.BaseMapLayerUI');
+
+/**
+ * @deprecated Please use goog.require('plugin.basemap.ui.BaseMapLayerUI').Controller instead.
+ */
+plugin.basemap.ui.BaseMapLayerUICtrl = plugin.basemap.ui.BaseMapLayerUI.Controller;
+
+/**
+ * @deprecated Please use goog.require('plugin.basemap.ui.BaseMapLayerUI').directive instead.
+ */
+plugin.basemap.ui.baseMapLayerUIDirective = plugin.basemap.ui.BaseMapLayerUI.directive;

--- a/src/plugin/basemap/v2/basemapstate.js
+++ b/src/plugin/basemap/v2/basemapstate.js
@@ -1,8 +1,13 @@
 goog.module('plugin.basemap.v2.BaseMapState');
 goog.module.declareLegacyNamespace();
 
+const googDomXml = goog.require('goog.dom.xml');
+const log = goog.require('goog.log');
+const MapContainer = goog.require('os.MapContainer');
 const net = goog.require('os.net');
 const LayerState = goog.require('os.state.v2.LayerState');
+const BaseProvider = goog.require('os.ui.data.BaseProvider');
+const xml = goog.require('os.xml');
 const basemap = goog.require('plugin.basemap');
 const BaseMap = goog.require('plugin.basemap.layer.BaseMap');
 const BaseMapTag = goog.require('plugin.basemap.v2.BaseMapTag');
@@ -51,7 +56,7 @@ class BaseMapState extends LayerState {
   layerToXML(layer, options, opt_exclusions, opt_layerConfig) {
     var layerEl = super.layerToXML(layer, options, opt_exclusions, opt_layerConfig);
     if (layerEl) {
-      goog.dom.xml.setAttributes(layerEl, {
+      googDomXml.setAttributes(layerEl, {
         'type': layer.getLayerOptions()['baseType'] || 'wms'
       });
     }
@@ -64,12 +69,12 @@ class BaseMapState extends LayerState {
   defaultConfigToXML(key, value, layerEl) {
     switch (key) {
       case 'minResolution':
-        var maxZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-        os.xml.appendElement(BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
+        var maxZoom = Math.round(MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+        xml.appendElement(BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
         break;
       case 'maxResolution':
-        var minZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-        os.xml.appendElement(BaseMapTag.MIN_ZOOM, layerEl, minZoom);
+        var minZoom = Math.round(MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+        xml.appendElement(BaseMapTag.MIN_ZOOM, layerEl, minZoom);
         break;
       case 'minZoom':
       case 'maxZoom':
@@ -89,7 +94,7 @@ class BaseMapState extends LayerState {
     options['baseType'] = options['type'].toUpperCase();
     options['layerType'] = basemap.LAYER_TYPE;
     options['type'] = basemap.TYPE;
-    options['id'] = options['id'].replace(os.ui.data.BaseProvider.ID_DELIMITER, '-');
+    options['id'] = options['id'].replace(BaseProvider.ID_DELIMITER, '-');
 
     if (typeof options['url'] == 'string') {
       options['crossOrigin'] = net.getCrossOrigin(/** @type {string} */ (options['url']));
@@ -113,7 +118,7 @@ class BaseMapState extends LayerState {
  * Logger
  * @type {goog.log.Logger}
  */
-logger = goog.log.getLogger('plugin.basemap.v2.BaseMapState');
+logger = log.getLogger('plugin.basemap.v2.BaseMapState');
 
 
 exports = BaseMapState;

--- a/src/plugin/basemap/v2/basemapstate.js
+++ b/src/plugin/basemap/v2/basemapstate.js
@@ -1,130 +1,119 @@
-goog.provide('plugin.basemap.v2.BaseMapState');
-goog.provide('plugin.basemap.v2.BaseMapTag');
+goog.module('plugin.basemap.v2.BaseMapState');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.string');
-goog.require('os.net');
-goog.require('os.state.v2.LayerState');
-goog.require('plugin.basemap');
-goog.require('plugin.basemap.layer.BaseMap');
-
-
-/**
- * XML tags for base map state
- * @enum {string}
- */
-plugin.basemap.v2.BaseMapTag = {
-  MAX_ZOOM: 'maxZoom',
-  MIN_ZOOM: 'minZoom'
-};
-
+const net = goog.require('os.net');
+const LayerState = goog.require('os.state.v2.LayerState');
+const basemap = goog.require('plugin.basemap');
+const BaseMap = goog.require('plugin.basemap.layer.BaseMap');
+const BaseMapTag = goog.require('plugin.basemap.v2.BaseMapTag');
 
 
 /**
- * @extends {os.state.v2.LayerState}
- * @constructor
+ * Basemap state v2.
+ * @unrestricted
  */
-plugin.basemap.v2.BaseMapState = function() {
-  plugin.basemap.v2.BaseMapState.base(this, 'constructor');
-  this.description = 'Saves the current map layers';
-  this['enabled'] = false;
-  this.rootAttrs = {
-    'type': 'map'
-  };
-  this.title = 'Map Layers';
+class BaseMapState extends LayerState {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.description = 'Saves the current map layers';
+    this['enabled'] = false;
+    this.rootAttrs = {
+      'type': 'map'
+    };
+    this.title = 'Map Layers';
+
+    /**
+     * @type {goog.log.Logger}
+     * @protected
+     */
+    this.logger = logger;
+  }
 
   /**
-   * @type {goog.log.Logger}
-   * @protected
+   * @inheritDoc
    */
-  this.logger = plugin.basemap.v2.BaseMapState.LOGGER_;
-};
-goog.inherits(plugin.basemap.v2.BaseMapState, os.state.v2.LayerState);
+  isValid(layer) {
+    try {
+      return layer instanceof BaseMap && layer.getLayerOptions() != null;
+    } catch (e) {
+      // may not be a os.layer.ILayer... so don't persist it
+    }
+
+    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  layerToXML(layer, options, opt_exclusions, opt_layerConfig) {
+    var layerEl = super.layerToXML(layer, options, opt_exclusions, opt_layerConfig);
+    if (layerEl) {
+      goog.dom.xml.setAttributes(layerEl, {
+        'type': layer.getLayerOptions()['baseType'] || 'wms'
+      });
+    }
+    return layerEl;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  defaultConfigToXML(key, value, layerEl) {
+    switch (key) {
+      case 'minResolution':
+        var maxZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+        os.xml.appendElement(BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
+        break;
+      case 'maxResolution':
+        var minZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+        os.xml.appendElement(BaseMapTag.MIN_ZOOM, layerEl, minZoom);
+        break;
+      case 'minZoom':
+      case 'maxZoom':
+        // ignore these - min/max resolution will be converted instead
+        break;
+      default:
+        super.defaultConfigToXML(key, value, layerEl);
+        break;
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  xmlToOptions(node) {
+    var options = super.xmlToOptions(node);
+    options['baseType'] = options['type'].toUpperCase();
+    options['layerType'] = basemap.LAYER_TYPE;
+    options['type'] = basemap.TYPE;
+    options['id'] = options['id'].replace(os.ui.data.BaseProvider.ID_DELIMITER, '-');
+
+    if (typeof options['url'] == 'string') {
+      options['crossOrigin'] = net.getCrossOrigin(/** @type {string} */ (options['url']));
+    }
+
+    // zoom is 1 higher in opensphere than in legacy apps
+    if (typeof options['minZoom'] === 'number') {
+      options['minZoom'] = options['minZoom'] + 1;
+    }
+
+    if (typeof options['maxZoom'] === 'number') {
+      options['maxZoom'] = options['maxZoom'] + 1;
+    }
+
+    return options;
+  }
+}
 
 
 /**
  * Logger
  * @type {goog.log.Logger}
- * @private
- * @const
  */
-plugin.basemap.v2.BaseMapState.LOGGER_ = goog.log.getLogger('plugin.basemap.v2.BaseMapState');
+logger = goog.log.getLogger('plugin.basemap.v2.BaseMapState');
 
 
-/**
- * @inheritDoc
- */
-plugin.basemap.v2.BaseMapState.prototype.isValid = function(layer) {
-  try {
-    return layer instanceof plugin.basemap.layer.BaseMap && layer.getLayerOptions() != null;
-  } catch (e) {
-    // may not be a os.layer.ILayer... so don't persist it
-  }
-
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.v2.BaseMapState.prototype.layerToXML = function(layer, options, opt_exclusions, opt_layerConfig) {
-  var layerEl = plugin.basemap.v2.BaseMapState.base(this, 'layerToXML',
-      layer, options, opt_exclusions, opt_layerConfig);
-  if (layerEl) {
-    goog.dom.xml.setAttributes(layerEl, {
-      'type': layer.getLayerOptions()['baseType'] || 'wms'
-    });
-  }
-  return layerEl;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.v2.BaseMapState.prototype.defaultConfigToXML = function(key, value, layerEl) {
-  switch (key) {
-    case 'minResolution':
-      var maxZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-      os.xml.appendElement(plugin.basemap.v2.BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
-      break;
-    case 'maxResolution':
-      var minZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-      os.xml.appendElement(plugin.basemap.v2.BaseMapTag.MIN_ZOOM, layerEl, minZoom);
-      break;
-    case 'minZoom':
-    case 'maxZoom':
-      // ignore these - min/max resolution will be converted instead
-      break;
-    default:
-      plugin.basemap.v2.BaseMapState.base(this, 'defaultConfigToXML', key, value, layerEl);
-      break;
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.v2.BaseMapState.prototype.xmlToOptions = function(node) {
-  var options = plugin.basemap.v2.BaseMapState.base(this, 'xmlToOptions', node);
-  options['baseType'] = options['type'].toUpperCase();
-  options['layerType'] = plugin.basemap.LAYER_TYPE;
-  options['type'] = plugin.basemap.TYPE;
-  options['id'] = options['id'].replace(os.ui.data.BaseProvider.ID_DELIMITER, '-');
-
-  if (typeof options['url'] == 'string') {
-    options['crossOrigin'] = os.net.getCrossOrigin(/** @type {string} */ (options['url']));
-  }
-
-  // zoom is 1 higher in opensphere than in legacy apps
-  if (typeof options['minZoom'] === 'number') {
-    options['minZoom'] = options['minZoom'] + 1;
-  }
-
-  if (typeof options['maxZoom'] === 'number') {
-    options['maxZoom'] = options['maxZoom'] + 1;
-  }
-
-  return options;
-};
+exports = BaseMapState;

--- a/src/plugin/basemap/v2/basemaptag.js
+++ b/src/plugin/basemap/v2/basemaptag.js
@@ -1,0 +1,11 @@
+goog.module('plugin.basemap.v2.BaseMapTag');
+goog.module.declareLegacyNamespace();
+
+/**
+ * XML tags for base map state
+ * @enum {string}
+ */
+exports = {
+  MAX_ZOOM: 'maxZoom',
+  MIN_ZOOM: 'minZoom'
+};

--- a/src/plugin/basemap/v3/basemapstate.js
+++ b/src/plugin/basemap/v3/basemapstate.js
@@ -1,8 +1,13 @@
 goog.module('plugin.basemap.v3.BaseMapState');
 goog.module.declareLegacyNamespace();
 
+const googDomXml = goog.require('goog.dom.xml');
+const log = goog.require('goog.log');
+const MapContainer = goog.require('os.MapContainer');
 const net = goog.require('os.net');
 const LayerState = goog.require('os.state.v3.LayerState');
+const BaseProvider = goog.require('os.ui.data.BaseProvider');
+const xml = goog.require('os.xml');
 const basemap = goog.require('plugin.basemap');
 const BaseMap = goog.require('plugin.basemap.layer.BaseMap');
 const BaseMapTag = goog.require('plugin.basemap.v3.BaseMapTag');
@@ -51,7 +56,7 @@ class BaseMapState extends LayerState {
   layerToXML(layer, options, opt_exclusions, opt_layerConfig) {
     var layerEl = super.layerToXML(layer, options, opt_exclusions, opt_layerConfig);
     if (layerEl) {
-      goog.dom.xml.setAttributes(layerEl, {
+      googDomXml.setAttributes(layerEl, {
         'type': layer.getLayerOptions()['baseType'] || 'wms'
       });
     }
@@ -64,12 +69,12 @@ class BaseMapState extends LayerState {
   defaultConfigToXML(key, value, layerEl) {
     switch (key) {
       case 'minResolution':
-        var maxZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-        os.xml.appendElement(BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
+        var maxZoom = Math.round(MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+        xml.appendElement(BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
         break;
       case 'maxResolution':
-        var minZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-        os.xml.appendElement(BaseMapTag.MIN_ZOOM, layerEl, minZoom);
+        var minZoom = Math.round(MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+        xml.appendElement(BaseMapTag.MIN_ZOOM, layerEl, minZoom);
         break;
       case 'minZoom':
       case 'maxZoom':
@@ -89,7 +94,7 @@ class BaseMapState extends LayerState {
     options['baseType'] = options['type'].toUpperCase();
     options['layerType'] = basemap.LAYER_TYPE;
     options['type'] = basemap.TYPE;
-    options['id'] = options['id'].replace(os.ui.data.BaseProvider.ID_DELIMITER, '-');
+    options['id'] = options['id'].replace(BaseProvider.ID_DELIMITER, '-');
 
     if (typeof options['url'] == 'string') {
       options['crossOrigin'] = net.getCrossOrigin(/** @type {string} */ (options['url']));
@@ -113,7 +118,7 @@ class BaseMapState extends LayerState {
  * Logger
  * @type {goog.log.Logger}
  */
-const logger = goog.log.getLogger('plugin.basemap.v3.BaseMapState');
+const logger = log.getLogger('plugin.basemap.v3.BaseMapState');
 
 
 exports = BaseMapState;

--- a/src/plugin/basemap/v3/basemapstate.js
+++ b/src/plugin/basemap/v3/basemapstate.js
@@ -1,130 +1,119 @@
-goog.provide('plugin.basemap.v3.BaseMapState');
-goog.provide('plugin.basemap.v3.BaseMapTag');
+goog.module('plugin.basemap.v3.BaseMapState');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.string');
-goog.require('os.net');
-goog.require('os.state.v3.LayerState');
-goog.require('plugin.basemap');
-goog.require('plugin.basemap.layer.BaseMap');
-
-
-/**
- * XML tags for base map state
- * @enum {string}
- */
-plugin.basemap.v3.BaseMapTag = {
-  MAX_ZOOM: 'maxZoom',
-  MIN_ZOOM: 'minZoom'
-};
-
+const net = goog.require('os.net');
+const LayerState = goog.require('os.state.v3.LayerState');
+const basemap = goog.require('plugin.basemap');
+const BaseMap = goog.require('plugin.basemap.layer.BaseMap');
+const BaseMapTag = goog.require('plugin.basemap.v3.BaseMapTag');
 
 
 /**
- * @extends {os.state.v3.LayerState}
- * @constructor
+ * Basemap state v3.
+ * @unrestricted
  */
-plugin.basemap.v3.BaseMapState = function() {
-  plugin.basemap.v3.BaseMapState.base(this, 'constructor');
-  this.description = 'Saves the current map layers';
-  this['enabled'] = false;
-  this.rootAttrs = {
-    'type': 'map'
-  };
-  this.title = 'Map Layers';
+class BaseMapState extends LayerState {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.description = 'Saves the current map layers';
+    this['enabled'] = false;
+    this.rootAttrs = {
+      'type': 'map'
+    };
+    this.title = 'Map Layers';
+
+    /**
+     * @type {goog.log.Logger}
+     * @protected
+     */
+    this.logger = logger;
+  }
 
   /**
-   * @type {goog.log.Logger}
-   * @protected
+   * @inheritDoc
    */
-  this.logger = plugin.basemap.v3.BaseMapState.LOGGER_;
-};
-goog.inherits(plugin.basemap.v3.BaseMapState, os.state.v3.LayerState);
+  isValid(layer) {
+    try {
+      return layer instanceof BaseMap && layer.getLayerOptions() != null;
+    } catch (e) {
+      // may not be a os.layer.ILayer... so don't persist it
+    }
+
+    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  layerToXML(layer, options, opt_exclusions, opt_layerConfig) {
+    var layerEl = super.layerToXML(layer, options, opt_exclusions, opt_layerConfig);
+    if (layerEl) {
+      goog.dom.xml.setAttributes(layerEl, {
+        'type': layer.getLayerOptions()['baseType'] || 'wms'
+      });
+    }
+    return layerEl;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  defaultConfigToXML(key, value, layerEl) {
+    switch (key) {
+      case 'minResolution':
+        var maxZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+        os.xml.appendElement(BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
+        break;
+      case 'maxResolution':
+        var minZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+        os.xml.appendElement(BaseMapTag.MIN_ZOOM, layerEl, minZoom);
+        break;
+      case 'minZoom':
+      case 'maxZoom':
+        // ignore these - min/max resolution will be converted instead
+        break;
+      default:
+        super.defaultConfigToXML(key, value, layerEl);
+        break;
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  xmlToOptions(node) {
+    var options = super.xmlToOptions(node);
+    options['baseType'] = options['type'].toUpperCase();
+    options['layerType'] = basemap.LAYER_TYPE;
+    options['type'] = basemap.TYPE;
+    options['id'] = options['id'].replace(os.ui.data.BaseProvider.ID_DELIMITER, '-');
+
+    if (typeof options['url'] == 'string') {
+      options['crossOrigin'] = net.getCrossOrigin(/** @type {string} */ (options['url']));
+    }
+
+    // zoom is 1 higher in opensphere than in legacy apps
+    if (typeof options['minZoom'] === 'number') {
+      options['minZoom'] = options['minZoom'] + 1;
+    }
+
+    if (typeof options['maxZoom'] === 'number') {
+      options['maxZoom'] = options['maxZoom'] + 1;
+    }
+
+    return options;
+  }
+}
 
 
 /**
  * Logger
  * @type {goog.log.Logger}
- * @private
- * @const
  */
-plugin.basemap.v3.BaseMapState.LOGGER_ = goog.log.getLogger('plugin.basemap.v3.BaseMapState');
+const logger = goog.log.getLogger('plugin.basemap.v3.BaseMapState');
 
 
-/**
- * @inheritDoc
- */
-plugin.basemap.v3.BaseMapState.prototype.isValid = function(layer) {
-  try {
-    return layer instanceof plugin.basemap.layer.BaseMap && layer.getLayerOptions() != null;
-  } catch (e) {
-    // may not be a os.layer.ILayer... so don't persist it
-  }
-
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.v3.BaseMapState.prototype.layerToXML = function(layer, options, opt_exclusions, opt_layerConfig) {
-  var layerEl = plugin.basemap.v3.BaseMapState.base(this, 'layerToXML',
-      layer, options, opt_exclusions, opt_layerConfig);
-  if (layerEl) {
-    goog.dom.xml.setAttributes(layerEl, {
-      'type': layer.getLayerOptions()['baseType'] || 'wms'
-    });
-  }
-  return layerEl;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.v3.BaseMapState.prototype.defaultConfigToXML = function(key, value, layerEl) {
-  switch (key) {
-    case 'minResolution':
-      var maxZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-      os.xml.appendElement(plugin.basemap.v3.BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
-      break;
-    case 'maxResolution':
-      var minZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-      os.xml.appendElement(plugin.basemap.v3.BaseMapTag.MIN_ZOOM, layerEl, minZoom);
-      break;
-    case 'minZoom':
-    case 'maxZoom':
-      // ignore these - min/max resolution will be converted instead
-      break;
-    default:
-      plugin.basemap.v3.BaseMapState.base(this, 'defaultConfigToXML', key, value, layerEl);
-      break;
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.v3.BaseMapState.prototype.xmlToOptions = function(node) {
-  var options = plugin.basemap.v3.BaseMapState.base(this, 'xmlToOptions', node);
-  options['baseType'] = options['type'].toUpperCase();
-  options['layerType'] = plugin.basemap.LAYER_TYPE;
-  options['type'] = plugin.basemap.TYPE;
-  options['id'] = options['id'].replace(os.ui.data.BaseProvider.ID_DELIMITER, '-');
-
-  if (typeof options['url'] == 'string') {
-    options['crossOrigin'] = os.net.getCrossOrigin(/** @type {string} */ (options['url']));
-  }
-
-  // zoom is 1 higher in opensphere than in legacy apps
-  if (typeof options['minZoom'] === 'number') {
-    options['minZoom'] = options['minZoom'] + 1;
-  }
-
-  if (typeof options['maxZoom'] === 'number') {
-    options['maxZoom'] = options['maxZoom'] + 1;
-  }
-
-  return options;
-};
+exports = BaseMapState;

--- a/src/plugin/basemap/v3/basemaptag.js
+++ b/src/plugin/basemap/v3/basemaptag.js
@@ -1,0 +1,11 @@
+goog.module('plugin.basemap.v3.BaseMapTag');
+goog.module.declareLegacyNamespace();
+
+/**
+ * XML tags for base map state
+ * @enum {string}
+ */
+exports = {
+  MAX_ZOOM: 'maxZoom',
+  MIN_ZOOM: 'minZoom'
+};

--- a/src/plugin/basemap/v4/basemapstate.js
+++ b/src/plugin/basemap/v4/basemapstate.js
@@ -1,131 +1,120 @@
-goog.provide('plugin.basemap.v4.BaseMapState');
-goog.provide('plugin.basemap.v4.BaseMapTag');
+goog.module('plugin.basemap.v4.BaseMapState');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.string');
-goog.require('os.net');
-goog.require('os.state.v4.LayerState');
-goog.require('plugin.basemap');
-goog.require('plugin.basemap.layer.BaseMap');
-
-
-/**
- * XML tags for base map state
- * @enum {string}
- */
-plugin.basemap.v4.BaseMapTag = {
-  MAX_ZOOM: 'maxZoom',
-  MIN_ZOOM: 'minZoom'
-};
-
+const net = goog.require('os.net');
+const LayerState = goog.require('os.state.v4.LayerState');
+const basemap = goog.require('plugin.basemap');
+const BaseMap = goog.require('plugin.basemap.layer.BaseMap');
+const BaseMapTag = goog.require('plugin.basemap.v4.BaseMapTag');
 
 
 /**
- * @extends {os.state.v4.LayerState}
- * @constructor
+ * Basemap state v4.
+ * @unrestricted
  */
-plugin.basemap.v4.BaseMapState = function() {
-  plugin.basemap.v4.BaseMapState.base(this, 'constructor');
-  this.description = 'Saves the current map layers';
-  this['enabled'] = false;
-  this.rootName = 'mapLayers';
-  this.rootAttrs = {
-    'type': 'map'
-  };
-  this.title = 'Map Layers';
+class BaseMapState extends LayerState {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.description = 'Saves the current map layers';
+    this['enabled'] = false;
+    this.rootName = 'mapLayers';
+    this.rootAttrs = {
+      'type': 'map'
+    };
+    this.title = 'Map Layers';
+
+    /**
+     * @type {goog.log.Logger}
+     * @protected
+     */
+    this.logger = logger;
+  }
 
   /**
-   * @type {goog.log.Logger}
-   * @protected
+   * @inheritDoc
    */
-  this.logger = plugin.basemap.v4.BaseMapState.LOGGER_;
-};
-goog.inherits(plugin.basemap.v4.BaseMapState, os.state.v4.LayerState);
+  isValid(layer) {
+    try {
+      return layer instanceof BaseMap && layer.getLayerOptions() != null;
+    } catch (e) {
+      // may not be a os.layer.ILayer... so don't persist it
+    }
+
+    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  layerToXML(layer, options, opt_exclusions, opt_layerConfig) {
+    var layerEl = super.layerToXML(layer, options, opt_exclusions, opt_layerConfig);
+    if (layerEl) {
+      goog.dom.xml.setAttributes(layerEl, {
+        'type': layer.getLayerOptions()['baseType'] || 'wms'
+      });
+    }
+    return layerEl;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  defaultConfigToXML(key, value, layerEl) {
+    switch (key) {
+      case 'minResolution':
+        var maxZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+        os.xml.appendElement(BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
+        break;
+      case 'maxResolution':
+        var minZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+        os.xml.appendElement(BaseMapTag.MIN_ZOOM, layerEl, minZoom);
+        break;
+      case 'minZoom':
+      case 'maxZoom':
+        // ignore these - min/max resolution will be converted instead
+        break;
+      default:
+        super.defaultConfigToXML(key, value, layerEl);
+        break;
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  xmlToOptions(node) {
+    var options = super.xmlToOptions(node);
+    options['baseType'] = options['type'].toUpperCase();
+    options['layerType'] = basemap.LAYER_TYPE;
+    options['type'] = basemap.TYPE;
+    options['id'] = options['id'].replace(os.ui.data.BaseProvider.ID_DELIMITER, '-');
+
+    if (typeof options['url'] == 'string') {
+      options['crossOrigin'] = net.getCrossOrigin(/** @type {string} */ (options['url']));
+    }
+
+    // zoom is 1 higher in opensphere than in legacy apps
+    if (typeof options['minZoom'] === 'number') {
+      options['minZoom'] = options['minZoom'] + 1;
+    }
+
+    if (typeof options['maxZoom'] === 'number') {
+      options['maxZoom'] = options['maxZoom'] + 1;
+    }
+
+    return options;
+  }
+}
 
 
 /**
  * Logger
  * @type {goog.log.Logger}
- * @private
- * @const
  */
-plugin.basemap.v4.BaseMapState.LOGGER_ = goog.log.getLogger('plugin.basemap.v4.BaseMapState');
+const logger = goog.log.getLogger('plugin.basemap.v4.BaseMapState');
 
 
-/**
- * @inheritDoc
- */
-plugin.basemap.v4.BaseMapState.prototype.isValid = function(layer) {
-  try {
-    return layer instanceof plugin.basemap.layer.BaseMap && layer.getLayerOptions() != null;
-  } catch (e) {
-    // may not be a os.layer.ILayer... so don't persist it
-  }
-
-  return false;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.v4.BaseMapState.prototype.layerToXML = function(layer, options, opt_exclusions, opt_layerConfig) {
-  var layerEl = plugin.basemap.v4.BaseMapState.base(this, 'layerToXML',
-      layer, options, opt_exclusions, opt_layerConfig);
-  if (layerEl) {
-    goog.dom.xml.setAttributes(layerEl, {
-      'type': layer.getLayerOptions()['baseType'] || 'wms'
-    });
-  }
-  return layerEl;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.v4.BaseMapState.prototype.defaultConfigToXML = function(key, value, layerEl) {
-  switch (key) {
-    case 'minResolution':
-      var maxZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-      os.xml.appendElement(plugin.basemap.v4.BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
-      break;
-    case 'maxResolution':
-      var minZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-      os.xml.appendElement(plugin.basemap.v4.BaseMapTag.MIN_ZOOM, layerEl, minZoom);
-      break;
-    case 'minZoom':
-    case 'maxZoom':
-      // ignore these - min/max resolution will be converted instead
-      break;
-    default:
-      plugin.basemap.v4.BaseMapState.base(this, 'defaultConfigToXML', key, value, layerEl);
-      break;
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.basemap.v4.BaseMapState.prototype.xmlToOptions = function(node) {
-  var options = plugin.basemap.v4.BaseMapState.base(this, 'xmlToOptions', node);
-  options['baseType'] = options['type'].toUpperCase();
-  options['layerType'] = plugin.basemap.LAYER_TYPE;
-  options['type'] = plugin.basemap.TYPE;
-  options['id'] = options['id'].replace(os.ui.data.BaseProvider.ID_DELIMITER, '-');
-
-  if (typeof options['url'] == 'string') {
-    options['crossOrigin'] = os.net.getCrossOrigin(/** @type {string} */ (options['url']));
-  }
-
-  // zoom is 1 higher in opensphere than in legacy apps
-  if (typeof options['minZoom'] === 'number') {
-    options['minZoom'] = options['minZoom'] + 1;
-  }
-
-  if (typeof options['maxZoom'] === 'number') {
-    options['maxZoom'] = options['maxZoom'] + 1;
-  }
-
-  return options;
-};
+exports = BaseMapState;

--- a/src/plugin/basemap/v4/basemapstate.js
+++ b/src/plugin/basemap/v4/basemapstate.js
@@ -70,16 +70,26 @@ class BaseMapState extends LayerState {
   defaultConfigToXML(key, value, layerEl) {
     switch (key) {
       case 'minResolution':
-        var maxZoom = Math.round(MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-        xml.appendElement(BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
+        if (!hasMaxZoom(layerEl) && typeof value === 'number') {
+          var maxZoom = Math.round(MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+          xml.appendElement(BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
+        }
         break;
       case 'maxResolution':
-        var minZoom = Math.round(MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-        xml.appendElement(BaseMapTag.MIN_ZOOM, layerEl, minZoom);
+        if (!hasMinZoom(layerEl) && typeof value === 'number') {
+          var minZoom = Math.round(MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+          xml.appendElement(BaseMapTag.MIN_ZOOM, layerEl, minZoom);
+        }
         break;
       case 'minZoom':
+        if (!hasMinZoom(layerEl) && typeof value === 'number') {
+          xml.appendElement(BaseMapTag.MIN_ZOOM, layerEl, value - 1);
+        }
+        break;
       case 'maxZoom':
-        // ignore these - min/max resolution will be converted instead
+        if (!hasMaxZoom(layerEl) && typeof value === 'number') {
+          xml.appendElement(BaseMapTag.MAX_ZOOM, layerEl, value - 1);
+        }
         break;
       default:
         super.defaultConfigToXML(key, value, layerEl);
@@ -113,6 +123,22 @@ class BaseMapState extends LayerState {
     return options;
   }
 }
+
+
+/**
+ * If a max zoom element is present.
+ * @param {!Element} el
+ * @return {boolean}
+ */
+const hasMaxZoom = (el) => !!el.querySelector(BaseMapTag.MAX_ZOOM);
+
+
+/**
+ * If a min zoom element is present.
+ * @param {!Element} el
+ * @return {boolean}
+ */
+const hasMinZoom = (el) => !!el.querySelector(BaseMapTag.MIN_ZOOM);
 
 
 /**

--- a/src/plugin/basemap/v4/basemapstate.js
+++ b/src/plugin/basemap/v4/basemapstate.js
@@ -1,8 +1,13 @@
 goog.module('plugin.basemap.v4.BaseMapState');
 goog.module.declareLegacyNamespace();
 
+const googDomXml = goog.require('goog.dom.xml');
+const log = goog.require('goog.log');
+const MapContainer = goog.require('os.MapContainer');
 const net = goog.require('os.net');
 const LayerState = goog.require('os.state.v4.LayerState');
+const BaseProvider = goog.require('os.ui.data.BaseProvider');
+const xml = goog.require('os.xml');
 const basemap = goog.require('plugin.basemap');
 const BaseMap = goog.require('plugin.basemap.layer.BaseMap');
 const BaseMapTag = goog.require('plugin.basemap.v4.BaseMapTag');
@@ -52,7 +57,7 @@ class BaseMapState extends LayerState {
   layerToXML(layer, options, opt_exclusions, opt_layerConfig) {
     var layerEl = super.layerToXML(layer, options, opt_exclusions, opt_layerConfig);
     if (layerEl) {
-      goog.dom.xml.setAttributes(layerEl, {
+      googDomXml.setAttributes(layerEl, {
         'type': layer.getLayerOptions()['baseType'] || 'wms'
       });
     }
@@ -65,12 +70,12 @@ class BaseMapState extends LayerState {
   defaultConfigToXML(key, value, layerEl) {
     switch (key) {
       case 'minResolution':
-        var maxZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-        os.xml.appendElement(BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
+        var maxZoom = Math.round(MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+        xml.appendElement(BaseMapTag.MAX_ZOOM, layerEl, maxZoom);
         break;
       case 'maxResolution':
-        var minZoom = Math.round(os.MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
-        os.xml.appendElement(BaseMapTag.MIN_ZOOM, layerEl, minZoom);
+        var minZoom = Math.round(MapContainer.getInstance().resolutionToZoom(/** @type {number} */ (value)) - 1);
+        xml.appendElement(BaseMapTag.MIN_ZOOM, layerEl, minZoom);
         break;
       case 'minZoom':
       case 'maxZoom':
@@ -90,7 +95,7 @@ class BaseMapState extends LayerState {
     options['baseType'] = options['type'].toUpperCase();
     options['layerType'] = basemap.LAYER_TYPE;
     options['type'] = basemap.TYPE;
-    options['id'] = options['id'].replace(os.ui.data.BaseProvider.ID_DELIMITER, '-');
+    options['id'] = options['id'].replace(BaseProvider.ID_DELIMITER, '-');
 
     if (typeof options['url'] == 'string') {
       options['crossOrigin'] = net.getCrossOrigin(/** @type {string} */ (options['url']));
@@ -114,7 +119,7 @@ class BaseMapState extends LayerState {
  * Logger
  * @type {goog.log.Logger}
  */
-const logger = goog.log.getLogger('plugin.basemap.v4.BaseMapState');
+const logger = log.getLogger('plugin.basemap.v4.BaseMapState');
 
 
 exports = BaseMapState;

--- a/src/plugin/basemap/v4/basemaptag.js
+++ b/src/plugin/basemap/v4/basemaptag.js
@@ -1,0 +1,11 @@
+goog.module('plugin.basemap.v4.BaseMapTag');
+goog.module.declareLegacyNamespace();
+
+/**
+ * XML tags for base map state
+ * @enum {string}
+ */
+exports = {
+  MAX_ZOOM: 'maxZoom',
+  MIN_ZOOM: 'minZoom'
+};

--- a/src/plugin/cesium/terrainlayer.js
+++ b/src/plugin/cesium/terrainlayer.js
@@ -1,13 +1,12 @@
 goog.module('plugin.cesium.TerrainLayer');
 
-goog.require('plugin.basemap.terrainNodeUIDirective');
-
 const log = goog.require('goog.log');
 const dispatcher = goog.require('os.Dispatcher');
 const MapEvent = goog.require('os.MapEvent');
 const LayerNode = goog.require('os.data.LayerNode');
 const LayerType = goog.require('os.layer.LayerType');
 const Icons = goog.require('os.ui.Icons');
+const {directiveTag: terrainNodeUi} = goog.require('plugin.basemap.TerrainNodeUI');
 const {CESIUM_ONLY_LAYER} = goog.require('plugin.cesium');
 const Layer = goog.require('plugin.cesium.Layer');
 
@@ -37,7 +36,7 @@ class TerrainLayer extends Layer {
     this.setOSType(CESIUM_ONLY_LAYER);
     this.setIcons(Icons.TERRAIN);
     this.setExplicitType(LayerType.TERRAIN);
-    this.setNodeUI('<terrainnodeui></terrainnodeui>');
+    this.setNodeUI(`<${terrainNodeUi}></${terrainNodeUi}>`);
     this.log = logger;
 
     /**

--- a/test/plugin/basemap/basemapdescriptor.test.js
+++ b/test/plugin/basemap/basemapdescriptor.test.js
@@ -1,17 +1,14 @@
-goog.require('os');
-goog.require('goog.events.EventTarget');
-goog.require('os.events.LayerConfigEventType');
-goog.require('os.events.LayerEventType');
 goog.require('os.mock');
 goog.require('plugin.basemap');
 goog.require('plugin.basemap.BaseMapDescriptor');
-goog.require('plugin.basemap.BaseMapPlugin');
-
 
 describe('plugin.basemap.BaseMapDescriptor', function() {
+  const basemap = goog.module.get('plugin.basemap');
+  const BaseMapDescriptor = goog.module.get('plugin.basemap.BaseMapDescriptor');
+
   it('should have the correct defaults', function() {
-    var d = new plugin.basemap.BaseMapDescriptor();
-    expect(d.getDescriptorType()).toBe(plugin.basemap.ID);
+    var d = new BaseMapDescriptor();
+    expect(d.getDescriptorType()).toBe(basemap.ID);
     expect(d.getTags()).toContain('GEOINT');
     expect(d.getType()).toBe('Map Layers');
     expect(d.canDelete()).toBe(true);

--- a/test/plugin/basemap/basemapprovider.test.js
+++ b/test/plugin/basemap/basemapprovider.test.js
@@ -1,9 +1,16 @@
 goog.require('goog.events.EventTarget');
+goog.require('os.data.DataManager');
 goog.require('os.map.terrain');
 goog.require('os.mock');
+goog.require('plugin.basemap');
 goog.require('plugin.basemap.BaseMapProvider');
 
 describe('plugin.basemap.BaseMapProvider', function() {
+  const DataManager = goog.module.get('os.data.DataManager');
+  const terrain = goog.module.get('os.map.terrain');
+  const basemap = goog.module.get('plugin.basemap');
+  const BaseMapProvider = goog.module.get('plugin.basemap.BaseMapProvider');
+
   var expectedTerrainType = 'testTerrain';
   var expectedTerrainOptions = {
     url: 'http://terrain.com/'
@@ -27,7 +34,7 @@ describe('plugin.basemap.BaseMapProvider', function() {
         title: 'Ignore Me'
       },
       four: {
-        type: plugin.basemap.TERRAIN_TYPE,
+        type: basemap.TERRAIN_TYPE,
         baseType: expectedTerrainType,
         options: expectedTerrainOptions
       }
@@ -40,13 +47,13 @@ describe('plugin.basemap.BaseMapProvider', function() {
     }
   };
 
-  var p = new plugin.basemap.BaseMapProvider();
+  var p = new BaseMapProvider();
 
   it('should configure from both maps and userMaps', function() {
     p.configure(config);
 
     // it should've added four descriptors to the data manager, since unrecognized types should be ignored
-    var dm = os.dataManager;
+    var dm = DataManager.getInstance();
 
     // base maps are identified from config
     expect(dm.getDescriptor('basemap#one')).toBeTruthy();
@@ -64,7 +71,7 @@ describe('plugin.basemap.BaseMapProvider', function() {
     expect(p.defaults_).toContain('two');
 
     // terrain is configured on the map
-    var providers = os.map.terrain.getTerrainProviders();
+    var providers = terrain.getTerrainProviders();
     expect(providers.length).toBe(1);
 
     var terrainOptions = providers[0];
@@ -74,7 +81,7 @@ describe('plugin.basemap.BaseMapProvider', function() {
   });
 
   it('should load descriptors', function() {
-    var dm = os.dataManager;
+    var dm = DataManager.getInstance();
 
     expect(p.getDescriptors().length).toBe(4);
     expect(p.getChildren()).toBeFalsy();
@@ -88,7 +95,7 @@ describe('plugin.basemap.BaseMapProvider', function() {
   });
 
   it('can remove descriptors', function() {
-    var descriptor = os.dataManager.getDescriptor(p.getTerrainId());
+    var descriptor = DataManager.getInstance().getDescriptor(p.getTerrainId());
     expect(descriptor).toBeTruthy();
 
     p.removeDescriptor(descriptor);

--- a/test/plugin/basemap/v4/basemapstate.test.js
+++ b/test/plugin/basemap/v4/basemapstate.test.js
@@ -13,10 +13,16 @@ goog.require('plugin.basemap.v4.BaseMapState');
 goog.require('plugin.file.kml.KMLField');
 goog.require('plugin.ogc.OGCLayerDescriptor');
 goog.require('plugin.ogc.wfs.WFSLayerConfig');
-
-
+goog.require('plugin.ogc.wms.WMSLayerConfig');
 
 describe('plugin.basemap.v4.BaseMapState', function() {
+  const StateManager = goog.module.get('os.state.StateManager');
+  const xml = goog.module.get('os.xml');
+  const basemap = goog.module.get('plugin.basemap');
+  const BaseMapState = goog.module.get('plugin.basemap.v4.BaseMapState');
+  const OGCLayerDescriptor = goog.module.get('plugin.ogc.OGCLayerDescriptor');
+  const WMSLayerConfig = goog.module.get('plugin.ogc.wms.WMSLayerConfig');
+
   var stateManager = null;
 
   var expectPropertiesInAToBeSameInB = function(a, b, exclusions) {
@@ -46,13 +52,12 @@ describe('plugin.basemap.v4.BaseMapState', function() {
   };
 
   beforeEach(function() {
-    os.stateManager = os.state.StateManager.getInstance();
-    stateManager = os.state.StateManager.getInstance();
+    stateManager = StateManager.getInstance();
     stateManager.setVersion('v4');
   });
 
   it('should exist', function() {
-    expect(plugin.basemap.v4.BaseMapState).not.toBe(undefined);
+    expect(BaseMapState).not.toBe(undefined);
   });
 
 
@@ -107,7 +112,7 @@ describe('plugin.basemap.v4.BaseMapState', function() {
       // creating an empty one in the hope that any new
       // layer options that may get added will get incorporated
       // and validated.
-      var descriptor = new plugin.ogc.OGCLayerDescriptor();
+      var descriptor = new OGCLayerDescriptor();
       descriptor.setWmsEnabled(true);
       descriptor.setWfsEnabled(false);
 
@@ -117,7 +122,7 @@ describe('plugin.basemap.v4.BaseMapState', function() {
         title: 'test'
       };
 
-      var lc = new plugin.ogc.wms.WMSLayerConfig();
+      var lc = new WMSLayerConfig();
       var layer = lc.createLayer(createLayerOptions);
 
       var descriptorOptions = descriptor.getLayerOptions();
@@ -131,7 +136,7 @@ describe('plugin.basemap.v4.BaseMapState', function() {
       // default option is added, good to have that present in case
       // it causes an issue.
       layer.setLayerOptions(defaultOptions);
-      var state = new plugin.basemap.v4.BaseMapState();
+      var state = new BaseMapState();
       var xmlRootDocument = stateManager.createStateObject(function() {}, 'test state', 'desc', defaultOptions.tags);
       var stateOptions = stateManager.createStateOptions(function() {}, 'test state', 'desc', defaultOptions.tags);
       stateOptions.doc = xmlRootDocument;
@@ -139,7 +144,7 @@ describe('plugin.basemap.v4.BaseMapState', function() {
       xmlRootDocument.firstElementChild.appendChild(rootObj);
       var result = state.layerToXML(layer, stateOptions);
       rootObj.appendChild(result);
-      var seralizedDoc = os.xml.serialize(stateOptions.doc);
+      var seralizedDoc = xml.serialize(stateOptions.doc);
       var xmlLintResult = xmllint.validateXML({
         xml: seralizedDoc,
         schema: resultSchemas
@@ -150,13 +155,13 @@ describe('plugin.basemap.v4.BaseMapState', function() {
       var mapLayersNode = xmlRootDocument.firstElementChild.querySelector('mapLayers');
       var restoredOptions = state.xmlToOptions(mapLayersNode.firstElementChild);
       expect(restoredOptions).toBeDefined();
-      // method does a basic value comparision with expect(a?).toBe(b?) for most of the
+      // method does a basic value comparision with expect(a?).toBe(b?) for mos1t of the
       // values defined in the orginal default optons.
       expectPropertiesInAToBeSameInB(defaultOptions, restoredOptions,
           ['id', 'type', 'layerType']);
 
-      expect(restoredOptions.type).toBe(plugin.basemap.TYPE);
-      expect(restoredOptions.layerType).toBe(plugin.basemap.LAYER_TYPE);
+      expect(restoredOptions.type).toBe(basemap.TYPE);
+      expect(restoredOptions.layerType).toBe(basemap.LAYER_TYPE);
       expect(restoredOptions.id).toBe('basemap-streetmap');
     });
   });


### PR DESCRIPTION
This transform was straightforward, no additional refactors necessary.

I did notice a bug preventing `minZoom` and `maxZoom` from being saved to state files for basemaps. The layer config did not have `minResolution` or `maxResolution` keys, which we were depending on to be converted to zoom levels. To resolve this, the first zoom or resolution key encountered for min/max zoom will be converted to XML and the other key ignored if present. These values should be equivalent if both are present.