### PR TITLE
fix(annotation): update annotation edit height and fix tui task icon

### DIFF
--- a/scss/os/_overrides_tuieditor.scss
+++ b/scss/os/_overrides_tuieditor.scss
@@ -573,7 +573,8 @@
       }
 
       &.tui-task::before {
-        content: '\f046';
+        content: '\f14a';
+        font-weight: normal;
       }
 
       &.tui-indent::before {

--- a/src/os/annotation/annotation.js
+++ b/src/os/annotation/annotation.js
@@ -64,7 +64,7 @@ os.annotation.MAX_DEFAULT_WIDTH = 350;
  * @type {number}
  * @const
  */
-os.annotation.EDIT_HEIGHT = 270;
+os.annotation.EDIT_HEIGHT = 340;
 
 
 /**


### PR DESCRIPTION
- Updated the annotation edit minimum height so the OK/Cancel buttons are visible again.
- Fixed the unicode string for the TUI editor Task button icon. The `fa-check-square-o` icon from FA4 is now `fa-check-square` with the regular font weight.