### PR TITLE
feat(auth): adds basic api/hooks for servers with special auth support

### DIFF
--- a/.htmlvalidate.json
+++ b/.htmlvalidate.json
@@ -15,7 +15,9 @@
     }],
     "wcag/h32": "off",
     "wcag/h37": "off",
-    "text-content": "off"
+    "text-content": "off",
+    "wcag/h30": "off",
+    "prefer-native-element": "off"
   }
 }
 

--- a/src/os/auth.js
+++ b/src/os/auth.js
@@ -1,0 +1,107 @@
+goog.module('os.auth');
+goog.module.declareLegacyNamespace();
+
+const Settings = goog.require('os.config.Settings');
+const AlertManager = goog.require('os.alert.AlertManager');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+
+
+/**
+ * @typedef {{
+ *   title: string,
+ *   pattern: RegExp,
+ *   tooltip: string,
+ *   message: string,
+ *   link: string
+ * }}
+ */
+let AuthEntry;
+
+
+/**
+ * Registry of available authentication entries from settings.
+ * @type {Object<string, AuthEntry>}
+ */
+const registry = {};
+
+
+/**
+ * Map of auth entries to whether they've fired an alert in the current app session.
+ * @type {Object<string, boolean>}
+ */
+const alerts = {};
+
+
+/**
+ * The settings key for the authentication entries.
+ * @type {string}
+ */
+const SettingKey = 'os.auth';
+
+
+/**
+ * Initializes the authentication entries from settings
+ */
+const initAuth = () => {
+  const authSettings = Settings.getInstance().get(SettingKey, {});
+
+  for (const key in authSettings) {
+    const item = authSettings[key];
+
+    registry[key] = {
+      title: /** @type {string} */ (item['title']),
+      pattern: new RegExp(item['pattern'], 'i'),
+      tooltip: /** @type {string} */ (item['tooltip']),
+      message: /** @type {string} */ (item['message']),
+      link: /** @type {string} */ (item['link'])
+    };
+  }
+};
+
+
+/**
+ * Initializes the authentication entries from settings.
+ * @param {?string} urlOrName The URL or name to test for authentication requirements.
+ * @return {?AuthEntry}
+ */
+const getAuth = (urlOrName) => {
+  let authEntry = null;
+
+  for (const key in registry) {
+    const entry = registry[key];
+
+    if (entry && entry.pattern.test(urlOrName)) {
+      authEntry = entry;
+    }
+  }
+
+  return authEntry;
+};
+
+
+/**
+ * Fires an alert message indicating that the user needs to authenticate with a given service..
+ * @param {?string} urlOrName The URL or name to test for authentication requirements.
+ */
+const alertAuth = (urlOrName) => {
+  const auth = getAuth(urlOrName);
+
+  if (auth && !alerts[auth.title]) {
+    let message = auth.message;
+    if (auth.link) {
+      // if a link is available, add a link to open the auth page
+      message += `<br><br><a href="${auth.link}" target="_blank">Click here to go to the login page</a>`;
+    }
+
+    AlertManager.getInstance().sendAlert(message, AlertEventSeverity.INFO);
+    alerts[auth.title] = true;
+  }
+};
+
+
+exports = {
+  AuthEntry,
+  initAuth,
+  getAuth,
+  alertAuth
+};

--- a/src/os/auth.js
+++ b/src/os/auth.js
@@ -101,6 +101,7 @@ const alertAuth = (urlOrName) => {
 
 exports = {
   AuthEntry,
+  SettingKey,
   initAuth,
   getAuth,
   alertAuth

--- a/src/os/mainctrl.js
+++ b/src/os/mainctrl.js
@@ -11,6 +11,7 @@ goog.require('os');
 goog.require('os.MapContainer');
 goog.require('os.MapEvent');
 goog.require('os.action.EventType');
+goog.require('os.auth');
 goog.require('os.bearing.BearingSettings');
 goog.require('os.buffer');
 goog.require('os.column.ColumnMappingManager');
@@ -434,6 +435,9 @@ os.MainCtrl.prototype.initialize = function() {
 
   // initialize the nav bars
   os.ui.navbaroptions.init();
+
+  // initialize any authentication settings
+  os.auth.initAuth();
 
   this.addControlsToHelp_();
   os.ui.help.metricsOption.addToNav();

--- a/src/os/mixin/urltilemixin.js
+++ b/src/os/mixin/urltilemixin.js
@@ -288,14 +288,6 @@ ol.source.UrlTile.prototype.loadingDelay_ = null;
 
 
 /**
- * Flag for whether this source has alerted an error due to missing authentication.
- * @type {boolean}
- * @private
- */
-ol.source.UrlTile.prototype.authAlerted_ = false;
-
-
-/**
  * @inheritDoc
  */
 ol.source.UrlTile.prototype.disposeInternal = function() {
@@ -425,12 +417,11 @@ ol.source.UrlTile.prototype.onImageLoadOrError_ = function(evt) {
   } else {
     this.errorCount_++;
 
-    if (!this.authAlerted_) {
-      const urls = this.getUrls();
-      urls.forEach((url) => {
-        os.auth.alertAuth(url);
-      });
-    }
+    // request failed, check if it's potentially due to a missing authentication with the server
+    const urls = this.getUrls();
+    urls.forEach((url) => {
+      os.auth.alertAuth(url);
+    });
   }
 
   this.decrementLoading();

--- a/src/os/mixin/urltilemixin.js
+++ b/src/os/mixin/urltilemixin.js
@@ -8,7 +8,9 @@ goog.require('goog.events.EventType');
 goog.require('ol.events');
 goog.require('ol.source.TileEventType');
 goog.require('ol.source.UrlTile');
+goog.require('os.alert.AlertManager');
 goog.require('os.array');
+goog.require('os.auth');
 goog.require('os.events.PropertyChangeEvent');
 goog.require('os.implements');
 goog.require('os.ol.source.ILoadingSource');
@@ -286,6 +288,14 @@ ol.source.UrlTile.prototype.loadingDelay_ = null;
 
 
 /**
+ * Flag for whether this source has alerted an error due to missing authentication.
+ * @type {boolean}
+ * @private
+ */
+ol.source.UrlTile.prototype.authAlerted_ = false;
+
+
+/**
  * @inheritDoc
  */
 ol.source.UrlTile.prototype.disposeInternal = function() {
@@ -414,6 +424,13 @@ ol.source.UrlTile.prototype.onImageLoadOrError_ = function(evt) {
     this.loadCount_++;
   } else {
     this.errorCount_++;
+
+    if (!this.authAlerted_) {
+      const urls = this.getUrls();
+      urls.forEach((url) => {
+        os.auth.alertAuth(url);
+      });
+    }
   }
 
   this.decrementLoading();

--- a/src/os/ui/data/baseprovider.js
+++ b/src/os/ui/data/baseprovider.js
@@ -240,7 +240,7 @@ os.ui.data.BaseProvider.prototype.formatIcons = function() {
 
   const auth = this.getAuth();
   if (auth) {
-    icons = `<i class="fa fa-sign-in" title="${auth.tooltip}"></i>`;
+    icons = `<i class="fas fa-sign-in-alt" title="${auth.tooltip}"></i>`;
 
     if (auth.link) {
       // if a link is available, make the icon clickable

--- a/src/os/ui/data/baseprovider.js
+++ b/src/os/ui/data/baseprovider.js
@@ -1,5 +1,6 @@
 goog.provide('os.ui.data.BaseProvider');
 
+goog.require('os.auth');
 goog.require('os.data.IDataProvider');
 goog.require('os.events.PropertyChangeEvent');
 goog.require('os.ui.slick.SlickTreeNode');
@@ -157,6 +158,18 @@ os.ui.data.BaseProvider.prototype.getShowWhenEmpty = function() {
  * @inheritDoc
  */
 os.ui.data.BaseProvider.prototype.getInfo = function() {
+  const auth = this.getAuth();
+
+  if (auth) {
+    let message = auth.message;
+    if (auth.link) {
+      // if a link is available, add a link to open the auth page
+      message += `<br><br><a href="${auth.link}" target="_blank">Click here to go to the login page</a>`;
+    }
+
+    return message;
+  }
+
   return '';
 };
 
@@ -206,4 +219,34 @@ os.ui.data.BaseProvider.prototype.getUniqueId = function() {
   }
 
   return id;
+};
+
+
+/**
+ * Gets the authentication info for the server (if any).
+ *
+ * @return {?os.auth.AuthEntry}
+ */
+os.ui.data.BaseProvider.prototype.getAuth = function() {
+  return os.auth.getAuth(this.getLabel());
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.data.BaseProvider.prototype.formatIcons = function() {
+  let icons = '';
+
+  const auth = this.getAuth();
+  if (auth) {
+    icons = `<i class="fa fa-sign-in" title="${auth.tooltip}"></i>`;
+
+    if (auth.link) {
+      // if a link is available, make the icon clickable
+      icons = `<a class="c-glyph" href="${auth.link}" target="_blank">${icons}</a>`;
+    }
+  }
+
+  return icons;
 };

--- a/src/os/ui/server/abstractloadingserver.js
+++ b/src/os/ui/server/abstractloadingserver.js
@@ -128,7 +128,7 @@ os.ui.server.AbstractLoadingServer.prototype.formatIcons = function() {
 
   if (this.getError()) {
     var message = 'Server failed to load. See the log/alerts window for details.';
-    icons += `<i class="fa fa-warning text-warning" title="${message}"></i>`;
+    icons += `<i class="fas fa-exclamation-triangle text-warning" title="${message}"></i>`;
   }
 
 

--- a/src/os/ui/server/abstractloadingserver.js
+++ b/src/os/ui/server/abstractloadingserver.js
@@ -1,6 +1,7 @@
 goog.provide('os.ui.server.AbstractLoadingServer');
 
 goog.require('ol.array');
+goog.require('os.auth');
 goog.require('os.data.DataProviderEvent');
 goog.require('os.data.DataProviderEventType');
 goog.require('os.data.ILoadingProvider');
@@ -124,10 +125,12 @@ os.ui.server.AbstractLoadingServer.prototype.finish = function() {
  */
 os.ui.server.AbstractLoadingServer.prototype.formatIcons = function() {
   var icons = os.ui.server.AbstractLoadingServer.base(this, 'formatIcons');
+
   if (this.getError()) {
     var message = 'Server failed to load. See the log/alerts window for details.';
-    icons += '<i class="fa fa-warning text-warning" title="' + message + '"></i>';
+    icons += `<i class="fa fa-warning text-warning" title="${message}"></i>`;
   }
+
 
   return icons;
 };
@@ -325,4 +328,12 @@ os.ui.server.AbstractLoadingServer.prototype.onChildChange = function(e) {
     // the server will fire an event when it finishes loading to update the tree.
     os.ui.server.AbstractLoadingServer.base(this, 'onChildChange', e);
   }
+};
+
+
+/**
+ * @inheritDoc
+ */
+os.ui.server.AbstractLoadingServer.prototype.getAuth = function() {
+  return os.auth.getAuth(this.getUrl());
 };

--- a/src/os/ui/servers.js
+++ b/src/os/ui/servers.js
@@ -123,6 +123,7 @@ os.ui.ServersCtrl.prototype.updateData_ = function() {
 
       if (item.includeInServers()) {
         var type = os.dataManager.getProviderTypeByClass(item.constructor);
+        var auth = item.getAuth();
         data.push({
           'id': id,
           'enabled': item.getEnabled(),
@@ -131,7 +132,9 @@ os.ui.ServersCtrl.prototype.updateData_ = function() {
           'error': item.getError(),
           'label': item.getLabel(),
           'item': item,
-          'hasView': !!im.getImportUI(type)
+          'hasView': !!im.getImportUI(type),
+          'authLink': auth && auth.link,
+          'authTooltip': auth && auth.tooltip
         });
 
         if (item instanceof os.ui.server.AbstractLoadingServer) {

--- a/test/os/auth.test.js
+++ b/test/os/auth.test.js
@@ -1,0 +1,79 @@
+goog.require('os.alert.AlertManager');
+goog.require('os.auth');
+goog.require('os.config.Settings');
+goog.require('os.data.RecordField');
+goog.require('os.mock');
+
+
+describe('plugin.imagery.menu', () => {
+  const {
+    SettingKey,
+    initAuth,
+    getAuth,
+    alertAuth
+  } = goog.module.get('os.auth');
+  const Settings = goog.module.get('os.config.Settings');
+  const AlertManager = goog.module.get('os.alert.AlertManager');
+
+  const settingsAuth = {
+    'test': {
+      'title': 'My Test Auth',
+      'tooltip': 'Test Tooltip',
+      'message': 'Go here to authenticate with the test server.',
+      'pattern': '(http://my.test.url|Test Name)',
+      'link': 'http://my.test.url/login'
+    }
+  };
+
+  it('should initialize from settings', () => {
+    // check before adding anything to settings
+    let testAuth = getAuth('http://my.test.url');
+    expect(testAuth).toBe(null);
+
+    // add the test object and check that we get something
+    Settings.getInstance().set(SettingKey, settingsAuth);
+    initAuth();
+
+    testAuth = getAuth('http://my.test.url');
+    expect(testAuth.title).toBe('My Test Auth');
+    expect(testAuth.tooltip).toBe('Test Tooltip');
+    expect(testAuth.message).toBe('Go here to authenticate with the test server.');
+    expect(testAuth.pattern instanceof RegExp).toBe(true);
+    expect(testAuth.link).toBe('http://my.test.url/login');
+  });
+
+  it('should get auth objects from settings by URL or name', () => {
+    Settings.getInstance().set(SettingKey, settingsAuth);
+    initAuth();
+
+    testAuth = getAuth('http://my.test.url');
+    expect(testAuth.title).toBe('My Test Auth');
+    expect(testAuth.tooltip).toBe('Test Tooltip');
+    expect(testAuth.message).toBe('Go here to authenticate with the test server.');
+    expect(testAuth.pattern instanceof RegExp).toBe(true);
+    expect(testAuth.link).toBe('http://my.test.url/login');
+
+    testAuth = null;
+
+    // test it with a name
+    testAuth = getAuth('Test Name');
+    expect(testAuth.title).toBe('My Test Auth');
+    expect(testAuth.tooltip).toBe('Test Tooltip');
+    expect(testAuth.message).toBe('Go here to authenticate with the test server.');
+    expect(testAuth.pattern instanceof RegExp).toBe(true);
+    expect(testAuth.link).toBe('http://my.test.url/login');
+  });
+
+  it('should send alerts exactly once per auth entry', () => {
+    Settings.getInstance().set(SettingKey, settingsAuth);
+    initAuth();
+    spyOn(AlertManager.getInstance(), 'sendAlert').andCallThrough();
+
+    // verify that we attempt to fire an alert
+    alertAuth('http://my.test.url');
+
+    const calls = AlertManager.getInstance().sendAlert.calls;
+    expect(calls.length).toBe(1);
+    expect(calls[0].args[0]).toContain(`Go here to authenticate with the test server.`);
+  });
+});

--- a/views/config/servers.html
+++ b/views/config/servers.html
@@ -24,6 +24,9 @@
               <i ng-if="item.loading" class="fa fa-fw fa-spin fa-spinner" title="Loading..."></i>
             </span>
             <span>
+              <a type="button" role="button" ng-if="item.authLink" class="btn btn-secondary btn-sm" title="{{item.authTooltip}}" href="{{item.authLink}}" target="_blank">
+                <i class="fa fa-fw fa-sign-in"></i>
+              </a>
               <button type="button" class="btn btn-secondary btn-sm" ng-if="item.hasView"
                   ng-click="servers.edit(item.item)" title="{{item.edit ? 'Edit' : 'View'}} server">
                 <i class="fa fa-fw" ng-class="item.edit ? 'fa-pencil' : 'fa-eye'"></i>


### PR DESCRIPTION
Adds an API for registering servers that support additional authentication methodologies besides PKI/basic auth. It supports registration of a pattern to match servers as well as ways to link out and message to the user that they are connecting to a server that may provide more data than it appears on the surface.