### PR TITLE
refactor(query): use query instance api for managers

### DIFF
--- a/src/os/command/nonqueryclearcmd.js
+++ b/src/os/command/nonqueryclearcmd.js
@@ -3,7 +3,7 @@ goog.module.declareLegacyNamespace();
 
 const State = goog.require('os.command.State');
 const {getMapContainer} = goog.require('os.map.instance');
-const areaManager = goog.require('os.query.AreaManager');
+const {getAreaManager} = goog.require('os.query.instance');
 
 const ICommand = goog.requireType('os.command.ICommand');
 
@@ -53,7 +53,7 @@ class NonQueryClear {
 
     var features = getMapContainer().getFeatures();
     var featuresToRemove = [];
-    var am = areaManager.getInstance();
+    var am = getAreaManager();
 
     if (features.length > 0) {
       for (var i = 0; i < features.length; i++) {

--- a/src/os/command/queryclearcmd.js
+++ b/src/os/command/queryclearcmd.js
@@ -2,7 +2,7 @@ goog.module('os.command.QueryClear');
 goog.module.declareLegacyNamespace();
 
 const State = goog.require('os.command.State');
-const AreaManager = goog.require('os.query.AreaManager');
+const {getAreaManager} = goog.require('os.query.instance');
 
 const ICommand = goog.requireType('os.command.ICommand');
 
@@ -55,7 +55,7 @@ class QueryClear {
    */
   execute() {
     this.state = State.EXECUTING;
-    var am = AreaManager.getInstance();
+    var am = getAreaManager();
     var list = am.getAll();
 
     for (var i = 0, n = list.length; i < n; i++) {
@@ -75,7 +75,7 @@ class QueryClear {
   revert() {
     this.state = State.REVERTING;
 
-    var am = AreaManager.getInstance();
+    var am = getAreaManager();
     var list = am.getAll();
 
     for (var i = 0, n = list.length; i < n; i++) {

--- a/src/os/data/areatreesearch.js
+++ b/src/os/data/areatreesearch.js
@@ -1,6 +1,7 @@
 goog.provide('os.data.AreaTreeSearch');
+
 goog.require('os.data.AreaNode');
-goog.require('os.query.AreaManager');
+goog.require('os.query.instance');
 goog.require('os.ui.slick.AbstractGroupByTreeSearch');
 
 
@@ -24,7 +25,7 @@ goog.inherits(os.data.AreaTreeSearch, os.ui.slick.AbstractGroupByTreeSearch);
  * @inheritDoc
  */
 os.data.AreaTreeSearch.prototype.getSearchItems = function() {
-  return os.ui.areaManager.getAll();
+  return os.query.instance.getAreaManager().getAll();
 };
 
 
@@ -44,7 +45,7 @@ os.data.AreaTreeSearch.prototype.setupNode = function(item) {
  * @override
  */
 os.data.AreaTreeSearch.prototype.fillListFromSearch = function(list) {
-  var areas = os.ui.areaManager.getAll();
+  var areas = os.query.instance.getAreaManager().getAll();
   if (areas && areas.length > 0) {
     for (var i = 0, n = areas.length; i < n; i++) {
       list.push(new os.data.AreaNode(areas[i]));

--- a/src/os/layer/vector.js
+++ b/src/os/layer/vector.js
@@ -20,6 +20,7 @@ goog.require('os.layer.PropertyChange');
 goog.require('os.legend');
 goog.require('os.legend.ILegendRenderer');
 goog.require('os.net');
+goog.require('os.query.instance');
 goog.require('os.registerClass');
 goog.require('os.source');
 goog.require('os.source.ISource');
@@ -432,7 +433,7 @@ os.layer.Vector.prototype.getFASet = function() {
     icons.push(os.ui.Icons.STATE);
   }
 
-  if (os.query.QueryManager.getInstance().hasEnabledEntries(this.getId())) {
+  if (os.query.instance.getQueryManager().hasEnabledEntries(this.getId())) {
     icons.push(os.ui.Icons.FILTER);
   }
 
@@ -488,7 +489,7 @@ os.layer.Vector.prototype.getIconSet = function() {
       icons.push(os.ui.Icons.STATE);
     }
 
-    if (os.query.QueryManager.getInstance().hasEnabledEntries(this.getId())) {
+    if (os.query.instance.getQueryManager().hasEnabledEntries(this.getId())) {
       icons.push(os.ui.Icons.FILTER);
     }
   }

--- a/src/plugin/arc/layer/arcfeaturelayerconfig.js
+++ b/src/plugin/arc/layer/arcfeaturelayerconfig.js
@@ -1,6 +1,5 @@
 goog.module('plugin.arc.layer.ArcFeatureLayerConfig');
 
-const queryManager = goog.require('os.query.QueryManager');
 const log = goog.require('goog.log');
 const FeatureImporter = goog.require('os.im.FeatureImporter');
 const OrientationMapping = goog.require('os.im.mapping.OrientationMapping');
@@ -12,6 +11,7 @@ const ParamModifier = goog.require('os.net.ParamModifier');
 const Request = goog.require('os.net.Request');
 const TemporalHandler = goog.require('os.query.TemporalHandler');
 const TemporalQueryManager = goog.require('os.query.TemporalQueryManager');
+const {getQueryManager} = goog.require('os.query.instance');
 const ArcJSONParser = goog.require('plugin.arc.ArcJSONParser');
 const arc = goog.require('plugin.arc');
 const ArcFilterModifier = goog.require('plugin.arc.query.ArcFilterModifier');
@@ -76,7 +76,7 @@ class ArcFeatureLayerConfig extends AbstractDataSourceLayerConfig {
 
       var handler = new ArcQueryHandler();
       handler.setSource(source);
-      queryManager.getInstance().registerHandler(handler);
+      getQueryManager().registerHandler(handler);
 
       if (useTemporal) {
         var tqModifier = new ParamModifier('time', 'time', '{time}', '');

--- a/src/plugin/descriptor/facet/areafacet.js
+++ b/src/plugin/descriptor/facet/areafacet.js
@@ -5,7 +5,7 @@ const Promise = goog.require('goog.Promise');
 
 const IAreaTest = goog.require('os.data.IAreaTest');
 const osImplements = goog.require('os.implements');
-const AreaManager = goog.require('os.query.AreaManager');
+const {getAreaManager} = goog.require('os.query.instance');
 const BaseFacet = goog.require('os.search.BaseFacet');
 
 const IDataDescriptor = goog.requireType('os.data.IDataDescriptor');
@@ -33,7 +33,7 @@ class Area extends BaseFacet {
    * @inheritDoc
    */
   valueToLabel(value) {
-    var area = AreaManager.getInstance().get(value);
+    var area = getAreaManager().get(value);
 
     if (area) {
       return /** @type {string} */ (area.get('title'));
@@ -48,7 +48,7 @@ class Area extends BaseFacet {
   load(item, facets) {
     return this.updateCache_(
         item,
-        AreaManager.getInstance().getAll(),
+        getAreaManager().getAll(),
         function(areaId) {
           BaseFacet.update('Area', areaId, facets);
         });
@@ -63,7 +63,7 @@ class Area extends BaseFacet {
     if (areaIds) {
       BaseFacet.updateResults('Area', results);
 
-      var areas = AreaManager.getInstance().getAll();
+      var areas = getAreaManager().getAll();
       if (areas) {
         areas = areas.filter(function(area) {
           return areaIds.indexOf(/** @type {string} */ (area.getId())) > -1;

--- a/src/plugin/ogc/wfs/querywfslayerconfig.js
+++ b/src/plugin/ogc/wfs/querywfslayerconfig.js
@@ -4,9 +4,9 @@ goog.module.declareLegacyNamespace();
 const ParamModifier = goog.require('os.net.ParamModifier');
 const ModifierConstants = goog.require('os.ogc.filter.ModifierConstants');
 const OGCFilterModifier = goog.require('os.ogc.filter.OGCFilterModifier');
-const queryManager = goog.require('os.query.QueryManager');
 const TemporalHandler = goog.require('os.query.TemporalHandler');
 const TemporalQueryManager = goog.require('os.query.TemporalQueryManager');
+const {getQueryManager} = goog.require('os.query.instance');
 const FilterIDModifier = goog.require('plugin.ogc.query.FilterIDModifier');
 const OGCQueryHandler = goog.require('plugin.ogc.query.OGCQueryHandler');
 const OGCTemporalFormatter = goog.require('plugin.ogc.query.OGCTemporalFormatter');
@@ -44,7 +44,7 @@ class QueryWFSLayerConfig extends WFSLayerConfig {
     var relatedLayer = options['relatedLayer'] != null ? options['relatedLayer'] : null;
 
     // add connections to the query managers
-    var qm = queryManager.getInstance();
+    var qm = getQueryManager();
     if (featureIDs || useTemporal || useSpatial || useFilter || useExclusions) {
       var ogcFilterOptions = /** @type {OGCFilterModifierOptions} */ ({
         exclusions: useExclusions,


### PR DESCRIPTION
Replaces hard dependencies on area/query managers with the instance API's. This is not exhaustive of all references, but resolves dependency issues in external projects. Remaining references will be replaced as files are transformed to modules.