### PR TITLE
fix(kml): deconstruct mirrored icons back to local copies on import

### DIFF
--- a/src/os/style/iconreader.js
+++ b/src/os/style/iconreader.js
@@ -175,8 +175,14 @@ os.style.IconReader.translateIcons = function(config) {
   // replace google maps/earth icon urls with our copies
   var src = /** @type {string|undefined} */ (config['src']);
   if (src) {
-    if (os.ui.file.kml.GMAPS_SEARCH.test(src)) {
-      config['src'] = os.ui.file.kml.replaceGoogleUri(src);
+    const isGmaps = os.ui.file.kml.GMAPS_SEARCH.test(src);
+    const isMirror = src.indexOf(os.ui.file.kml.mirror) != -1;
+    if (isGmaps || isMirror) {
+      if (isGmaps) {
+        config['src'] = os.ui.file.kml.replaceGoogleUri(src);
+      } else {
+        config['src'] = os.ui.file.kml.replaceExportableUri(src);
+      }
 
       // if an anchor was not specified, fix it (because failing at "Pin the tail on the donkey" is embarrassing)
       if (!config['anchor'] && src.indexOf('/pushpin/') > -1) {

--- a/src/os/ui/file/kml/kml.js
+++ b/src/os/ui/file/kml/kml.js
@@ -352,6 +352,17 @@ os.ui.file.kml.replaceGoogleUri = function(src) {
 
 
 /**
+ * Replace our mirrored source URL with with the application image path.
+ * It doesn't really make sense to treat it as an external URL, does it?
+ * @param {string|null|undefined} src The image source URL.
+ * @return {!string} The icon src.
+ */
+os.ui.file.kml.replaceExportableUri = function(src) {
+  return src.replace(os.ui.file.kml.mirror, os.ui.file.kml.ICON_PATH);
+};
+
+
+/**
  * Replace the Google icon URL with the non-relative image URL.
  *
  * @param {string|null|undefined} src The image source URL.


### PR DESCRIPTION
It seems like if Google URIs are replaced with an internal hosted path to the icon, we might want to replace those to the default icon path when importing KML back into the application.

Not doing this has potential to cause issues with the versioned build folders. Openlayers 2D mode falls back to a default icon if it 404s (missing symlink with the default mirror path etc.) but Cesium doesn't render anything at all.