### PR TITLE
fix(style): feature style commands no longer error

### DIFF
--- a/src/os/command/abstractlayerstylecmd.js
+++ b/src/os/command/abstractlayerstylecmd.js
@@ -21,6 +21,7 @@ class AbstractLayerStyle extends AbstractStyle {
    */
   constructor(layerId, value, opt_oldValue) {
     super(layerId, value, opt_oldValue);
+    this.updateOldValue();
   }
 
   /**

--- a/src/os/command/abstractstylecmd.js
+++ b/src/os/command/abstractstylecmd.js
@@ -64,7 +64,7 @@ class AbstractStyle {
      * @type {T}
      * @protected
      */
-    this.oldValue = opt_oldValue != null ? opt_oldValue : this.getOldValue();
+    this.oldValue = opt_oldValue;
 
     /**
      * @type {T}

--- a/src/os/command/abstractvectorstylecmd.js
+++ b/src/os/command/abstractvectorstylecmd.js
@@ -24,6 +24,7 @@ class AbstractVectorStyle extends AbstractStyle {
    */
   constructor(layerId, value, opt_oldValue) {
     super(layerId, value, opt_oldValue);
+    this.updateOldValue();
   }
 
   /**

--- a/src/os/command/feature/featurecentershapecmd.js
+++ b/src/os/command/feature/featurecentershapecmd.js
@@ -33,6 +33,10 @@ class FeatureCenterShape extends AbstractFeatureStyle {
    */
   getOldValue() {
     var feature = /** @type {Feature} */ (this.getFeature());
+    if (feature == null) {
+      return null;
+    }
+
     var shape = feature.get(StyleField.CENTER_SHAPE);
     return shape ? shape : osStyle.ShapeType.POINT;
   }

--- a/src/os/command/feature/featurecolorcmd.js
+++ b/src/os/command/feature/featurecolorcmd.js
@@ -78,6 +78,10 @@ class FeatureColor extends AbstractFeatureStyle {
    */
   getOldValue() {
     var feature = /** @type {Feature} */ (this.getFeature());
+    if (feature == null) {
+      return null;
+    }
+
     var config = /** @type {Array<Object>|Object|undefined} */ (this.getFeatureConfigs(feature));
     if (Array.isArray(config)) {
       config = config[0];

--- a/src/os/command/feature/featureiconcmd.js
+++ b/src/os/command/feature/featureiconcmd.js
@@ -32,6 +32,10 @@ class FeatureIcon extends AbstractFeatureStyle {
    */
   getOldValue() {
     var feature = /** @type {Feature} */ (this.getFeature());
+    if (feature == null) {
+      return null;
+    }
+
     var configs = /** @type {Array<Object>|Object|undefined} */ (this.getFeatureConfigs(feature));
     if (Array.isArray(configs)) {
       configs = configs.length > 1 ? configs[1] : configs[0];

--- a/src/os/command/feature/featurelabelcmd.js
+++ b/src/os/command/feature/featurelabelcmd.js
@@ -40,6 +40,10 @@ class FeatureLabel extends AbstractFeatureStyle {
    */
   getOldValue() {
     var feature = /** @type {Feature} */ (this.getFeature());
+    if (feature == null) {
+      return null;
+    }
+
     var config = /** @type {Array<Object>|Object|undefined} */ (this.getFeatureConfigs(feature));
     var labelColumns = [];
     if (config) {

--- a/src/os/command/feature/featurelabelcolorcmd.js
+++ b/src/os/command/feature/featurelabelcolorcmd.js
@@ -37,6 +37,10 @@ class FeatureLabelColor extends AbstractFeatureStyle {
    */
   getOldValue() {
     var feature = /** @type {Feature} */ (this.getFeature());
+    if (feature == null) {
+      return null;
+    }
+
     var labelColor = feature.get(StyleField.LABEL_COLOR);
     return labelColor ? labelColor : osStyle.DEFAULT_LAYER_COLOR;
   }

--- a/src/os/command/feature/featurelabelsizecmd.js
+++ b/src/os/command/feature/featurelabelsizecmd.js
@@ -33,6 +33,10 @@ class FeatureLabelSize extends AbstractFeatureStyle {
    */
   getOldValue() {
     var feature = /** @type {Feature} */ (this.getFeature());
+    if (feature == null) {
+      return null;
+    }
+
     var labelSize = feature.get(StyleField.LABEL_SIZE);
     return labelSize ? labelSize : label.DEFAULT_SIZE;
   }

--- a/src/os/command/feature/featurelinedashcmd.js
+++ b/src/os/command/feature/featurelinedashcmd.js
@@ -30,6 +30,10 @@ class FeatureLineDash extends AbstractFeatureStyle {
    */
   getOldValue() {
     var feature = /** @type {Feature} */ (this.getFeature());
+    if (feature == null) {
+      return null;
+    }
+
     var config = /** @type {Array<Object>|Object|undefined} */ (this.getFeatureConfigs(feature));
     if (Array.isArray(config)) {
       config = config[0];

--- a/src/os/command/feature/featureopacitycmd.js
+++ b/src/os/command/feature/featureopacitycmd.js
@@ -64,6 +64,10 @@ class FeatureOpacity extends AbstractFeatureStyle {
   getOldValue() {
     var ret;
     var feature = /** @type {Feature} */ (this.getFeature());
+    if (feature == null) {
+      return null;
+    }
+
     var config = /** @type {Array<Object>|Object|undefined} */ (this.getFeatureConfigs(feature));
     if (Array.isArray(config)) {
       config = config[0];

--- a/src/os/command/feature/featureshapecmd.js
+++ b/src/os/command/feature/featureshapecmd.js
@@ -34,6 +34,10 @@ class FeatureShape extends AbstractFeatureStyle {
    */
   getOldValue() {
     var feature = /** @type {Feature} */ (this.getFeature());
+    if (feature == null) {
+      return null;
+    }
+
     var shape = feature.get(StyleField.SHAPE);
     return shape ? shape : osStyle.ShapeType.POINT;
   }

--- a/src/os/command/feature/featureshowlabelcmd.js
+++ b/src/os/command/feature/featureshowlabelcmd.js
@@ -33,6 +33,10 @@ class FeatureShowLabel extends AbstractFeatureStyle {
    */
   getOldValue() {
     var feature = /** @type {Feature} */ (this.getFeature());
+    if (feature == null) {
+      return null;
+    }
+
     var showLabels = feature.get(StyleField.SHOW_LABELS);
     return showLabels ? showLabels : true;
   }

--- a/src/os/command/feature/featuresizecmd.js
+++ b/src/os/command/feature/featuresizecmd.js
@@ -30,6 +30,10 @@ class FeatureSize extends AbstractFeatureStyle {
    */
   getOldValue() {
     var feature = /** @type {Feature} */ (this.getFeature());
+    if (feature == null) {
+      return null;
+    }
+
     var config = /** @type {Array<Object>|Object|undefined} */ (this.getFeatureConfigs(feature));
     if (Array.isArray(config)) {
       config = config[0];

--- a/src/os/command/layerstylecmd.js
+++ b/src/os/command/layerstylecmd.js
@@ -35,6 +35,8 @@ class LayerStyle extends AbstractStyle {
      * @protected
      */
     this.callback = callback;
+
+    this.updateOldValue();
   }
 
   /**

--- a/src/os/command/vectorlayercolorcmd.js
+++ b/src/os/command/vectorlayercolorcmd.js
@@ -91,6 +91,16 @@ class VectorLayerColor extends AbstractVectorStyle {
   /**
    * @inheritDoc
    */
+  updateOldValue() {
+    // Only update old value if we have a changeMode -- prevents AbstractVectorStyle from setting oldValue too early
+    if (this.changeMode != null) {
+      super.updateOldValue();
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
   applyValue(config, value) {
     if (this.changeMode === ColorChangeType.FILL) {
       osStyle.setFillColor(config, value);

--- a/src/os/command/vectorlayercolorcmd.js
+++ b/src/os/command/vectorlayercolorcmd.js
@@ -36,7 +36,9 @@ class VectorLayerColor extends AbstractVectorStyle {
      * @protected
      */
     this.changeMode = opt_changeMode;
-    this.updateOldValue();
+
+    // AbstractVectorStyle may set the old value too early (if we have opt_changeMode come in)
+    this.oldValue = opt_oldColor || this.getOldValue();
 
     if (this.changeMode === ColorChangeType.FILL) {
       this.title = 'Change Layer Fill Color';
@@ -86,16 +88,6 @@ class VectorLayerColor extends AbstractVectorStyle {
     }
 
     return ret;
-  }
-
-  /**
-   * @inheritDoc
-   */
-  updateOldValue() {
-    // Only update old value if we have a changeMode -- prevents AbstractVectorStyle from setting oldValue too early
-    if (this.changeMode != null) {
-      super.updateOldValue();
-    }
   }
 
   /**

--- a/src/plugin/heatmap/cmd/gradientcmd.js
+++ b/src/plugin/heatmap/cmd/gradientcmd.js
@@ -16,6 +16,7 @@ class Gradient extends AbstractStyle {
   constructor(layerId, value, opt_oldValue) {
     super(layerId, value, opt_oldValue);
     this.title = 'Change heatmap gradient';
+    this.updateOldValue();
   }
 
   /**

--- a/src/plugin/heatmap/cmd/intensitycmd.js
+++ b/src/plugin/heatmap/cmd/intensitycmd.js
@@ -16,6 +16,7 @@ class Intensity extends AbstractStyle {
   constructor(layerId, value, opt_oldValue) {
     super(layerId, value, opt_oldValue);
     this.title = 'Change heatmap intensity';
+    this.updateOldValue();
   }
 
   /**

--- a/src/plugin/heatmap/cmd/sizecmd.js
+++ b/src/plugin/heatmap/cmd/sizecmd.js
@@ -16,6 +16,7 @@ class Size extends AbstractStyle {
   constructor(layerId, value, opt_oldValue) {
     super(layerId, value, opt_oldValue);
     this.title = 'Change heatmap intensity';
+    this.updateOldValue();
   }
 
   /**


### PR DESCRIPTION
Noticed that attempting to edit the style of a Place (or other KML feature) would throw a console error if done via the Layers window rather than the Feature Edit window. Seems like, due to the es6 updates to commands, the `getOldValue()` call in `AbstractStyle.prototype.constructor` was throwing (as `AbstractFeatureStyle.prototype.featureId` can't be set until after it executes).

Tried a couple things, but this seemed like the safest method.