### PR TITLE
fix(basemaps): fixes basemap group id and crossorigin in states

### DIFF
--- a/src/os/layer/config/abstracttilelayerconfig.js
+++ b/src/os/layer/config/abstracttilelayerconfig.js
@@ -329,7 +329,6 @@ os.layer.config.AbstractTileLayerConfig.expandUrls = function(urls) {
  *
  * @param {string} url the url to expand
  * @return {Array<string>} the full list of urls corresponding to the url range.
- * @protected
  */
 os.layer.config.AbstractTileLayerConfig.expandUrl = function(url) {
   var urls = [];

--- a/src/os/state/v4/baselayerstate.js
+++ b/src/os/state/v4/baselayerstate.js
@@ -818,6 +818,11 @@ os.state.v4.BaseLayerState.prototype.analyzeOptions = function(options, id) {
     layerOptions['id'] = os.state.AbstractState.createId(id, /** @type {string} */ (layerOptions['id']));
     layerOptions['exportEnabled'] = true;
 
+    if (layerOptions['groupId']) {
+      // update the group ID if it's present to be unique to this state
+      layerOptions['groupId'] = os.state.AbstractState.createId(id, /** @type {string} */ (layerOptions['groupId']));
+    }
+
     var descriptor = os.dataManager.getDescriptor(id.substring(0, id.length - 1));
     if (descriptor) {
       layerOptions['provider'] = descriptor.getTitle();

--- a/src/plugin/basemap/v4/basemapstate.js
+++ b/src/plugin/basemap/v4/basemapstate.js
@@ -4,7 +4,6 @@ goog.module.declareLegacyNamespace();
 const googDomXml = goog.require('goog.dom.xml');
 const log = goog.require('goog.log');
 const MapContainer = goog.require('os.MapContainer');
-const net = goog.require('os.net');
 const LayerState = goog.require('os.state.v4.LayerState');
 const BaseProvider = goog.require('os.ui.data.BaseProvider');
 const xml = goog.require('os.xml');
@@ -106,10 +105,6 @@ class BaseMapState extends LayerState {
     options['layerType'] = basemap.LAYER_TYPE;
     options['type'] = basemap.TYPE;
     options['id'] = options['id'].replace(BaseProvider.ID_DELIMITER, '-');
-
-    if (typeof options['url'] == 'string') {
-      options['crossOrigin'] = net.getCrossOrigin(/** @type {string} */ (options['url']));
-    }
 
     // zoom is 1 higher in opensphere than in legacy apps
     if (typeof options['minZoom'] === 'number') {


### PR DESCRIPTION
Basemaps now save with a group ID that is unique to the statefile. Grouping will now only occur within layers from the state rather than between state and non-state layers. Cross origin behavior will now respect the value saved in the statefile for basemaps. Basemaps already often override the value set in settings, so this PR prefers the value saved to the state.