### PR TITLE
chore(html-validate): limit html-validate version to 4.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     "conventional-recommended-bump": "^0.3.0",
     "eslint": "^7.26.0",
     "eslint-config-opensphere": "^5.0.0",
-    "html-validate": "^4.2.0",
+    "html-validate": "~4.13.1",
     "html-validate-angular": "^2.9.0",
     "husky": "^3.0.1",
     "json": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,15 +895,15 @@
     lodash "^4.17.4"
     read-pkg-up "^7.0.0"
 
-"@sidvind/better-ajv-errors@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@sidvind/better-ajv-errors/-/better-ajv-errors-0.8.0.tgz#b173358ad318d42f779b8f7b062115968996796d"
-  integrity sha512-GHNHkyHpCWjMENEJZ1ScsGOUvy41GVPd9SSSK/h7d9hYdKbpzSgFeXCB2g7XTswNKJD/G5GU5KLlZspLkb/Myg==
+"@sidvind/better-ajv-errors@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@sidvind/better-ajv-errors/-/better-ajv-errors-0.9.0.tgz#fcc84df0d2a68b100a4d6b9b2cc7066525c42dee"
+  integrity sha512-GeeIsUsq8eUB7kvDq+fS0wpD0hZ56xrqsaVTiJEmSWqEK+BvTd29mah3AWDublvRx2dWQ/qMbvb3Ml98Huedcw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     chalk "^4.0.0"
     json-to-ast "^2.0.3"
-    jsonpointer "^4.0.1"
+    jsonpointer "^4.1.0"
     leven "^3.1.0"
 
 "@sindresorhus/is@^0.7.0":
@@ -6540,14 +6540,14 @@ html-validate-angular@^2.9.0:
   resolved "https://registry.yarnpkg.com/html-validate-angular/-/html-validate-angular-2.9.0.tgz#2510284eb168baea8a33ce3320fbdce024e66db1"
   integrity sha512-hUVWhREFMd/kXnNYkmRNFE2EsOP8pMQZs6mFysUt5vNKkUz+uBdeJL0/GBs9E4zt8ZSE4DS2fHV0N6LyumO9RQ==
 
-html-validate@^4.2.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/html-validate/-/html-validate-4.12.0.tgz#a7ace26b1f8426161935aef83c1a1c11855e66e3"
-  integrity sha512-9XKcGbx6dOKmHIFb6I9qPVuGoqFXiNkSKTlECy1xkljMLN8Rs52d/i6OZmOmHa02QOv5RdqwR3GXiVv9CEKKsg==
+html-validate@~4.13.1:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/html-validate/-/html-validate-4.13.1.tgz#b4cbe9a3e9b7f7591586f219e42f92cebadad314"
+  integrity sha512-HCx9saspLiI9uL1XHpqEpV+yc/td5A4HR9HHNffuody4WNDuLDpLe4Sx6PXoBMIjdgozoiBrFSJqKMa3vwprBg==
   dependencies:
     "@babel/code-frame" "^7.10.0"
     "@html-validate/stylish" "^1.0.0"
-    "@sidvind/better-ajv-errors" "^0.8.0"
+    "@sidvind/better-ajv-errors" "^0.9.0"
     acorn-walk "^8.0.0"
     ajv "^7.0.0"
     deepmerge "^4.2.0"
@@ -7849,7 +7849,7 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsonpointer@^4.0.0, jsonpointer@^4.0.1:
+jsonpointer@^4.0.0, jsonpointer@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.1.0.tgz#501fb89986a2389765ba09e6053299ceb4f2c2cc"
   integrity sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==


### PR DESCRIPTION
This should fix our new errors on the nightly build: 
`error  Attribute "multiple" is not allowed on <input type="hidden">  input-attributes`
and
`error  Attribute "required" is not allowed on <input type="hidden">  input-attributes`

This appears to fail on `ng-require` attributes 