### PR TITLE
Transform alert/action/array/bearing/buffer/column/control/easing/events to modules

### DIFF
--- a/.jscodeshift.json
+++ b/.jscodeshift.json
@@ -64,6 +64,7 @@
     "os.dataManager": "DataManager",
     "os.osDataManager": "OSDataManager",
     "os.extent": "osExtent",
+    "os.geo.jsts": "osJsts",
     "os.feature": "osFeature",
     "os.file": "osFile",
     "os.file.File": "OSFile",

--- a/src/os/action/eventtype.js
+++ b/src/os/action/eventtype.js
@@ -1,12 +1,13 @@
-goog.provide('os.action.EventType');
+goog.module('os.action.EventType');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.events.EventType');
+const GoogEventType = goog.require('goog.events.EventType');
 
 
 /**
  * @enum {string}
  */
-os.action.EventType = {
+exports = {
 
   // layer
   IDENTIFY: 'identify',
@@ -23,7 +24,7 @@ os.action.EventType = {
   FEATURE_LIST: 'layer:featureList',
 
   // map
-  COPY: goog.events.EventType.COPY,
+  COPY: GoogEventType.COPY,
   RESET_VIEW: 'resetView',
   RESET_ROTATION: 'resetRotation',
   TOGGLE_VIEW: 'toggleView',

--- a/src/os/alert/alertmanager.js
+++ b/src/os/alert/alertmanager.js
@@ -85,7 +85,7 @@ class AlertManager extends goog.events.EventTarget {
 
   /**
    * Get the global alert manager instance.
-   * @return {AlertManager}
+   * @return {!AlertManager}
    */
   static getInstance() {
     if (!instance) {
@@ -97,7 +97,7 @@ class AlertManager extends goog.events.EventTarget {
 
   /**
    * Set the global alert manager instance.
-   * @param {!AlertManager} value The AlertManager instance to set.
+   * @param {AlertManager} value The AlertManager instance to set.
    */
   static setInstance(value) {
     instance = value;

--- a/src/os/alert/alertmanagerinstance.js
+++ b/src/os/alert/alertmanagerinstance.js
@@ -2,12 +2,13 @@
  * This is added for backward compatibility with files that goog.require('os.alertManager'). This can be removed if
  * those are replaced with `goog.require('os.alert.AlertManager')` and use `getInstance()`.
  */
-goog.provide('os.alertManager');
+goog.module('os.alertManager');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.alert.AlertManager');
+const AlertManager = goog.require('os.alert.AlertManager');
 
 /**
  * Global alert manager instance.
- * @type {os.alert.AlertManager}
+ * @type {!AlertManager}
  */
-os.alertManager = os.alert.AlertManager.getInstance();
+exports = AlertManager.getInstance();

--- a/src/os/array/array.js
+++ b/src/os/array/array.js
@@ -1,13 +1,14 @@
-goog.provide('os.array');
+goog.module('os.array');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.array');
-goog.require('goog.math');
+const googArray = goog.require('goog.array');
+const math = goog.require('goog.math');
 
 
 /**
  * Inserts a value into a sorted array. The array is not modified if the value is already present.
  *
- * This modifies {@link goog.array.binaryInsert} to return the insertion index instead of a boolean.
+ * This modifies {@link googArray.binaryInsert} to return the insertion index instead of a boolean.
  *
  * @param {IArrayLike<VALUE>} array The array to modify.
  * @param {VALUE} value The object to insert.
@@ -18,24 +19,23 @@ goog.require('goog.math');
  * @return {number} The insertion index, or -1 if the value was already in the array.
  * @template VALUE
  */
-os.array.binaryInsert = function(array, value, opt_compareFn) {
-  var index = goog.array.binarySearch(array, value, opt_compareFn);
+const binaryInsert = function(array, value, opt_compareFn) {
+  var index = googArray.binarySearch(array, value, opt_compareFn);
   if (index < 0) {
     index = -index - 1;
-    goog.array.insertAt(array, value, index);
+    googArray.insertAt(array, value, index);
     return index;
   }
 
   return -1;
 };
 
-
 /**
  * Clear an array.
  *
  * @param {IArrayLike<?>} arr The array or array-like object.
  */
-os.array.clear = function(arr) {
+const clear = function(arr) {
   if (Array.isArray(arr)) {
     arr.length = 0;
   } else if (arr && arr.length != null) {
@@ -44,7 +44,6 @@ os.array.clear = function(arr) {
     }
   }
 };
-
 
 /**
  * Calls a function for each element in an array.
@@ -55,12 +54,11 @@ os.array.clear = function(arr) {
  * @param {S=} opt_obj The object to be used as the value of 'this' within f.
  * @template T,S
  */
-os.array.forEach = function(arr, f, opt_obj) {
+const forEach = function(arr, f, opt_obj) {
   if (arr && arr.length != null) {
     Array.prototype.forEach.call(arr, f, opt_obj);
   }
 };
-
 
 /**
  * Sort items by the specified field in ascending order. Inject the field using bind or goog.partial.
@@ -71,10 +69,9 @@ os.array.forEach = function(arr, f, opt_obj) {
  * @return {number}
  * @template VALUE
  */
-os.array.sortByField = function(field, a, b) {
-  return goog.array.defaultCompare(a[field], b[field]);
+const sortByField = function(field, a, b) {
+  return googArray.defaultCompare(a[field], b[field]);
 };
-
 
 /**
  * Sort items by the specified field in descending order. Inject the field using bind or goog.partial.
@@ -85,10 +82,9 @@ os.array.sortByField = function(field, a, b) {
  * @return {number}
  * @template VALUE
  */
-os.array.sortByFieldDesc = function(field, a, b) {
-  return goog.array.defaultCompare(b[field], a[field]);
+const sortByFieldDesc = function(field, a, b) {
+  return googArray.defaultCompare(b[field], a[field]);
 };
-
 
 /**
  * Calls a function for each element in an array. Skips holes in the array, does nothing if the array is null/undefined.
@@ -100,8 +96,7 @@ os.array.sortByFieldDesc = function(field, a, b) {
  * @template T,S
  * @deprecated Please use {@link os.array.forEach} instead.
  */
-os.array.forEachSafe = os.array.forEach;
-
+const forEachSafe = forEach;
 
 /**
  * Copies array elements from a source array to a destination array.
@@ -112,12 +107,11 @@ os.array.forEachSafe = os.array.forEach;
  * @param {number} destPos Destination start index
  * @param {number} length Number of elements to copy
  */
-os.array.arrayCopy = function(src, srcPos, dest, destPos, length) {
+const arrayCopy = function(src, srcPos, dest, destPos, length) {
   for (var i = srcPos; i < srcPos + length; i += 1) {
     dest[destPos++] = src[i];
   }
 };
-
 
 /**
  * Copies array elements from a source array to a destination array.
@@ -126,7 +120,7 @@ os.array.arrayCopy = function(src, srcPos, dest, destPos, length) {
  * @param {Array} arr2 first array to check interesection
  * @return {Array} an array with only the items present that are in both arrays
  */
-os.array.intersection = function(arr1, arr2) {
+const intersection = function(arr1, arr2) {
   var t;
   // Optimization so that indexOf loops over smaller array
   if (arr1.length > arr2.length) {
@@ -139,9 +133,8 @@ os.array.intersection = function(arr1, arr2) {
   });
 };
 
-
 /**
- * Based on the goog.array.removeDuplicates method. This function discovers all the duplicate entries in an array
+ * Based on the googArray.removeDuplicates method. This function discovers all the duplicate entries in an array
  * and returns them.
  *
  * @param {Array<T>} arr The array to search for duplicates
@@ -149,7 +142,7 @@ os.array.intersection = function(arr1, arr2) {
  * @return {Array<T>}
  * @template T
  */
-os.array.findDuplicates = function(arr, opt_hashFn) {
+const findDuplicates = function(arr, opt_hashFn) {
   var returnArray = [];
   var defaultHashFn = function(item) {
     return goog.isObject(current) ? 'o' + goog.getUid(current) :
@@ -174,9 +167,8 @@ os.array.findDuplicates = function(arr, opt_hashFn) {
   return returnArray;
 };
 
-
 /**
- * Based on the goog.array.removeDuplicates method but will also work when the items you are comparing are arrays,
+ * Based on the googArray.removeDuplicates method but will also work when the items you are comparing are arrays,
  * which is really common in our code. Also returns true if duplicate was found, for convenience
  *
  * @param {Array<T>} arr The array to search for duplicates
@@ -185,9 +177,9 @@ os.array.findDuplicates = function(arr, opt_hashFn) {
  * @return {boolean} returns true if a duplicate was found
  * @template T
  */
-os.array.removeDuplicates = function(arr, opt_rv, opt_hashFn) {
+const removeDuplicates = function(arr, opt_rv, opt_hashFn) {
   var returnArray = opt_rv || arr;
-  // this default function is different from the goog.array one
+  // this default function is different from the googArray one
   // it checks if an object is also an array before just checking the uid, if it is an array then allow comparison of
   // the stringified array
   var defaultHashFn = function(item) {
@@ -218,7 +210,6 @@ os.array.removeDuplicates = function(arr, opt_rv, opt_hashFn) {
   return duplicateFound;
 };
 
-
 /**
  * @typedef {{
  *  data: Array,
@@ -226,8 +217,7 @@ os.array.removeDuplicates = function(arr, opt_rv, opt_hashFn) {
  *  indexer: function(Object, boolean):(string|number)
  * }}
  */
-os.array.JoinSet;
-
+let JoinSet;
 
 /**
  * @typedef {{
@@ -235,52 +225,49 @@ os.array.JoinSet;
  *  key: ?(string|number)
  * }}
  */
-os.array.JoinSubset;
-
+let JoinSubset;
 
 /**
  * @typedef {Object<string|number, Array<Object>>}
  */
-os.array.JoinIndex;
-
+let JoinIndex;
 
 /**
- * Sorts {@link os.array.JoinSet}'s by their crossProduct.
+ * Sorts {@link JoinSet}'s by their crossProduct.
  *
- * @param {os.array.JoinSet} a
- * @param {os.array.JoinSet} b
+ * @param {JoinSet} a
+ * @param {JoinSet} b
  * @return {number}
  */
-os.array.crossProductSort = function(a, b) {
-  return -1 * goog.array.defaultCompare(a.crossProduct, b.crossProduct);
+const crossProductSort = function(a, b) {
+  return -1 * googArray.defaultCompare(a.crossProduct, b.crossProduct);
 };
 
-
 /**
- * @param {Array<os.array.JoinSet>} sets An array of sets. Only one set with a <code>crossProduct</code>
+ * @param {Array<JoinSet>} sets An array of sets. Only one set with a <code>crossProduct</code>
  *  of <code>true</code> is supported.
  * @param {function(Object, Object):Object} copyFunction copy(from, to) implementation for the data in sets
  * @throws {Error} If two sets with <code>crossProduct = true</code> are given
  * @return {Array}
  */
-os.array.join = function(sets, copyFunction) {
+const join = function(sets, copyFunction) {
   var joined = [];
-  sets = sets.sort(os.array.crossProductSort);
+  sets = sets.sort(crossProductSort);
 
   var index = sets.reduce(
       /**
-       * @param {os.array.JoinIndex} index The index to populate
-       * @param {os.array.JoinSet} set The current join set
+       * @param {JoinIndex} index The index to populate
+       * @param {JoinSet} set The current join set
        * @param {number} i The current index
-       * @return {os.array.JoinIndex} The index
+       * @return {JoinIndex} The index
        * @private
        */
       function(index, set, i) {
         return set.data.reduce(
             /**
-             * @param {os.array.JoinIndex} index The index to populate
+             * @param {JoinIndex} index The index to populate
              * @param {Object} item The data item
-             * @return {os.array.JoinIndex} The index
+             * @return {JoinIndex} The index
              */
             function(index, item) {
               var indexValue = set.indexer(item, set.crossProduct);
@@ -316,13 +303,12 @@ os.array.join = function(sets, copyFunction) {
   return joined;
 };
 
-
 /**
  * Searches a flattened 2-dimensional array for the specified target using the binary search algorithm. The array is
  * assumed to contain equal-length groups of values, and the target is searched using a group length (stride) and offset
  * within each group.
  *
- * If no opt_compareFn is specified, elements are compared using `goog.array.defaultCompare`, which compares the
+ * If no opt_compareFn is specified, elements are compared using `googArray.defaultCompare`, which compares the
  * elements using the built in < and > operators. This will produce the expected behavior for homogeneous arrays of
  * String(s) and Number(s).
  *
@@ -346,11 +332,11 @@ os.array.join = function(sets, copyFunction) {
  *                  >= 0 iff target is found, and the return value will be the first index of the found <b>group</b>.
  * @template TARGET, VALUE
  */
-os.array.binaryStrideSearch = function(arr, target, stride, offset, opt_compareFn) {
-  var compareFn = opt_compareFn || goog.array.defaultCompare;
+const binaryStrideSearch = function(arr, target, stride, offset, opt_compareFn) {
+  var compareFn = opt_compareFn || googArray.defaultCompare;
 
   // ensure the offset is within the group bounds
-  offset = goog.math.clamp(offset, 0, stride - 1);
+  offset = math.clamp(offset, 0, stride - 1);
 
   var left = 0; // inclusive
   var right = arr.length; // exclusive
@@ -376,4 +362,23 @@ os.array.binaryStrideSearch = function(arr, target, stride, offset, opt_compareF
   // left is the index if found, or the insertion point otherwise.
   // ~left is a shorthand for -left - 1.
   return found ? left : ~left;
+};
+
+exports = {
+  binaryInsert,
+  clear,
+  forEach,
+  sortByField,
+  sortByFieldDesc,
+  forEachSafe,
+  arrayCopy,
+  intersection,
+  findDuplicates,
+  removeDuplicates,
+  crossProductSort,
+  join,
+  binaryStrideSearch,
+  JoinSet,
+  JoinSubset,
+  JoinIndex
 };

--- a/src/os/bearing/bearing.js
+++ b/src/os/bearing/bearing.js
@@ -1,79 +1,52 @@
-goog.provide('os.bearing');
-goog.provide('os.bearing.BearingSettingsKeys');
-goog.provide('os.bearing.BearingType');
+goog.module('os.bearing');
+goog.module.declareLegacyNamespace();
 
-goog.require('os.config.Settings');
-goog.require('os.net.Request');
-
-
-/**
- * Enumeration of available bearing types.
- * @enum {string}
- */
-os.bearing.BearingType = {
-  TRUE_NORTH: 'trueNorth',
-  MAGNETIC: 'magnetic'
-};
-
-
-/**
- * The base key used by all display settings.
- * @type {string}
- * @const
- */
-os.bearing.BASE_KEY = 'bearing.';
-
-
-/**
- * Display settings keys.
- * @enum {string}
- */
-os.bearing.BearingSettingsKeys = {
-  COF_URL: os.bearing.BASE_KEY + 'cofUrl',
-  COF_VERSION: os.bearing.BASE_KEY + 'cofVersion',
-  BEARING_TYPE: os.bearing.BASE_KEY + 'type',
-  MAGNETIC_NORTH_HELP_URL: os.bearing.BASE_KEY + 'magneticNorthHelpUrl'
-};
+const dispose = goog.require('goog.dispose');
+const NetEventType = goog.require('goog.net.EventType');
+const {ROOT} = goog.require('os');
+const BearingSettingsKeys = goog.require('os.bearing.BearingSettingsKeys');
+const BearingType = goog.require('os.bearing.BearingType');
+const interpolate = goog.require('os.interpolate');
+const InterpolateMethod = goog.require('os.interpolate.Method');
+const Settings = goog.require('os.config.Settings');
+const osMath = goog.require('os.math');
+const Request = goog.require('os.net.Request');
 
 
 /**
  * A function that takes a lat, lon, altitude, and date and returns magnetic
  * field details for that date and time (such as declination).
  * @type {?GeoMagFunction}
- * @private
  */
-os.bearing.geomag_ = null;
-
+let geoMagFn = null;
 
 /**
  * Loads the geomagnetic model.
  */
-os.bearing.loadGeomag = function() {
-  if (!os.bearing.geomag_) {
-    var url = os.ROOT + os.settings.get(os.bearing.BearingSettingsKeys.COF_URL);
-    var request = new os.net.Request(url);
-    request.listenOnce(goog.net.EventType.SUCCESS, os.bearing.onGeomag);
-    request.listenOnce(goog.net.EventType.ERROR, os.bearing.onGeomag);
+const loadGeomag = function() {
+  if (!geoMagFn) {
+    var url = ROOT + Settings.getInstance().get(BearingSettingsKeys.COF_URL);
+    var request = new Request(url);
+    request.listenOnce(NetEventType.SUCCESS, onGeomag);
+    request.listenOnce(NetEventType.ERROR, onGeomag);
     request.load();
   }
 };
 
-
 /**
  * Handles geomagnetic model load.
  *
- * @param {goog.events.Event} event
+ * @param {NetEventType} event
  */
-os.bearing.onGeomag = function(event) {
-  if (event.type === goog.net.EventType.SUCCESS) {
-    var response = /** @type {os.net.Request} */ (event.target).getResponse();
+const onGeomag = function(event) {
+  if (event.type === NetEventType.SUCCESS) {
+    var response = /** @type {Request} */ (event.target).getResponse();
     var wmm = cof2Obj(/** @type {string} */ (response));
-    os.bearing.geomag_ = geoMagFactory(wmm);
+    geoMagFn = geoMagFactory(wmm);
   }
 
-  goog.dispose(event.target);
+  dispose(event.target);
 };
-
 
 /**
  * Creates a geomagnetic data object for a coordinate in lon/lat and a date.
@@ -81,15 +54,14 @@ os.bearing.onGeomag = function(event) {
  * @param {!Date} date The date
  * @return {!Object} The magnetic model details for the given time and location
  */
-os.bearing.geomag = function(coord, date) {
-  if (os.bearing.geomag_ && coord) {
+const geomag = function(coord, date) {
+  if (geoMagFn && coord) {
     // convert altitude from meters to feet
-    return os.bearing.geomag_(coord[1], coord[0], (coord[2] || 0) * 3.28084, date);
+    return geoMagFn(coord[1], coord[0], (coord[2] || 0) * 3.28084, date);
   }
 
   return {};
 };
-
 
 /**
  * Gets the bearing between two points. Based on the current application setting, it will be the true north or magnetic
@@ -98,17 +70,16 @@ os.bearing.geomag = function(coord, date) {
  * @param {!ol.Coordinate} coord1 The starting coordinate
  * @param {!ol.Coordinate} coord2 The ending coordinate
  * @param {!Date} date The date, only useful for magnetic bearing calculation
- * @param {!os.interpolate.Method=} opt_method The method to use. Defaults to the user setting for interpolation method.
+ * @param {!InterpolateMethod=} opt_method The method to use. Defaults to the user setting for interpolation method.
  * @return {number}
  */
-os.bearing.getBearing = function(coord1, coord2, date, opt_method) {
-  opt_method = opt_method || os.interpolate.getMethod();
+const getBearing = function(coord1, coord2, date, opt_method) {
+  opt_method = opt_method || interpolate.getMethod();
 
-  var bearing = opt_method === os.interpolate.Method.GEODESIC ? osasm.geodesicInverse(coord1, coord2).initialBearing :
+  var bearing = opt_method === InterpolateMethod.GEODESIC ? osasm.geodesicInverse(coord1, coord2).initialBearing :
     osasm.rhumbInverse(coord1, coord2).bearing;
-  return os.bearing.modifyBearing(bearing, coord1, date);
+  return modifyBearing(bearing, coord1, date);
 };
-
 
 /**
  * Modifies a bearing by converting it to magnetic north (if applicable) and normalizing it.
@@ -119,17 +90,16 @@ os.bearing.getBearing = function(coord1, coord2, date, opt_method) {
  * @param {string=} opt_bearingType Optional bearing type override.
  * @return {number} The normalized bearing
  */
-os.bearing.modifyBearing = function(bearing, coord, date, opt_bearingType) {
+const modifyBearing = function(bearing, coord, date, opt_bearingType) {
   var bearingType = opt_bearingType ||
-      os.settings.get(os.bearing.BearingSettingsKeys.BEARING_TYPE, os.bearing.BearingType.TRUE_NORTH);
-  if (coord && bearingType == os.bearing.BearingType.MAGNETIC && os.bearing.geomag_) {
-    var geomag = os.bearing.geomag(coord, date);
-    bearing = bearing - geomag['dec'];
+      Settings.getInstance().get(BearingSettingsKeys.BEARING_TYPE, BearingType.TRUE_NORTH);
+  if (coord && bearingType == BearingType.MAGNETIC && geoMagFn) {
+    var geomagResult = geomag(coord, date);
+    bearing = bearing - geomagResult['dec'];
   }
 
   return bearing < 0 ? 360 + bearing : bearing;
 };
-
 
 /**
  * Gets a formatted bearing between two points. This appends a T (true) or M (magnetic) and the degree symbol.
@@ -139,10 +109,19 @@ os.bearing.modifyBearing = function(bearing, coord, date, opt_bearingType) {
  * @param {string=} opt_bearingType Optional bearing type override.
  * @return {string} String formatted version of the bearing.
  */
-os.bearing.getFormattedBearing = function(bearing, opt_precision, opt_bearingType) {
+const getFormattedBearing = function(bearing, opt_precision, opt_bearingType) {
   opt_precision = opt_precision !== undefined ? opt_precision : 5;
   var bearingType = opt_bearingType ||
-      os.settings.get(os.bearing.BearingSettingsKeys.BEARING_TYPE, os.bearing.BearingType.TRUE_NORTH);
-  var typeString = bearingType == os.bearing.BearingType.TRUE_NORTH ? 'T' : 'M';
-  return os.math.toFixed(bearing, opt_precision) + '° ' + typeString;
+      Settings.getInstance().get(BearingSettingsKeys.BEARING_TYPE, BearingType.TRUE_NORTH);
+  var typeString = bearingType == BearingType.TRUE_NORTH ? 'T' : 'M';
+  return osMath.toFixed(bearing, opt_precision) + '° ' + typeString;
+};
+
+exports = {
+  loadGeomag,
+  onGeomag,
+  geomag,
+  getBearing,
+  modifyBearing,
+  getFormattedBearing
 };

--- a/src/os/bearing/bearing.js
+++ b/src/os/bearing/bearing.js
@@ -21,6 +21,12 @@ const Request = goog.require('os.net.Request');
 let geoMagFn = null;
 
 /**
+ * If the geomag library has loaded.
+ * @return {boolean}
+ */
+const isGeomagLoaded = () => !!geoMagFn;
+
+/**
  * Loads the geomagnetic model.
  */
 const loadGeomag = function() {
@@ -118,6 +124,7 @@ const getFormattedBearing = function(bearing, opt_precision, opt_bearingType) {
 };
 
 exports = {
+  isGeomagLoaded,
   loadGeomag,
   onGeomag,
   geomag,

--- a/src/os/bearing/bearingsettings.js
+++ b/src/os/bearing/bearingsettings.js
@@ -1,124 +1,31 @@
-goog.provide('os.bearing.BearingSettings');
-goog.provide('os.bearing.BearingSettingsCtrl');
-goog.require('os.bearing');
-goog.require('os.config.Settings');
-goog.require('os.ui.Module');
-goog.require('os.ui.config.SettingPlugin');
-goog.require('os.ui.popover.popoverDirective');
+goog.module('os.bearing.BearingSettings');
+goog.module.declareLegacyNamespace();
 
+const bearing = goog.require('os.bearing');
+const {directiveTag: settingsUi} = goog.require('os.bearing.BearingSettingsUI');
+const SettingPlugin = goog.require('os.ui.config.SettingPlugin');
 
 
 /**
  * Settings plugin for controlling bearing settings. When it is instantiated, it lazy loads the geomagnetic
  * data needed for calculating magnetic north bearings.
- *
- * @extends {os.ui.config.SettingPlugin}
- * @constructor
  */
-os.bearing.BearingSettings = function() {
-  os.bearing.BearingSettings.base(this, 'constructor');
-
-  this.setLabel('Bearing');
-  this.setCategories(['Map']);
-  this.setDescription('Choose whether bearings are displayed with as true north or magnetic north');
-  this.setTags(['bearing', 'north', 'true', 'magnetic']);
-  this.setIcon('fa fa-compass');
-  this.setUI('bearing-setting');
-
-  os.bearing.loadGeomag();
-};
-goog.inherits(os.bearing.BearingSettings, os.ui.config.SettingPlugin);
-
-
-/**
- * The bearing settings directive
- *
- * @return {angular.Directive}
- */
-os.bearing.BearingSettingsDirective = function() {
-  return {
-    restrict: 'AE',
-    replace: true,
-    templateUrl: os.ROOT + 'views/config/bearingsettings.html',
-    controller: os.bearing.BearingSettingsCtrl,
-    controllerAs: 'ctrl'
-  };
-};
-
-
-/**
- * Add the directive to the module
- */
-os.ui.Module.directive('bearingSetting', [os.bearing.BearingSettingsDirective]);
-
-
-
-/**
- * Controller for bearing settings
- *
- * @param {angular.Scope} $scope
- * @constructor
- * @ngInject
- */
-os.bearing.BearingSettingsCtrl = function($scope) {
+class BearingSettings extends SettingPlugin {
   /**
-   * @type {angular.Scope}
-   * @private
+   * Constructor.
    */
-  this.scope_ = $scope;
+  constructor() {
+    super();
 
-  os.settings.listen(os.bearing.BearingSettingsKeys.BEARING_TYPE, this.onBearingChange_, false, this);
+    this.setLabel('Bearing');
+    this.setCategories(['Map']);
+    this.setDescription('Choose whether bearings are displayed with as true north or magnetic north');
+    this.setTags(['bearing', 'north', 'true', 'magnetic']);
+    this.setIcon('fa fa-compass');
+    this.setUI(settingsUi);
 
-  /**
-   * @type {string}
-   */
-  this['format'] = /** @type {string} */ (os.settings.get(
-      os.bearing.BearingSettingsKeys.BEARING_TYPE, os.bearing.BearingType.TRUE_NORTH));
-
-  var cofVersion = /** @type {string} */ (os.settings.get(os.bearing.BearingSettingsKeys.COF_VERSION, '2015-2020'));
-  var helpUrl = /** @type {string} */ (os.settings.get(os.bearing.BearingSettingsKeys.MAGNETIC_NORTH_HELP_URL));
-
-  this.scope_['cofVersion'] = cofVersion;
-  this.scope_['helpUrl'] = helpUrl;
-
-  this.scope_.$watch('ctrl.format', this.update.bind(this));
-  this.scope_.$on('$destroy', this.destroy_.bind(this));
-};
-
-
-/**
- * Destroy
- *
- * @private
- */
-os.bearing.BearingSettingsCtrl.prototype.destroy_ = function() {
-  os.settings.unlisten(os.bearing.BearingSettingsKeys.BEARING_TYPE, this.onBearingChange_, false, this);
-};
-
-
-/**
- * Listen for changes from the system and update the setting display
- *
- * @param {os.events.SettingChangeEvent} event
- * @private
- */
-os.bearing.BearingSettingsCtrl.prototype.onBearingChange_ = function(event) {
-  if (typeof event.newVal == 'string' && event.newVal !== event.oldVal) {
-    this['format'] = event.newVal;
-    os.ui.apply(this.scope_);
+    bearing.loadGeomag();
   }
-};
+}
 
-
-/**
- * Update and store setting.
- *
- * @param {os.ui.location.Format=} opt_new
- * @param {os.ui.location.Format=} opt_old
- * @export
- */
-os.bearing.BearingSettingsCtrl.prototype.update = function(opt_new, opt_old) {
-  if (opt_new && opt_old && opt_new !== opt_old) {
-    os.settings.set(os.bearing.BearingSettingsKeys.BEARING_TYPE, opt_new);
-  }
-};
+exports = BearingSettings;

--- a/src/os/bearing/bearingsettingskeys.js
+++ b/src/os/bearing/bearingsettingskeys.js
@@ -1,0 +1,20 @@
+goog.module('os.bearing.BearingSettingsKeys');
+goog.module.declareLegacyNamespace();
+
+
+/**
+ * The base key used by all bearing settings.
+ * @type {string}
+ */
+const baseKey = 'bearing.';
+
+/**
+ * Bearing settings keys.
+ * @enum {string}
+ */
+exports = {
+  COF_URL: baseKey + 'cofUrl',
+  COF_VERSION: baseKey + 'cofVersion',
+  BEARING_TYPE: baseKey + 'type',
+  MAGNETIC_NORTH_HELP_URL: baseKey + 'magneticNorthHelpUrl'
+};

--- a/src/os/bearing/bearingsettingsui.js
+++ b/src/os/bearing/bearingsettingsui.js
@@ -1,0 +1,119 @@
+goog.module('os.bearing.BearingSettingsUI');
+goog.module.declareLegacyNamespace();
+
+const {ROOT} = goog.require('os');
+const BearingSettingsKeys = goog.require('os.bearing.BearingSettingsKeys');
+const BearingType = goog.require('os.bearing.BearingType');
+const Settings = goog.require('os.config.Settings');
+const osUi = goog.require('os.ui');
+const Module = goog.require('os.ui.Module');
+
+const SettingChangeEvent = goog.requireType('os.events.SettingChangeEvent');
+const LocationFormat = goog.requireType('os.ui.location.Format');
+
+
+/**
+ * The bearing settings directive
+ * @return {angular.Directive}
+ */
+const directive = function() {
+  return {
+    restrict: 'AE',
+    replace: true,
+    templateUrl: ROOT + 'views/config/bearingsettings.html',
+    controller: Controller,
+    controllerAs: 'ctrl'
+  };
+};
+
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'bearing-setting';
+
+
+/**
+ * Add the directive to the module
+ */
+Module.directive('bearingSetting', [directive]);
+
+
+
+/**
+ * Controller for bearing settings
+ * @unrestricted
+ */
+class Controller {
+  /**
+   * Constructor.
+   * @param {angular.Scope} $scope
+   * @ngInject
+   */
+  constructor($scope) {
+    /**
+     * @type {angular.Scope}
+     * @private
+     */
+    this.scope_ = $scope;
+
+    const settings = Settings.getInstance();
+    settings.listen(BearingSettingsKeys.BEARING_TYPE, this.onBearingChange_, false, this);
+
+    /**
+     * @type {string}
+     */
+    this['format'] = /** @type {string} */ (settings.get(BearingSettingsKeys.BEARING_TYPE, BearingType.TRUE_NORTH));
+
+    var cofVersion = /** @type {string} */ (settings.get(BearingSettingsKeys.COF_VERSION, '2015-2020'));
+    var helpUrl = /** @type {string} */ (settings.get(BearingSettingsKeys.MAGNETIC_NORTH_HELP_URL));
+
+    this.scope_['cofVersion'] = cofVersion;
+    this.scope_['helpUrl'] = helpUrl;
+
+    this.scope_.$watch('ctrl.format', this.update.bind(this));
+    this.scope_.$on('$destroy', this.destroy_.bind(this));
+  }
+
+  /**
+   * Destroy
+   *
+   * @private
+   */
+  destroy_() {
+    Settings.getInstance().unlisten(BearingSettingsKeys.BEARING_TYPE, this.onBearingChange_, false, this);
+  }
+
+  /**
+   * Listen for changes from the system and update the setting display
+   *
+   * @param {SettingChangeEvent} event
+   * @private
+   */
+  onBearingChange_(event) {
+    if (typeof event.newVal == 'string' && event.newVal !== event.oldVal) {
+      this['format'] = event.newVal;
+      osUi.apply(this.scope_);
+    }
+  }
+
+  /**
+   * Update and store setting.
+   *
+   * @param {LocationFormat=} opt_new
+   * @param {LocationFormat=} opt_old
+   * @export
+   */
+  update(opt_new, opt_old) {
+    if (opt_new && opt_old && opt_new !== opt_old) {
+      Settings.getInstance().set(BearingSettingsKeys.BEARING_TYPE, opt_new);
+    }
+  }
+}
+
+exports = {
+  directive,
+  directiveTag,
+  Controller
+};

--- a/src/os/bearing/bearingtype.js
+++ b/src/os/bearing/bearingtype.js
@@ -1,0 +1,12 @@
+goog.module('os.bearing.BearingType');
+goog.module.declareLegacyNamespace();
+
+
+/**
+ * Enumeration of available bearing types.
+ * @enum {string}
+ */
+exports = {
+  TRUE_NORTH: 'trueNorth',
+  MAGNETIC: 'magnetic'
+};

--- a/src/os/buffer/buffer.js
+++ b/src/os/buffer/buffer.js
@@ -166,7 +166,7 @@ const allowLivePreview = function(config) {
  * @param {boolean=} opt_preview If the features should only be returned for preview
  * @return {Array<!Feature>} The new areas
  */
-const createFromConfig = function(config, opt_preview) {
+let createFromConfig_ = function(config, opt_preview) {
   if (isConfigValid(config)) {
     var distance = math.convertUnits(config['distance'], Units.METERS, config['units']);
     var areas = [];
@@ -266,6 +266,26 @@ const createFromConfig = function(config, opt_preview) {
 };
 
 /**
+ * Creates buffer regions from a buffer config and adds them to the area manager.
+ *
+ * @param {BufferConfig} config The buffer config
+ * @param {boolean=} opt_preview If the features should only be returned for preview
+ * @return {Array<!Feature>} The new areas
+ */
+const createFromConfig = function(config, opt_preview) {
+  return createFromConfig_(config, opt_preview);
+};
+
+/**
+ * Replace default createFromConfig implementation.
+ *
+ * @param {!function(BufferConfig, boolean=):Array<!Feature>} f The new implementation
+ */
+const setCreateFromConfig = function(f) {
+  createFromConfig_ = f;
+};
+
+/**
  * Launch a dialog to create buffer regions around features.
  *
  * @param {Object} options
@@ -306,6 +326,7 @@ exports = {
   isConfigValid,
   allowLivePreview,
   createFromConfig,
+  setCreateFromConfig,
   launchDialog,
   BufferConfig
 };

--- a/src/os/buffer/buffer.js
+++ b/src/os/buffer/buffer.js
@@ -1,11 +1,26 @@
-goog.provide('os.buffer');
+goog.module('os.buffer');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.Feature');
-goog.require('os.command.ParallelCommand');
-goog.require('os.geo.jsts');
 goog.require('os.ui.buffer.bufferDialogDirective');
-goog.require('os.ui.query');
-goog.require('os.ui.query.cmd.AreaAdd');
+
+const userAgent = goog.require('goog.userAgent');
+const Feature = goog.require('ol.Feature');
+const GeometryType = goog.require('ol.geom.GeometryType');
+const CommandProcessor = goog.require('os.command.CommandProcessor');
+const ParallelCommand = goog.require('os.command.ParallelCommand');
+const Settings = goog.require('os.config.Settings');
+const RecordField = goog.require('os.data.RecordField');
+const osFeature = goog.require('os.feature');
+const osJsts = goog.require('os.geo.jsts');
+const math = goog.require('os.math');
+const Units = goog.require('os.math.Units');
+const osStyle = goog.require('os.style');
+const AreaAdd = goog.require('os.ui.query.cmd.AreaAdd');
+const osWindow = goog.require('os.ui.window');
+
+const Geometry = goog.requireType('ol.geom.Geometry');
+const GeometryCollection = goog.requireType('ol.geom.GeometryCollection');
+const SimpleGeometry = goog.requireType('ol.geom.SimpleGeometry');
 
 
 /**
@@ -17,136 +32,120 @@ goog.require('os.ui.query.cmd.AreaAdd');
  *   title: string,
  *   description: string,
  *   tags: string,
- *   geometry: (ol.geom.Geometry|undefined),
- *   features: !Array<!ol.Feature>
+ *   geometry: (Geometry|undefined),
+ *   features: !Array<!Feature>
  * }}
  */
-os.buffer.BufferConfig;
-
+let BufferConfig;
 
 /**
  * Icon used for the buffer region feature.
  * @type {string}
- * @const
  */
-os.buffer.ICON = 'fa-dot-circle-o';
-
+const ICON = 'fa-dot-circle-o';
 
 /**
  * The base settings key to use for buffer region configuration.
  * @type {string}
- * @const
  */
-os.buffer.BASE_KEY = 'bufferRegion.';
-
+const BASE_KEY = 'bufferRegion.';
 
 /**
  * @enum {string}
  */
-os.buffer.BufferSetting = {
-  DISTANCE: os.buffer.BASE_KEY + 'distance',
-  UNITS: os.buffer.BASE_KEY + 'units'
+const BufferSetting = {
+  DISTANCE: BASE_KEY + 'distance',
+  UNITS: BASE_KEY + 'units'
 };
-
 
 /**
  * Style config for buffer previews.
  * @type {Object}
- * @const
  */
-os.buffer.PREVIEW_STYLE = {
+const PREVIEW_STYLE = {
   'fill': {
     'color': 'rgba(0,255,255,.15)'
   },
   'stroke': {
-    'width': os.style.DEFAULT_FEATURE_SIZE,
+    'width': osStyle.DEFAULT_FEATURE_SIZE,
     'color': 'rgba(0,255,255,1)'
   }
 };
 
-
 /**
  * Default title for buffer areas.
  * @type {string}
- * @const
  */
-os.buffer.DEFAULT_TITLE = 'Buffer Region';
-
+const DEFAULT_TITLE = 'Buffer Region';
 
 /**
  * Limitation on the number of features that can be buffered in live preview mode.
  * @type {number}
- * @const
  */
-os.buffer.FEATURE_LIMIT = goog.userAgent.WEBKIT ? 500 : 100;
-
+const FEATURE_LIMIT = userAgent.WEBKIT ? 500 : 100;
 
 /**
  * Limitation on the number of source verticies that can be buffered in live preview mode.
  * @type {number}
- * @const
  */
-os.buffer.VERTEX_LIMIT = goog.userAgent.WEBKIT ? 5000 : 2000;
-
+const VERTEX_LIMIT = userAgent.WEBKIT ? 5000 : 2000;
 
 /**
  * Create a default configuration object for a buffer region.
  *
- * @return {!os.buffer.BufferConfig}
+ * @return {!BufferConfig}
  */
-os.buffer.getBaseConfig = function() {
+const getBaseConfig = function() {
+  const settings = Settings.getInstance();
   return {
-    'distance': /** @type {number} */ (os.settings.get(os.buffer.BufferSetting.DISTANCE, 5)),
-    'units': /** @type {string} */ (os.settings.get(os.buffer.BufferSetting.UNITS,
-        os.math.Units.KILOMETERS)),
+    'distance': /** @type {number} */ (settings.get(BufferSetting.DISTANCE, 5)),
+    'units': /** @type {string} */ (settings.get(BufferSetting.UNITS, Units.KILOMETERS)),
     'outside': true,
     'inside': false,
-    'title': os.buffer.DEFAULT_TITLE,
+    'title': DEFAULT_TITLE,
     'description': '',
     'tags': '',
     'features': []
   };
 };
 
-
 /**
  * Save a buffer region configuration to settings.
  *
- * @param {!os.buffer.BufferConfig} config
+ * @param {!BufferConfig} config
  */
-os.buffer.saveConfig = function(config) {
-  os.settings.set(os.buffer.BufferSetting.DISTANCE, config['distance']);
-  os.settings.set(os.buffer.BufferSetting.UNITS, config['units']);
+const saveConfig = function(config) {
+  const settings = Settings.getInstance();
+  settings.set(BufferSetting.DISTANCE, config['distance']);
+  settings.set(BufferSetting.UNITS, config['units']);
 };
-
 
 /**
  * Creates buffer regions from a buffer config and adds them to the area manager.
  *
- * @param {os.buffer.BufferConfig} config The buffer config
+ * @param {BufferConfig} config The buffer config
  * @return {boolean}
  */
-os.buffer.isConfigValid = function(config) {
+const isConfigValid = function(config) {
   return config['features'] && config['features'].length > 0 && config['distance'] != null;
 };
-
 
 /**
  * If live preview mode should be allowed in the buffer form.
  *
- * @param {os.buffer.BufferConfig} config The buffer config
+ * @param {BufferConfig} config The buffer config
  * @return {boolean}
  */
-os.buffer.allowLivePreview = function(config) {
+const allowLivePreview = function(config) {
   if (config['features']) {
-    if (config['features'].length > os.buffer.FEATURE_LIMIT) {
+    if (config['features'].length > FEATURE_LIMIT) {
       return false;
     }
 
     var vertexCount = 0;
-    for (var i = 0; i < config['features'].length && vertexCount < os.buffer.VERTEX_LIMIT; i++) {
+    for (var i = 0; i < config['features'].length && vertexCount < VERTEX_LIMIT; i++) {
       var feature = config['features'][i];
-      var geometry = /** @type {ol.geom.SimpleGeometry} */ (feature.getGeometry());
+      var geometry = /** @type {SimpleGeometry} */ (feature.getGeometry());
       if (geometry) {
         var stride = geometry.getStride();
         var coordinates = geometry.getFlatCoordinates();
@@ -154,30 +153,29 @@ os.buffer.allowLivePreview = function(config) {
       }
     }
 
-    return vertexCount < os.buffer.VERTEX_LIMIT;
+    return vertexCount < VERTEX_LIMIT;
   }
 
   return true;
 };
 
-
 /**
  * Creates buffer regions from a buffer config and adds them to the area manager.
  *
- * @param {os.buffer.BufferConfig} config The buffer config
+ * @param {BufferConfig} config The buffer config
  * @param {boolean=} opt_preview If the features should only be returned for preview
- * @return {Array<!ol.Feature>} The new areas
+ * @return {Array<!Feature>} The new areas
  */
-os.buffer.createFromConfig = function(config, opt_preview) {
-  if (os.buffer.isConfigValid(config)) {
-    var distance = os.math.convertUnits(config['distance'], os.math.Units.METERS, config['units']);
+const createFromConfig = function(config, opt_preview) {
+  if (isConfigValid(config)) {
+    var distance = math.convertUnits(config['distance'], Units.METERS, config['units']);
     var areas = [];
 
     for (var i = 0; i < config['features'].length; i++) {
       var feature = config['features'][i];
 
       // try to set the title from the config
-      var featureTitle = os.buffer.DEFAULT_TITLE;
+      var featureTitle = DEFAULT_TITLE;
       if (config['titleColumn']) {
         // try the property value first
         featureTitle = feature.get(config['titleColumn']['field']);
@@ -198,8 +196,8 @@ os.buffer.createFromConfig = function(config, opt_preview) {
 
       var featGeom = feature.getGeometry();
       if (featGeom) {
-        var geoms = (featGeom.getType() == ol.geom.GeometryType.GEOMETRY_COLLECTION) ?
-        /** @type {!ol.geom.GeometryCollection} */ (featGeom).getGeometriesArray() : [featGeom];
+        var geoms = (featGeom.getType() == GeometryType.GEOMETRY_COLLECTION) ?
+        /** @type {!GeometryCollection} */ (featGeom).getGeometriesArray() : [featGeom];
 
         for (var j = 0, n = geoms.length; j < n; j++) {
           var absDistance = Math.abs(distance);
@@ -208,36 +206,36 @@ os.buffer.createFromConfig = function(config, opt_preview) {
           var inner;
 
           if (config['outside'] && config['inside']) {
-            outer = os.geo.jsts.buffer(geoms[j], absDistance);
-            inner = os.geo.jsts.buffer(geoms[j], -absDistance);
+            outer = osJsts.buffer(geoms[j], absDistance);
+            inner = osJsts.buffer(geoms[j], -absDistance);
 
             // if either buffer operation fails, do not create a buffer!
             if (outer && inner) {
               // remove the inner buffer from the outer to create an area surrounding the original geometry
-              var result = os.geo.jsts.removeFrom(new ol.Feature(outer), new ol.Feature(inner));
+              var result = osJsts.removeFrom(new Feature(outer), new Feature(inner));
               if (result) {
                 buffer = result.getGeometry();
               }
             }
           } else if (config['outside']) {
-            buffer = os.geo.jsts.buffer(geoms[j], absDistance);
+            buffer = osJsts.buffer(geoms[j], absDistance);
           } else if (config['inside']) {
-            buffer = os.geo.jsts.buffer(geoms[j], -absDistance);
+            buffer = osJsts.buffer(geoms[j], -absDistance);
           }
 
           if (buffer) {
-            var area = new ol.Feature(buffer);
+            var area = new Feature(buffer);
             area.setId(i);
             area.set('title', '' + featureTitle);
             area.set('description', config['descColumn'] ? feature.get(config['descColumn']['field']) :
               config['description']);
             area.set('tags', config['tagsColumn'] ? feature.get(config['tagsColumn']['field']) :
               config['tags']);
-            area.set(os.data.RecordField.DRAWING_LAYER_NODE, false);
+            area.set(RecordField.DRAWING_LAYER_NODE, false);
 
-            var source = os.feature.getSource(feature);
+            var source = osFeature.getSource(feature);
             if (source) {
-              area.set(os.data.RecordField.SOURCE_NAME, source.getTitle(), true);
+              area.set(RecordField.SOURCE_NAME, source.getTitle(), true);
             }
 
             areas.push(area);
@@ -250,14 +248,14 @@ os.buffer.createFromConfig = function(config, opt_preview) {
       if (!opt_preview) {
         var cmds = [];
         for (var i = 0; i < areas.length; i++) {
-          var area = new os.ui.query.cmd.AreaAdd(areas[i]);
+          var area = new AreaAdd(areas[i]);
           cmds.push(area);
         }
 
-        var cmd = new os.command.ParallelCommand();
+        var cmd = new ParallelCommand();
         cmd.setCommands(cmds);
         cmd.title = 'Add buffer region' + (cmds.length > 1 ? 's' : '');
-        os.command.CommandProcessor.getInstance().addCommand(cmd);
+        CommandProcessor.getInstance().addCommand(cmd);
       }
 
       return areas;
@@ -267,21 +265,20 @@ os.buffer.createFromConfig = function(config, opt_preview) {
   return null;
 };
 
-
 /**
  * Launch a dialog to create buffer regions around features.
  *
  * @param {Object} options
  */
-os.buffer.launchDialog = function(options) {
+const launchDialog = function(options) {
   var windowId = 'Buffer';
-  if (os.ui.window.exists(windowId)) {
-    os.ui.window.bringToFront(windowId);
+  if (osWindow.exists(windowId)) {
+    osWindow.bringToFront(windowId);
   } else {
     var windowOptions = {
       'id': windowId,
       'label': 'Create Buffer Region' + (options['features'] ? '' : 's'),
-      'icon': 'fa ' + os.buffer.ICON,
+      'icon': 'fa ' + ICON,
       'x': 'center',
       'y': 'center',
       'width': '425',
@@ -292,6 +289,23 @@ os.buffer.launchDialog = function(options) {
     };
 
     var template = '<bufferdialog></bufferdialog>';
-    os.ui.window.create(windowOptions, template, undefined, undefined, undefined, options);
+    osWindow.create(windowOptions, template, undefined, undefined, undefined, options);
   }
+};
+
+exports = {
+  ICON,
+  BASE_KEY,
+  BufferSetting,
+  PREVIEW_STYLE,
+  DEFAULT_TITLE,
+  FEATURE_LIMIT,
+  VERTEX_LIMIT,
+  getBaseConfig,
+  saveConfig,
+  isConfigValid,
+  allowLivePreview,
+  createFromConfig,
+  launchDialog,
+  BufferConfig
 };

--- a/src/os/column/columnmapping.js
+++ b/src/os/column/columnmapping.js
@@ -1,10 +1,12 @@
 goog.module('os.column.ColumnMapping');
 goog.module.declareLegacyNamespace();
 
+const asserts = goog.require('goog.asserts');
 const dom = goog.require('goog.dom');
 const googDomXml = goog.require('goog.dom.xml');
 const EventTarget = goog.require('goog.events.EventTarget');
 const log = goog.require('goog.log');
+const googString = goog.require('goog.string');
 const olArray = goog.require('ol.array');
 const ColumnMappingEvent = goog.require('os.column.ColumnMappingEvent');
 const ColumnMappingEventType = goog.require('os.column.ColumnMappingEventType');
@@ -41,7 +43,7 @@ class ColumnMapping extends EventTarget {
      * @type {!string}
      * @private
      */
-    this.id_ = goog.string.getRandomString();
+    this.id_ = googString.getRandomString();
 
     /**
      * @type {?string}
@@ -80,7 +82,7 @@ class ColumnMapping extends EventTarget {
    * @inheritDoc
    */
   setId(value) {
-    this.id_ = value || goog.string.getRandomString();
+    this.id_ = value || googString.getRandomString();
   }
 
   /**
@@ -185,9 +187,9 @@ class ColumnMapping extends EventTarget {
           var type = mappingEl.getAttribute(ColumnMappingAttr.TYPE);
           var name = mappingEl.getAttribute(ColumnMappingAttr.NAME);
 
-          goog.asserts.assertString(type);
+          asserts.assertString(type);
           this.setValueType(type);
-          goog.asserts.assertString(name);
+          asserts.assertString(name);
           this.setName(name);
 
           var description = /** @type {string} */ (mappingEl.getAttribute(ColumnMappingAttr.DESCRIPTION));

--- a/src/os/column/columnmapping.js
+++ b/src/os/column/columnmapping.js
@@ -1,33 +1,22 @@
-goog.provide('os.column.ColumnMapping');
-goog.provide('os.column.ColumnMappingTag');
-goog.require('goog.array');
-goog.require('goog.dom');
-goog.require('goog.dom.xml');
-goog.require('goog.events.EventTarget');
-goog.require('goog.log');
-goog.require('ol.array');
-goog.require('os.column.ColumnMappingEvent');
-goog.require('os.column.ColumnMappingEventType');
-goog.require('os.column.ColumnModel');
-goog.require('os.column.IColumnMapping');
+goog.module('os.column.ColumnMapping');
+goog.module.declareLegacyNamespace();
 
-
-/**
- * Enumeration of column mapping tags
- * @enum {string}
- */
-os.column.ColumnMappingTag = {
-  COLUMN_MAPPING: 'columnMapping',
-  COLUMN_MAPPINGS: 'columnMappings',
-  COLUMN: 'column'
-};
+const dom = goog.require('goog.dom');
+const googDomXml = goog.require('goog.dom.xml');
+const EventTarget = goog.require('goog.events.EventTarget');
+const log = goog.require('goog.log');
+const olArray = goog.require('ol.array');
+const ColumnMappingEvent = goog.require('os.column.ColumnMappingEvent');
+const ColumnMappingEventType = goog.require('os.column.ColumnMappingEventType');
+const ColumnMappingTag = goog.require('os.column.ColumnMappingTag');
+const IColumnMapping = goog.require('os.column.IColumnMapping'); // eslint-disable-line
 
 
 /**
  * Enumeration of column mapping attributes
  * @enum {string}
  */
-os.column.ColumnMappingAttr = {
+const ColumnMappingAttr = {
   TYPE: 'type',
   NAME: 'name',
   DESCRIPTION: 'description',
@@ -35,279 +24,263 @@ os.column.ColumnMappingAttr = {
 };
 
 
-
 /**
  * Base implementation of a column mapping.
  *
- * @implements {os.column.IColumnMapping}
- * @extends {goog.events.EventTarget}
- * @constructor
+ * @implements {IColumnMapping}
+ * @unrestricted
  */
-os.column.ColumnMapping = function() {
-  os.column.ColumnMapping.base(this, 'constructor');
+class ColumnMapping extends EventTarget {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    /**
+     * @type {!string}
+     * @private
+     */
+    this.id_ = goog.string.getRandomString();
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this['name'] = null;
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this['description'] = null;
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.valueType_ = null;
+
+    /**
+     * Array of column models.
+     * @type {Array<osx.column.ColumnModel>}
+     * @private
+     */
+    this.columns_ = [];
+  }
 
   /**
-   * @type {!string}
-   * @private
+   * @inheritDoc
    */
-  this.id_ = goog.string.getRandomString();
+  getId() {
+    return this.id_;
+  }
 
   /**
-   * @type {?string}
-   * @private
+   * @inheritDoc
    */
-  this['name'] = null;
+  setId(value) {
+    this.id_ = value || goog.string.getRandomString();
+  }
 
   /**
-   * @type {?string}
-   * @private
+   * @inheritDoc
    */
-  this['description'] = null;
+  getName() {
+    return this['name'];
+  }
 
   /**
-   * @type {?string}
-   * @private
+   * @inheritDoc
    */
-  this.valueType_ = null;
+  setName(value) {
+    this['name'] = value;
+  }
 
   /**
-   * Array of column models.
-   * @type {Array<osx.column.ColumnModel>}
-   * @private
+   * @inheritDoc
    */
-  this.columns_ = [];
-};
-goog.inherits(os.column.ColumnMapping, goog.events.EventTarget);
+  getDescription() {
+    return this['description'];
+  }
 
+  /**
+   * @inheritDoc
+   */
+  setDescription(value) {
+    this['description'] = value;
+  }
 
-/**
- * Logger
- * @type {goog.log.Logger}
- * @private
- */
-os.column.ColumnMapping.LOGGER_ = goog.log.getLogger('os.column.ColumnMapping');
+  /**
+   * @inheritDoc
+   */
+  getValueType() {
+    return this.valueType_;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  setValueType(value) {
+    this.valueType_ = value;
+  }
 
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.getId = function() {
-  return this.id_;
-};
+  /**
+   * @inheritDoc
+   */
+  addColumn(layerKey, column, opt_units) {
+    var columnModel = {
+      'column': column,
+      'layer': layerKey,
+      'units': opt_units || ''
+    };
 
+    this.columns_.push(columnModel);
 
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.setId = function(value) {
-  this.id_ = value || goog.string.getRandomString();
-};
+    var event = new ColumnMappingEvent(ColumnMappingEventType.COLUMN_ADDED, columnModel);
+    this.dispatchEvent(event);
+  }
 
+  /**
+   * @inheritDoc
+   */
+  removeColumn(columnModel) {
+    var removed = olArray.remove(this.columns_, columnModel);
 
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.getName = function() {
-  return this['name'];
-};
+    var model = removed ? columnModel : null;
+    var event = new ColumnMappingEvent(ColumnMappingEventType.COLUMN_REMOVED, model);
+    this.dispatchEvent(event);
+  }
 
+  /**
+   * @inheritDoc
+   */
+  getColumns() {
+    return this.columns_;
+  }
 
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.setName = function(value) {
-  this['name'] = value;
-};
+  /**
+   * @inheritDoc
+   */
+  getColumn(layerKey) {
+    var found = olArray.find(this.columns_, function(columnModel) {
+      return columnModel['layer'] === layerKey;
+    });
 
+    return found;
+  }
 
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.getDescription = function() {
-  return this['description'];
-};
+  /**
+   * Loads raw XML mapping data
+   *
+   * @param {string} xml
+   */
+  loadMapping(xml) {
+    var doc = googDomXml.loadXml(xml);
 
+    try {
+      if (doc) {
+        var mappingEl = dom.getFirstElementChild(doc);
+        if (mappingEl && mappingEl.tagName === ColumnMappingTag.COLUMN_MAPPING) {
+          var type = mappingEl.getAttribute(ColumnMappingAttr.TYPE);
+          var name = mappingEl.getAttribute(ColumnMappingAttr.NAME);
 
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.setDescription = function(value) {
-  this['description'] = value;
-};
+          goog.asserts.assertString(type);
+          this.setValueType(type);
+          goog.asserts.assertString(name);
+          this.setName(name);
 
+          var description = /** @type {string} */ (mappingEl.getAttribute(ColumnMappingAttr.DESCRIPTION));
+          this.setDescription(description);
 
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.getValueType = function() {
-  return this.valueType_;
-};
+          var columns = mappingEl.querySelectorAll(ColumnMappingTag.COLUMN);
+          if (columns) {
+            for (var i = 0, n = columns.length; i < n; i++) {
+              var column = columns[i];
+              var layer = column.getAttribute(ColumnMappingAttr.LAYER);
+              var columnText = column.textContent;
 
-
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.setValueType = function(value) {
-  this.valueType_ = value;
-};
-
-
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.addColumn = function(layerKey, column, opt_units) {
-  var columnModel = {
-    'column': column,
-    'layer': layerKey,
-    'units': opt_units || ''
-  };
-
-  this.columns_.push(columnModel);
-
-  var event = new os.column.ColumnMappingEvent(os.column.ColumnMappingEventType.COLUMN_ADDED, columnModel);
-  this.dispatchEvent(event);
-};
-
-
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.removeColumn = function(columnModel) {
-  var removed = ol.array.remove(this.columns_, columnModel);
-
-  var model = removed ? columnModel : null;
-  var event = new os.column.ColumnMappingEvent(os.column.ColumnMappingEventType.COLUMN_REMOVED, model);
-  this.dispatchEvent(event);
-};
-
-
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.getColumns = function() {
-  return this.columns_;
-};
-
-
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.getColumn = function(layerKey) {
-  var found = ol.array.find(this.columns_, function(columnModel) {
-    return columnModel['layer'] === layerKey;
-  });
-
-  return found;
-};
-
-
-/**
- * Loads raw XML mapping data
- *
- * @param {string} xml
- */
-os.column.ColumnMapping.prototype.loadMapping = function(xml) {
-  var doc = goog.dom.xml.loadXml(xml);
-
-  try {
-    if (doc) {
-      var mappingEl = goog.dom.getFirstElementChild(doc);
-      if (mappingEl && mappingEl.tagName === os.column.ColumnMappingTag.COLUMN_MAPPING) {
-        var type = mappingEl.getAttribute(os.column.ColumnMappingAttr.TYPE);
-        var name = mappingEl.getAttribute(os.column.ColumnMappingAttr.NAME);
-
-        goog.asserts.assertString(type);
-        this.setValueType(type);
-        goog.asserts.assertString(name);
-        this.setName(name);
-
-        var description = /** @type {string} */ (mappingEl.getAttribute(os.column.ColumnMappingAttr.DESCRIPTION));
-        this.setDescription(description);
-
-        var columns = mappingEl.querySelectorAll(os.column.ColumnMappingTag.COLUMN);
-        if (columns) {
-          for (var i = 0, n = columns.length; i < n; i++) {
-            var column = columns[i];
-            var layer = column.getAttribute(os.column.ColumnMappingAttr.LAYER);
-            var columnText = column.textContent;
-
-            if (layer && columnText) {
-              this.addColumn(layer, columnText);
+              if (layer && columnText) {
+                this.addColumn(layer, columnText);
+              }
             }
           }
         }
       }
+    } catch (e) {
+      // log it, shouldn't break anything
+      log.error(logger, 'Failed to load column mapping: ' + xml);
     }
-  } catch (e) {
-    // log it, shouldn't break anything
-    goog.log.error(os.column.ColumnMapping.LOGGER_, 'Failed to load column mapping: ' + xml);
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  writeMapping() {
+    var xml = '';
+    var cTag = ColumnMappingTag.COLUMN;
+    var cmTag = ColumnMappingTag.COLUMN_MAPPING;
+    var name = this['name'] || 'New Association';
+    var type = this.valueType_ || 'string';
+    var desc = this['description'] || '';
 
-/**
- * Writes raw XML mapping data
- *
- * @return {string}
- */
-os.column.ColumnMapping.prototype.writeMapping = function() {
-  var xml = '';
-  var cTag = os.column.ColumnMappingTag.COLUMN;
-  var cmTag = os.column.ColumnMappingTag.COLUMN_MAPPING;
-  var name = this['name'] || 'New Association';
-  var type = this.valueType_ || 'string';
-  var desc = this['description'] || '';
+    try {
+      xml += '<' + cmTag + ' name="' + name + '" type="' + type + '" description="' + desc + '">';
 
-  try {
-    xml += '<' + cmTag + ' name="' + name + '" type="' + type + '" description="' + desc + '">';
+      for (var i = 0, ii = this.columns_.length; i < ii; i++) {
+        var columnModel = this.columns_[i];
+        var layer = columnModel['layer'];
+        var columnText = columnModel['column'];
+        xml += '<' + cTag + ' layer="' + layer + '">' + columnText + '</' + cTag + '>';
+      }
 
-    for (var i = 0, ii = this.columns_.length; i < ii; i++) {
-      var columnModel = this.columns_[i];
-      var layer = columnModel['layer'];
-      var columnText = columnModel['column'];
-      xml += '<' + cTag + ' layer="' + layer + '">' + columnText + '</' + cTag + '>';
+      xml += '</' + cmTag + '>';
+    } catch (e) {
+      log.error(logger, 'Failed to write column mapping: ' + this.getName());
+      return '';
     }
 
-    xml += '</' + cmTag + '>';
-  } catch (e) {
-    goog.log.error(os.column.ColumnMapping.LOGGER_, 'Failed to write column mapping: ' + this.getName());
-    return '';
+    return xml;
   }
 
-  return xml;
-};
+  /**
+   * @inheritDoc
+   */
+  persist(opt_to) {
+    var to = opt_to || {};
+    to['id'] = this.getId();
+    to['columnMapping'] = this.writeMapping();
 
-
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.persist = function(opt_to) {
-  var to = opt_to || {};
-  to['id'] = this.getId();
-  to['columnMapping'] = this.writeMapping();
-
-  return to;
-};
-
-
-/**
- * @inheritDoc
- */
-os.column.ColumnMapping.prototype.restore = function(config) {
-  this.setId(/** @type {!string} */ (config['id']));
-  var xml = /** @type {string} */ (config['columnMapping']);
-  if (xml) {
-    this.loadMapping(xml);
+    return to;
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  restore(config) {
+    this.setId(/** @type {!string} */ (config['id']));
+    var xml = /** @type {string} */ (config['columnMapping']);
+    if (xml) {
+      this.loadMapping(xml);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  clone() {
+    var cm = new ColumnMapping();
+    var config = this.persist();
+    cm.restore(config);
+    return cm;
+  }
+}
 
 /**
- * @inheritDoc
+ * Logger
+ * @type {log.Logger}
  */
-os.column.ColumnMapping.prototype.clone = function() {
-  var cm = new os.column.ColumnMapping();
-  var config = this.persist();
-  cm.restore(config);
-  return cm;
-};
+const logger = log.getLogger('os.column.ColumnMapping');
+
+
+exports = ColumnMapping;

--- a/src/os/column/columnmappingevent.js
+++ b/src/os/column/columnmappingevent.js
@@ -1,32 +1,36 @@
-goog.provide('os.column.ColumnMappingEvent');
-goog.require('goog.events.Event');
-goog.require('os.column.ColumnMappingEventType');
+goog.module('os.column.ColumnMappingEvent');
+goog.module.declareLegacyNamespace();
 
+const GoogEvent = goog.require('goog.events.Event');
+
+const ColumnMappingEventType = goog.requireType('os.column.ColumnMappingEventType');
 
 
 /**
  * Event representing changes to column mappings.
- *
- * @param {os.column.ColumnMappingEventType} type
- * @param {?osx.column.ColumnModel} column
- * @extends {goog.events.Event}
- * @constructor
  */
-os.column.ColumnMappingEvent = function(type, column) {
-  os.column.ColumnMappingEvent.base(this, 'constructor', type);
+class ColumnMappingEvent extends GoogEvent {
+  /**
+   * Constructor.
+   * @param {ColumnMappingEventType} type
+   * @param {?osx.column.ColumnModel} column
+   */
+  constructor(type, column) {
+    super(type);
+
+    /**
+     * @type {?osx.column.ColumnModel}
+     * @private
+     */
+    this.column_ = column;
+  }
 
   /**
-   * @type {?osx.column.ColumnModel}
-   * @private
+   * @return {?osx.column.ColumnModel}
    */
-  this.column_ = column;
-};
-goog.inherits(os.column.ColumnMappingEvent, goog.events.Event);
+  getColumn() {
+    return this.column_;
+  }
+}
 
-
-/**
- * @return {?osx.column.ColumnModel}
- */
-os.column.ColumnMappingEvent.prototype.getColumn = function() {
-  return this.column_;
-};
+exports = ColumnMappingEvent;

--- a/src/os/column/columnmappingeventtype.js
+++ b/src/os/column/columnmappingeventtype.js
@@ -1,11 +1,10 @@
-goog.provide('os.column');
-goog.provide('os.column.ColumnMappingEventType');
-
+goog.module('os.column.ColumnMappingEventType');
+goog.module.declareLegacyNamespace();
 
 /**
  * @enum {string}
  */
-os.column.ColumnMappingEventType = {
+exports = {
   MAPPINGS_CHANGE: 'mappingsChange',
   COLUMN_ADDED: 'columnAdded',
   COLUMN_REMOVED: 'columnRemoved'

--- a/src/os/column/columnmappingmanager.js
+++ b/src/os/column/columnmappingmanager.js
@@ -1,7 +1,9 @@
 goog.module('os.column.ColumnMappingManager');
 goog.module.declareLegacyNamespace();
 
+const Deferred = goog.require('goog.async.Deferred');
 const Delay = goog.require('goog.async.Delay');
+const log = goog.require('goog.log');
 const {COLUMN_MAPPINGS_STORAGE_KEY} = goog.require('os');
 const ColumnMapping = goog.require('os.column.ColumnMapping');
 const ColumnMappingEventType = goog.require('os.column.ColumnMappingEventType');
@@ -58,7 +60,7 @@ class ColumnMappingManager extends CollectionManager {
    * @return {!goog.async.Deferred}
    */
   save() {
-    goog.log.info(this.log, 'Saving column associations.');
+    log.info(this.log, 'Saving column associations.');
     var mappings = this.getAll();
     var toSave = [];
     for (var i = 0, ii = mappings.length; i < ii; i++) {
@@ -66,7 +68,7 @@ class ColumnMappingManager extends CollectionManager {
     }
 
     Settings.getInstance().set(COLUMN_MAPPINGS_STORAGE_KEY, toSave);
-    return goog.async.Deferred.succeed();
+    return Deferred.succeed();
   }
 
   /**
@@ -75,9 +77,9 @@ class ColumnMappingManager extends CollectionManager {
    * @return {!goog.async.Deferred<Array<IColumnMapping>>}
    */
   load() {
-    goog.log.info(this.log, 'Loading column associations...');
+    log.info(this.log, 'Loading column associations...');
     var mappings = Settings.getInstance().get(COLUMN_MAPPINGS_STORAGE_KEY);
-    return goog.async.Deferred.succeed(mappings).addCallback(this.onMappingsLoaded_, this);
+    return Deferred.succeed(mappings).addCallback(this.onMappingsLoaded_, this);
   }
 
   /**
@@ -90,7 +92,7 @@ class ColumnMappingManager extends CollectionManager {
   onMappingsLoaded_(data) {
     var mappings = this.parseMappings_(data);
     this.bulkAdd(mappings);
-    goog.log.info(this.log, 'Loaded ' + mappings.length + ' associations(s) from storage.');
+    log.info(this.log, 'Loaded ' + mappings.length + ' associations(s) from storage.');
 
     return mappings;
   }
@@ -328,7 +330,7 @@ let instance;
  * Logger
  * @type {goog.log.Logger}
  */
-const logger = goog.log.getLogger('os.column.ColumnMappingManager');
+const logger = log.getLogger('os.column.ColumnMappingManager');
 
 
 exports = ColumnMappingManager;

--- a/src/os/column/columnmappingmanager.js
+++ b/src/os/column/columnmappingmanager.js
@@ -1,320 +1,334 @@
-goog.provide('os.column.ColumnMappingManager');
+goog.module('os.column.ColumnMappingManager');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.async.Delay');
-goog.require('os');
-goog.require('os.column.ColumnMapping');
-goog.require('os.column.ColumnMappingEventType');
-goog.require('os.column.IColumnMapping');
-goog.require('os.data.CollectionManager');
+const Delay = goog.require('goog.async.Delay');
+const {COLUMN_MAPPINGS_STORAGE_KEY} = goog.require('os');
+const ColumnMapping = goog.require('os.column.ColumnMapping');
+const ColumnMappingEventType = goog.require('os.column.ColumnMappingEventType');
+const Settings = goog.require('os.config.Settings');
+const CollectionManager = goog.require('os.data.CollectionManager');
 
+const ColumnMappingEvent = goog.requireType('os.column.ColumnMappingEvent');
+const IColumnMapping = goog.requireType('os.column.IColumnMapping');
 
 
 /**
  * Manages column mappings.
  *
- * @extends {os.data.CollectionManager<os.column.IColumnMapping>}
- * @constructor
+ * @extends {CollectionManager<IColumnMapping>}
  */
-os.column.ColumnMappingManager = function() {
-  os.column.ColumnMappingManager.base(this, 'constructor');
-
+class ColumnMappingManager extends CollectionManager {
   /**
-   * @type {goog.log.Logger}
-   * @protected
+   * Constructor.
    */
-  this.log = os.column.ColumnMappingManager.LOGGER_;
+  constructor() {
+    super();
+
+    /**
+     * @type {goog.log.Logger}
+     * @protected
+     */
+    this.log = logger;
+
+    /**
+     * @type {Object<string, string>}
+     * @private
+     */
+    this.layerColumnMap_ = {};
+
+    /**
+     * @type {Delay}
+     * @private
+     */
+    this.changeDelay_ = new Delay(this.onChangeDelay_, 100, this);
+
+    this.load();
+  }
 
   /**
-   * @type {Object<string, string>}
+   * @inheritDoc
+   */
+  getId(item) {
+    return item.getId() || '';
+  }
+
+  /**
+   * Saves the mappings.
+   *
+   * @return {!goog.async.Deferred}
+   */
+  save() {
+    goog.log.info(this.log, 'Saving column associations.');
+    var mappings = this.getAll();
+    var toSave = [];
+    for (var i = 0, ii = mappings.length; i < ii; i++) {
+      toSave.push(mappings[i].persist());
+    }
+
+    Settings.getInstance().set(COLUMN_MAPPINGS_STORAGE_KEY, toSave);
+    return goog.async.Deferred.succeed();
+  }
+
+  /**
+   * Loads the mappings.
+   *
+   * @return {!goog.async.Deferred<Array<IColumnMapping>>}
+   */
+  load() {
+    goog.log.info(this.log, 'Loading column associations...');
+    var mappings = Settings.getInstance().get(COLUMN_MAPPINGS_STORAGE_KEY);
+    return goog.async.Deferred.succeed(mappings).addCallback(this.onMappingsLoaded_, this);
+  }
+
+  /**
+   * Parses and adds mappings loaded from storage.
+   *
+   * @param {Object} data
+   * @return {Array<!IColumnMapping>}
    * @private
    */
-  this.layerColumnMap_ = {};
+  onMappingsLoaded_(data) {
+    var mappings = this.parseMappings_(data);
+    this.bulkAdd(mappings);
+    goog.log.info(this.log, 'Loaded ' + mappings.length + ' associations(s) from storage.');
+
+    return mappings;
+  }
 
   /**
-   * @type {goog.async.Delay}
+   * Parses and creates a set of mappings from a persisted list.
+   *
+   * @param {string|Object} data
+   * @return {Array<!IColumnMapping>}
    * @private
    */
-  this.changeDelay_ = new goog.async.Delay(this.onChangeDelay_, 100, this);
+  parseMappings_(data) {
+    var mappings = [];
 
-  this.load();
-};
-goog.inherits(os.column.ColumnMappingManager, os.data.CollectionManager);
-goog.addSingletonGetter(os.column.ColumnMappingManager);
+    if (data) {
+      var arr = /** @type {Array} */ (typeof data === 'string' ? JSON.parse(data) : data);
+      for (var i = 0, ii = arr.length; i < ii; i++) {
+        var value = /** @type {!Object} */ (arr[i]);
+        var cm = new ColumnMapping();
+        cm.restore(value);
+        mappings.push(cm);
+      }
+    }
+
+    return mappings;
+  }
+
+  /**
+   * Adds an array of mappings.
+   *
+   * @param {Array<IColumnMapping>} mappings
+   */
+  bulkAdd(mappings) {
+    for (var i = 0, ii = mappings.length; i < ii; i++) {
+      this.add(mappings[i]);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  add(mapping) {
+    var columns = mapping.getColumns();
+    var id = mapping.getId();
+
+    for (var i = 0, ii = columns.length; i < ii; i++) {
+      this.addManagedColumn_(columns[i], id);
+    }
+
+    mapping.listen(ColumnMappingEventType.COLUMN_ADDED, this.onColumnAdded_, false, this);
+    mapping.listen(ColumnMappingEventType.COLUMN_REMOVED, this.onColumnRemoved_, false, this);
+
+    this.onChange();
+
+    return super.add(mapping);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  remove(itemOrId) {
+    var mapping = this.get(itemOrId);
+    if (mapping) {
+      var columns = mapping.getColumns();
+      for (var i = 0, ii = columns.length; i < ii; i++) {
+        this.removeManagedColumn_(columns[i]);
+      }
+
+      mapping.unlisten(ColumnMappingEventType.COLUMN_ADDED, this.onColumnAdded_, false, this);
+      mapping.unlisten(ColumnMappingEventType.COLUMN_REMOVED, this.onColumnRemoved_, false, this);
+    }
+
+    this.onChange();
+
+    return super.remove(mapping);
+  }
+
+  /**
+   * Handler for when a column is added to a managed column mapping.
+   *
+   * @param {ColumnMappingEvent} event
+   * @private
+   */
+  onColumnAdded_(event) {
+    var mapping = /** @type {ColumnMapping} */ (event.target);
+    var id = mapping.getId();
+    var column = event.getColumn();
+    if (column) {
+      this.addManagedColumn_(column, id);
+    }
+  }
+
+  /**
+   * Handler for when a column is removed from a managed column mapping.
+   *
+   * @param {ColumnMappingEvent} event
+   * @private
+   */
+  onColumnRemoved_(event) {
+    var column = event.getColumn();
+    if (column) {
+      this.removeManagedColumn_(column);
+    }
+  }
+
+  /**
+   * Deregisters a managed column.
+   *
+   * @param {osx.column.ColumnModel} column
+   * @param {string} id
+   * @private
+   */
+  addManagedColumn_(column, id) {
+    // register this mapping as the owner of its respective columns
+    var hash = ColumnMappingManager.hashColumn(column);
+    this.layerColumnMap_[hash] = id;
+  }
+
+  /**
+   * Deregisters a managed column.
+   *
+   * @param {osx.column.ColumnModel} column
+   * @private
+   */
+  removeManagedColumn_(column) {
+    // deregister this mapping as the owner of its respective columns
+    var hash = ColumnMappingManager.hashColumn(column);
+    delete this.layerColumnMap_[hash];
+  }
+
+  /**
+   * Takes a hashed column/layer ID and attempts to get the owner ID from the layerColumnMap_. Returns the mapping
+   * that owns that column/layer pair if there is one, and null if not.
+   *
+   * @param {string|osx.column.ColumnModel} hashOrModel
+   * @return {?IColumnMapping}
+   */
+  getOwnerMapping(hashOrModel) {
+    var id = null;
+
+    if (typeof hashOrModel === 'string') {
+      id = this.layerColumnMap_[hashOrModel];
+    } else {
+      var hash = ColumnMappingManager.hashColumn(hashOrModel);
+      id = this.layerColumnMap_[hash];
+    }
+
+    return this.get(id);
+  }
+
+  /**
+   * Starts the change delay.
+   */
+  onChange() {
+    this.changeDelay_.start();
+  }
+
+  /**
+   * Handles change delay. Saves the mappings and fires a change event to notify external clients.
+   *
+   * @private
+   */
+  onChangeDelay_() {
+    this.save();
+    this.dispatchEvent(ColumnMappingEventType.MAPPINGS_CHANGE);
+  }
+
+  /**
+   * Clears the mapping manager and returns the remove mappings
+   *
+   * @return {Array<IColumnMapping>} The removed mappings
+   */
+  clear() {
+    var mappings = this.getAll();
+    var removed = [];
+
+    for (var i = 0, ii = mappings.length; i < ii; i++) {
+      this.remove(mappings[i]);
+      removed.push(mappings[i]);
+    }
+
+    return removed;
+  }
+
+  /**
+   * Constructs a column hash, used to keep track of which column/layer pairs are in use.
+   *
+   * @param {osx.column.ColumnModel} column
+   * @return {string}
+   */
+  static hashColumn(column) {
+    return ColumnMappingManager.hashLayerColumn(column['layer'], column['column']);
+  }
+
+  /**
+   * Hashes a layer name and a column name.
+   *
+   * @param {string} layerName
+   * @param {string} columnName
+   * @return {string}
+   */
+  static hashLayerColumn(layerName, columnName) {
+    return layerName + '#' + columnName;
+  }
+
+  /**
+   * Get the global instance.
+   * @return {!ColumnMappingManager}
+   */
+  static getInstance() {
+    if (!instance) {
+      instance = new ColumnMappingManager();
+    }
+
+    return instance;
+  }
+
+  /**
+   * Set the global instance.
+   * @param {ColumnMappingManager} value
+   */
+  static setInstance(value) {
+    instance = value;
+  }
+}
+
+/**
+ * Global instance.
+ * @type {ColumnMappingManager|undefined}
+ */
+let instance;
 
 
 /**
  * Logger
  * @type {goog.log.Logger}
- * @const
- * @private
  */
-os.column.ColumnMappingManager.LOGGER_ = goog.log.getLogger('os.column.ColumnMappingManager');
+const logger = goog.log.getLogger('os.column.ColumnMappingManager');
 
 
-/**
- * @inheritDoc
- */
-os.column.ColumnMappingManager.prototype.getId = function(item) {
-  return item.getId() || '';
-};
-
-
-/**
- * Saves the mappings.
- *
- * @return {!goog.async.Deferred}
- */
-os.column.ColumnMappingManager.prototype.save = function() {
-  goog.log.info(this.log, 'Saving column associations.');
-  var mappings = this.getAll();
-  var toSave = [];
-  for (var i = 0, ii = mappings.length; i < ii; i++) {
-    toSave.push(mappings[i].persist());
-  }
-
-  os.settings.set(os.COLUMN_MAPPINGS_STORAGE_KEY, toSave);
-  return goog.async.Deferred.succeed();
-};
-
-
-/**
- * Loads the mappings.
- *
- * @return {!goog.async.Deferred<Array<os.column.IColumnMapping>>}
- */
-os.column.ColumnMappingManager.prototype.load = function() {
-  goog.log.info(this.log, 'Loading column associations...');
-  var mappings = os.settings.get(os.COLUMN_MAPPINGS_STORAGE_KEY);
-  return goog.async.Deferred.succeed(mappings).addCallback(this.onMappingsLoaded_, this);
-};
-
-
-/**
- * Parses and adds mappings loaded from storage.
- *
- * @param {Object} data
- * @return {Array<!os.column.IColumnMapping>}
- * @private
- */
-os.column.ColumnMappingManager.prototype.onMappingsLoaded_ = function(data) {
-  var mappings = this.parseMappings_(data);
-  this.bulkAdd(mappings);
-  goog.log.info(this.log, 'Loaded ' + mappings.length + ' associations(s) from storage.');
-
-  return mappings;
-};
-
-
-/**
- * Parses and creates a set of mappings from a persisted list.
- *
- * @param {string|Object} data
- * @return {Array<!os.column.IColumnMapping>}
- * @private
- */
-os.column.ColumnMappingManager.prototype.parseMappings_ = function(data) {
-  var mappings = [];
-
-  if (data) {
-    var arr = /** @type {Array} */ (typeof data === 'string' ? JSON.parse(data) : data);
-    for (var i = 0, ii = arr.length; i < ii; i++) {
-      var value = /** @type {!Object} */ (arr[i]);
-      var cm = new os.column.ColumnMapping();
-      cm.restore(value);
-      mappings.push(cm);
-    }
-  }
-
-  return mappings;
-};
-
-
-/**
- * Adds an array of mappings.
- *
- * @param {Array<os.column.IColumnMapping>} mappings
- */
-os.column.ColumnMappingManager.prototype.bulkAdd = function(mappings) {
-  for (var i = 0, ii = mappings.length; i < ii; i++) {
-    this.add(mappings[i]);
-  }
-};
-
-
-/**
- * @inheritDoc
- */
-os.column.ColumnMappingManager.prototype.add = function(mapping) {
-  var columns = mapping.getColumns();
-  var id = mapping.getId();
-
-  for (var i = 0, ii = columns.length; i < ii; i++) {
-    this.addManagedColumn_(columns[i], id);
-  }
-
-  mapping.listen(os.column.ColumnMappingEventType.COLUMN_ADDED, this.onColumnAdded_, false, this);
-  mapping.listen(os.column.ColumnMappingEventType.COLUMN_REMOVED, this.onColumnRemoved_, false, this);
-
-  this.onChange();
-
-  return os.column.ColumnMappingManager.base(this, 'add', mapping);
-};
-
-
-/**
- * @inheritDoc
- */
-os.column.ColumnMappingManager.prototype.remove = function(itemOrId) {
-  var mapping = this.get(itemOrId);
-  if (mapping) {
-    var columns = mapping.getColumns();
-    for (var i = 0, ii = columns.length; i < ii; i++) {
-      this.removeManagedColumn_(columns[i]);
-    }
-
-    mapping.unlisten(os.column.ColumnMappingEventType.COLUMN_ADDED, this.onColumnAdded_, false, this);
-    mapping.unlisten(os.column.ColumnMappingEventType.COLUMN_REMOVED, this.onColumnRemoved_, false, this);
-  }
-
-  this.onChange();
-
-  return os.column.ColumnMappingManager.base(this, 'remove', mapping);
-};
-
-
-/**
- * Handler for when a column is added to a managed column mapping.
- *
- * @param {os.column.ColumnMappingEvent} event
- * @private
- */
-os.column.ColumnMappingManager.prototype.onColumnAdded_ = function(event) {
-  var mapping = /** @type {os.column.ColumnMapping} */ (event.target);
-  var id = mapping.getId();
-  var column = event.getColumn();
-  if (column) {
-    this.addManagedColumn_(column, id);
-  }
-};
-
-
-/**
- * Handler for when a column is removed from a managed column mapping.
- *
- * @param {os.column.ColumnMappingEvent} event
- * @private
- */
-os.column.ColumnMappingManager.prototype.onColumnRemoved_ = function(event) {
-  var column = event.getColumn();
-  if (column) {
-    this.removeManagedColumn_(column);
-  }
-};
-
-
-/**
- * Deregisters a managed column.
- *
- * @param {osx.column.ColumnModel} column
- * @param {string} id
- * @private
- */
-os.column.ColumnMappingManager.prototype.addManagedColumn_ = function(column, id) {
-  // register this mapping as the owner of its respective columns
-  var hash = os.column.ColumnMappingManager.hashColumn(column);
-  this.layerColumnMap_[hash] = id;
-};
-
-
-/**
- * Deregisters a managed column.
- *
- * @param {osx.column.ColumnModel} column
- * @private
- */
-os.column.ColumnMappingManager.prototype.removeManagedColumn_ = function(column) {
-  // deregister this mapping as the owner of its respective columns
-  var hash = os.column.ColumnMappingManager.hashColumn(column);
-  delete this.layerColumnMap_[hash];
-};
-
-
-/**
- * Takes a hashed column/layer ID and attempts to get the owner ID from the layerColumnMap_. Returns the mapping
- * that owns that column/layer pair if there is one, and null if not.
- *
- * @param {string|osx.column.ColumnModel} hashOrModel
- * @return {?os.column.IColumnMapping}
- */
-os.column.ColumnMappingManager.prototype.getOwnerMapping = function(hashOrModel) {
-  var id = null;
-
-  if (typeof hashOrModel === 'string') {
-    id = this.layerColumnMap_[hashOrModel];
-  } else {
-    var hash = os.column.ColumnMappingManager.hashColumn(hashOrModel);
-    id = this.layerColumnMap_[hash];
-  }
-
-  return this.get(id);
-};
-
-
-/**
- * Starts the change delay.
- */
-os.column.ColumnMappingManager.prototype.onChange = function() {
-  this.changeDelay_.start();
-};
-
-
-/**
- * Handles change delay. Saves the mappings and fires a change event to notify external clients.
- *
- * @private
- */
-os.column.ColumnMappingManager.prototype.onChangeDelay_ = function() {
-  this.save();
-  this.dispatchEvent(os.column.ColumnMappingEventType.MAPPINGS_CHANGE);
-};
-
-
-/**
- * Clears the mapping manager and returns the remove mappings
- *
- * @return {Array<os.column.IColumnMapping>} The removed mappings
- */
-os.column.ColumnMappingManager.prototype.clear = function() {
-  var mappings = this.getAll();
-  var removed = [];
-
-  for (var i = 0, ii = mappings.length; i < ii; i++) {
-    this.remove(mappings[i]);
-    removed.push(mappings[i]);
-  }
-
-  return removed;
-};
-
-
-/**
- * Constructs a column hash, used to keep track of which column/layer pairs are in use.
- *
- * @param {osx.column.ColumnModel} column
- * @return {string}
- */
-os.column.ColumnMappingManager.hashColumn = function(column) {
-  return os.column.ColumnMappingManager.hashLayerColumn(column['layer'], column['column']);
-};
-
-
-/**
- * Hashes a layer name and a column name.
- *
- * @param {string} layerName
- * @param {string} columnName
- * @return {string}
- */
-os.column.ColumnMappingManager.hashLayerColumn = function(layerName, columnName) {
-  return layerName + '#' + columnName;
-};
+exports = ColumnMappingManager;

--- a/src/os/column/columnmappingtag.js
+++ b/src/os/column/columnmappingtag.js
@@ -1,0 +1,12 @@
+goog.module('os.column.ColumnMappingTag');
+goog.module.declareLegacyNamespace();
+
+/**
+ * Enumeration of column mapping tags
+ * @enum {string}
+ */
+exports = {
+  COLUMN_MAPPING: 'columnMapping',
+  COLUMN_MAPPINGS: 'columnMappings',
+  COLUMN: 'column'
+};

--- a/src/os/column/icolumnmapping.js
+++ b/src/os/column/icolumnmapping.js
@@ -1,107 +1,104 @@
-goog.provide('os.column.ColumnModel');
-goog.provide('os.column.IColumnMapping');
-goog.require('goog.events.Listenable');
-goog.require('os.IPersistable');
+goog.module('os.column.IColumnMapping');
+goog.module.declareLegacyNamespace();
+
+const Listenable = goog.requireType('goog.events.Listenable');
+const IPersistable = goog.requireType('os.IPersistable');
+
 
 /**
  * Base interface representing a column mapping.
  *
- * @extends {os.IPersistable}
- * @extends {goog.events.Listenable}
+ * @extends {IPersistable}
+ * @extends {Listenable}
  * @interface
  */
-os.column.IColumnMapping = function() {};
+class IColumnMapping {
+  /**
+   * Get the ID
+   * @return {!string}
+   */
+  getId() {}
 
+  /**
+   * Set the ID
+   * @param {!string} value
+   */
+  setId(value) {}
 
-/**
- * Get the ID
- * @return {!string}
- */
-os.column.IColumnMapping.prototype.getId;
+  /**
+   * Get the value type
+   * @return {?string}
+   */
+  getValueType() {}
 
+  /**
+   * Set the value type
+   * @param {string} value
+   */
+  setValueType(value) {}
 
-/**
- * Set the ID
- * @param {!string} value
- */
-os.column.IColumnMapping.prototype.setId;
+  /**
+   * Get the name
+   * @return {?string}
+   */
+  getName() {}
 
+  /**
+   * Set the name
+   * @param {string} value
+   */
+  setName(value) {}
 
-/**
- * Get the value type
- * @return {?string}
- */
-os.column.IColumnMapping.prototype.getValueType;
+  /**
+   * Get the description
+   * @return {?string}
+   */
+  getDescription() {}
 
+  /**
+   * Set the description
+   * @param {string} value
+   */
+  setDescription(value) {}
 
-/**
- * Set the value type
- * @param {string} value
- */
-os.column.IColumnMapping.prototype.setValueType;
+  /**
+   * Adds a column by its layerKey and column field.
+   * @param {string} layerKey The layer key
+   * @param {string} column The column field string
+   * @param {string=} opt_units The optional units to use
+   */
+  addColumn(layerKey, column, opt_units) {}
 
+  /**
+   * Removes a column model.
+   * @param {osx.column.ColumnModel} columnModel
+   */
+  removeColumn(columnModel) {}
 
-/**
- * Get the name
- * @return {?string}
- */
-os.column.IColumnMapping.prototype.getName;
+  /**
+   * Gets the columns from the mapping.
+   * @return {Array<osx.column.ColumnModel>}
+   */
+  getColumns() {}
 
+  /**
+   * Gets a particular column model for a given layer key.
+   * @param {string} layerKey
+   * @return {?osx.column.ColumnModel}
+   */
+  getColumn(layerKey) {}
 
-/**
- * Set the name
- * @param {string} value
- */
-os.column.IColumnMapping.prototype.setName;
+  /**
+   * Clones the column mapping.
+   * @return {IColumnMapping}
+   */
+  clone() {}
 
+  /**
+   * Writes raw XML mapping data
+   * @return {string}
+   */
+  writeMapping() {}
+}
 
-/**
- * Get the description
- * @return {?string}
- */
-os.column.IColumnMapping.prototype.getDescription;
-
-
-/**
- * Set the description
- * @param {string} value
- */
-os.column.IColumnMapping.prototype.setDescription;
-
-
-/**
- * Adds a column by its layerKey and column field.
- * @param {string} layerKey The layer key
- * @param {string} column The column field string
- * @param {string=} opt_units The optional units to use
- */
-os.column.IColumnMapping.prototype.addColumn;
-
-
-/**
- * Removes a column model.
- * @param {osx.column.ColumnModel} columnModel
- */
-os.column.IColumnMapping.prototype.removeColumn;
-
-
-/**
- * Gets the columns from the mapping.
- * @return {Array<osx.column.ColumnModel>}
- */
-os.column.IColumnMapping.prototype.getColumns;
-
-
-/**
- * Gets a particular column model for a given layer key.
- * @param {string} layerKey
- * @return {?osx.column.ColumnModel}
- */
-os.column.IColumnMapping.prototype.getColumn;
-
-
-/**
- * Clones the column mapping.
- * @return {os.column.IColumnMapping}
- */
-os.column.IColumnMapping.prototype.clone;
+exports = IColumnMapping;

--- a/src/os/config/themesettings.js
+++ b/src/os/config/themesettings.js
@@ -11,6 +11,8 @@ goog.require('ol.array');
 goog.require('os.config.Settings');
 goog.require('os.ui.config.SettingPlugin');
 
+goog.requireType('os.events.SettingChangeEvent');
+
 
 /**
  * @extends {os.ui.config.SettingPlugin}
@@ -160,7 +162,7 @@ os.config.ThemeSettingsCtrl.prototype.destroy_ = function() {
 /**
  * Handle units change via settings.
  *
- * @param {os.events.PropertyChangeEvent} event
+ * @param {os.events.SettingChangeEvent} event
  * @private
  */
 os.config.ThemeSettingsCtrl.prototype.onSettingsChange_ = function(event) {
@@ -174,7 +176,7 @@ os.config.ThemeSettingsCtrl.prototype.onSettingsChange_ = function(event) {
 /**
  * Handle units change via settings.
  *
- * @param {os.events.PropertyChangeEvent} event
+ * @param {os.events.SettingChangeEvent} event
  * @private
  */
 os.config.ThemeSettingsCtrl.prototype.onAccessibilitySettingsChange_ = function(event) {

--- a/src/os/control/alertpopup.js
+++ b/src/os/control/alertpopup.js
@@ -1,24 +1,30 @@
-goog.provide('os.control.AlertPopup');
-goog.require('ol.control.Control');
+goog.module('os.control.AlertPopup');
+goog.module.declareLegacyNamespace();
+
 goog.require('os.ui.alert.alertPopupDirective');
 
+const Control = goog.require('ol.control.Control');
+const osUi = goog.require('os.ui');
 
 
 /**
  * Make the alert popups a map control so we can position it properly within
  * the map bounds
- *
- * @extends {ol.control.Control}
- * @constructor
  */
-os.control.AlertPopup = function() {
-  // compile angular element
-  var compile = /** @type {!angular.$compile} */ (os.ui.injector.get('$compile'));
-  var scope = /** @type {!angular.Scope} */ (os.ui.injector.get('$rootScope')).$new();
-  var el = compile('<alert-popup></alert-popup>')(scope)[0];
+class AlertPopup extends Control {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    // compile angular element
+    var compile = /** @type {!angular.$compile} */ (osUi.injector.get('$compile'));
+    var scope = /** @type {!angular.Scope} */ (osUi.injector.get('$rootScope')).$new();
+    var el = compile('<alert-popup></alert-popup>')(scope)[0];
 
-  os.control.AlertPopup.base(this, 'constructor', {
-    element: el
-  });
-};
-goog.inherits(os.control.AlertPopup, ol.control.Control);
+    super({
+      element: el
+    });
+  }
+}
+
+exports = AlertPopup;

--- a/src/os/control/attribution.js
+++ b/src/os/control/attribution.js
@@ -1,138 +1,124 @@
-goog.provide('os.control.Attribution');
+goog.module('os.control.Attribution');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.dom.safe');
-goog.require('goog.html.SafeHtml');
-goog.require('ol.control.Attribution');
-goog.require('os.fn');
+const SafeHtml = goog.require('goog.html.SafeHtml');
+const OLAttribution = goog.require('ol.control.Attribution');
 
-/**
- * @constructor
- * @extends {ol.control.Attribution}
- * @param {olx.control.AttributionOptions=} opt_options Attribution options.
- */
-os.control.Attribution = function(opt_options) {
-  os.control.Attribution.base(this, 'constructor', opt_options);
-};
-goog.inherits(os.control.Attribution, ol.control.Attribution);
 
 /**
- * Whether to check if a layer is visible at the current resolution before adding to attribution.
- *
- * If true, the layer attribution will be added only if the layer would be shown. If false,
- * the layer attribution will not be resolution sensitive.
- *
- * @type {boolean}
  */
-os.control.Attribution.CheckVisibleAtResolution = true;
-
-/**
- * @inheritDoc
- * @suppress {accessControls}
- */
-os.control.Attribution.prototype.getSourceAttributions_ = function(frameState) {
+class Attribution extends OLAttribution {
   /**
-   * Used to determine if an attribution already exists.
-   * @type {Object.<string, boolean>}
+   * Constructor.
+   * @param {olx.control.AttributionOptions=} opt_options Attribution options.
    */
-  var lookup = {};
+  constructor(opt_options) {
+    super(opt_options);
+  }
 
   /**
-   * A list of visible attributions.
-   * @type {Array.<string>}
+   * @inheritDoc
+   * @suppress {accessControls}
    */
-  var visibleAttributions = [];
+  getSourceAttributions_(frameState) {
+    /**
+     * Used to determine if an attribution already exists.
+     * @type {Object<string, boolean>}
+     */
+    var lookup = {};
 
-  var layerStatesArray = frameState.layerStatesArray;
-  var resolution = frameState.viewState.resolution;
-  for (var i = 0, ii = layerStatesArray.length; i < ii; ++i) {
-    var layerState = layerStatesArray[i];
-    if (os.control.Attribution.CheckVisibleAtResolution) {
-      if (!os.control.Attribution.visibleAtResolution(layerState, resolution)) {
-        continue;
-      }
-    }
+    /**
+     * A list of visible attributions.
+     * @type {Array<string>}
+     */
+    var visibleAttributions = [];
 
-    var source = layerState.layer.getSource();
-    if (!source) {
-      continue;
-    }
-
-    var attributionGetter = source.getAttributions2();
-    if (!attributionGetter) {
-      continue;
-    }
-
-    var attributions = attributionGetter(frameState);
-    if (!attributions) {
-      continue;
-    }
-
-    if (Array.isArray(attributions)) {
-      for (var j = 0, jj = attributions.length; j < jj; ++j) {
-        if (!(attributions[j] in lookup)) {
-          visibleAttributions.push(attributions[j]);
-          lookup[attributions[j]] = true;
+    var layerStatesArray = frameState.layerStatesArray;
+    var resolution = frameState.viewState.resolution;
+    for (var i = 0, ii = layerStatesArray.length; i < ii; ++i) {
+      var layerState = layerStatesArray[i];
+      if (checkVisibleAtResolution) {
+        if (!visibleAtResolution(layerState, resolution)) {
+          continue;
         }
       }
-    } else if (!(attributions in lookup)) {
-      visibleAttributions.push(attributions);
-      lookup[attributions] = true;
+
+      var source = layerState.layer.getSource();
+      if (!source) {
+        continue;
+      }
+
+      var attributionGetter = source.getAttributions2();
+      if (!attributionGetter) {
+        continue;
+      }
+
+      var attributions = attributionGetter(frameState);
+      if (!attributions) {
+        continue;
+      }
+
+      if (Array.isArray(attributions)) {
+        for (var j = 0, jj = attributions.length; j < jj; ++j) {
+          if (!(attributions[j] in lookup)) {
+            visibleAttributions.push(attributions[j]);
+            lookup[attributions[j]] = true;
+          }
+        }
+      } else if (!(attributions in lookup)) {
+        visibleAttributions.push(attributions);
+        lookup[attributions] = true;
+      }
     }
+    return visibleAttributions;
   }
-  return visibleAttributions;
-};
 
-/**
- * @inheritDoc
- * @suppress {accessControls}
- */
-os.control.Attribution.prototype.updateElement_ = function(frameState) {
-  if (!frameState) {
-    if (this.renderedVisible_) {
-      this.element.style.display = 'none';
-      this.renderedVisible_ = false;
+  /**
+   * @inheritDoc
+   * @suppress {accessControls}
+   */
+  updateElement_(frameState) {
+    if (!frameState) {
+      if (this.renderedVisible_) {
+        this.element.style.display = 'none';
+        this.renderedVisible_ = false;
+      }
+      return;
     }
-    return;
-  }
 
-  var attributions = this.getSourceAttributions_(frameState);
-  if (ol.array.equals(attributions, this.renderedAttributions_)) {
-    return;
-  }
+    var attributions = this.getSourceAttributions_(frameState);
+    if (ol.array.equals(attributions, this.renderedAttributions_)) {
+      return;
+    }
 
-  // remove everything
-  goog.dom.removeChildren(this.ulElement_);
+    // remove everything
+    goog.dom.removeChildren(this.ulElement_);
 
-  // add the label
-  var label;
-  if (attributions.length > 1) {
-    label = goog.html.SafeHtml.create('li', undefined, 'Sources:');
-  } else {
-    label = goog.html.SafeHtml.create('li', undefined, 'Source:');
-  }
+    // add the label
+    var label;
+    if (attributions.length > 1) {
+      label = SafeHtml.create('li', undefined, 'Sources:');
+    } else {
+      label = SafeHtml.create('li', undefined, 'Source:');
+    }
 
-  goog.dom.appendChild(this.ulElement_, goog.dom.safeHtmlToNode(label));
-
-  // append the attributions
-  for (var i = 0, ii = attributions.length; i < ii; ++i) {
-    label = goog.html.SafeHtml.create('li', undefined, attributions[i]);
     goog.dom.appendChild(this.ulElement_, goog.dom.safeHtmlToNode(label));
+
+    // append the attributions
+    for (var i = 0, ii = attributions.length; i < ii; ++i) {
+      label = SafeHtml.create('li', undefined, attributions[i]);
+      goog.dom.appendChild(this.ulElement_, goog.dom.safeHtmlToNode(label));
+    }
+
+    var visible = attributions.length > 0;
+    if (this.renderedVisible_ != visible) {
+      this.element.style.display = visible ? '' : 'none';
+      this.renderedVisible_ = visible;
+    }
+
+    this.renderedAttributions_ = attributions;
   }
-
-  var visible = attributions.length > 0;
-  if (this.renderedVisible_ != visible) {
-    this.element.style.display = visible ? '' : 'none';
-    this.renderedVisible_ = visible;
-  }
-
-  this.renderedAttributions_ = attributions;
-};
-
-/**
- * @suppress {accessControls}
- */
-ol.control.Attribution.prototype.insertLogos_ = os.fn.noop;
-
+}
 
 /**
  * Replaces `ol.layer.Layer.visibleAtResolution` because Openlayers only checks the layerState for visibility. This does
@@ -142,7 +128,26 @@ ol.control.Attribution.prototype.insertLogos_ = os.fn.noop;
  * @param {number} resolution Resolution.
  * @return {boolean} The layer is visible at the given resolution.
  */
-os.control.Attribution.visibleAtResolution = function(layerState, resolution) {
+const visibleAtResolution = (layerState, resolution) => {
   return layerState.layer.getVisible() && resolution >= layerState.minResolution &&
       resolution < layerState.maxResolution;
 };
+
+/**
+ * Whether to check if a layer is visible at the current resolution before adding to attribution.
+ *
+ * If true, the layer attribution will be added only if the layer would be shown. If false,
+ * the layer attribution will not be resolution sensitive.
+ *
+ * @type {boolean}
+ */
+const checkVisibleAtResolution = true;
+
+/**
+ * Disable this behavior from OpenLayers.
+ * @suppress {accessControls}
+ */
+OLAttribution.prototype.insertLogos_ = () => {};
+
+
+exports = Attribution;

--- a/src/os/control/attribution.js
+++ b/src/os/control/attribution.js
@@ -1,7 +1,9 @@
 goog.module('os.control.Attribution');
 goog.module.declareLegacyNamespace();
 
+const dom = goog.require('goog.dom');
 const SafeHtml = goog.require('goog.html.SafeHtml');
+const olArray = goog.require('ol.array');
 const OLAttribution = goog.require('ol.control.Attribution');
 
 
@@ -87,12 +89,12 @@ class Attribution extends OLAttribution {
     }
 
     var attributions = this.getSourceAttributions_(frameState);
-    if (ol.array.equals(attributions, this.renderedAttributions_)) {
+    if (olArray.equals(attributions, this.renderedAttributions_)) {
       return;
     }
 
     // remove everything
-    goog.dom.removeChildren(this.ulElement_);
+    dom.removeChildren(this.ulElement_);
 
     // add the label
     var label;
@@ -102,12 +104,12 @@ class Attribution extends OLAttribution {
       label = SafeHtml.create('li', undefined, 'Source:');
     }
 
-    goog.dom.appendChild(this.ulElement_, goog.dom.safeHtmlToNode(label));
+    dom.appendChild(this.ulElement_, dom.safeHtmlToNode(label));
 
     // append the attributions
     for (var i = 0, ii = attributions.length; i < ii; ++i) {
       label = SafeHtml.create('li', undefined, attributions[i]);
-      goog.dom.appendChild(this.ulElement_, goog.dom.safeHtmlToNode(label));
+      dom.appendChild(this.ulElement_, dom.safeHtmlToNode(label));
     }
 
     var visible = attributions.length > 0;

--- a/src/os/control/control.js
+++ b/src/os/control/control.js
@@ -1,24 +1,24 @@
-goog.provide('os.control');
+goog.module('os.control');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.Collection');
-goog.require('ol.control');
-goog.require('os.control.AlertPopup');
-goog.require('os.control.Attribution');
-goog.require('os.control.MapMode');
-goog.require('os.control.Rotate');
-goog.require('os.control.ScaleLine');
-goog.require('os.control.Zoom');
-goog.require('os.control.ZoomLevel');
-goog.require('os.ol.control.MousePosition');
+const Collection = goog.require('ol.Collection');
+const AlertPopup = goog.require('os.control.AlertPopup');
+const Attribution = goog.require('os.control.Attribution');
+const MapMode = goog.require('os.control.MapMode');
+const Rotate = goog.require('os.control.Rotate');
+const ScaleLine = goog.require('os.control.ScaleLine');
+const Zoom = goog.require('os.control.Zoom');
+const ZoomLevel = goog.require('os.control.ZoomLevel');
+const MousePosition = goog.require('os.ol.control.MousePosition');
 
 
 /**
- * @return {ol.Collection}
+ * @return {Collection}
  */
-os.control.getControls = function() {
+const getControls = function() {
   var controls = [];
 
-  var scaleLine = new os.control.ScaleLine({
+  var scaleLine = new ScaleLine({
     className: 'ol-scale-line',
     target: document.getElementById('scale-line')
   });
@@ -28,7 +28,7 @@ os.control.getControls = function() {
 
   var mousePositionEle = document.getElementById('mouse-position');
   if (mousePositionEle) {
-    var mousePositionControl = new os.ol.control.MousePosition({
+    var mousePositionControl = new MousePosition({
       projection: os.proj.EPSG4326,
       className: 'ol-mouse-position',
       target: mousePositionEle,
@@ -40,30 +40,34 @@ os.control.getControls = function() {
     controls.push(mousePositionControl);
   }
 
-  var zoomLevel = new os.control.ZoomLevel({
+  var zoomLevel = new ZoomLevel({
     target: document.getElementById('zoom-level')
   });
   el = zoomLevel.getElement();
   el.className += ' position-relative';
   controls.push(zoomLevel);
 
-  var zoomCtrl = new os.control.Zoom();
+  var zoomCtrl = new Zoom();
   controls.push(zoomCtrl);
 
-  var rotate = new os.control.Rotate();
+  var rotate = new Rotate();
   controls.push(rotate);
 
-  var mapMode = new os.control.MapMode();
+  var mapMode = new MapMode();
   controls.push(mapMode);
 
-  var alerts = new os.control.AlertPopup();
+  var alerts = new AlertPopup();
   controls.push(alerts);
 
-  var attributions = new os.control.Attribution(/** @type {olx.control.AttributionOptions} */ ({
+  var attributions = new Attribution(/** @type {olx.control.AttributionOptions} */ ({
     collapsible: false
   }));
 
   controls.push(attributions);
 
-  return new ol.Collection(controls);
+  return new Collection(controls);
+};
+
+exports = {
+  getControls
 };

--- a/src/os/control/control.js
+++ b/src/os/control/control.js
@@ -10,6 +10,7 @@ const ScaleLine = goog.require('os.control.ScaleLine');
 const Zoom = goog.require('os.control.Zoom');
 const ZoomLevel = goog.require('os.control.ZoomLevel');
 const MousePosition = goog.require('os.ol.control.MousePosition');
+const osProj = goog.require('os.proj');
 
 
 /**
@@ -29,7 +30,7 @@ const getControls = function() {
   var mousePositionEle = document.getElementById('mouse-position');
   if (mousePositionEle) {
     var mousePositionControl = new MousePosition({
-      projection: os.proj.EPSG4326,
+      projection: osProj.EPSG4326,
       className: 'ol-mouse-position',
       target: mousePositionEle,
       undefinedHTML: '&nbsp;',

--- a/src/os/control/mapmodecontrol.js
+++ b/src/os/control/mapmodecontrol.js
@@ -1,134 +1,139 @@
-goog.provide('os.control.MapMode');
+goog.module('os.control.MapMode');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.dom');
-goog.require('goog.dom.classlist');
-goog.require('ol');
-goog.require('ol.control.Control');
-goog.require('ol.css');
-goog.require('ol.events');
-goog.require('ol.events.EventType');
+const dom = goog.require('goog.dom');
+const Control = goog.require('ol.control.Control');
+const css = goog.require('ol.css');
+const events = goog.require('ol.events');
+const EventType = goog.require('ol.events.EventType');
+const dispatcher = goog.require('os.Dispatcher');
+const mapInstance = goog.require('os.map.instance');
 
+const ol = goog.requireType('ol');
 
 
 /**
  * A button control to toggle between 2D and 3D views.
  * To style this control use css selector `.ol-mapmode`.
- *
- * @param {osx.control.MapModeOptions=} opt_options Map mode options.
- * @extends {ol.control.Control}
- * @constructor
  */
-os.control.MapMode = function(opt_options) {
-  var options = opt_options ? opt_options : {};
-
-  var className = options.className != null ? options.className : 'ol-mapmode';
-  var textClass = options.textClass != null ? options.textClass : 'ol-mapmode-text';
-
+class MapMode extends Control {
   /**
-   * Default tooltip to display on the button.
-   * @type {string}
-   * @protected
+   * Constructor.
+   * @param {osx.control.MapModeOptions=} opt_options Map mode options.
    */
-  this.defaultTooltip = options.tipLabel ? options.tipLabel : 'Toggle 2D/3D view';
+  constructor(opt_options) {
+    var options = opt_options ? opt_options : {};
 
-  /**
-   * The control content element.
-   * @type {Element|undefined}
-   * @protected
-   */
-  this.content = goog.dom.createDom('SPAN', textClass);
+    var className = options.className != null ? options.className : 'ol-mapmode';
+    var textClass = options.textClass != null ? options.textClass : 'ol-mapmode-text';
+    var content = dom.createDom('SPAN', textClass);
+    var cssClasses = className + ' ' + css.CLASS_UNSELECTABLE + ' ' + css.CLASS_CONTROL;
+    var defaultTooltip = options.tipLabel ? options.tipLabel : 'Toggle 2D/3D view';
 
-  /**
-   * Element to display when the map view is loading.
-   * @type {Element|undefined}
-   * @protected
-   */
-  this.loadingEl = goog.dom.createDom('I', 'fa fa-spin fa-spinner');
+    var button = dom.createDom('BUTTON', {
+      'class': className + '-toggle',
+      'type': 'button',
+      'title': defaultTooltip
+    }, content);
 
-  /**
-   * @type {Element|undefined}
-   * @protected
-   */
-  this.button = goog.dom.createDom('BUTTON', {
-    'class': className + '-toggle',
-    'type': 'button',
-    'title': this.defaultTooltip
-  }, this.content);
+    var element = dom.createDom('DIV', cssClasses, button);
 
-  ol.events.listen(this.button, ol.events.EventType.CLICK, os.control.MapMode.prototype.handleClick_, this);
+    super({
+      element: element,
+      target: options.target
+    });
 
-  var cssClasses = className + ' ' + ol.css.CLASS_UNSELECTABLE + ' ' + ol.css.CLASS_CONTROL;
-  var element = goog.dom.createDom('DIV', cssClasses, this.button);
+    /**
+     * Default tooltip to display on the button.
+     * @type {string}
+     * @protected
+     */
+    this.defaultTooltip = defaultTooltip;
 
-  os.control.MapMode.base(this, 'constructor', {
-    element: element,
-    target: options.target
-  });
+    /**
+     * The control content element.
+     * @type {Element|undefined}
+     * @protected
+     */
+    this.content = content;
 
-  this.updateContent_();
-  os.MapContainer.getInstance().listen(goog.events.EventType.PROPERTYCHANGE, this.onMapChange_, false, this);
-};
-goog.inherits(os.control.MapMode, ol.control.Control);
+    /**
+     * Element to display when the map view is loading.
+     * @type {Element|undefined}
+     * @protected
+     */
+    this.loadingEl = dom.createDom('I', 'fa fa-spin fa-spinner');
 
+    /**
+     * @type {Element|undefined}
+     * @protected
+     */
+    this.button = button;
 
-/**
- * @inheritDoc
- */
-os.control.MapMode.prototype.disposeInternal = function() {
-  os.MapContainer.getInstance().unlisten(goog.events.EventType.PROPERTYCHANGE, this.onMapChange_, false, this);
+    events.listen(this.button, EventType.CLICK, MapMode.prototype.handleClick_, this);
 
-  if (this.button) {
-    ol.events.unlisten(this.button, ol.events.EventType.CLICK, os.control.MapMode.prototype.handleClick_, this);
-    this.button = undefined;
-  }
-
-  this.content = undefined;
-  this.loadingEl = undefined;
-};
-
-
-/**
- * Handle click events on the control.
- *
- * @param {Event} event The event.
- * @private
- */
-os.control.MapMode.prototype.handleClick_ = function(event) {
-  event.preventDefault();
-  os.dispatcher.dispatchEvent(os.action.EventType.TOGGLE_VIEW);
-};
-
-
-/**
- * Handle property change events from the map container.
- *
- * @param {os.events.PropertyChangeEvent} event The event.
- * @private
- */
-os.control.MapMode.prototype.onMapChange_ = function(event) {
-  var p = event.getProperty();
-  if (p === os.MapChange.INIT3D || p === os.MapChange.VIEW3D) {
     this.updateContent_();
+    mapInstance.getMapContainer().listen(goog.events.EventType.PROPERTYCHANGE, this.onMapChange_, false, this);
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    mapInstance.getMapContainer().unlisten(goog.events.EventType.PROPERTYCHANGE, this.onMapChange_, false, this);
 
-/**
- * Update HTML content in the control.
- *
- * @private
- */
-os.control.MapMode.prototype.updateContent_ = function() {
-  if (this.button && this.content && this.loadingEl) {
-    var map = os.MapContainer.getInstance();
-    if (map.isInitializingWebGL()) {
-      goog.dom.setTextContent(this.content, '');
-      this.content.appendChild(this.loadingEl);
-      this.button.title = 'Initializing 3D view';
-    } else {
-      goog.dom.removeNode(this.loadingEl);
-      goog.dom.setTextContent(this.content, map.is3DEnabled() ? '3D' : '2D');
-      this.button.title = this.defaultTooltip;
+    if (this.button) {
+      events.unlisten(this.button, EventType.CLICK, MapMode.prototype.handleClick_, this);
+      this.button = undefined;
+    }
+
+    this.content = undefined;
+    this.loadingEl = undefined;
+  }
+
+  /**
+   * Handle click events on the control.
+   *
+   * @param {Event} event The event.
+   * @private
+   */
+  handleClick_(event) {
+    event.preventDefault();
+    dispatcher.getInstance().dispatchEvent(os.action.EventType.TOGGLE_VIEW);
+  }
+
+  /**
+   * Handle property change events from the map container.
+   *
+   * @param {os.events.PropertyChangeEvent} event The event.
+   * @private
+   */
+  onMapChange_(event) {
+    var p = event.getProperty();
+    if (p === os.MapChange.INIT3D || p === os.MapChange.VIEW3D) {
+      this.updateContent_();
     }
   }
-};
+
+  /**
+   * Update HTML content in the control.
+   *
+   * @private
+   */
+  updateContent_() {
+    if (this.button && this.content && this.loadingEl) {
+      var map = mapInstance.getMapContainer();
+      if (map.isInitializingWebGL()) {
+        dom.setTextContent(this.content, '');
+        this.content.appendChild(this.loadingEl);
+        this.button.title = 'Initializing 3D view';
+      } else {
+        dom.removeNode(this.loadingEl);
+        dom.setTextContent(this.content, map.is3DEnabled() ? '3D' : '2D');
+        this.button.title = this.defaultTooltip;
+      }
+    }
+  }
+}
+
+exports = MapMode;

--- a/src/os/control/mapmodecontrol.js
+++ b/src/os/control/mapmodecontrol.js
@@ -2,14 +2,15 @@ goog.module('os.control.MapMode');
 goog.module.declareLegacyNamespace();
 
 const dom = goog.require('goog.dom');
+const GoogEventType = goog.require('goog.events.EventType');
 const Control = goog.require('ol.control.Control');
 const css = goog.require('ol.css');
 const events = goog.require('ol.events');
 const EventType = goog.require('ol.events.EventType');
 const dispatcher = goog.require('os.Dispatcher');
+const MapChange = goog.require('os.MapChange');
+const osActionEventType = goog.require('os.action.EventType');
 const mapInstance = goog.require('os.map.instance');
-
-const ol = goog.requireType('ol');
 
 
 /**
@@ -73,14 +74,14 @@ class MapMode extends Control {
     events.listen(this.button, EventType.CLICK, MapMode.prototype.handleClick_, this);
 
     this.updateContent_();
-    mapInstance.getMapContainer().listen(goog.events.EventType.PROPERTYCHANGE, this.onMapChange_, false, this);
+    mapInstance.getMapContainer().listen(GoogEventType.PROPERTYCHANGE, this.onMapChange_, false, this);
   }
 
   /**
    * @inheritDoc
    */
   disposeInternal() {
-    mapInstance.getMapContainer().unlisten(goog.events.EventType.PROPERTYCHANGE, this.onMapChange_, false, this);
+    mapInstance.getMapContainer().unlisten(GoogEventType.PROPERTYCHANGE, this.onMapChange_, false, this);
 
     if (this.button) {
       events.unlisten(this.button, EventType.CLICK, MapMode.prototype.handleClick_, this);
@@ -99,7 +100,7 @@ class MapMode extends Control {
    */
   handleClick_(event) {
     event.preventDefault();
-    dispatcher.getInstance().dispatchEvent(os.action.EventType.TOGGLE_VIEW);
+    dispatcher.getInstance().dispatchEvent(osActionEventType.TOGGLE_VIEW);
   }
 
   /**
@@ -110,7 +111,7 @@ class MapMode extends Control {
    */
   onMapChange_(event) {
     var p = event.getProperty();
-    if (p === os.MapChange.INIT3D || p === os.MapChange.VIEW3D) {
+    if (p === MapChange.INIT3D || p === MapChange.VIEW3D) {
       this.updateContent_();
     }
   }

--- a/src/os/control/mapmodecontrol.js
+++ b/src/os/control/mapmodecontrol.js
@@ -10,7 +10,7 @@ const EventType = goog.require('ol.events.EventType');
 const dispatcher = goog.require('os.Dispatcher');
 const MapChange = goog.require('os.MapChange');
 const osActionEventType = goog.require('os.action.EventType');
-const mapInstance = goog.require('os.map.instance');
+const {getMapContainer} = goog.require('os.map.instance');
 
 
 /**
@@ -74,14 +74,14 @@ class MapMode extends Control {
     events.listen(this.button, EventType.CLICK, MapMode.prototype.handleClick_, this);
 
     this.updateContent_();
-    mapInstance.getMapContainer().listen(GoogEventType.PROPERTYCHANGE, this.onMapChange_, false, this);
+    getMapContainer().listen(GoogEventType.PROPERTYCHANGE, this.onMapChange_, false, this);
   }
 
   /**
    * @inheritDoc
    */
   disposeInternal() {
-    mapInstance.getMapContainer().unlisten(GoogEventType.PROPERTYCHANGE, this.onMapChange_, false, this);
+    getMapContainer().unlisten(GoogEventType.PROPERTYCHANGE, this.onMapChange_, false, this);
 
     if (this.button) {
       events.unlisten(this.button, EventType.CLICK, MapMode.prototype.handleClick_, this);
@@ -123,7 +123,7 @@ class MapMode extends Control {
    */
   updateContent_() {
     if (this.button && this.content && this.loadingEl) {
-      var map = mapInstance.getMapContainer();
+      var map = getMapContainer();
       if (map.isInitializingWebGL()) {
         dom.setTextContent(this.content, '');
         this.content.appendChild(this.loadingEl);

--- a/src/os/control/rotatecontrol.js
+++ b/src/os/control/rotatecontrol.js
@@ -4,7 +4,7 @@ goog.module.declareLegacyNamespace();
 const classlist = goog.require('goog.dom.classlist');
 const OLRotate = goog.require('ol.control.Rotate');
 const css = goog.require('ol.css');
-const mapInstance = goog.require('os.map.instance');
+const {getMapContainer} = goog.require('os.map.instance');
 
 
 /**
@@ -28,7 +28,7 @@ class Rotate extends OLRotate {
    * @suppress {accessControls}
    */
   resetNorth_() {
-    var mapContainer = mapInstance.getMapContainer();
+    var mapContainer = getMapContainer();
     if (mapContainer.is3DEnabled()) {
       mapContainer.resetRotation();
     } else {
@@ -48,7 +48,7 @@ class Rotate extends OLRotate {
 const render = function(mapEvent) {
   var rotation;
 
-  var mapContainer = mapInstance.getMapContainer();
+  var mapContainer = getMapContainer();
   if (mapContainer.is3DEnabled()) {
     var camera = mapContainer.getWebGLCamera();
     if (!camera) {

--- a/src/os/control/rotatecontrol.js
+++ b/src/os/control/rotatecontrol.js
@@ -1,7 +1,9 @@
 goog.module('os.control.Rotate');
 goog.module.declareLegacyNamespace();
 
+const classlist = goog.require('goog.dom.classlist');
 const OLRotate = goog.require('ol.control.Rotate');
+const css = goog.require('ol.css');
 const mapInstance = goog.require('os.map.instance');
 
 
@@ -66,8 +68,8 @@ const render = function(mapEvent) {
   if (rotation != this.rotation_) {
     var transform = 'rotate(' + rotation + 'rad)';
     if (this.autoHide_) {
-      goog.dom.classlist.enable(
-          this.element, ol.css.CLASS_HIDDEN, rotation === 0);
+      classlist.enable(
+          this.element, css.CLASS_HIDDEN, rotation === 0);
     }
     this.label_.style.msTransform = transform;
     this.label_.style.webkitTransform = transform;

--- a/src/os/control/rotatecontrol.js
+++ b/src/os/control/rotatecontrol.js
@@ -1,52 +1,52 @@
-goog.provide('os.control.Rotate');
+goog.module('os.control.Rotate');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.control.Rotate');
-
+const OLRotate = goog.require('ol.control.Rotate');
+const mapInstance = goog.require('os.map.instance');
 
 
 /**
  * Overrides the OpenLayers rotate control to allow resetting rotation in WebGL.
- *
- * @param {olx.control.RotateOptions=} opt_options Rotate options.
- * @extends {ol.control.Rotate}
- * @constructor
  */
-os.control.Rotate = function(opt_options) {
-  var options = opt_options || {};
-  options.autoHide = false;
-  options.render = os.control.Rotate.render;
+class Rotate extends OLRotate {
+  /**
+   * Constructor.
+   * @param {olx.control.RotateOptions=} opt_options Rotate options.
+   */
+  constructor(opt_options) {
+    var options = opt_options || {};
+    options.autoHide = false;
+    options.render = render;
 
-  os.control.Rotate.base(this, 'constructor', options);
-};
-goog.inherits(os.control.Rotate, ol.control.Rotate);
-
-
-/**
- * @inheritDoc
- * @suppress {accessControls}
- */
-os.control.Rotate.prototype.resetNorth_ = function() {
-  var mapContainer = os.MapContainer.getInstance();
-  if (mapContainer.is3DEnabled()) {
-    mapContainer.resetRotation();
-  } else {
-    os.control.Rotate.superClass_.resetNorth_.call(this);
+    super(options);
   }
-};
 
+  /**
+   * @inheritDoc
+   * @suppress {accessControls}
+   */
+  resetNorth_() {
+    var mapContainer = mapInstance.getMapContainer();
+    if (mapContainer.is3DEnabled()) {
+      mapContainer.resetRotation();
+    } else {
+      super.resetNorth_();
+    }
+  }
+}
 
 /**
  * Update the rotate control element.
  *
  * @param {ol.MapEvent} mapEvent Map event.
- * @this ol.control.Rotate
+ * @this OLRotate
  *
  * @suppress {accessControls}
  */
-os.control.Rotate.render = function(mapEvent) {
+const render = function(mapEvent) {
   var rotation;
 
-  var mapContainer = os.MapContainer.getInstance();
+  var mapContainer = mapInstance.getMapContainer();
   if (mapContainer.is3DEnabled()) {
     var camera = mapContainer.getWebGLCamera();
     if (!camera) {
@@ -76,3 +76,5 @@ os.control.Rotate.render = function(mapEvent) {
 
   this.rotation_ = rotation;
 };
+
+exports = Rotate;

--- a/src/os/control/scaleline.js
+++ b/src/os/control/scaleline.js
@@ -1,217 +1,213 @@
-goog.provide('os.control.ScaleLine');
+goog.module('os.control.ScaleLine');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.dom');
-goog.require('goog.dom.safe');
-goog.require('goog.html.SafeHtml');
-goog.require('ol.control.ScaleLine');
-goog.require('ol.control.ScaleLineUnits');
-goog.require('ol.proj');
-goog.require('os.config.Settings');
-goog.require('os.geo');
-goog.require('os.map');
-goog.require('os.math');
-
+const safe = goog.require('goog.dom.safe');
+const SafeHtml = goog.require('goog.html.SafeHtml');
+const OLScaleLine = goog.require('ol.control.ScaleLine');
+const ScaleLineUnits = goog.require('ol.control.ScaleLineUnits');
+const olProj = goog.require('ol.proj');
+const osMap = goog.require('os.map');
+const {UnitSystem} = goog.require('os.unit');
 
 
 /**
- * @constructor
- * @param {olx.control.ScaleLineOptions=} opt_options
- * @extends {ol.control.ScaleLine}
  */
-os.control.ScaleLine = function(opt_options) {
-  os.control.ScaleLine.base(this, 'constructor', opt_options);
+class ScaleLine extends OLScaleLine {
+  /**
+   * Constructor.
+   * @param {olx.control.ScaleLineOptions=} opt_options
+   */
+  constructor(opt_options) {
+    super(opt_options);
 
-  // initialize from unit manager
-  var um = os.unit.UnitManager.getInstance();
-  this.setUnits(/** @type {ol.control.ScaleLineUnits<string>} */ (um.getSelectedSystem()));
+    // initialize from unit manager
+    var um = os.unit.UnitManager.getInstance();
+    this.setUnits(/** @type {ScaleLineUnits<string>} */ (um.getSelectedSystem()));
 
-  // listen for unit manager changes
-  um.listen(goog.events.EventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
-};
-goog.inherits(os.control.ScaleLine, ol.control.ScaleLine);
-
-
-/**
- * @inheritDoc
- */
-os.control.ScaleLine.prototype.disposeInternal = function() {
-  os.unit.UnitManager.getInstance().unlisten(goog.events.EventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
-  os.control.ScaleLine.base(this, 'disposeInternal');
-};
-
-
-/**
- * @param {os.events.PropertyChangeEvent} event
- * @protected
- */
-os.control.ScaleLine.prototype.onUnitsChange = function(event) {
-  var newVal = event.getNewValue();
-  if (typeof newVal === 'string' && newVal != this.getUnits()) {
-    this.setUnits(/** @type {ol.control.ScaleLineUnits<string>} */ (newVal));
-  }
-};
-
-
-/**
- * Hide the control.
- *
- * @protected
- * @suppress {accessControls}
- */
-os.control.ScaleLine.prototype.hide = function() {
-  if (this.renderedVisible_) {
-    this.element_.style.display = 'none';
-    this.renderedVisible_ = false;
-  }
-};
-
-
-/**
- * This is a copy of the original OpenLayers code, with additional bits for showing a single unit
- *
- * @inheritDoc
- * @suppress {accessControls}
- */
-os.control.ScaleLine.prototype.updateElement_ = function() {
-  var viewState = this.viewState_;
-
-  if (!viewState) {
-    this.hide();
-    return;
+    // listen for unit manager changes
+    um.listen(goog.events.EventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
   }
 
-  // The goal of the original Openlayers logic here is to get meters/pixel.
-  // However, it is wrong (see issue #7086 for Openlayers) for some projections.
-  var map = this.getMap();
-
-  var p1 = map.getPixelFromCoordinate(viewState.center);
-  if (!p1) {
-    this.hide();
-    return;
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    os.unit.UnitManager.getInstance().unlisten(goog.events.EventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
+    super.disposeInternal();
   }
 
-  var p2 = p1.slice();
-  p2[0] += 1;
-
-  var c1 = map.getCoordinateFromPixel(p1);
-  var c2 = map.getCoordinateFromPixel(p2);
-  if (!c1 || !c2) {
-    this.hide();
-    return;
-  }
-
-  c1 = ol.proj.toLonLat(c1, os.map.PROJECTION);
-  c2 = ol.proj.toLonLat(c2, os.map.PROJECTION);
-
-  var pointResolution = window.osasm ? osasm.geodesicInverse(c1, c2).distance : NaN;
-  var nominalCount = this.minWidth_ * pointResolution;
-  var suffix = '';
-  var units = this.getUnits();
-  if (units == ol.control.ScaleLineUnits.DEGREES) {
-    var metersPerDegree = ol.proj.METERS_PER_UNIT[ol.proj.Units.DEGREES];
-    pointResolution /= metersPerDegree;
-    if (nominalCount < metersPerDegree / 60) {
-      suffix = '\u2033'; // seconds
-      pointResolution *= 3600;
-    } else if (nominalCount < metersPerDegree) {
-      suffix = '\u2032'; // minutes
-      pointResolution *= 60;
-    } else {
-      suffix = '\u00b0'; // degrees
+  /**
+   * @param {os.events.PropertyChangeEvent} event
+   * @protected
+   */
+  onUnitsChange(event) {
+    var newVal = event.getNewValue();
+    if (typeof newVal === 'string' && newVal != this.getUnits()) {
+      this.setUnits(/** @type {ScaleLineUnits<string>} */ (newVal));
     }
-  } else if (units == ol.control.ScaleLineUnits.IMPERIAL) {
-    if (nominalCount < 0.9144) {
-      suffix = 'in';
-      pointResolution /= 0.0254;
-    } else if (nominalCount < 1609.344) {
-      suffix = 'ft';
-      pointResolution /= 0.3048;
-    } else {
+  }
+
+  /**
+   * Hide the control.
+   *
+   * @protected
+   * @suppress {accessControls}
+   */
+  hide() {
+    if (this.renderedVisible_) {
+      this.element_.style.display = 'none';
+      this.renderedVisible_ = false;
+    }
+  }
+
+  /**
+   * This is a copy of the original OpenLayers code, with additional bits for showing a single unit
+   *
+   * @inheritDoc
+   * @suppress {accessControls}
+   */
+  updateElement_() {
+    var viewState = this.viewState_;
+
+    if (!viewState) {
+      this.hide();
+      return;
+    }
+
+    // The goal of the original Openlayers logic here is to get meters/pixel.
+    // However, it is wrong (see issue #7086 for Openlayers) for some projections.
+    var map = this.getMap();
+
+    var p1 = map.getPixelFromCoordinate(viewState.center);
+    if (!p1) {
+      this.hide();
+      return;
+    }
+
+    var p2 = p1.slice();
+    p2[0] += 1;
+
+    var c1 = map.getCoordinateFromPixel(p1);
+    var c2 = map.getCoordinateFromPixel(p2);
+    if (!c1 || !c2) {
+      this.hide();
+      return;
+    }
+
+    c1 = olProj.toLonLat(c1, osMap.PROJECTION);
+    c2 = olProj.toLonLat(c2, osMap.PROJECTION);
+
+    var pointResolution = window.osasm ? osasm.geodesicInverse(c1, c2).distance : NaN;
+    var nominalCount = this.minWidth_ * pointResolution;
+    var suffix = '';
+    var units = this.getUnits();
+    if (units == ScaleLineUnits.DEGREES) {
+      var metersPerDegree = olProj.METERS_PER_UNIT[olProj.Units.DEGREES];
+      pointResolution /= metersPerDegree;
+      if (nominalCount < metersPerDegree / 60) {
+        suffix = '\u2033'; // seconds
+        pointResolution *= 3600;
+      } else if (nominalCount < metersPerDegree) {
+        suffix = '\u2032'; // minutes
+        pointResolution *= 60;
+      } else {
+        suffix = '\u00b0'; // degrees
+      }
+    } else if (units == ScaleLineUnits.IMPERIAL) {
+      if (nominalCount < 0.9144) {
+        suffix = 'in';
+        pointResolution /= 0.0254;
+      } else if (nominalCount < 1609.344) {
+        suffix = 'ft';
+        pointResolution /= 0.3048;
+      } else {
+        suffix = 'mi';
+        pointResolution /= 1609.344;
+      }
+    } else if (units == ScaleLineUnits.NAUTICAL || units == UnitSystem.NAUTICALMILE) {
+      pointResolution /= 1852;
+      suffix = 'nmi';
+    } else if (units == ScaleLineUnits.METRIC) {
+      if (nominalCount < 1) {
+        suffix = 'mm';
+        pointResolution *= 1000;
+      } else if (nominalCount < 1000) {
+        suffix = 'm';
+      } else {
+        suffix = 'km';
+        pointResolution /= 1000;
+      }
+    } else if (units == ScaleLineUnits.US) {
+      if (nominalCount < 0.9144) {
+        suffix = 'in';
+        pointResolution *= 39.37;
+      } else if (nominalCount < 1609.344) {
+        suffix = 'ft';
+        pointResolution /= 0.30480061;
+      } else {
+        suffix = 'mi';
+        pointResolution /= 1609.3472;
+      }
+    } else if (units == UnitSystem.MILE) { // allow for other unit systems
       suffix = 'mi';
-      pointResolution /= 1609.344;
-    }
-  } else if (units == ol.control.ScaleLineUnits.NAUTICAL || units == os.unit.UnitSystem.NAUTICALMILE) {
-    pointResolution /= 1852;
-    suffix = 'nmi';
-  } else if (units == ol.control.ScaleLineUnits.METRIC) {
-    if (nominalCount < 1) {
-      suffix = 'mm';
-      pointResolution *= 1000;
-    } else if (nominalCount < 1000) {
-      suffix = 'm';
-    } else {
-      suffix = 'km';
-      pointResolution /= 1000;
-    }
-  } else if (units == ol.control.ScaleLineUnits.US) {
-    if (nominalCount < 0.9144) {
-      suffix = 'in';
-      pointResolution *= 39.37;
-    } else if (nominalCount < 1609.344) {
+      pointResolution /= 1609.3472;
+    } else if (units == UnitSystem.YARD) {
+      suffix = 'yd';
+      pointResolution *= 1.09361;
+    } else if (units == UnitSystem.FEET) {
       suffix = 'ft';
       pointResolution /= 0.30480061;
     } else {
-      suffix = 'mi';
-      pointResolution /= 1609.3472;
+      ol.asserts.assert(false, 33); // Invalid units
     }
-  } else if (units == os.unit.UnitSystem.MILE) { // allow for other unit systems
-    suffix = 'mi';
-    pointResolution /= 1609.3472;
-  } else if (units == os.unit.UnitSystem.YARD) {
-    suffix = 'yd';
-    pointResolution *= 1.09361;
-  } else if (units == os.unit.UnitSystem.FEET) {
-    suffix = 'ft';
-    pointResolution /= 0.30480061;
-  } else {
-    ol.asserts.assert(false, 33); // Invalid units
-  }
 
-  var i = 3 * Math.floor(Math.log(this.minWidth_ * pointResolution) / Math.log(10));
-  var count;
-  var width;
-  while (true) {
-    count = ol.control.ScaleLine.LEADING_DIGITS[((i % 3) + 3) % 3] * Math.pow(10, Math.floor(i / 3));
-    width = Math.round(count / pointResolution);
-    if (isNaN(width)) {
-      this.element_.style.display = 'none';
-      this.renderedVisible_ = false;
-      return;
-    } else if (width >= this.minWidth_) {
-      break;
+    var i = 3 * Math.floor(Math.log(this.minWidth_ * pointResolution) / Math.log(10));
+    var count;
+    var width;
+    while (true) {
+      count = OLScaleLine.LEADING_DIGITS[((i % 3) + 3) % 3] * Math.pow(10, Math.floor(i / 3));
+      width = Math.round(count / pointResolution);
+      if (isNaN(width)) {
+        this.element_.style.display = 'none';
+        this.renderedVisible_ = false;
+        return;
+      } else if (width >= this.minWidth_) {
+        break;
+      }
+      ++i;
     }
-    ++i;
+
+    var displayNum = count;
+    if (count < 1E-2 || count > 1E4) { // fixes overlapping labels at zoom level 20+ and 3-
+      displayNum = count.toExponential();
+    }
+    var html = displayNum + ' ' + suffix;
+
+    if (this.renderedHTML_ != html && this.innerElement_) {
+      safe.setInnerHtml(this.innerElement_, SafeHtml.htmlEscape(html));
+      this.renderedHTML_ = html;
+    }
+
+    if (this.renderedWidth_ != width) {
+      this.innerElement_.style.width = width + 'px';
+      this.renderedWidth_ = width;
+    }
+
+    if (!this.renderedVisible_) {
+      this.element_.style.display = '';
+      this.renderedVisible_ = true;
+    }
   }
 
-  var displayNum = count;
-  if (count < 1E-2 || count > 1E4) { // fixes overlapping labels at zoom level 20+ and 3-
-    displayNum = count.toExponential();
+  /**
+   * Get the element
+   *
+   * @suppress {accessControls}
+   * @return {Element}
+   */
+  getElement() {
+    return this.element_;
   }
-  var html = displayNum + ' ' + suffix;
+}
 
-  if (this.renderedHTML_ != html && this.innerElement_) {
-    goog.dom.safe.setInnerHtml(this.innerElement_, goog.html.SafeHtml.htmlEscape(html));
-    this.renderedHTML_ = html;
-  }
-
-  if (this.renderedWidth_ != width) {
-    this.innerElement_.style.width = width + 'px';
-    this.renderedWidth_ = width;
-  }
-
-  if (!this.renderedVisible_) {
-    this.element_.style.display = '';
-    this.renderedVisible_ = true;
-  }
-};
-
-
-/**
- * Get the element
- *
- * @suppress {accessControls}
- * @return {Element}
- */
-os.control.ScaleLine.prototype.getElement = function() {
-  return this.element_;
-};
+exports = ScaleLine;

--- a/src/os/control/scaleline.js
+++ b/src/os/control/scaleline.js
@@ -2,12 +2,17 @@ goog.module('os.control.ScaleLine');
 goog.module.declareLegacyNamespace();
 
 const safe = goog.require('goog.dom.safe');
+const GoogEventType = goog.require('goog.events.EventType');
 const SafeHtml = goog.require('goog.html.SafeHtml');
+const asserts = goog.require('ol.asserts');
 const OLScaleLine = goog.require('ol.control.ScaleLine');
 const ScaleLineUnits = goog.require('ol.control.ScaleLineUnits');
 const olProj = goog.require('ol.proj');
 const osMap = goog.require('os.map');
 const {UnitSystem} = goog.require('os.unit');
+const UnitManager = goog.require('os.unit.UnitManager');
+
+const PropertyChangeEvent = goog.requireType('os.events.PropertyChangeEvent');
 
 
 /**
@@ -21,23 +26,23 @@ class ScaleLine extends OLScaleLine {
     super(opt_options);
 
     // initialize from unit manager
-    var um = os.unit.UnitManager.getInstance();
+    var um = UnitManager.getInstance();
     this.setUnits(/** @type {ScaleLineUnits<string>} */ (um.getSelectedSystem()));
 
     // listen for unit manager changes
-    um.listen(goog.events.EventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
+    um.listen(GoogEventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
   }
 
   /**
    * @inheritDoc
    */
   disposeInternal() {
-    os.unit.UnitManager.getInstance().unlisten(goog.events.EventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
+    UnitManager.getInstance().unlisten(GoogEventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
     super.disposeInternal();
   }
 
   /**
-   * @param {os.events.PropertyChangeEvent} event
+   * @param {PropertyChangeEvent} event
    * @protected
    */
   onUnitsChange(event) {
@@ -158,7 +163,7 @@ class ScaleLine extends OLScaleLine {
       suffix = 'ft';
       pointResolution /= 0.30480061;
     } else {
-      ol.asserts.assert(false, 33); // Invalid units
+      asserts.assert(false, 33); // Invalid units
     }
 
     var i = 3 * Math.floor(Math.log(this.minWidth_ * pointResolution) / Math.log(10));

--- a/src/os/control/zoomcontrol.js
+++ b/src/os/control/zoomcontrol.js
@@ -3,7 +3,7 @@ goog.module.declareLegacyNamespace();
 
 const OLZoom = goog.require('ol.control.Zoom');
 const interaction = goog.require('os.interaction');
-const mapInstance = goog.require('os.map.instance');
+const {getMapContainer} = goog.require('os.map.instance');
 
 
 /**
@@ -23,7 +23,7 @@ class Zoom extends OLZoom {
    * @suppress {accessControls}
    */
   zoomByDelta_(delta) {
-    var mapContainer = mapInstance.getMapContainer();
+    var mapContainer = getMapContainer();
     if (mapContainer.is3DEnabled()) {
       var camera = mapContainer.getWebGLCamera();
       if (camera) {

--- a/src/os/control/zoomcontrol.js
+++ b/src/os/control/zoomcontrol.js
@@ -1,36 +1,39 @@
-goog.provide('os.control.Zoom');
+goog.module('os.control.Zoom');
+goog.module.declareLegacyNamespace();
 
-goog.require('ol.control.Zoom');
-goog.require('os.interaction');
-
+const OLZoom = goog.require('ol.control.Zoom');
+const interaction = goog.require('os.interaction');
+const mapInstance = goog.require('os.map.instance');
 
 
 /**
  * Overrides the OpenLayers zoom control to allow zooming in/out in WebGL.
- *
- * @param {olx.control.ZoomOptions=} opt_options Zoom options.
- * @extends {ol.control.Zoom}
- * @constructor
  */
-os.control.Zoom = function(opt_options) {
-  os.control.Zoom.base(this, 'constructor', opt_options);
-};
-goog.inherits(os.control.Zoom, ol.control.Zoom);
-
-
-/**
- * @inheritDoc
- * @suppress {accessControls}
- */
-os.control.Zoom.prototype.zoomByDelta_ = function(delta) {
-  var mapContainer = os.MapContainer.getInstance();
-  if (mapContainer.is3DEnabled()) {
-    var camera = mapContainer.getWebGLCamera();
-    if (camera) {
-      delta = os.interaction.getZoomDelta(true, delta < 0);
-      camera.zoomByDelta(delta);
-    }
-  } else {
-    os.control.Zoom.superClass_.zoomByDelta_.call(this, delta);
+class Zoom extends OLZoom {
+  /**
+   * Constructor.
+   * @param {olx.control.ZoomOptions=} opt_options Zoom options.
+   */
+  constructor(opt_options) {
+    super(opt_options);
   }
-};
+
+  /**
+   * @inheritDoc
+   * @suppress {accessControls}
+   */
+  zoomByDelta_(delta) {
+    var mapContainer = mapInstance.getMapContainer();
+    if (mapContainer.is3DEnabled()) {
+      var camera = mapContainer.getWebGLCamera();
+      if (camera) {
+        delta = interaction.getZoomDelta(true, delta < 0);
+        camera.zoomByDelta(delta);
+      }
+    } else {
+      super.zoomByDelta_(delta);
+    }
+  }
+}
+
+exports = Zoom;

--- a/src/os/control/zoomlevel.js
+++ b/src/os/control/zoomlevel.js
@@ -10,7 +10,7 @@ const style = goog.require('goog.style');
 const Control = goog.require('ol.control.Control');
 const css = goog.require('ol.css');
 const osMap = goog.require('os.map');
-const mapInstance = goog.require('os.map.instance');
+const {getMapContainer} = goog.require('os.map.instance');
 const UnitManager = goog.require('os.unit.UnitManager');
 const ScaleLineUnits = goog.requireType('ol.control.ScaleLineUnits');
 
@@ -187,7 +187,7 @@ class ZoomLevel extends Control {
     // this value should *only* be set if the displayed text needs to change
     var altitude;
 
-    var map = mapInstance.getMapContainer();
+    var map = getMapContainer();
     if (map.is3DEnabled()) {
       var camera = map.getWebGLCamera();
       if (!camera) {
@@ -246,7 +246,7 @@ class ZoomLevel extends Control {
     // this value should *only* be set if the displayed text needs to change
     var resolution;
 
-    var map = mapInstance.getMapContainer();
+    var map = getMapContainer();
     if (map.is3DEnabled()) {
       var camera = map.getWebGLCamera();
       if (!camera) {

--- a/src/os/control/zoomlevel.js
+++ b/src/os/control/zoomlevel.js
@@ -1,170 +1,298 @@
-goog.provide('os.control.ZoomLevel');
-goog.provide('os.control.ZoomLevelOptions');
+goog.module('os.control.ZoomLevel');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.dom');
-goog.require('goog.dom.TagName');
-goog.require('goog.dom.classes');
-goog.require('goog.dom.safe');
-goog.require('goog.html.SafeHtml');
-goog.require('ol.control.Control');
-goog.require('ol.control.ScaleLineUnits');
-goog.require('ol.css');
-goog.require('os.map');
-goog.require('os.unit.UnitManager');
+const dom = goog.require('goog.dom');
+const TagName = goog.require('goog.dom.TagName');
+const safe = goog.require('goog.dom.safe');
+const SafeHtml = goog.require('goog.html.SafeHtml');
+const Control = goog.require('ol.control.Control');
+const css = goog.require('ol.css');
+const osMap = goog.require('os.map');
+const mapInstance = goog.require('os.map.instance');
+const UnitManager = goog.require('os.unit.UnitManager');
+const ScaleLineUnits = goog.requireType('ol.control.ScaleLineUnits');
 
-
-/**
- * @typedef {{
- *   className: (string|undefined),
- *   target: (Element|undefined)
- *   }}
- */
-os.control.ZoomLevelOptions;
-
+const ZoomLevelOptions = goog.requireType('os.control.ZoomLevelOptions');
 
 
 /**
  * Displays the current zoom level and altitude.
- *
- * @param {os.control.ZoomLevelOptions=} opt_options Scale line options.
- * @extends {ol.control.Control}
- * @constructor
  */
-os.control.ZoomLevel = function(opt_options) {
-  var options = opt_options || {};
-
-  var className = options.className !== undefined ? options.className : 'ol-zoom-level';
-
+class ZoomLevel extends Control {
   /**
-   * @type {Element}
-   * @private
+   * Constructor.
+   * @param {ZoomLevelOptions=} opt_options Scale line options.
    */
-  this.element_ = goog.dom.createDom(goog.dom.TagName.DIV, {
-    'class': className + ' ' + ol.css.CLASS_UNSELECTABLE
-  });
+  constructor(opt_options) {
+    var options = opt_options || {};
 
-  /**
-   * @type {Element}
-   * @private
-   */
-  this.altElement_ = goog.dom.createDom(goog.dom.TagName.SPAN, {
-    'class': 'altitude-text mr-1'
-  });
-  this.element_.appendChild(this.altElement_);
+    var className = options.className !== undefined ? options.className : 'ol-zoom-level';
+    var element = dom.createDom(TagName.DIV, {
+      'class': className + ' ' + css.CLASS_UNSELECTABLE
+    });
 
-  var separator = goog.dom.createDom(goog.dom.TagName.SPAN, {
-    'class': 'separator mr-1'
-  });
-  goog.dom.safe.setInnerHtml(separator, goog.html.SafeHtml.htmlEscape('|'));
-  this.element_.appendChild(separator);
+    super({
+      element: element,
+      render: render,
+      target: options.target
+    });
 
-  /**
-   * @type {Element}
-   * @private
-   */
-  this.zoomElement_ = goog.dom.createDom(goog.dom.TagName.SPAN, {
-    'class': 'zoom-text mr-1'
-  });
-  this.element_.appendChild(this.zoomElement_);
+    /**
+     * @type {Element}
+     * @private
+     */
+    this.element_ = element;
 
-  /**
-   * @type {number|undefined}
-   * @private
-   */
-  this.lastAltitudeVal_ = undefined;
+    /**
+     * @type {Element}
+     * @private
+     */
+    this.altElement_ = dom.createDom(TagName.SPAN, {
+      'class': 'altitude-text mr-1'
+    });
+    this.element_.appendChild(this.altElement_);
 
-  /**
-   * @type {number|undefined}
-   * @private
-   */
-  this.lastZoomVal_ = undefined;
+    var separator = dom.createDom(TagName.SPAN, {
+      'class': 'separator mr-1'
+    });
+    safe.setInnerHtml(separator, SafeHtml.htmlEscape('|'));
+    this.element_.appendChild(separator);
 
-  /**
-   * @type {?olx.ViewState}
-   * @private
-   */
-  this.viewState_ = null;
+    /**
+     * @type {Element}
+     * @private
+     */
+    this.zoomElement_ = dom.createDom(TagName.SPAN, {
+      'class': 'zoom-text mr-1'
+    });
+    this.element_.appendChild(this.zoomElement_);
 
-  os.control.ZoomLevel.base(this, 'constructor', {
-    element: this.element_,
-    render: os.control.ZoomLevel.render_,
-    target: options.target
-  });
+    /**
+     * @type {number|undefined}
+     * @private
+     */
+    this.lastAltitudeVal_ = undefined;
 
-  // initialize from unit manager
-  var um = os.unit.UnitManager.getInstance();
-  var units = /** @type {ol.control.ScaleLineUnits<string>} */ (um.getSelectedSystem());
-  this.setAltitudeUnits(units);
+    /**
+     * @type {number|undefined}
+     * @private
+     */
+    this.lastZoomVal_ = undefined;
 
-  // listen for unit manager changes
-  um.listen(goog.events.EventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
-};
-goog.inherits(os.control.ZoomLevel, ol.control.Control);
+    /**
+     * @type {?olx.ViewState}
+     * @private
+     */
+    this.viewState_ = null;
 
+    // initialize from unit manager
+    var um = UnitManager.getInstance();
+    var units = /** @type {ScaleLineUnits<string>} */ (um.getSelectedSystem());
+    this.setAltitudeUnits(units);
 
-/**
- * @inheritDoc
- */
-os.control.ZoomLevel.prototype.disposeInternal = function() {
-  os.control.ZoomLevel.base(this, 'disposeInternal');
-  os.unit.UnitManager.getInstance().unlisten(goog.events.EventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
-};
-
-
-/**
- * Toggle showing zoom/altitude on mouse click.
- *
- * @protected
- */
-os.control.ZoomLevel.prototype.reset = function() {
-  // clear cached values
-  this.lastAltitudeVal_ = undefined;
-  this.lastZoomVal_ = undefined;
-
-  // update the text
-  this.updateElement();
-};
-
-
-/**
- * Return the units to use in the zoom level when displaying altitude.
- *
- * @return {ol.control.ScaleLineUnits|undefined}
- */
-os.control.ZoomLevel.prototype.getAltitudeUnits = function() {
-  return /** @type {ol.control.ScaleLineUnits|undefined} */ (this.get(os.control.ZoomLevel.Property_.UNITS));
-};
-
-
-/**
- * Set the units to use in the zoom level when displaying altitude.
- *
- * @param {ol.control.ScaleLineUnits} units The units to use
- */
-os.control.ZoomLevel.prototype.setAltitudeUnits = function(units) {
-  this.set(os.control.ZoomLevel.Property_.UNITS, units);
-};
-
-
-/**
- * @param {os.events.PropertyChangeEvent} event
- * @protected
- */
-os.control.ZoomLevel.prototype.onUnitsChange = function(event) {
-  var newVal = event.getNewValue();
-  if (typeof newVal === 'string' && newVal != this.getAltitudeUnits()) {
-    this.setAltitudeUnits(/** @type {ol.control.ScaleLineUnits<string>} */ (newVal));
-    this.reset();
+    // listen for unit manager changes
+    um.listen(goog.events.EventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
   }
-};
 
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
+    UnitManager.getInstance().unlisten(goog.events.EventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
+  }
+
+  /**
+   * Toggle showing zoom/altitude on mouse click.
+   *
+   * @protected
+   */
+  reset() {
+    // clear cached values
+    this.lastAltitudeVal_ = undefined;
+    this.lastZoomVal_ = undefined;
+
+    // update the text
+    this.updateElement();
+  }
+
+  /**
+   * Return the units to use in the zoom level when displaying altitude.
+   *
+   * @return {ScaleLineUnits|undefined}
+   */
+  getAltitudeUnits() {
+    return /** @type {ScaleLineUnits|undefined} */ (this.get(Property.UNITS));
+  }
+
+  /**
+   * Set the units to use in the zoom level when displaying altitude.
+   *
+   * @param {ScaleLineUnits} units The units to use
+   */
+  setAltitudeUnits(units) {
+    this.set(Property.UNITS, units);
+  }
+
+  /**
+   * @param {os.events.PropertyChangeEvent} event
+   * @protected
+   */
+  onUnitsChange(event) {
+    var newVal = event.getNewValue();
+    if (typeof newVal === 'string' && newVal != this.getAltitudeUnits()) {
+      this.setAltitudeUnits(/** @type {ScaleLineUnits<string>} */ (newVal));
+      this.reset();
+    }
+  }
+
+  /**
+   * Hide the altitude control.
+   *
+   * @protected
+   */
+  hideAltitude() {
+    goog.style.setElementShown(this.altElement_, false);
+    this.lastAltitudeVal_ = undefined;
+  }
+
+  /**
+   * Hide the zoom level control.
+   *
+   * @protected
+   */
+  hideZoom() {
+    goog.style.setElementShown(this.zoomElement_, false);
+    this.lastZoomVal_ = undefined;
+  }
+
+  /**
+   * Update the control text.
+   *
+   * @protected
+   */
+  updateElement() {
+    this.updateAltitudeText();
+    this.updateZoomText();
+  }
+
+  /**
+   * Update the control text for altitude.
+   *
+   * @protected
+   */
+  updateAltitudeText() {
+    // this value should *only* be set if the displayed text needs to change
+    var altitude;
+
+    var map = mapInstance.getMapContainer();
+    if (map.is3DEnabled()) {
+      var camera = map.getWebGLCamera();
+      if (!camera) {
+        this.hideAltitude();
+        return;
+      }
+
+      // in 3d mode, track the last altitude by camera altitude
+      var camAltitude = camera.getAltitude();
+      if (camAltitude != this.lastAltitudeVal_) {
+        this.lastAltitudeVal_ = altitude = camAltitude;
+      }
+    } else {
+      var viewState = this.viewState_;
+      if (!viewState) {
+        this.hideAltitude();
+        return;
+      }
+
+      // in 2d mode, track the last altitude by view resolution
+      if (viewState.resolution != this.lastAltitudeVal_) {
+        this.lastAltitudeVal_ = viewState.resolution;
+        var sizeObj = map.getMap().getSize();
+        altitude = osMap.distanceForResolution([sizeObj[0], sizeObj[1]], viewState.resolution);
+      }
+    }
+
+    // null/undefined likely means the value hasn't changed
+    if (altitude != null) {
+      if (isNaN(altitude)) {
+        this.hideAltitude();
+      }
+
+      // altitude value has been set, so update the displayed value
+      var um = UnitManager.getInstance();
+      if (this.altElement_) {
+        safe.setInnerHtml(this.altElement_, SafeHtml.htmlEscape(
+            'Altitude: ' + um.formatToBestFit('distance', altitude, 'm', um.getBaseSystem(), 3)));
+        goog.style.setElementShown(this.altElement_, true);
+      }
+    }
+  }
+
+  /**
+   * Update the control text for zoom level.
+   *
+   * @protected
+   */
+  updateZoomText() {
+    var viewState = this.viewState_;
+    if (!viewState) {
+      this.hideZoom();
+      return;
+    }
+
+    // this value should *only* be set if the displayed text needs to change
+    var resolution;
+
+    var map = mapInstance.getMapContainer();
+    if (map.is3DEnabled()) {
+      var camera = map.getWebGLCamera();
+      if (!camera) {
+        this.hideZoom();
+        return;
+      }
+
+      // in 3d mode, track the last zoom level by camera altitude. this prevents converting the altitude on every render.
+      var altitude = camera.getAltitude();
+      if (this.lastZoomVal_ != altitude) {
+        this.lastZoomVal_ = altitude;
+        resolution = camera.calcResolutionForDistance(altitude, 0);
+      }
+    } else if (viewState.resolution != this.lastZoomVal_) {
+      // in 2d mode, track the last zoom level by view resolution
+      this.lastZoomVal_ = viewState.resolution;
+      resolution = viewState.resolution;
+    }
+
+    // null/undefined likely means the value hasn't changed
+    if (resolution != null) {
+      // resolution value has been set, so update the displayed zoom level
+      var zoom = osMap.resolutionToZoom(resolution, viewState.projection);
+      if (zoom == null || zoom == Infinity || isNaN(zoom)) {
+        this.hideZoom();
+      } else {
+        safe.setInnerHtml(/** @type {!Element} */ (this.zoomElement_),
+            SafeHtml.htmlEscape('Zoom: ' + zoom.toFixed(1)));
+        goog.style.setElementShown(this.zoomElement_, true);
+      }
+    }
+  }
+
+  /**
+   * Get the element
+   *
+   * @return {Element}
+   */
+  getElement() {
+    return this.element_;
+  }
+}
 
 /**
  * @param {ol.MapEvent} mapEvent Event.
- * @this os.control.ZoomLevel
- * @private
+ * @this ZoomLevel
  */
-os.control.ZoomLevel.render_ = function(mapEvent) {
+const render = function(mapEvent) {
   var frameState = mapEvent.frameState;
   if (frameState === null) {
     this.viewState_ = null;
@@ -176,156 +304,11 @@ os.control.ZoomLevel.render_ = function(mapEvent) {
 
 
 /**
- * Hide the altitude control.
- *
- * @protected
- */
-os.control.ZoomLevel.prototype.hideAltitude = function() {
-  goog.style.setElementShown(this.altElement_, false);
-  this.lastAltitudeVal_ = undefined;
-};
-
-
-/**
- * Hide the zoom level control.
- *
- * @protected
- */
-os.control.ZoomLevel.prototype.hideZoom = function() {
-  goog.style.setElementShown(this.zoomElement_, false);
-  this.lastZoomVal_ = undefined;
-};
-
-
-/**
- * Update the control text.
- *
- * @protected
- */
-os.control.ZoomLevel.prototype.updateElement = function() {
-  this.updateAltitudeText();
-  this.updateZoomText();
-};
-
-
-/**
- * Update the control text for altitude.
- *
- * @protected
- */
-os.control.ZoomLevel.prototype.updateAltitudeText = function() {
-  // this value should *only* be set if the displayed text needs to change
-  var altitude;
-
-  var map = os.MapContainer.getInstance();
-  if (map.is3DEnabled()) {
-    var camera = map.getWebGLCamera();
-    if (!camera) {
-      this.hideAltitude();
-      return;
-    }
-
-    // in 3d mode, track the last altitude by camera altitude
-    var camAltitude = camera.getAltitude();
-    if (camAltitude != this.lastAltitudeVal_) {
-      this.lastAltitudeVal_ = altitude = camAltitude;
-    }
-  } else {
-    var viewState = this.viewState_;
-    if (!viewState) {
-      this.hideAltitude();
-      return;
-    }
-
-    // in 2d mode, track the last altitude by view resolution
-    if (viewState.resolution != this.lastAltitudeVal_) {
-      this.lastAltitudeVal_ = viewState.resolution;
-      var sizeObj = map.getMap().getSize();
-      altitude = os.map.distanceForResolution([sizeObj[0], sizeObj[1]], viewState.resolution);
-    }
-  }
-
-  // null/undefined likely means the value hasn't changed
-  if (altitude != null) {
-    if (isNaN(altitude)) {
-      this.hideAltitude();
-    }
-
-    // altitude value has been set, so update the displayed value
-    var um = os.unit.UnitManager.getInstance();
-    if (this.altElement_) {
-      goog.dom.safe.setInnerHtml(this.altElement_, goog.html.SafeHtml.htmlEscape(
-          'Altitude: ' + um.formatToBestFit('distance', altitude, 'm', um.getBaseSystem(), 3)));
-      goog.style.setElementShown(this.altElement_, true);
-    }
-  }
-};
-
-
-/**
- * Update the control text for zoom level.
- *
- * @protected
- */
-os.control.ZoomLevel.prototype.updateZoomText = function() {
-  var viewState = this.viewState_;
-  if (!viewState) {
-    this.hideZoom();
-    return;
-  }
-
-  // this value should *only* be set if the displayed text needs to change
-  var resolution;
-
-  var map = os.MapContainer.getInstance();
-  if (map.is3DEnabled()) {
-    var camera = map.getWebGLCamera();
-    if (!camera) {
-      this.hideZoom();
-      return;
-    }
-
-    // in 3d mode, track the last zoom level by camera altitude. this prevents converting the altitude on every render.
-    var altitude = camera.getAltitude();
-    if (this.lastZoomVal_ != altitude) {
-      this.lastZoomVal_ = altitude;
-      resolution = camera.calcResolutionForDistance(altitude, 0);
-    }
-  } else if (viewState.resolution != this.lastZoomVal_) {
-    // in 2d mode, track the last zoom level by view resolution
-    this.lastZoomVal_ = viewState.resolution;
-    resolution = viewState.resolution;
-  }
-
-  // null/undefined likely means the value hasn't changed
-  if (resolution != null) {
-    // resolution value has been set, so update the displayed zoom level
-    var zoom = os.map.resolutionToZoom(resolution, viewState.projection);
-    if (zoom == null || zoom == Infinity || isNaN(zoom)) {
-      this.hideZoom();
-    } else {
-      goog.dom.safe.setInnerHtml(/** @type {!Element} */ (this.zoomElement_),
-          goog.html.SafeHtml.htmlEscape('Zoom: ' + zoom.toFixed(1)));
-      goog.style.setElementShown(this.zoomElement_, true);
-    }
-  }
-};
-
-
-/**
  * @enum {string}
- * @private
  */
-os.control.ZoomLevel.Property_ = {
+const Property = {
   UNITS: 'units'
 };
 
 
-/**
- * Get the element
- *
- * @return {Element}
- */
-os.control.ZoomLevel.prototype.getElement = function() {
-  return this.element_;
-};
+exports = ZoomLevel;

--- a/src/os/control/zoomlevel.js
+++ b/src/os/control/zoomlevel.js
@@ -4,7 +4,9 @@ goog.module.declareLegacyNamespace();
 const dom = goog.require('goog.dom');
 const TagName = goog.require('goog.dom.TagName');
 const safe = goog.require('goog.dom.safe');
+const GoogEventType = goog.require('goog.events.EventType');
 const SafeHtml = goog.require('goog.html.SafeHtml');
+const style = goog.require('goog.style');
 const Control = goog.require('ol.control.Control');
 const css = goog.require('ol.css');
 const osMap = goog.require('os.map');
@@ -91,7 +93,7 @@ class ZoomLevel extends Control {
     this.setAltitudeUnits(units);
 
     // listen for unit manager changes
-    um.listen(goog.events.EventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
+    um.listen(GoogEventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
   }
 
   /**
@@ -99,7 +101,7 @@ class ZoomLevel extends Control {
    */
   disposeInternal() {
     super.disposeInternal();
-    UnitManager.getInstance().unlisten(goog.events.EventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
+    UnitManager.getInstance().unlisten(GoogEventType.PROPERTYCHANGE, this.onUnitsChange, false, this);
   }
 
   /**
@@ -152,7 +154,7 @@ class ZoomLevel extends Control {
    * @protected
    */
   hideAltitude() {
-    goog.style.setElementShown(this.altElement_, false);
+    style.setElementShown(this.altElement_, false);
     this.lastAltitudeVal_ = undefined;
   }
 
@@ -162,7 +164,7 @@ class ZoomLevel extends Control {
    * @protected
    */
   hideZoom() {
-    goog.style.setElementShown(this.zoomElement_, false);
+    style.setElementShown(this.zoomElement_, false);
     this.lastZoomVal_ = undefined;
   }
 
@@ -224,7 +226,7 @@ class ZoomLevel extends Control {
       if (this.altElement_) {
         safe.setInnerHtml(this.altElement_, SafeHtml.htmlEscape(
             'Altitude: ' + um.formatToBestFit('distance', altitude, 'm', um.getBaseSystem(), 3)));
-        goog.style.setElementShown(this.altElement_, true);
+        style.setElementShown(this.altElement_, true);
       }
     }
   }
@@ -273,7 +275,7 @@ class ZoomLevel extends Control {
       } else {
         safe.setInnerHtml(/** @type {!Element} */ (this.zoomElement_),
             SafeHtml.htmlEscape('Zoom: ' + zoom.toFixed(1)));
-        goog.style.setElementShown(this.zoomElement_, true);
+        style.setElementShown(this.zoomElement_, true);
       }
     }
   }

--- a/src/os/control/zoomleveloptions.js
+++ b/src/os/control/zoomleveloptions.js
@@ -1,0 +1,11 @@
+goog.module('os.control.ZoomLevelOptions');
+
+/**
+ * @typedef {{
+ *   className: (string|undefined),
+ *   target: (Element|undefined)
+ * }}
+ */
+let ZoomLevelOptions;
+
+exports = ZoomLevelOptions;

--- a/src/os/easing/easing.js
+++ b/src/os/easing/easing.js
@@ -1,12 +1,11 @@
-goog.provide('os.easing');
-
+goog.module('os.easing');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * @typedef {function(number, number, number, number)}
  */
-os.easing.EasingFunction;
-
+let EasingFunction;
 
 /**
  * Linear easing function
@@ -17,11 +16,10 @@ os.easing.EasingFunction;
  * @param {number} d The duration or total number of steps
  * @return {number}
  */
-os.easing.easeLinear = function(t, b, c, d) {
+const easeLinear = function(t, b, c, d) {
   t /= d;
   return c * t + b;
 };
-
 
 /**
  * Quintic easing function
@@ -32,12 +30,11 @@ os.easing.easeLinear = function(t, b, c, d) {
  * @param {number} d The duration or total number of steps
  * @return {number}
  */
-os.easing.easeQuintic = function(t, b, c, d) {
+const easeQuintic = function(t, b, c, d) {
   t /= d;
   t--;
   return c * (t * t * t * t * t + 1) + b;
 };
-
 
 /**
  * Quartic easing function
@@ -48,7 +45,7 @@ os.easing.easeQuintic = function(t, b, c, d) {
  * @param {number} d The duration or total number of steps
  * @return {number}
  */
-os.easing.easeQuartic = function(t, b, c, d) {
+const easeQuartic = function(t, b, c, d) {
   t = t / (d / 2);
   if (t < 1) {
     return c * t * t * t * t / 2 + b;
@@ -57,7 +54,6 @@ os.easing.easeQuartic = function(t, b, c, d) {
   return -c * (t * t * t * t - 2) / 2 + b;
 };
 
-
 /**
  * Quartic easing function
  *
@@ -67,7 +63,7 @@ os.easing.easeQuartic = function(t, b, c, d) {
  * @param {number} d The duration or total number of steps
  * @return {number}
  */
-os.easing.easeCubic = function(t, b, c, d) {
+const easeCubic = function(t, b, c, d) {
   t = t / (d / 2);
   if (t < 1) {
     return c * t * t / 2 + b;
@@ -75,7 +71,6 @@ os.easing.easeCubic = function(t, b, c, d) {
   t -= 2;
   return -c * (t * t - 2) / 2 + b;
 };
-
 
 /**
  * Exponential easing function
@@ -86,7 +81,7 @@ os.easing.easeCubic = function(t, b, c, d) {
  * @param {number} d The duration or total number of steps
  * @return {number}
  */
-os.easing.easeExpo = function(t, b, c, d) {
+const easeExpo = function(t, b, c, d) {
   t = t / (d / 2);
   if (t < 1) {
     return c * Math.pow(2, 10 * (t - 1)) / 2 + b;
@@ -94,7 +89,6 @@ os.easing.easeExpo = function(t, b, c, d) {
   t--;
   return c * (-Math.pow(2, -10 * t) + 2) / 2 + b;
 };
-
 
 /**
  * Circular easing function (this is CircleIn, not CircleOut)
@@ -105,11 +99,10 @@ os.easing.easeExpo = function(t, b, c, d) {
  * @param {number} d The duration or total number of steps
  * @return {number}
  */
-os.easing.easeCircular = function(t, b, c, d) {
+const easeCircular = function(t, b, c, d) {
   t /= d;
   return -c * (Math.sqrt(1 - t * t) - 1) + b;
 };
-
 
 /**
  * Sinusoidal easing function
@@ -120,6 +113,17 @@ os.easing.easeCircular = function(t, b, c, d) {
  * @param {number} d The duration or total number of steps
  * @return {number}
  */
-os.easing.easeSinusoidal = function(t, b, c, d) {
+const easeSinusoidal = function(t, b, c, d) {
   return (b + c) * (1 - Math.cos(Math.PI * t / d)) / 2;
+};
+
+exports = {
+  easeLinear,
+  easeQuintic,
+  easeQuartic,
+  easeCubic,
+  easeExpo,
+  easeCircular,
+  easeSinusoidal,
+  EasingFunction
 };

--- a/src/os/events/errorevent.js
+++ b/src/os/events/errorevent.js
@@ -1,32 +1,36 @@
-goog.provide('os.events.ErrorEvent');
-goog.require('goog.events.Event');
+goog.module('os.events.ErrorEvent');
+goog.module.declareLegacyNamespace();
 
+const GoogEvent = goog.require('goog.events.Event');
+const EventType = goog.require('os.events.EventType');
 
 
 /**
  * Event object which contains error message
- *
- * @constructor
- * @extends {goog.events.Event}
- * @param {?string} message
- * @param {string=} opt_type
- * @param {Object=} opt_target
  */
-os.events.ErrorEvent = function(message, opt_type, opt_target) {
-  os.events.ErrorEvent.base(this, 'constructor', opt_type || os.events.EventType.ERROR, opt_target);
+class ErrorEvent extends GoogEvent {
+  /**
+   * Constructor.
+   * @param {?string} message
+   * @param {string=} opt_type
+   * @param {Object=} opt_target
+   */
+  constructor(message, opt_type, opt_target) {
+    super(opt_type || EventType.ERROR, opt_target);
+
+    /**
+     * @type {?string}
+     * @private
+     */
+    this.message_ = message;
+  }
 
   /**
-   * @type {?string}
-   * @private
+   * @return {?string}
    */
-  this.message_ = message;
-};
-goog.inherits(os.events.ErrorEvent, goog.events.Event);
+  getMessage() {
+    return this.message_;
+  }
+}
 
-
-/**
- * @return {?string}
- */
-os.events.ErrorEvent.prototype.getMessage = function() {
-  return this.message_;
-};
+exports = ErrorEvent;

--- a/src/os/events/event.js
+++ b/src/os/events/event.js
@@ -1,43 +1,45 @@
-goog.provide('os.events.Event');
-goog.require('goog.events.Event');
+goog.module('os.events.Event');
+goog.module.declareLegacyNamespace();
 
+const GoogEvent = goog.require('goog.events.Event');
 
 
 /**
  * Simple event extension designed to carry anything as a payload.
- *
- * @param {string} type
- * @param {*=} opt_data
- * @extends {goog.events.Event}
- * @constructor
  */
-os.events.Event = function(type, opt_data) {
-  os.events.Event.base(this, 'constructor', type);
+class Event extends GoogEvent {
+  /**
+   * Constructor.
+   * @param {string} type
+   * @param {*=} opt_data
+   */
+  constructor(type, opt_data) {
+    super(type);
+
+    /**
+     * Generic payload data.
+     * @type {*}
+     */
+    this.data = opt_data;
+  }
 
   /**
-   * Generic payload data.
-   * @type {*}
+   * Get the event data.
+   *
+   * @return {*}
    */
-  this.data = opt_data;
-};
-goog.inherits(os.events.Event, goog.events.Event);
+  getData() {
+    return this.data;
+  }
 
+  /**
+   * Set the event data.
+   *
+   * @param {*} value
+   */
+  setData(value) {
+    this.data = value;
+  }
+}
 
-/**
- * Get the event data.
- *
- * @return {*}
- */
-os.events.Event.prototype.getData = function() {
-  return this.data;
-};
-
-
-/**
- * Set the event data.
- *
- * @param {*} value
- */
-os.events.Event.prototype.setData = function(value) {
-  this.data = value;
-};
+exports = Event;

--- a/src/os/events/eventfactory.js
+++ b/src/os/events/eventfactory.js
@@ -1,4 +1,5 @@
-goog.provide('os.events.EventFactory');
+goog.module('os.events.EventFactory');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -7,7 +8,7 @@ goog.provide('os.events.EventFactory');
  * @param {!string} type The type of event to create
  * @return {!Event}
  */
-os.events.EventFactory.createEvent = function(type) {
+const createEvent = function(type) {
   var event;
   try {
     // modern browsers
@@ -18,4 +19,8 @@ os.events.EventFactory.createEvent = function(type) {
     event.initEvent(type, true, true);
   }
   return event;
+};
+
+exports = {
+  createEvent
 };

--- a/src/os/events/eventtype.js
+++ b/src/os/events/eventtype.js
@@ -1,10 +1,11 @@
-goog.provide('os.events.EventType');
+goog.module('os.events.EventType');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * @enum {string}
  */
-os.events.EventType = {
+exports = {
   CANCEL: 'cancel',
   COMPLETE: 'complete',
   ERROR: 'error',

--- a/src/os/events/layerconfigevent.js
+++ b/src/os/events/layerconfigevent.js
@@ -1,29 +1,25 @@
-goog.provide('os.events.LayerConfigEvent');
-goog.provide('os.events.LayerConfigEventType');
-goog.require('goog.events.Event');
+goog.module('os.events.LayerConfigEvent');
+goog.module.declareLegacyNamespace();
+
+const GoogEvent = goog.require('goog.events.Event');
 
 
 /**
- * @enum {string}
  */
-os.events.LayerConfigEventType = {
-  CONFIGURE_AND_ADD: 'configureAndAddLayer'
-};
-
-
-
-/**
- * @param {string} type
- * @param {Object.<string, *>} options
- * @extends {goog.events.Event}
- * @constructor
- */
-os.events.LayerConfigEvent = function(type, options) {
-  os.events.LayerConfigEvent.base(this, 'constructor', type);
-
+class LayerConfigEvent extends GoogEvent {
   /**
-   * @type {Object.<string, *>|Array.<Object.<string, *>>}
+   * Constructor.
+   * @param {string} type
+   * @param {Object<string, *>} options
    */
-  this.options = options;
-};
-goog.inherits(os.events.LayerConfigEvent, goog.events.Event);
+  constructor(type, options) {
+    super(type);
+
+    /**
+     * @type {Object<string, *>|Array<Object<string, *>>}
+     */
+    this.options = options;
+  }
+}
+
+exports = LayerConfigEvent;

--- a/src/os/events/layerconfigeventtype.js
+++ b/src/os/events/layerconfigeventtype.js
@@ -1,0 +1,10 @@
+goog.module('os.events.LayerConfigEventType');
+goog.module.declareLegacyNamespace();
+
+
+/**
+ * @enum {string}
+ */
+exports = {
+  CONFIGURE_AND_ADD: 'configureAndAddLayer'
+};

--- a/src/os/events/layerevent.js
+++ b/src/os/events/layerevent.js
@@ -1,52 +1,41 @@
-goog.provide('os.events.LayerEvent');
-goog.provide('os.events.LayerEventType');
-goog.require('goog.events.Event');
+goog.module('os.events.LayerEvent');
+goog.module.declareLegacyNamespace();
+
+const GoogEvent = goog.require('goog.events.Event');
+
+const OLEventTarget = goog.requireType('ol.events.EventTarget');
 
 
 /**
- * @enum {string}
  */
-os.events.LayerEventType = {
-  ADD: 'addLayer',
-  CHANGE: 'layer:change',
-  REMOVE: 'removeLayer',
-  RENAME: 'renameLayer',
-  MOVE: 'moveLayer',
-  SYNC: 'syncLayer',
-  IDENTIFY: 'identifyLayer',
-  COLOR_CHANGE: 'layerColorChange',
-  BASELAYER_CHANGE: 'baseLayerChange'
-};
-
-
-
-/**
- * @param {string} type
- * @param {ol.layer.Layer|string} layer
- * @param {number=} opt_index
- * @extends {goog.events.Event}
- * @constructor
- */
-os.events.LayerEvent = function(type, layer, opt_index) {
-  os.events.LayerEvent.base(this, 'constructor', type);
-
+class LayerEvent extends GoogEvent {
   /**
-   * @type {ol.layer.Layer|string}
+   * Constructor.
+   * @param {string} type
+   * @param {ol.layer.Layer|string} layer
+   * @param {number=} opt_index
    */
-  this.layer = layer;
+  constructor(type, layer, opt_index) {
+    super(type);
 
-  /**
-   * @type {number}
-   */
-  this.index = opt_index != null ? opt_index : -1;
-};
-goog.inherits(os.events.LayerEvent, goog.events.Event);
+    /**
+     * @type {ol.layer.Layer|string}
+     */
+    this.layer = layer;
 
+    /**
+     * @type {number}
+     */
+    this.index = opt_index != null ? opt_index : -1;
+  }
+}
 
 /**
  * Override the type so these events can be used with {@link ol.events.EventTarget.prototype.dispatchEvent}.
  *
- * @type {EventTarget|ol.events.EventTarget|undefined}
+ * @type {EventTarget|OLEventTarget|undefined}
  * @suppress {duplicate}
  */
-os.events.LayerEvent.prototype.target;
+LayerEvent.prototype.target;
+
+exports = LayerEvent;

--- a/src/os/events/layereventtype.js
+++ b/src/os/events/layereventtype.js
@@ -1,0 +1,18 @@
+goog.module('os.events.LayerEventType');
+goog.module.declareLegacyNamespace();
+
+
+/**
+ * @enum {string}
+ */
+exports = {
+  ADD: 'addLayer',
+  CHANGE: 'layer:change',
+  REMOVE: 'removeLayer',
+  RENAME: 'renameLayer',
+  MOVE: 'moveLayer',
+  SYNC: 'syncLayer',
+  IDENTIFY: 'identifyLayer',
+  COLOR_CHANGE: 'layerColorChange',
+  BASELAYER_CHANGE: 'baseLayerChange'
+};

--- a/src/os/events/payloadevent.js
+++ b/src/os/events/payloadevent.js
@@ -1,55 +1,60 @@
-goog.provide('os.events.PayloadEvent');
+goog.module('os.events.PayloadEvent');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.events.Event');
+const GoogEvent = goog.require('goog.events.Event');
 
+const OLEventTarget = goog.requireType('ol.events.EventTarget');
 
 
 /**
  * An event carrying an arbitrary data payload.
  *
- * @param {string} type The event type.
- * @param {T=} opt_payload The payload.
- * @extends {goog.events.Event}
- * @constructor
  * @template T
  */
-os.events.PayloadEvent = function(type, opt_payload) {
-  os.events.PayloadEvent.base(this, 'constructor', type);
+class PayloadEvent extends GoogEvent {
+  /**
+   * Constructor.
+   * @param {string} type The event type.
+   * @param {T=} opt_payload The payload.
+   */
+  constructor(type, opt_payload) {
+    super(type);
+
+    /**
+     * The property
+     * @type {?T}
+     * @private
+     */
+    this.payload_ = opt_payload;
+  }
 
   /**
-   * The property
-   * @type {?T}
-   * @private
+   * Gets the payload.
+   *
+   * @return {?T}
    */
-  this.payload_ = opt_payload;
-};
-goog.inherits(os.events.PayloadEvent, goog.events.Event);
+  getPayload() {
+    return this.payload_;
+  }
+
+  /**
+   * Sets the payload.
+   *
+   * @param {T} value The payload to set.
+   */
+  setPayload(value) {
+    this.payload_ = value;
+  }
+}
 
 
 /**
  * Override the type so these events can be used with {@link ol.events.EventTarget.prototype.dispatchEvent}.
  *
- * @type {EventTarget|ol.events.EventTarget|undefined}
+ * @type {EventTarget|OLEventTarget|undefined}
  * @suppress {duplicate}
  */
-os.events.PayloadEvent.prototype.target;
+PayloadEvent.prototype.target;
 
 
-/**
- * Gets the payload.
- *
- * @return {?T}
- */
-os.events.PayloadEvent.prototype.getPayload = function() {
-  return this.payload_;
-};
-
-
-/**
- * Sets the payload.
- *
- * @param {T} value The payload to set.
- */
-os.events.PayloadEvent.prototype.setPayload = function(value) {
-  this.payload_ = value;
-};
+exports = PayloadEvent;

--- a/src/os/events/propertychangeevent.js
+++ b/src/os/events/propertychangeevent.js
@@ -1,82 +1,86 @@
-goog.provide('os.events.PropertyChangeEvent');
-goog.require('goog.events.Event');
-goog.require('goog.events.EventType');
+goog.module('os.events.PropertyChangeEvent');
+goog.module.declareLegacyNamespace();
 
+const GoogEvent = goog.require('goog.events.Event');
+const GoogEventType = goog.require('goog.events.EventType');
+
+const OLEventTarget = goog.requireType('ol.events.EventTarget');
 
 
 /**
  * A property change event.
- *
- * @param {string=} opt_property The property that changed
- * @param {*=} opt_newVal The new value
- * @param {*=} opt_oldVal The old value
- * @param {Object=} opt_target Reference to the object that is the target of
- *     this event. It has to implement the {@code EventTarget} interface
- *     declared at {@link http://developer.mozilla.org/en/DOM/EventTarget}.
- * @extends {goog.events.Event}
- * @constructor
  */
-os.events.PropertyChangeEvent = function(opt_property, opt_newVal, opt_oldVal, opt_target) {
-  os.events.PropertyChangeEvent.base(this, 'constructor', goog.events.EventType.PROPERTYCHANGE, opt_target);
+class PropertyChangeEvent extends GoogEvent {
+  /**
+   * Constructor.
+   * @param {string=} opt_property The property that changed
+   * @param {*=} opt_newVal The new value
+   * @param {*=} opt_oldVal The old value
+   * @param {Object=} opt_target Reference to the object that is the target of
+   *     this event. It has to implement the {@code EventTarget} interface
+   *     declared at {@link http://developer.mozilla.org/en/DOM/EventTarget}.
+   */
+  constructor(opt_property, opt_newVal, opt_oldVal, opt_target) {
+    super(GoogEventType.PROPERTYCHANGE, opt_target);
+
+    /**
+     * The property
+     * @type {?string}
+     * @private
+     */
+    this.property_ = opt_property !== undefined ? opt_property : null;
+
+    /**
+     * The new value
+     * @type {?*}
+     * @private
+     */
+    this.newVal_ = opt_newVal !== undefined ? opt_newVal : null;
+
+    /**
+     * The old value
+     * @type {?*}
+     * @private
+     */
+    this.oldVal_ = opt_oldVal !== undefined ? opt_oldVal : null;
+  }
 
   /**
-   * The property
-   * @type {?string}
-   * @private
+   * Gets the property that changed
+   *
+   * @return {?string}
    */
-  this.property_ = opt_property !== undefined ? opt_property : null;
+  getProperty() {
+    return this.property_;
+  }
 
   /**
-   * The new value
-   * @type {?*}
-   * @private
+   * Gets the new value of the property
+   *
+   * @return {?*}
    */
-  this.newVal_ = opt_newVal !== undefined ? opt_newVal : null;
+  getNewValue() {
+    return this.newVal_;
+  }
 
   /**
-   * The old value
-   * @type {?*}
-   * @private
+   * Gets the old value of the property
+   *
+   * @return {?*}
    */
-  this.oldVal_ = opt_oldVal !== undefined ? opt_oldVal : null;
-};
-goog.inherits(os.events.PropertyChangeEvent, goog.events.Event);
+  getOldValue() {
+    return this.oldVal_;
+  }
+}
 
 
 /**
  * Override the type so these events can be used with {@link ol.events.EventTarget.prototype.dispatchEvent}.
  *
- * @type {EventTarget|ol.events.EventTarget|undefined}
+ * @type {EventTarget|OLEventTarget|undefined}
  * @suppress {duplicate}
  */
-os.events.PropertyChangeEvent.prototype.target;
+PropertyChangeEvent.prototype.target;
 
 
-/**
- * Gets the property that changed
- *
- * @return {?string}
- */
-os.events.PropertyChangeEvent.prototype.getProperty = function() {
-  return this.property_;
-};
-
-
-/**
- * Gets the new value of the property
- *
- * @return {?*}
- */
-os.events.PropertyChangeEvent.prototype.getNewValue = function() {
-  return this.newVal_;
-};
-
-
-/**
- * Gets the old value of the property
- *
- * @return {?*}
- */
-os.events.PropertyChangeEvent.prototype.getOldValue = function() {
-  return this.oldVal_;
-};
+exports = PropertyChangeEvent;

--- a/src/os/events/selectiontype.js
+++ b/src/os/events/selectiontype.js
@@ -1,23 +1,13 @@
-goog.provide('os.events.SelectionType');
+goog.module('os.events.SelectionType');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * @enum {string}
  */
-os.events.SelectionType = {
+exports = {
   ADDED: 'selectedItemsAdded',
   CHANGED: 'selectedItemsChanged',
   REMOVED: 'selectedItemsRemoved',
   CLEAR: 'selectedItemsCleared'
-};
-
-
-/**
- * Test if an event type is a selection type.
- *
- * @param {?string} type The event type
- * @return {boolean}
- */
-os.events.isSelectionType = function(type) {
-  return !!type && goog.object.containsValue(os.events.SelectionType, type);
 };

--- a/src/os/events/settingchangeevent.js
+++ b/src/os/events/settingchangeevent.js
@@ -1,35 +1,38 @@
-goog.provide('os.events.SettingChangeEvent');
-goog.require('goog.events.Event');
-goog.require('goog.events.EventType');
+goog.module('os.events.SettingChangeEvent');
+goog.module.declareLegacyNamespace();
 
+const GoogEvent = goog.require('goog.events.Event');
 
 
 /**
  * A setting change event.
- *
- * @param {string} type The setting that changed
- * @param {*=} opt_newVal The new value
- * @param {*=} opt_oldVal The old value
- * @param {Object=} opt_target Reference to the object that is the target of
- *     this event. It has to implement the {@code EventTarget} interface
- *     declared at {@link http://developer.mozilla.org/en/DOM/EventTarget}.
- * @extends {goog.events.Event}
- * @constructor
  */
-os.events.SettingChangeEvent = function(type, opt_newVal, opt_oldVal, opt_target) {
-  os.events.SettingChangeEvent.base(this, 'constructor', type, opt_target);
-
+class SettingChangeEvent extends GoogEvent {
   /**
-   * The new value
-   * @type {?*}
+   * Constructor.
+   * @param {string} type The setting that changed
+   * @param {*=} opt_newVal The new value
+   * @param {*=} opt_oldVal The old value
+   * @param {Object=} opt_target Reference to the object that is the target of
+   *     this event. It has to implement the {@code EventTarget} interface
+   *     declared at {@link http://developer.mozilla.org/en/DOM/EventTarget}.
    */
-  this.newVal = opt_newVal != undefined ? opt_newVal : null;
+  constructor(type, opt_newVal, opt_oldVal, opt_target) {
+    super(type, opt_target);
+
+    /**
+     * The new value
+     * @type {?*}
+     */
+    this.newVal = opt_newVal != undefined ? opt_newVal : null;
 
 
-  /**
-   * The old value
-   * @type {?*}
-   */
-  this.oldVal = opt_oldVal != undefined ? opt_oldVal : null;
-};
-goog.inherits(os.events.SettingChangeEvent, goog.events.Event);
+    /**
+     * The old value
+     * @type {?*}
+     */
+    this.oldVal = opt_oldVal != undefined ? opt_oldVal : null;
+  }
+}
+
+exports = SettingChangeEvent;

--- a/src/os/layer/preset/layerpresetmanager.js
+++ b/src/os/layer/preset/layerpresetmanager.js
@@ -5,6 +5,7 @@ const Debouncer = goog.require('goog.async.Debouncer');
 const Dispatcher = goog.require('os.Dispatcher');
 const Disposable = goog.require('goog.Disposable');
 const GoogEventType = goog.require('goog.events.EventType');
+const PropertyChangeEvent = goog.require('os.events.PropertyChangeEvent');
 const IFilterable = goog.require('os.filter.IFilterable');
 const {getImportActionManager} = goog.require('os.im.action');
 const ILayer = goog.require('os.layer.ILayer');
@@ -26,7 +27,6 @@ const IPresetService = goog.requireType('os.layer.preset.IPresetService');
 const LayerEvent = goog.requireType('os.events.LayerEvent');
 const {EventsKey: OlEventsKey} = goog.requireType('ol');
 const OlLayer = goog.requireType('ol.layer.Layer');
-const PropertyChangeEvent = goog.requireType('os.events.PropertyChangeEvent');
 
 
 /**
@@ -177,7 +177,7 @@ class LayerPresetManager extends Disposable {
    */
   onLayerStyleChanged_(layerId, layer, check, event) {
     // check that the style does/doesn't match the Preset. If not, set the clean over to false and stop listening
-    if (layer && event['getProperty'] && event.getProperty() == 'style') {
+    if (layer && event instanceof PropertyChangeEvent && event.getProperty() == 'style') {
       if (this.isLayerStyleDirty(layerId, layer, check, event)) {
         const meta = /** @type {!LayerPresetsMetaData} */ (this.presets_.entry(layerId)[2]);
 

--- a/test/os/alert/alertevent.test.js
+++ b/test/os/alert/alertevent.test.js
@@ -2,14 +2,17 @@ goog.require('os.alert.AlertEvent');
 goog.require('os.alert.AlertEventSeverity');
 
 describe('os.alert.AlertEvent', function() {
+  const AlertEvent = goog.module.get('os.alert.AlertEvent');
+  const AlertEventSeverity = goog.module.get('os.alert.AlertEventSeverity');
+
   const msg = 'This is a test';
 
   it('should fully describe alert events', function() {
-    const evt = new os.alert.AlertEvent(msg, os.alert.AlertEventSeverity.INFO);
+    const evt = new AlertEvent(msg, AlertEventSeverity.INFO);
 
     expect(evt.getMessage()).toBe(msg);
-    expect(evt.getSeverity()).toBe(os.alert.AlertEventSeverity.INFO);
-    expect(evt.getLimit()).toBe(os.alert.AlertEvent.DEFAULT_LIMIT);
+    expect(evt.getSeverity()).toBe(AlertEventSeverity.INFO);
+    expect(evt.getLimit()).toBe(AlertEvent.DEFAULT_LIMIT);
     expect(evt.getDismissDispatcher()).toBe(null);
     expect(evt.getCount()).toBe(1);
   });

--- a/test/os/array/array.test.js
+++ b/test/os/array/array.test.js
@@ -1,7 +1,11 @@
+goog.require('goog.array');
 goog.require('os.array');
 
 
 describe('os.array', function() {
+  const googArray = goog.module.get('goog.array');
+  const osArray = goog.module.get('os.array');
+
   it('should return indexes for a binary insert', function() {
     var list = [2, 4, 6, 8];
     var values = [
@@ -12,13 +16,13 @@ describe('os.array', function() {
       {value: 9, index: 7}];
 
     values.forEach(function(item) {
-      expect(os.array.binaryInsert(list, item.value)).toBe(item.index);
+      expect(osArray.binaryInsert(list, item.value)).toBe(item.index);
     });
   });
 
   it('should clear arrays and array-like objects', function() {
     var array = [1, 2, 3];
-    os.array.clear(array);
+    osArray.clear(array);
     expect(array.length).toBe(0);
 
     var obj = {
@@ -28,7 +32,7 @@ describe('os.array', function() {
       length: 3
     };
 
-    os.array.clear(obj);
+    osArray.clear(obj);
     expect(obj['0']).toBeUndefined();
 
     var keys = 0;
@@ -50,7 +54,7 @@ describe('os.array', function() {
     };
 
     var calls = 0;
-    os.array.forEach(array, function(el, idx, arr) {
+    osArray.forEach(array, function(el, idx, arr) {
       expect(el).toBe(array[idx]);
       expect(arr).toBe(array);
       calls++;
@@ -58,7 +62,7 @@ describe('os.array', function() {
     expect(calls).toBe(array.length);
 
     calls = 0;
-    os.array.forEach(obj, function(el, idx, arr) {
+    osArray.forEach(obj, function(el, idx, arr) {
       expect(el).toBe(obj[idx]);
       expect(arr).toBe(obj);
       calls++;
@@ -70,7 +74,7 @@ describe('os.array', function() {
     var things = [undefined, null];
 
     things.forEach(function(arg) {
-      expect(os.array.forEachSafe.bind(null, arg)).not.toThrow();
+      expect(osArray.forEachSafe.bind(null, arg)).not.toThrow();
     });
   });
 
@@ -78,7 +82,7 @@ describe('os.array', function() {
     var list = [1, 1, 2, 3, 5, 8];
 
     var sum = 0;
-    os.array.forEachSafe(list, function(num) {
+    osArray.forEachSafe(list, function(num) {
       sum += num;
     });
 
@@ -97,7 +101,7 @@ describe('os.array', function() {
     var srcStart = 2;
     var destStart = 8;
     var length = 3;
-    os.array.arrayCopy(src, srcStart, dest, destStart, length);
+    osArray.arrayCopy(src, srcStart, dest, destStart, length);
 
     for (var i = 0, n = dest.length; i < n; i++) {
       if (i < destStart || i >= destStart + length) {
@@ -112,7 +116,7 @@ describe('os.array', function() {
     var thing = {thing: true};
     var list = [0, 0, false, '', null, undefined, 1, true, 2, 2, 2, 3, 4, '4',
       'yay', 'yay', null, null, undefined, undefined, thing, {thing: true}, thing];
-    var dupes = os.array.findDuplicates(list);
+    var dupes = osArray.findDuplicates(list);
 
     expect(dupes.length).toBe(9);
     expect(dupes[0]).toBe(0);
@@ -138,17 +142,17 @@ describe('os.array', function() {
     };
 
     var arr = [a, b];
-    var sorted = arr.sort(goog.partial(os.array.sortByField, 'num'));
-    expect(goog.array.equals(sorted, [a, b])).toBeTruthy();
+    var sorted = arr.sort(goog.partial(osArray.sortByField, 'num'));
+    expect(googArray.equals(sorted, [a, b])).toBeTruthy();
 
-    sorted = arr.sort(goog.partial(os.array.sortByFieldDesc, 'num'));
-    expect(goog.array.equals(sorted, [b, a])).toBeTruthy();
+    sorted = arr.sort(goog.partial(osArray.sortByFieldDesc, 'num'));
+    expect(googArray.equals(sorted, [b, a])).toBeTruthy();
 
-    sorted = arr.sort(goog.partial(os.array.sortByField, 'str'));
-    expect(goog.array.equals(sorted, [a, b])).toBeTruthy();
+    sorted = arr.sort(goog.partial(osArray.sortByField, 'str'));
+    expect(googArray.equals(sorted, [a, b])).toBeTruthy();
 
-    sorted = arr.sort(goog.partial(os.array.sortByFieldDesc, 'str'));
-    expect(goog.array.equals(sorted, [b, a])).toBeTruthy();
+    sorted = arr.sort(goog.partial(osArray.sortByFieldDesc, 'str'));
+    expect(googArray.equals(sorted, [b, a])).toBeTruthy();
   });
 
   describe('os.array.join', function() {
@@ -169,7 +173,7 @@ describe('os.array', function() {
       return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
     };
 
-    var joinFuncs = [os.array.join];
+    var joinFuncs = [osArray.join];
 
     it('should join 2 sets', function() {
       for (var j = 0, jj = joinFuncs.length; j < jj; j++) {
@@ -534,7 +538,7 @@ describe('os.array', function() {
         crossProduct: true
       }];
 
-      expect(os.array.join.bind(null, sets, copyFunc)).toThrow();
+      expect(osArray.join.bind(null, sets, copyFunc)).toThrow();
     });
 
     it('should binary search arrays with a stride', function() {
@@ -545,50 +549,50 @@ describe('os.array', function() {
       // offset 0 values
 
       // values at the front of the array
-      expect(os.array.binaryStrideSearch(arr, -10, stride, 0)).toBe(~0);
+      expect(osArray.binaryStrideSearch(arr, -10, stride, 0)).toBe(~0);
 
       // values at the end of the array
-      expect(os.array.binaryStrideSearch(arr, 20, stride, 0)).toBe(~arr.length);
+      expect(osArray.binaryStrideSearch(arr, 20, stride, 0)).toBe(~arr.length);
 
       // values in the middle of the array
-      expect(os.array.binaryStrideSearch(arr, 3, stride, 0)).toBe(~2);
-      expect(os.array.binaryStrideSearch(arr, 5, stride, 0)).toBe(~4);
-      expect(os.array.binaryStrideSearch(arr, 7, stride, 0)).toBe(~6);
+      expect(osArray.binaryStrideSearch(arr, 3, stride, 0)).toBe(~2);
+      expect(osArray.binaryStrideSearch(arr, 5, stride, 0)).toBe(~4);
+      expect(osArray.binaryStrideSearch(arr, 7, stride, 0)).toBe(~6);
 
       // values in the array on the offset
-      expect(os.array.binaryStrideSearch(arr, 2, stride, 0)).toBe(0);
-      expect(os.array.binaryStrideSearch(arr, 4, stride, 0)).toBe(2);
-      expect(os.array.binaryStrideSearch(arr, 6, stride, 0)).toBe(4);
-      expect(os.array.binaryStrideSearch(arr, 8, stride, 0)).toBe(6);
+      expect(osArray.binaryStrideSearch(arr, 2, stride, 0)).toBe(0);
+      expect(osArray.binaryStrideSearch(arr, 4, stride, 0)).toBe(2);
+      expect(osArray.binaryStrideSearch(arr, 6, stride, 0)).toBe(4);
+      expect(osArray.binaryStrideSearch(arr, 8, stride, 0)).toBe(6);
 
       // values in the array not on the offset
-      expect(os.array.binaryStrideSearch(arr, 200, stride, 0)).toBe(~arr.length);
-      expect(os.array.binaryStrideSearch(arr, 400, stride, 0)).toBe(~arr.length);
-      expect(os.array.binaryStrideSearch(arr, 600, stride, 0)).toBe(~arr.length);
+      expect(osArray.binaryStrideSearch(arr, 200, stride, 0)).toBe(~arr.length);
+      expect(osArray.binaryStrideSearch(arr, 400, stride, 0)).toBe(~arr.length);
+      expect(osArray.binaryStrideSearch(arr, 600, stride, 0)).toBe(~arr.length);
 
       // offset 1 values
 
       // values at the front of the array
-      expect(os.array.binaryStrideSearch(arr, 0, stride, 1)).toBe(~0);
+      expect(osArray.binaryStrideSearch(arr, 0, stride, 1)).toBe(~0);
 
       // values at the end of the array
-      expect(os.array.binaryStrideSearch(arr, 1000, stride, 0)).toBe(~arr.length);
+      expect(osArray.binaryStrideSearch(arr, 1000, stride, 0)).toBe(~arr.length);
 
       // values in the middle of the array
-      expect(os.array.binaryStrideSearch(arr, 300, stride, 1)).toBe(~2);
-      expect(os.array.binaryStrideSearch(arr, 500, stride, 1)).toBe(~4);
-      expect(os.array.binaryStrideSearch(arr, 700, stride, 1)).toBe(~6);
+      expect(osArray.binaryStrideSearch(arr, 300, stride, 1)).toBe(~2);
+      expect(osArray.binaryStrideSearch(arr, 500, stride, 1)).toBe(~4);
+      expect(osArray.binaryStrideSearch(arr, 700, stride, 1)).toBe(~6);
 
       // values in the array on the offset
-      expect(os.array.binaryStrideSearch(arr, 200, stride, 1)).toBe(0);
-      expect(os.array.binaryStrideSearch(arr, 400, stride, 1)).toBe(2);
-      expect(os.array.binaryStrideSearch(arr, 600, stride, 1)).toBe(4);
-      expect(os.array.binaryStrideSearch(arr, 800, stride, 1)).toBe(6);
+      expect(osArray.binaryStrideSearch(arr, 200, stride, 1)).toBe(0);
+      expect(osArray.binaryStrideSearch(arr, 400, stride, 1)).toBe(2);
+      expect(osArray.binaryStrideSearch(arr, 600, stride, 1)).toBe(4);
+      expect(osArray.binaryStrideSearch(arr, 800, stride, 1)).toBe(6);
 
       // values in the array not on the offset
-      expect(os.array.binaryStrideSearch(arr, 2, stride, 1)).toBe(~0);
-      expect(os.array.binaryStrideSearch(arr, 4, stride, 1)).toBe(~0);
-      expect(os.array.binaryStrideSearch(arr, 6, stride, 1)).toBe(~0);
+      expect(osArray.binaryStrideSearch(arr, 2, stride, 1)).toBe(~0);
+      expect(osArray.binaryStrideSearch(arr, 4, stride, 1)).toBe(~0);
+      expect(osArray.binaryStrideSearch(arr, 6, stride, 1)).toBe(~0);
 
       // odd sized array
       arr.push(10);
@@ -597,54 +601,54 @@ describe('os.array', function() {
       // offset 0 values
 
       // values at the front of the array
-      expect(os.array.binaryStrideSearch(arr, -10, stride, 0)).toBe(~0);
+      expect(osArray.binaryStrideSearch(arr, -10, stride, 0)).toBe(~0);
 
       // values at the end of the array
-      expect(os.array.binaryStrideSearch(arr, 20, stride, 0)).toBe(~arr.length);
+      expect(osArray.binaryStrideSearch(arr, 20, stride, 0)).toBe(~arr.length);
 
       // values in the middle of the array
-      expect(os.array.binaryStrideSearch(arr, 3, stride, 0)).toBe(~2);
-      expect(os.array.binaryStrideSearch(arr, 5, stride, 0)).toBe(~4);
-      expect(os.array.binaryStrideSearch(arr, 7, stride, 0)).toBe(~6);
-      expect(os.array.binaryStrideSearch(arr, 9, stride, 0)).toBe(~8);
+      expect(osArray.binaryStrideSearch(arr, 3, stride, 0)).toBe(~2);
+      expect(osArray.binaryStrideSearch(arr, 5, stride, 0)).toBe(~4);
+      expect(osArray.binaryStrideSearch(arr, 7, stride, 0)).toBe(~6);
+      expect(osArray.binaryStrideSearch(arr, 9, stride, 0)).toBe(~8);
 
       // values in the array on the offset
-      expect(os.array.binaryStrideSearch(arr, 2, stride, 0)).toBe(0);
-      expect(os.array.binaryStrideSearch(arr, 4, stride, 0)).toBe(2);
-      expect(os.array.binaryStrideSearch(arr, 6, stride, 0)).toBe(4);
-      expect(os.array.binaryStrideSearch(arr, 8, stride, 0)).toBe(6);
-      expect(os.array.binaryStrideSearch(arr, 10, stride, 0)).toBe(8);
+      expect(osArray.binaryStrideSearch(arr, 2, stride, 0)).toBe(0);
+      expect(osArray.binaryStrideSearch(arr, 4, stride, 0)).toBe(2);
+      expect(osArray.binaryStrideSearch(arr, 6, stride, 0)).toBe(4);
+      expect(osArray.binaryStrideSearch(arr, 8, stride, 0)).toBe(6);
+      expect(osArray.binaryStrideSearch(arr, 10, stride, 0)).toBe(8);
 
       // values in the array not on the offset
-      expect(os.array.binaryStrideSearch(arr, 200, stride, 0)).toBe(~arr.length);
-      expect(os.array.binaryStrideSearch(arr, 400, stride, 0)).toBe(~arr.length);
-      expect(os.array.binaryStrideSearch(arr, 600, stride, 0)).toBe(~arr.length);
+      expect(osArray.binaryStrideSearch(arr, 200, stride, 0)).toBe(~arr.length);
+      expect(osArray.binaryStrideSearch(arr, 400, stride, 0)).toBe(~arr.length);
+      expect(osArray.binaryStrideSearch(arr, 600, stride, 0)).toBe(~arr.length);
 
       // offset 1 values
 
       // values at the front of the array
-      expect(os.array.binaryStrideSearch(arr, 0, stride, 1)).toBe(~0);
+      expect(osArray.binaryStrideSearch(arr, 0, stride, 1)).toBe(~0);
 
       // values at the end of the array
-      expect(os.array.binaryStrideSearch(arr, 1001, stride, 0)).toBe(~arr.length);
+      expect(osArray.binaryStrideSearch(arr, 1001, stride, 0)).toBe(~arr.length);
 
       // values in the middle of the array
-      expect(os.array.binaryStrideSearch(arr, 300, stride, 1)).toBe(~2);
-      expect(os.array.binaryStrideSearch(arr, 500, stride, 1)).toBe(~4);
-      expect(os.array.binaryStrideSearch(arr, 700, stride, 1)).toBe(~6);
-      expect(os.array.binaryStrideSearch(arr, 900, stride, 1)).toBe(~8);
+      expect(osArray.binaryStrideSearch(arr, 300, stride, 1)).toBe(~2);
+      expect(osArray.binaryStrideSearch(arr, 500, stride, 1)).toBe(~4);
+      expect(osArray.binaryStrideSearch(arr, 700, stride, 1)).toBe(~6);
+      expect(osArray.binaryStrideSearch(arr, 900, stride, 1)).toBe(~8);
 
       // values in the array on the offset
-      expect(os.array.binaryStrideSearch(arr, 200, stride, 1)).toBe(0);
-      expect(os.array.binaryStrideSearch(arr, 400, stride, 1)).toBe(2);
-      expect(os.array.binaryStrideSearch(arr, 600, stride, 1)).toBe(4);
-      expect(os.array.binaryStrideSearch(arr, 800, stride, 1)).toBe(6);
-      expect(os.array.binaryStrideSearch(arr, 1000, stride, 1)).toBe(8);
+      expect(osArray.binaryStrideSearch(arr, 200, stride, 1)).toBe(0);
+      expect(osArray.binaryStrideSearch(arr, 400, stride, 1)).toBe(2);
+      expect(osArray.binaryStrideSearch(arr, 600, stride, 1)).toBe(4);
+      expect(osArray.binaryStrideSearch(arr, 800, stride, 1)).toBe(6);
+      expect(osArray.binaryStrideSearch(arr, 1000, stride, 1)).toBe(8);
 
       // values in the array not on the offset
-      expect(os.array.binaryStrideSearch(arr, 2, stride, 1)).toBe(~0);
-      expect(os.array.binaryStrideSearch(arr, 4, stride, 1)).toBe(~0);
-      expect(os.array.binaryStrideSearch(arr, 6, stride, 1)).toBe(~0);
+      expect(osArray.binaryStrideSearch(arr, 2, stride, 1)).toBe(~0);
+      expect(osArray.binaryStrideSearch(arr, 4, stride, 1)).toBe(~0);
+      expect(osArray.binaryStrideSearch(arr, 6, stride, 1)).toBe(~0);
     });
 
     it('should throw an error if multiple data sets have crossProduct=true', function() {
@@ -662,7 +666,7 @@ describe('os.array', function() {
         crossProduct: true
       }];
 
-      expect(os.array.join.bind(null, sets, copyFunc)).toThrow();
+      expect(osArray.join.bind(null, sets, copyFunc)).toThrow();
     });
   });
 });

--- a/test/os/bearing/bearing.test.js
+++ b/test/os/bearing/bearing.test.js
@@ -1,56 +1,66 @@
 goog.require('os.bearing');
+goog.require('os.bearing.BearingSettingsKeys');
+goog.require('os.bearing.BearingType');
 goog.require('os.bearing.geomag.wait');
+goog.require('os.config.Settings');
 goog.require('os.interpolate');
+goog.require('os.interpolate.Method');
 goog.require('os.osasm.wait');
 
 
 describe('os.bearing', function() {
+  const bearing = goog.module.get('os.bearing');
+  const BearingSettingsKeys = goog.module.get('os.bearing.BearingSettingsKeys');
+  const BearingType = goog.module.get('os.bearing.BearingType');
+  const Settings = goog.module.get('os.config.Settings');
+  const Method = goog.module.get('os.interpolate.Method');
+
   // for the magnetic bearing calculations, the date matters, so we use this static date, otherwise the result
   // values will drift over time as the library simply uses new Date() otherwise
   var date = new Date(1488386496470);
 
   var precision = 8;
-  var geodesic = os.interpolate.Method.GEODESIC;
-  var rhumb = os.interpolate.Method.RHUMB;
+  var geodesic = Method.GEODESIC;
+  var rhumb = Method.RHUMB;
 
   it('should get bearings correctly', function() {
-    expect(os.bearing.getBearing([5, 10], [15, 20], date)).toBeCloseTo(42.99295488831754, precision);
-    expect(os.bearing.getBearing([5, 10], [15, 20], date, rhumb)).toBeCloseTo(44.14439180550811, precision);
+    expect(bearing.getBearing([5, 10], [15, 20], date)).toBeCloseTo(42.99295488831754, precision);
+    expect(bearing.getBearing([5, 10], [15, 20], date, rhumb)).toBeCloseTo(44.14439180550811, precision);
 
-    expect(os.bearing.getBearing([-50, 80], [75, -60], date)).toBeCloseTo(72.0382868370632, precision);
-    expect(os.bearing.getBearing([-50, 80], [75, -60], date, rhumb)).toBeCloseTo(149.74888585793278, precision);
+    expect(bearing.getBearing([-50, 80], [75, -60], date)).toBeCloseTo(72.0382868370632, precision);
+    expect(bearing.getBearing([-50, 80], [75, -60], date, rhumb)).toBeCloseTo(149.74888585793278, precision);
   });
 
   it('should default to geodesic', function() {
-    var a = os.bearing.getBearing([5, 10], [15, 20], date);
-    var b = os.bearing.getBearing([5, 10], [15, 20], date, geodesic);
+    var a = bearing.getBearing([5, 10], [15, 20], date);
+    var b = bearing.getBearing([5, 10], [15, 20], date, geodesic);
 
     expect(a).toBeCloseTo(b, 12);
   });
 
   it('should get magnetic bearings correctly', function() {
-    os.settings.set(os.bearing.BearingSettingsKeys.BEARING_TYPE, os.bearing.BearingType.MAGNETIC);
+    Settings.getInstance().set(BearingSettingsKeys.BEARING_TYPE, BearingType.MAGNETIC);
 
-    expect(os.bearing.getBearing([5, 10], [15, 20], date)).toBeCloseTo(44.180072479561, precision);
-    expect(os.bearing.getBearing([5, 10], [15, 20], date, rhumb)).toBeCloseTo(45.331509396800, precision);
+    expect(bearing.getBearing([5, 10], [15, 20], date)).toBeCloseTo(44.180072479561, precision);
+    expect(bearing.getBearing([5, 10], [15, 20], date, rhumb)).toBeCloseTo(45.331509396800, precision);
 
-    expect(os.bearing.getBearing([-50, 80], [75, -60], date)).toBeCloseTo(111.912444073130, precision);
-    expect(os.bearing.getBearing([-50, 80], [75, -60], date, rhumb)).toBeCloseTo(189.623043093919, precision);
+    expect(bearing.getBearing([-50, 80], [75, -60], date)).toBeCloseTo(111.912444073130, precision);
+    expect(bearing.getBearing([-50, 80], [75, -60], date, rhumb)).toBeCloseTo(189.623043093919, precision);
   });
 
   it('should format bearings correctly', function() {
-    os.settings.set(os.bearing.BearingSettingsKeys.BEARING_TYPE, os.bearing.BearingType.TRUE_NORTH);
+    Settings.getInstance().set(BearingSettingsKeys.BEARING_TYPE, BearingType.TRUE_NORTH);
 
-    expect(os.bearing.modifyBearing(-150, [5, 10], date)).toBe(210);
-    expect(os.bearing.modifyBearing(-50, [5, 10], date)).toBe(310);
-    expect(os.bearing.modifyBearing(165, [5, 10], date)).toBe(165);
+    expect(bearing.modifyBearing(-150, [5, 10], date)).toBe(210);
+    expect(bearing.modifyBearing(-50, [5, 10], date)).toBe(310);
+    expect(bearing.modifyBearing(165, [5, 10], date)).toBe(165);
   });
 
   it('should format magnetic bearings correctly', function() {
-    os.settings.set(os.bearing.BearingSettingsKeys.BEARING_TYPE, os.bearing.BearingType.MAGNETIC);
+    Settings.getInstance().set(BearingSettingsKeys.BEARING_TYPE, BearingType.MAGNETIC);
 
-    expect(os.bearing.modifyBearing(-150, [5, 10], date)).toBeCloseTo(211.2, 1);
-    expect(os.bearing.modifyBearing(-50, [60, 40], date)).toBeCloseTo(304.4, 1);
-    expect(os.bearing.modifyBearing(165, [-50, -30], date)).toBeCloseTo(182.5, 1);
+    expect(bearing.modifyBearing(-150, [5, 10], date)).toBeCloseTo(211.2, 1);
+    expect(bearing.modifyBearing(-50, [60, 40], date)).toBeCloseTo(304.4, 1);
+    expect(bearing.modifyBearing(165, [-50, -30], date)).toBeCloseTo(182.5, 1);
   });
 });

--- a/test/os/bearing/wait-for-geomag.mock.js
+++ b/test/os/bearing/wait-for-geomag.mock.js
@@ -5,16 +5,20 @@ goog.require('os.bearing');
 goog.require('os.net.Request');
 
 beforeEach(function() {
-  if (!os.bearing.geomag_) {
+  const NetEventType = goog.module.get('goog.net.EventType');
+  const bearing = goog.module.get('os.bearing');
+  const Request = goog.module.get('os.net.Request');
+
+  if (!bearing.isGeomagLoaded()) {
     runs(function() {
-      var request = new os.net.Request('/base/vendor/geomag/WMM.txt');
-      request.listenOnce(goog.net.EventType.SUCCESS, os.bearing.onGeomag);
-      request.listenOnce(goog.net.EventType.ERROR, os.bearing.onGeomag);
+      const request = new Request('/base/vendor/geomag/WMM.txt');
+      request.listenOnce(NetEventType.SUCCESS, bearing.onGeomag);
+      request.listenOnce(NetEventType.ERROR, bearing.onGeomag);
       request.load();
     });
 
     waitsFor(function() {
-      return !!os.bearing.geomag_;
+      return bearing.isGeomagLoaded();
     }, 'geomag to load');
   }
 });

--- a/test/os/buffer/buffer.test.js
+++ b/test/os/buffer/buffer.test.js
@@ -1,12 +1,24 @@
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.Point');
+goog.require('ol.geom.Polygon');
+goog.require('ol.proj');
 goog.require('os.buffer');
 goog.require('os.geo');
 goog.require('os.geo.jsts');
 goog.require('os.map');
+goog.require('os.proj');
 goog.require('os.query');
 
 describe('os.buffer', function() {
+  const LineString = goog.module.get('ol.geom.LineString');
+  const Point = goog.module.get('ol.geom.Point');
+  const Polygon = goog.module.get('ol.geom.Polygon');
+  const olProj = goog.module.get('ol.proj');
+  const geo = goog.module.get('os.geo');
+  const osJsts = goog.module.get('os.geo.jsts');
+  const osMap = goog.module.get('os.map');
+  const osProj = goog.module.get('os.proj');
+
   var checkPercentDiff = function(input, dist, geom, opt_all) {
     dist = Math.abs(dist);
     input.toLonLat();
@@ -25,7 +37,7 @@ describe('os.buffer', function() {
 
       for (var j = 0, m = geomCoords.length; j < m; j += geomLayout) {
         var p2 = geomCoords.slice(j, j + 2);
-        var d = os.geo.vincentyDistance(p1, p2);
+        var d = geo.vincentyDistance(p1, p2);
         min = Math.min(min, d);
 
         if (Math.abs(d - dist) / dist < 0.005) {
@@ -53,15 +65,15 @@ describe('os.buffer', function() {
   };
 
   it('should return null when the distance is zero', function() {
-    var geom = new ol.geom.Point([0, 0]);
-    var buffered = os.geo.jsts.buffer(geom, 0);
+    var geom = new Point([0, 0]);
+    var buffered = osJsts.buffer(geom, 0);
     expect(buffered).toBe(null);
   });
 
   it('should buffer points with absolute distances', function() {
-    var geom = new ol.geom.Point([0, 0]);
+    var geom = new Point([0, 0]);
     var dist = -100000;
-    var buffered = os.geo.jsts.buffer(geom, dist);
+    var buffered = osJsts.buffer(geom, dist);
     expect(checkPercentDiff(geom, dist, buffered, true)).toBe(true);
   });
 
@@ -69,116 +81,116 @@ describe('os.buffer', function() {
 
   distances.forEach(function(dist) {
     it('should buffer points into circles at easy latitudes dist=' + dist, function() {
-      var geom = new ol.geom.Point([0, 0]);
-      var buffered = os.geo.jsts.buffer(geom, dist);
+      var geom = new Point([0, 0]);
+      var buffered = osJsts.buffer(geom, dist);
       expect(checkPercentDiff(geom, dist, buffered, true)).toBe(true);
     });
 
     it('should buffer points into circles at mid latitudes dist=' + dist, function() {
-      var geom = new ol.geom.Point([40, 40]);
-      var buffered = os.geo.jsts.buffer(geom, dist);
+      var geom = new Point([40, 40]);
+      var buffered = osJsts.buffer(geom, dist);
       expect(checkPercentDiff(geom, dist, buffered, true)).toBe(true);
     });
 
     it('should buffer points into circles at high latitudes dist=' + dist, function() {
-      var geom = new ol.geom.Point([80, 80]);
-      var buffered = os.geo.jsts.buffer(geom, dist);
+      var geom = new Point([80, 80]);
+      var buffered = osJsts.buffer(geom, dist);
       expect(checkPercentDiff(geom, dist, buffered, true)).toBe(true);
     });
 
     it('should buffer points into circles at easy latitudes for other projections dist=' + dist, function() {
-      var originalProjection = os.map.PROJECTION;
-      os.map.PROJECTION = ol.proj.get(os.proj.EPSG3857);
+      var originalProjection = osMap.PROJECTION;
+      osMap.PROJECTION = olProj.get(osProj.EPSG3857);
 
-      var geom = new ol.geom.Point([0, 0]).osTransform();
-      var buffered = os.geo.jsts.buffer(geom, dist);
+      var geom = new Point([0, 0]).osTransform();
+      var buffered = osJsts.buffer(geom, dist);
       expect(checkPercentDiff(geom, dist, buffered, true)).toBe(true);
 
-      os.map.PROJECTION = originalProjection;
+      osMap.PROJECTION = originalProjection;
     });
 
     it('should buffer points into circles at mid latitudes for other projections dist=' + dist, function() {
-      var originalProjection = os.map.PROJECTION;
-      os.map.PROJECTION = ol.proj.get(os.proj.EPSG3857);
+      var originalProjection = osMap.PROJECTION;
+      osMap.PROJECTION = olProj.get(osProj.EPSG3857);
 
-      var geom = new ol.geom.Point([40, 40]).osTransform();
-      var buffered = os.geo.jsts.buffer(geom, dist);
+      var geom = new Point([40, 40]).osTransform();
+      var buffered = osJsts.buffer(geom, dist);
       expect(checkPercentDiff(geom, dist, buffered, true)).toBe(true);
 
-      os.map.PROJECTION = originalProjection;
+      osMap.PROJECTION = originalProjection;
     });
 
     it('should buffer points into circles at high latitudes for other projections dist=' + dist, function() {
-      var originalProjection = os.map.PROJECTION;
-      os.map.PROJECTION = ol.proj.get(os.proj.EPSG3857);
+      var originalProjection = osMap.PROJECTION;
+      osMap.PROJECTION = olProj.get(osProj.EPSG3857);
 
-      var geom = new ol.geom.Point([80, 80]).osTransform();
-      var buffered = os.geo.jsts.buffer(geom, dist);
+      var geom = new Point([80, 80]).osTransform();
+      var buffered = osJsts.buffer(geom, dist);
       expect(checkPercentDiff(geom, dist, buffered, true)).toBe(true);
 
-      os.map.PROJECTION = originalProjection;
+      osMap.PROJECTION = originalProjection;
     });
 
     it('should buffer lines at easy latitudes dist=' + dist, function() {
-      var geom = new ol.geom.LineString([[-1, -1], [1, 1]]);
-      var buffered = os.geo.jsts.buffer(geom, dist);
+      var geom = new LineString([[-1, -1], [1, 1]]);
+      var buffered = osJsts.buffer(geom, dist);
       expect(checkPercentDiff(geom, dist, buffered)).toBe(true);
     });
 
     it('should buffer lines at mid latitudes dist=' + dist, function() {
-      var geom = new ol.geom.LineString([[39, 39], [41, 41]]);
-      var buffered = os.geo.jsts.buffer(geom, dist);
+      var geom = new LineString([[39, 39], [41, 41]]);
+      var buffered = osJsts.buffer(geom, dist);
       expect(checkPercentDiff(geom, dist, buffered)).toBe(true);
     });
 
     it('should buffer lines at high latitudes dist=' + dist, function() {
-      var geom = new ol.geom.LineString([[79, 79], [81, 81]]);
-      var buffered = os.geo.jsts.buffer(geom, dist);
+      var geom = new LineString([[79, 79], [81, 81]]);
+      var buffered = osJsts.buffer(geom, dist);
       expect(checkPercentDiff(geom, dist, buffered)).toBe(true);
     });
 
     it('should buffer lines at easy latitudes for other projections dist=' + dist, function() {
-      var originalProjection = os.map.PROJECTION;
-      os.map.PROJECTION = ol.proj.get(os.proj.EPSG3857);
+      var originalProjection = osMap.PROJECTION;
+      osMap.PROJECTION = olProj.get(osProj.EPSG3857);
 
-      var geom = new ol.geom.LineString([[-1, -1], [1, 1]]).osTransform();
-      var buffered = os.geo.jsts.buffer(geom, dist);
+      var geom = new LineString([[-1, -1], [1, 1]]).osTransform();
+      var buffered = osJsts.buffer(geom, dist);
       expect(checkPercentDiff(geom, dist, buffered)).toBe(true);
 
-      os.map.PROJECTION = originalProjection;
+      osMap.PROJECTION = originalProjection;
     });
 
     it('should buffer lines at mid latitudes for other projections dist=' + dist, function() {
-      var originalProjection = os.map.PROJECTION;
-      os.map.PROJECTION = ol.proj.get(os.proj.EPSG3857);
+      var originalProjection = osMap.PROJECTION;
+      osMap.PROJECTION = olProj.get(osProj.EPSG3857);
 
-      var geom = new ol.geom.LineString([[39, 39], [41, 41]]).osTransform();
-      var buffered = os.geo.jsts.buffer(geom, dist);
+      var geom = new LineString([[39, 39], [41, 41]]).osTransform();
+      var buffered = osJsts.buffer(geom, dist);
       expect(checkPercentDiff(geom, dist, buffered)).toBe(true);
 
-      os.map.PROJECTION = originalProjection;
+      osMap.PROJECTION = originalProjection;
     });
 
     it('should buffer lines at high latitudes for other projections dist=' + dist, function() {
-      var originalProjection = os.map.PROJECTION;
-      os.map.PROJECTION = ol.proj.get(os.proj.EPSG3857);
+      var originalProjection = osMap.PROJECTION;
+      osMap.PROJECTION = olProj.get(osProj.EPSG3857);
 
-      var geom = new ol.geom.LineString([[79, 79], [81, 81]]).osTransform();
-      var buffered = os.geo.jsts.buffer(geom, dist);
+      var geom = new LineString([[79, 79], [81, 81]]).osTransform();
+      var buffered = osJsts.buffer(geom, dist);
       expect(checkPercentDiff(geom, dist, buffered)).toBe(true);
 
-      os.map.PROJECTION = originalProjection;
+      osMap.PROJECTION = originalProjection;
     });
 
     it('should buffer polygons dist=' + dist, function() {
-      var geom = new ol.geom.Polygon([[[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]]]);
-      var buffered = os.geo.jsts.buffer(geom, dist);
+      var geom = new Polygon([[[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]]]);
+      var buffered = osJsts.buffer(geom, dist);
       expect(checkPercentDiff(geom, dist, buffered)).toBe(true);
     });
 
     xit('should inner buffer polygons if distance is negative dist=' + dist, function() {
-      var geom = new ol.geom.Polygon([[[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]]]);
-      var buffered = os.geo.jsts.buffer(geom, -dist);
+      var geom = new Polygon([[[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]]]);
+      var buffered = osJsts.buffer(geom, -dist);
       expect(checkPercentDiff(geom, -dist, buffered)).toBe(true);
     });
   });

--- a/test/os/column/columnmapping.test.js
+++ b/test/os/column/columnmapping.test.js
@@ -2,6 +2,8 @@ goog.require('os.column.ColumnMapping');
 
 
 describe('os.column.ColumnMapping', function() {
+  const ColumnMapping = goog.module.get('os.column.ColumnMapping');
+
   var mappingString = '<columnMapping name="My Mapping" type="decimal" description="some description">' +
       '<column layer="https://fake.server.bits/ogc/wfsServer!!fake:layer1">layer1_column1</column>' +
       '<column layer="https://fake.server.bits/ogc/wfsServer!!fake:layer2">layer2_column5</column>' +
@@ -13,7 +15,7 @@ describe('os.column.ColumnMapping', function() {
   };
 
   it('should initialize correctly', function() {
-    var mapping = new os.column.ColumnMapping();
+    var mapping = new ColumnMapping();
     expect(mapping.getId()).not.toBe(null);
     expect(mapping.getName()).toBe(null);
     expect(mapping.getDescription()).toBe(null);
@@ -22,7 +24,7 @@ describe('os.column.ColumnMapping', function() {
   });
 
   it('should read a mapping XML string', function() {
-    var mapping = new os.column.ColumnMapping();
+    var mapping = new ColumnMapping();
     var xml = '<columnMapping name="Another Mapping" type="string" description="Another description">' +
         '<column layer="https://fake.server.bits/ogc/wfsServer!!fake:layer8">layer8_column7</column>' +
         '<column layer="https://fake.server.bits/ogc/wfsServer!!fake:layer4">layer4_column6</column>' +
@@ -46,7 +48,7 @@ describe('os.column.ColumnMapping', function() {
   });
 
   it('should write a mapping XML string', function() {
-    var mapping = new os.column.ColumnMapping();
+    var mapping = new ColumnMapping();
     var name = 'Yet Another Mapping??';
     var description = 'deeeescription';
     var valueType = 'decimal';
@@ -70,7 +72,7 @@ describe('os.column.ColumnMapping', function() {
   });
 
   it('should persist/restore to/from raw XML', function() {
-    var mapping = new os.column.ColumnMapping();
+    var mapping = new ColumnMapping();
 
     // restore from the raw string mapping
     mapping.restore(config);
@@ -93,7 +95,7 @@ describe('os.column.ColumnMapping', function() {
   });
 
   it('should add columns', function() {
-    var mapping = new os.column.ColumnMapping();
+    var mapping = new ColumnMapping();
     var layer = 'https://fake.server.bits/ogc/wfsServer!!fake:someLayer';
     var column = 'myLittleColumn';
 
@@ -106,7 +108,7 @@ describe('os.column.ColumnMapping', function() {
   });
 
   it('should remove columns', function() {
-    var mapping = new os.column.ColumnMapping();
+    var mapping = new ColumnMapping();
     var layer = 'https://fake.server.bits/ogc/wfsServer!!fake:someLayer';
     var column = 'myLittleColumn';
 
@@ -120,7 +122,7 @@ describe('os.column.ColumnMapping', function() {
   });
 
   it('should clone correctly', function() {
-    var mapping = new os.column.ColumnMapping();
+    var mapping = new ColumnMapping();
     mapping.restore(config);
 
     var clone = mapping.clone();

--- a/test/os/column/columnmappingmanager.test.js
+++ b/test/os/column/columnmappingmanager.test.js
@@ -1,9 +1,16 @@
+goog.require('goog.object');
 goog.require('os.column.ColumnMapping');
+goog.require('os.column.ColumnMappingEventType');
 goog.require('os.column.ColumnMappingManager');
 goog.require('os.mock');
 
 
 describe('os.column.ColumnMappingManager', function() {
+  const googObject = goog.module.get('goog.object');
+  const ColumnMapping = goog.module.get('os.column.ColumnMapping');
+  const ColumnMappingEventType = goog.module.get('os.column.ColumnMappingEventType');
+  const ColumnMappingManager = goog.module.get('os.column.ColumnMappingManager');
+
   var cmm;
   var mappingString = '<columnMapping name="My Mapping" type="decimal" description="some description">' +
       '<column layer="https://fake.server.bits/ogc/wfsServer!!fake:layer1">layer1_column1</column>' +
@@ -15,11 +22,11 @@ describe('os.column.ColumnMappingManager', function() {
     'id': id
   };
 
-  var mapping = new os.column.ColumnMapping();
+  var mapping = new ColumnMapping();
   mapping.restore(config);
 
   beforeEach(function() {
-    cmm = os.column.ColumnMappingManager.getInstance();
+    cmm = ColumnMappingManager.getInstance();
     cmm.clear();
     cmm.save();
   });
@@ -27,23 +34,23 @@ describe('os.column.ColumnMappingManager', function() {
   it('should hash columns with a "#" in the middle', function() {
     var layerName = 'https://fake.server.bits/ogc/wfsServer!!fake:layer69';
     var columnName = 'layer69_column416';
-    var hash = os.column.ColumnMappingManager.hashLayerColumn(layerName, columnName);
+    var hash = ColumnMappingManager.hashLayerColumn(layerName, columnName);
     expect(hash).toBe(layerName + '#' + columnName);
   });
 
   it('should add mappings and keep track of them by hash', function() {
     var column1 = mapping.getColumns()[0];
     var column2 = mapping.getColumns()[1];
-    var hash1 = os.column.ColumnMappingManager.hashColumn(column1);
-    var hash2 = os.column.ColumnMappingManager.hashColumn(column2);
+    var hash1 = ColumnMappingManager.hashColumn(column1);
+    var hash2 = ColumnMappingManager.hashColumn(column2);
 
     expect(cmm.items_.length).toBe(0);
-    expect(goog.object.getCount(cmm.layerColumnMap_)).toBe(0);
+    expect(googObject.getCount(cmm.layerColumnMap_)).toBe(0);
 
     cmm.add(mapping);
 
     expect(cmm.items_.length).toBe(1);
-    expect(goog.object.getCount(cmm.layerColumnMap_)).toBe(2);
+    expect(googObject.getCount(cmm.layerColumnMap_)).toBe(2);
     expect(cmm.layerColumnMap_[hash1]).toBe(id);
     expect(cmm.layerColumnMap_[hash2]).toBe(id);
   });
@@ -51,29 +58,29 @@ describe('os.column.ColumnMappingManager', function() {
   it('should add an owned column when a managed mapping does', function() {
     cmm.add(mapping);
     expect(cmm.items_.length).toBe(1);
-    expect(goog.object.getCount(cmm.layerColumnMap_)).toBe(2);
+    expect(googObject.getCount(cmm.layerColumnMap_)).toBe(2);
 
     var layerName = 'https://fake.server.bits/ogc/wfsServer!!fake:layer99';
     var columnName = 'layer99_column50';
-    var hash = os.column.ColumnMappingManager.hashLayerColumn(layerName, columnName);
+    var hash = ColumnMappingManager.hashLayerColumn(layerName, columnName);
     expect(cmm.layerColumnMap_[hash]).toBe(undefined);
 
     mapping.addColumn(layerName, columnName);
     expect(cmm.layerColumnMap_[hash]).toBe(id);
-    expect(goog.object.getCount(cmm.layerColumnMap_)).toBe(3);
+    expect(googObject.getCount(cmm.layerColumnMap_)).toBe(3);
   });
 
   it('should remove an owned column when a managed mapping does', function() {
     var column1 = mapping.getColumns()[0];
-    var hash1 = os.column.ColumnMappingManager.hashColumn(column1);
+    var hash1 = ColumnMappingManager.hashColumn(column1);
 
     cmm.add(mapping);
     expect(cmm.items_.length).toBe(1);
-    expect(goog.object.getCount(cmm.layerColumnMap_)).toBe(3);
+    expect(googObject.getCount(cmm.layerColumnMap_)).toBe(3);
     expect(cmm.layerColumnMap_[hash1]).toBe(id);
 
     mapping.removeColumn(column1);
-    expect(goog.object.getCount(cmm.layerColumnMap_)).toBe(2);
+    expect(googObject.getCount(cmm.layerColumnMap_)).toBe(2);
     expect(cmm.layerColumnMap_[hash1]).toBe(undefined);
   });
 
@@ -83,7 +90,7 @@ describe('os.column.ColumnMappingManager', function() {
       fired = true;
     };
 
-    cmm.listenOnce(os.column.ColumnMappingEventType.MAPPINGS_CHANGE, listener);
+    cmm.listenOnce(ColumnMappingEventType.MAPPINGS_CHANGE, listener);
     cmm.onChange();
 
     waitsFor(function() {
@@ -112,9 +119,9 @@ describe('os.column.ColumnMappingManager', function() {
     'id': id2
   };
 
-  var mapping1 = new os.column.ColumnMapping();
+  var mapping1 = new ColumnMapping();
   mapping1.restore(config1);
-  var mapping2 = new os.column.ColumnMapping();
+  var mapping2 = new ColumnMapping();
   mapping2.restore(config2);
 
   it('should be able to bulk add column mappings', function() {
@@ -127,7 +134,7 @@ describe('os.column.ColumnMappingManager', function() {
     expect(cmm.getAll().length).toBe(2);
 
     var column1 = mapping1.getColumns()[0];
-    var hash1 = os.column.ColumnMappingManager.hashColumn(column1);
+    var hash1 = ColumnMappingManager.hashColumn(column1);
     var ownerMapping = cmm.getOwnerMapping(hash1);
     expect(ownerMapping).toBe(mapping1);
 

--- a/test/os/easing/easing.js
+++ b/test/os/easing/easing.js
@@ -2,6 +2,8 @@ goog.require('os.easing');
 
 
 describe('os.easing', function() {
+  const osEasing = goog.module.get('os.easing');
+
   // test set 1
   var min1 = 0;
   var max1 = 1;
@@ -35,98 +37,98 @@ describe('os.easing', function() {
   };
 
   it('should test linear easing', function() {
-    expect(os.easing.easeLinear(0, min1, max1 - min1, steps1)).toBe(min1);
-    expect(os.easing.easeLinear(steps1, min1, max1 - min1, steps1)).toBe(max1);
-    expect(proximityTest(os.easing.easeLinear(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
-    expect(proximityTest(os.easing.easeLinear(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(max1);
-    expect(midpointTest(os.easing.easeLinear(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(true);
+    expect(osEasing.easeLinear(0, min1, max1 - min1, steps1)).toBe(min1);
+    expect(osEasing.easeLinear(steps1, min1, max1 - min1, steps1)).toBe(max1);
+    expect(proximityTest(osEasing.easeLinear(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
+    expect(proximityTest(osEasing.easeLinear(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(max1);
+    expect(midpointTest(osEasing.easeLinear(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(true);
 
-    expect(os.easing.easeLinear(0, min2, max2 - min2, steps2)).toBe(min2);
-    expect(os.easing.easeLinear(steps2, min2, max2 - min2, steps2)).toBe(max2);
-    expect(proximityTest(os.easing.easeLinear(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
-    expect(proximityTest(os.easing.easeLinear(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
-    expect(midpointTest(os.easing.easeLinear(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
+    expect(osEasing.easeLinear(0, min2, max2 - min2, steps2)).toBe(min2);
+    expect(osEasing.easeLinear(steps2, min2, max2 - min2, steps2)).toBe(max2);
+    expect(proximityTest(osEasing.easeLinear(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
+    expect(proximityTest(osEasing.easeLinear(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
+    expect(midpointTest(osEasing.easeLinear(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
   });
 
   it('should test exponential easing', function() {
-    expect(proximityTest(os.easing.easeExpo(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
-    expect(proximityTest(os.easing.easeExpo(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(max1);
-    expect(midpointTest(os.easing.easeExpo(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(true);
+    expect(proximityTest(osEasing.easeExpo(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
+    expect(proximityTest(osEasing.easeExpo(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(max1);
+    expect(midpointTest(osEasing.easeExpo(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(true);
 
-    expect(proximityTest(os.easing.easeExpo(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
-    expect(proximityTest(os.easing.easeExpo(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
-    expect(midpointTest(os.easing.easeExpo(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
+    expect(proximityTest(osEasing.easeExpo(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
+    expect(proximityTest(osEasing.easeExpo(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
+    expect(midpointTest(osEasing.easeExpo(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
   });
 
   it('should test cubic easing', function() {
-    expect(os.easing.easeCubic(0, min1, max1 - min1, steps1)).toBe(min1);
-    expect(os.easing.easeCubic(steps1, min1, max1 - min1, steps1)).toBe(max1);
-    expect(proximityTest(os.easing.easeCubic(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
-    expect(proximityTest(os.easing.easeCubic(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(max1);
-    expect(midpointTest(os.easing.easeCubic(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(true);
+    expect(osEasing.easeCubic(0, min1, max1 - min1, steps1)).toBe(min1);
+    expect(osEasing.easeCubic(steps1, min1, max1 - min1, steps1)).toBe(max1);
+    expect(proximityTest(osEasing.easeCubic(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
+    expect(proximityTest(osEasing.easeCubic(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(max1);
+    expect(midpointTest(osEasing.easeCubic(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(true);
 
-    expect(os.easing.easeCubic(0, min2, max2 - min2, steps2)).toBe(min2);
-    expect(os.easing.easeCubic(steps2, min2, max2 - min2, steps2)).toBe(max2);
-    expect(proximityTest(os.easing.easeCubic(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
-    expect(proximityTest(os.easing.easeCubic(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
-    expect(midpointTest(os.easing.easeCubic(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
+    expect(osEasing.easeCubic(0, min2, max2 - min2, steps2)).toBe(min2);
+    expect(osEasing.easeCubic(steps2, min2, max2 - min2, steps2)).toBe(max2);
+    expect(proximityTest(osEasing.easeCubic(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
+    expect(proximityTest(osEasing.easeCubic(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
+    expect(midpointTest(osEasing.easeCubic(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
   });
 
   it('should test quartic easing', function() {
-    expect(os.easing.easeQuartic(0, min1, max1 - min1, steps1)).toBe(min1);
-    expect(os.easing.easeQuartic(steps1, min1, max1 - min1, steps1)).toBe(max1);
-    expect(proximityTest(os.easing.easeQuartic(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
-    expect(proximityTest(os.easing.easeQuartic(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(max1);
-    expect(midpointTest(os.easing.easeQuartic(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(true);
+    expect(osEasing.easeQuartic(0, min1, max1 - min1, steps1)).toBe(min1);
+    expect(osEasing.easeQuartic(steps1, min1, max1 - min1, steps1)).toBe(max1);
+    expect(proximityTest(osEasing.easeQuartic(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
+    expect(proximityTest(osEasing.easeQuartic(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(max1);
+    expect(midpointTest(osEasing.easeQuartic(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(true);
 
-    expect(os.easing.easeQuartic(0, min2, max2 - min2, steps2)).toBe(min2);
-    expect(os.easing.easeQuartic(steps2, min2, max2 - min2, steps2)).toBe(max2);
-    expect(proximityTest(os.easing.easeQuartic(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
-    expect(proximityTest(os.easing.easeQuartic(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
-    expect(midpointTest(os.easing.easeQuartic(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
+    expect(osEasing.easeQuartic(0, min2, max2 - min2, steps2)).toBe(min2);
+    expect(osEasing.easeQuartic(steps2, min2, max2 - min2, steps2)).toBe(max2);
+    expect(proximityTest(osEasing.easeQuartic(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
+    expect(proximityTest(osEasing.easeQuartic(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
+    expect(midpointTest(osEasing.easeQuartic(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
   });
 
   it('should test quintic easing', function() {
-    expect(os.easing.easeQuintic(0, min1, max1 - min1, steps1)).toBe(min1);
-    expect(os.easing.easeQuintic(steps1, min1, max1 - min1, steps1)).toBe(max1);
-    expect(proximityTest(os.easing.easeQuintic(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
-    expect(proximityTest(os.easing.easeQuintic(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(max1);
-    expect(midpointTest(os.easing.easeQuintic(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(true);
+    expect(osEasing.easeQuintic(0, min1, max1 - min1, steps1)).toBe(min1);
+    expect(osEasing.easeQuintic(steps1, min1, max1 - min1, steps1)).toBe(max1);
+    expect(proximityTest(osEasing.easeQuintic(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
+    expect(proximityTest(osEasing.easeQuintic(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(max1);
+    expect(midpointTest(osEasing.easeQuintic(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(true);
 
-    expect(os.easing.easeQuintic(0, min2, max2 - min2, steps2)).toBe(min2);
-    expect(os.easing.easeQuintic(steps2, min2, max2 - min2, steps2)).toBe(max2);
-    expect(proximityTest(os.easing.easeQuintic(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
-    expect(proximityTest(os.easing.easeQuintic(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
-    expect(midpointTest(os.easing.easeQuintic(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
+    expect(osEasing.easeQuintic(0, min2, max2 - min2, steps2)).toBe(min2);
+    expect(osEasing.easeQuintic(steps2, min2, max2 - min2, steps2)).toBe(max2);
+    expect(proximityTest(osEasing.easeQuintic(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
+    expect(proximityTest(osEasing.easeQuintic(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
+    expect(midpointTest(osEasing.easeQuintic(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
   });
 
   it('should test circular in easing', function() {
-    expect(os.easing.easeCircular(0, min1, max1 - min1, steps1)).toBe(min1);
-    expect(os.easing.easeCircular(steps1, min1, max1 - min1, steps1)).toBe(max1);
-    expect(proximityTest(os.easing.easeCircular(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
-    expect(proximityTest(os.easing.easeCircular(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
-    expect(midpointTest(os.easing.easeCircular(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(false);
+    expect(osEasing.easeCircular(0, min1, max1 - min1, steps1)).toBe(min1);
+    expect(osEasing.easeCircular(steps1, min1, max1 - min1, steps1)).toBe(max1);
+    expect(proximityTest(osEasing.easeCircular(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
+    expect(proximityTest(osEasing.easeCircular(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
+    expect(midpointTest(osEasing.easeCircular(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(false);
 
-    expect(os.easing.easeCircular(0, min2, max2 - min2, steps2)).toBe(min2);
-    expect(os.easing.easeCircular(steps2, min2, max2 - min2, steps2)).toBe(max2);
-    expect(proximityTest(os.easing.easeCircular(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
-    expect(proximityTest(os.easing.easeCircular(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
-    expect(midpointTest(os.easing.easeCircular(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
+    expect(osEasing.easeCircular(0, min2, max2 - min2, steps2)).toBe(min2);
+    expect(osEasing.easeCircular(steps2, min2, max2 - min2, steps2)).toBe(max2);
+    expect(proximityTest(osEasing.easeCircular(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
+    expect(proximityTest(osEasing.easeCircular(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
+    expect(midpointTest(osEasing.easeCircular(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
   });
 
   it('should test sinusoidal easing', function() {
-    expect(os.easing.easeSinusoidal(0, min1, max1 - min1, steps1)).toBe(min1);
-    expect(os.easing.easeSinusoidal(steps1, min1, max1 - min1, steps1)).toBe(max1);
-    expect(os.easing.easeSinusoidal(steps1, min1, max1 - min1, steps1)).toBe(max1);
-    expect(proximityTest(os.easing.easeSinusoidal(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
-    expect(proximityTest(os.easing.easeSinusoidal(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(max1);
-    expect(midpointTest(os.easing.easeSinusoidal(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(true);
+    expect(osEasing.easeSinusoidal(0, min1, max1 - min1, steps1)).toBe(min1);
+    expect(osEasing.easeSinusoidal(steps1, min1, max1 - min1, steps1)).toBe(max1);
+    expect(osEasing.easeSinusoidal(steps1, min1, max1 - min1, steps1)).toBe(max1);
+    expect(proximityTest(osEasing.easeSinusoidal(steps1 * .49, min1, max1 - min1, steps1), min1, max1)).toBe(min1);
+    expect(proximityTest(osEasing.easeSinusoidal(steps1 * .51, min1, max1 - min1, steps1), min1, max1)).toBe(max1);
+    expect(midpointTest(osEasing.easeSinusoidal(steps1 * .5, min1, max1 - min1, steps1), min1, max1)).toBe(true);
 
-    expect(os.easing.easeSinusoidal(0, min2, max2 - min2, steps2)).toBe(min2);
-    expect(os.easing.easeSinusoidal(steps2, min2, max2 - min2, steps2)).toBe(max2);
-    expect(os.easing.easeSinusoidal(steps2, min2, max2 - min2, steps2)).toBe(max2);
-    expect(proximityTest(os.easing.easeSinusoidal(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
-    expect(proximityTest(os.easing.easeSinusoidal(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
-    expect(midpointTest(os.easing.easeSinusoidal(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
+    expect(osEasing.easeSinusoidal(0, min2, max2 - min2, steps2)).toBe(min2);
+    expect(osEasing.easeSinusoidal(steps2, min2, max2 - min2, steps2)).toBe(max2);
+    expect(osEasing.easeSinusoidal(steps2, min2, max2 - min2, steps2)).toBe(max2);
+    expect(proximityTest(osEasing.easeSinusoidal(steps2 * .49, min2, max2 - min2, steps2), min2, max2)).toBe(min2);
+    expect(proximityTest(osEasing.easeSinusoidal(steps2 * .51, min2, max2 - min2, steps2), min2, max2)).toBe(max2);
+    expect(midpointTest(osEasing.easeSinusoidal(steps2 * .5, min2, max2 - min2, steps2), min2, max2)).toBe(true);
   });
 });


### PR DESCRIPTION
Transforms the following under `src/os`:

- alert
- action
- array
- bearing
- buffer
- column
- control
- easing
- events

### Additional Changes

- The alert stack was mostly transformed, but we have a temporary file that makes the `os.alertManager` global available. This can be module with `declareLegacyNamespace` without breaking anything, so I converted it.
- Added `os.bearing.isGeomagLoaded` to check if the geomag library has finished loading. This avoids the need to check a private property in test initialization.
- `os.buffer.createFromConfig` is sometimes shared with an external window context. To do this, we place the reference in the external window. I added a setter to update this function, following the approach used in places/tracks/etc.
- Updated some API issues the compiler found when using `PropertyChangeEvent`.