### PR TITLE
Add UI to directly compare layers

### DIFF
--- a/scss/opensphere.scss
+++ b/scss/opensphere.scss
@@ -27,6 +27,7 @@
 @import 'os/formatter';
 @import 'os/glyph';
 @import 'os/iconpicker';
+@import 'os/layercompare';
 @import 'os/link';
 @import 'os/loading';
 @import 'os/loboptions';

--- a/scss/os/_layercompare.scss
+++ b/scss/os/_layercompare.scss
@@ -1,0 +1,52 @@
+$layer-compare-slider-radius: 1rem;
+
+.c-layer-compare-container {
+  overflow: hidden;
+  position: relative;
+}
+
+.c-layer-compare-item {
+  background-color: $modal-content-bg;
+  height: auto;
+  overflow: hidden;
+  position: absolute;
+  width: auto;
+
+  > img {
+    display: block;
+    vertical-align: middle;
+  }
+}
+
+.c-layer-compare-slider {
+  border: $border-width solid $border-color;
+  height: 100%;
+  left: 50%;
+  position: absolute;
+  z-index: 9;
+}
+
+.c-layer-compare-handle {
+  align-items: center;
+  background-color: $black;
+  border-radius: 50%;
+  cursor: ew-resize;
+  display: flex;
+  font-size: 1.25rem;
+  height: $layer-compare-slider-radius * 2;
+  justify-content: space-between;
+  left: -($layer-compare-slider-radius);
+  opacity: .5;
+  padding: 0 .1rem;
+  position: absolute;
+  top: calc(50% - #{$layer-compare-slider-radius});
+  width: $layer-compare-slider-radius * 2;
+
+  &:hover {
+    opacity: .75;
+  }
+}
+
+.c-layer-compare-top {
+  z-index: 1;
+}

--- a/scss/os/_layercompare.scss
+++ b/scss/os/_layercompare.scss
@@ -1,8 +1,13 @@
 $layer-compare-slider-radius: 1rem;
+$layer-compare-z-index-base: 1;
 
 .c-layer-compare-container {
   overflow: hidden;
   position: relative;
+}
+
+.c-layer-compare-control {
+  z-index: $layer-compare-z-index-base + 2;
 }
 
 .c-layer-compare-item {
@@ -23,7 +28,7 @@ $layer-compare-slider-radius: 1rem;
   height: 100%;
   left: 50%;
   position: absolute;
-  z-index: 9;
+  z-index: $layer-compare-z-index-base + 1;
 }
 
 .c-layer-compare-handle {
@@ -48,5 +53,5 @@ $layer-compare-slider-radius: 1rem;
 }
 
 .c-layer-compare-top {
-  z-index: 1;
+  z-index: $layer-compare-z-index-base;
 }

--- a/src/os/layer/tile.js
+++ b/src/os/layer/tile.js
@@ -725,6 +725,7 @@ os.layer.Tile.prototype.isEnabled = function() {
 os.layer.Tile.prototype.setEnabled = function(value) {
   // Layer does not have separate enabled/visible states, so this is a pass-through.
   this.setLayerVisible(value);
+  this.dispatchEvent(new os.events.PropertyChangeEvent(os.layer.PropertyChange.ENABLED, value, !value));
 };
 
 

--- a/src/os/ui/layer/compare/layercompareui.js
+++ b/src/os/ui/layer/compare/layercompareui.js
@@ -26,6 +26,7 @@ const {
 } = goog.require('os.ui.window');
 
 const EventKey = goog.requireType('goog.events.Key');
+const Control = goog.requireType('ol.control.Control');
 const Layer = goog.requireType('ol.layer.Layer');
 
 
@@ -59,11 +60,26 @@ const getBasemaps = () => getMapContainer().getLayers().filter(isBasemap);
 
 /**
  * If a layer is a basemap layer.
- * @param {!Layer} layer The layer.
+ * @param {Layer} layer The layer.
  * @return {boolean} If the layer is a basemap.
  */
 const isBasemap = (layer) => osImplements(layer, ILayer.ID) &&
 /** @type {ILayer} */ (layer).getOSType() === 'Map Layers';
+
+
+/**
+ * Create the controls to display on the map.
+ * @return {!Array<!Control>}
+ */
+const createControls = () => [
+  new RotateControl({
+    autoHide: false,
+    className: 'c-layer-compare-control ol-rotate'
+  }),
+  new ZoomControl({
+    className: 'c-layer-compare-control ol-zoom'
+  })
+];
 
 
 /**
@@ -225,15 +241,7 @@ class Controller {
       view: this.view
     });
 
-    const controls = new Collection([
-      new RotateControl({
-        autoHide: false,
-        className: 'c-layer-compare-control ol-rotate'
-      }),
-      new ZoomControl({
-        className: 'c-layer-compare-control ol-zoom'
-      })
-    ]);
+    const controls = new Collection(createControls());
 
     this.rightMap = new OLMap({
       controls,
@@ -340,12 +348,20 @@ class Controller {
 
     // Swap the order via CSS. This uses z-order to control which map is displayed on top, and the width of the top
     // map is adjusted by the slider (making it appear to be on the left).
+    //
+    // Map controls are also swapped to ensure they display on the right of the compare window.
     if (this.leftOnTop) {
       this.element.find(Selector.MAP_LEFT).addClass('c-layer-compare-top');
       this.element.find(Selector.MAP_RIGHT).removeClass('c-layer-compare-top').width('auto');
+
+      this.leftMap.getControls().clear();
+      this.rightMap.getControls().extend(createControls());
     } else {
       this.element.find(Selector.MAP_LEFT).removeClass('c-layer-compare-top').width('auto');
       this.element.find(Selector.MAP_RIGHT).addClass('c-layer-compare-top');
+
+      this.rightMap.getControls().clear();
+      this.leftMap.getControls().extend(createControls());
     }
 
     this.updateMapContainerWidth();

--- a/src/os/ui/layer/compare/layercompareui.js
+++ b/src/os/ui/layer/compare/layercompareui.js
@@ -7,6 +7,8 @@ const GoogEventType = goog.require('goog.events.EventType');
 const Collection = goog.require('ol.Collection');
 const OLMap = goog.require('ol.Map');
 const View = goog.require('ol.View');
+const RotateControl = goog.require('ol.control.Rotate');
+const ZoomControl = goog.require('ol.control.Zoom');
 const {getCenter: getExtentCenter} = goog.require('ol.extent');
 
 const {ROOT} = goog.require('os');
@@ -205,8 +207,18 @@ class Controller {
       view: this.view
     });
 
+    const controls = new Collection([
+      new RotateControl({
+        autoHide: false,
+        className: 'c-layer-compare-control ol-rotate'
+      }),
+      new ZoomControl({
+        className: 'c-layer-compare-control ol-zoom'
+      })
+    ]);
+
     this.rightMap = new OLMap({
-      controls: [],
+      controls,
       layers: this.rightLayers,
       target: rightEl,
       view: this.view
@@ -244,14 +256,16 @@ class Controller {
 
     const projection = osMap.PROJECTION;
     const center = mainView ? mainView.getCenter() : getExtentCenter(projection.getExtent());
+    const rotation = mainView ? mainView.getRotation() : 0;
     const zoom = mainView ? mainView.getZoom() : osMap.DEFAULT_ZOOM;
 
     return new View({
       center,
-      zoom,
-      projection,
       minZoom: osMap.MIN_ZOOM,
-      maxZoom: osMap.MAX_ZOOM
+      maxZoom: osMap.MAX_ZOOM,
+      projection,
+      rotation,
+      zoom
     });
   }
 

--- a/src/os/ui/layer/compare/layercompareui.js
+++ b/src/os/ui/layer/compare/layercompareui.js
@@ -1,0 +1,422 @@
+goog.module('os.ui.layer.compare.LayerCompareUI');
+goog.module.declareLegacyNamespace();
+
+const dispose = goog.require('goog.dispose');
+const {listen, unlistenByKey} = goog.require('goog.events');
+const GoogEventType = goog.require('goog.events.EventType');
+const Collection = goog.require('ol.Collection');
+const OLMap = goog.require('ol.Map');
+const View = goog.require('ol.View');
+const {createEmpty, isEmpty} = goog.require('ol.extent');
+
+const {ROOT} = goog.require('os');
+const {filterFalsey, reduceExtentFromLayers} = goog.require('os.fn');
+const osMap = goog.require('os.map');
+const Module = goog.require('os.ui.Module');
+const {resize, removeResize} = goog.require('os.ui');
+const {
+  bringToFront,
+  close: closeWindow,
+  create: createWindow,
+  exists: windowExists
+} = goog.require('os.ui.window');
+
+const EventKey = goog.requireType('goog.events.Key');
+const Layer = goog.requireType('ol.layer.Layer');
+
+
+/**
+ * Element selectors for the UI.
+ * @enum {string}
+ */
+const Selector = {
+  CONTAINER: '.js-layer-compare-container',
+  MAP_LEFT: '.js-layer-compare-left',
+  MAP_RIGHT: '.js-layer-compare-right',
+  SLIDER: '.js-layer-compare-slider'
+};
+
+
+/**
+ * @typedef {{
+ *   left: (Array<Layer>|undefined),
+ *   right: (Array<Layer>|undefined)
+ * }}
+ */
+let LayerCompareOptions;
+
+
+/**
+ * The layercompare directive.
+ * @return {angular.Directive}
+ */
+const directive = () => ({
+  restrict: 'E',
+  replace: true,
+  scope: true,
+  templateUrl: ROOT + 'views/layer/compare/layercompare.html',
+  controller: Controller,
+  controllerAs: 'ctrl'
+});
+
+
+/**
+ * The element tag for the directive.
+ * @type {string}
+ */
+const directiveTag = 'layercompare';
+
+
+/**
+ * Add the directive to the module.
+ */
+Module.directive(directiveTag, [directive]);
+
+
+/**
+ * Controller for the layercompare directive.
+ * @unrestricted
+ */
+class Controller {
+  /**
+   * Constructor.
+   * @param {!angular.Scope} $scope The Angular scope.
+   * @param {!angular.JQLite} $element The root DOM element.
+   * @ngInject
+   */
+  constructor($scope, $element) {
+    /**
+     * The Angular scope.
+     * @type {?angular.Scope}
+     * @protected
+     */
+    this.scope = $scope;
+
+    /**
+     * The root DOM element.
+     * @type {?angular.JQLite}
+     * @protected
+     */
+    this.element = $element;
+
+    /**
+     * The drag event listener keys.
+     * @type {Array<!EventKey>}
+     * @protected
+     */
+    this.dragListeners = null;
+
+    /**
+     * Offset from where the drag event started to the slider center.
+     * @type {number}
+     * @protected
+     */
+    this.dragOffset = 0;
+
+    /**
+     * The left layers to compare.
+     * @type {!Collection<Layer>}
+     * @protected
+     */
+    this.leftLayers = new Collection();
+
+    /**
+     * The left map.
+     * @type {OLMap}
+     * @protected
+     */
+    this.leftMap = null;
+
+    /**
+     * The right layers to compare.
+     * @type {!Collection<Layer>}
+     * @protected
+     */
+    this.rightLayers = new Collection();
+
+    /**
+     * The right map.
+     * @type {OLMap}
+     * @protected
+     */
+    this.rightMap = null;
+
+    /**
+     * If the "left" map is on top. Order is really determined by z-index and which element width is adjusted, so the
+     * selectors are really just to keep track of the two maps.
+     * @type {boolean}
+     * @protected
+     */
+    this.leftOnTop = true;
+
+    /**
+     * The shared map view.
+     * @type {View}
+     * @protected
+     */
+    this.view = null;
+
+    /**
+     * Prebound window resize handler.
+     * @type {function()}
+     * @protected
+     */
+    this.resizeFn = this.updateMapSize.bind(this);
+
+    // Updates the map sizes when the window is resized.
+    resize(this.element, this.resizeFn);
+  }
+
+  /**
+   * Angular $onDestroy lifecycle call.
+   */
+  $onDestroy() {
+    if (this.element) {
+      removeResize(this.element, this.resizeFn);
+    }
+
+    if (this.dragListeners) {
+      this.dragListeners.forEach(unlistenByKey);
+      this.dragListeners = null;
+    }
+
+    dispose(this.leftMap);
+    dispose(this.rightMap);
+    dispose(this.view);
+
+    this.scope = null;
+    this.element = null;
+  }
+
+  /**
+   * Angular $onInit lifecycle call.
+   */
+  $onInit() {
+    // Create two OpenLayers maps that share a view and are stacked on top of one another.
+    const leftEl = this.element.find(Selector.MAP_LEFT)[0];
+    const rightEl = this.element.find(Selector.MAP_RIGHT)[0];
+
+    this.view = new View({
+      center: [0, 0],
+      zoom: 3,
+      projection: osMap.PROJECTION,
+      minZoom: osMap.MIN_ZOOM,
+      maxZoom: osMap.MAX_ZOOM
+    });
+
+    this.leftMap = new OLMap({
+      controls: [],
+      layers: this.leftLayers,
+      target: leftEl,
+      view: this.view
+    });
+
+    this.rightMap = new OLMap({
+      controls: [],
+      layers: this.rightLayers,
+      target: rightEl,
+      view: this.view
+    });
+
+    // Update map canvases to fill the available space.
+    this.updateMapSize();
+
+    // Make the left map container 50% width for an initial split view.
+    this.element.find(Selector.MAP_LEFT).width('50%');
+
+    // Set the layers on each map.
+    const compareOptions = /** @type {LayerCompareOptions} */ (this.scope);
+    this.setCollectionLayers(this.leftLayers, compareOptions.left);
+    this.setCollectionLayers(this.rightLayers, compareOptions.right);
+
+    // Fit the view to the available layers.
+    this.fit();
+  }
+
+  /**
+   * Close the window.
+   * @export
+   */
+  close() {
+    closeWindow(this.element);
+  }
+
+  /**
+   * Fit layers to the window.
+   * @param {Array<!Layer>=} opt_layers The layer(s) to fit. Defaults to all layers.
+   * @export
+   */
+  fit(opt_layers) {
+    const layers = opt_layers || this.leftLayers.getArray().concat(this.rightLayers.getArray());
+    if (layers && this.view) {
+      let extent = layers.filter(filterFalsey).reduce(reduceExtentFromLayers, createEmpty());
+      if (isEmpty(extent)) {
+        extent = osMap.PROJECTION.getExtent();
+      }
+
+      this.view.fit(extent);
+    }
+  }
+
+  /**
+   * Set the layers in a collection.
+   * @param {Collection<Layer>} collection The collection.
+   * @param {Array<Layer>|undefined} layers The layers.
+   */
+  setCollectionLayers(collection, layers) {
+    collection.clear();
+
+    if (layers) {
+      layers.forEach((layer) => {
+        collection.push(layer);
+      });
+    }
+  }
+
+  /**
+   * Swap layers in the window.
+   * @export
+   */
+  swap() {
+    this.leftOnTop = !this.leftOnTop;
+
+    // Swap the order via CSS. This uses z-order to control which map is displayed on top, and the width of the top
+    // map is adjusted by the slider (making it appear to be on the left).
+    if (this.leftOnTop) {
+      this.element.find(Selector.MAP_LEFT).addClass('c-layer-compare-top');
+      this.element.find(Selector.MAP_RIGHT).removeClass('c-layer-compare-top').width('auto');
+    } else {
+      this.element.find(Selector.MAP_LEFT).removeClass('c-layer-compare-top').width('auto');
+      this.element.find(Selector.MAP_RIGHT).addClass('c-layer-compare-top');
+    }
+
+    this.updateMapContainerWidth();
+  }
+
+  /**
+   * Handle slider drag event.
+   * @param {Event} event The drag event.
+   * @protected
+   */
+  handleDrag(event) {
+    if (event && this.element) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const container = this.element.find(Selector.CONTAINER)[0];
+      if (container) {
+        // Move the slider to the mouse position, clamping within the bounds of the container.
+        const rect = container.getBoundingClientRect();
+        const offset = Math.round(Math.min(Math.max(event.clientX - rect.x - this.dragOffset, 0), rect.width));
+        this.element.find(Selector.SLIDER).css('left', `${offset}px`);
+
+        this.updateMapContainerWidth();
+      }
+    }
+  }
+
+  /**
+   * Update the width of the map container relative to the slider.
+   * @protected
+   */
+  updateMapContainerWidth() {
+    // Update the width of the top map. This makes it appear on the left side of the comparison.
+    const width = this.element.find(Selector.SLIDER).css('left');
+    const mapSelector = this.leftOnTop ? Selector.MAP_LEFT : Selector.MAP_RIGHT;
+    this.element.find(mapSelector).width(width);
+  }
+
+  /**
+   * Toggle dragging the compare slider.
+   * @param {Event} event The event.
+   * @export
+   */
+  toggleDrag(event) {
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const dragging = event.type === GoogEventType.MOUSEDOWN;
+      if (dragging && !this.dragListeners) {
+        // The click event origin is on the slider, but we want to move the line relative to the mousedown position so
+        // it doesn't jump on the first mousemove event. Determine the offset between the mouse event and the line.
+        const slider = this.element.find(Selector.SLIDER)[0];
+        if (slider) {
+          const sliderRect = slider.getBoundingClientRect();
+          // The extra offset is a little arbitrary and is due to the EW cursor being ~12px wide and the event is
+          // relative to the left edge. This tries to account for that to avoid an initial jump due to this difference.
+          this.dragOffset = event.clientX - sliderRect.x + 6;
+        } else {
+          this.dragOffset = 0;
+        }
+
+        this.dragListeners = [
+          listen(window, GoogEventType.MOUSEMOVE, this.handleDrag, false, this),
+          listen(window, GoogEventType.MOUSEUP, this.toggleDrag, false, this)
+        ];
+      } else if (!dragging && this.dragListeners) {
+        this.dragListeners.forEach(unlistenByKey);
+        this.dragListeners = null;
+      }
+    }
+  }
+
+  /**
+   * Update the OpenLayers map canvases to fill the container.
+   * @protected
+   */
+  updateMapSize() {
+    if (this.element && this.leftMap && this.rightMap) {
+      const container = this.element.find(Selector.CONTAINER);
+      const size = [container.width(), container.height()];
+      this.leftMap.setSize(size);
+      this.rightMap.setSize(size);
+    }
+  }
+}
+
+
+/**
+ * Identifier for the layer compare window.
+ * @type {string}
+ */
+const windowId = 'compare-layers';
+
+
+/**
+ * Launch the layer compare window.
+ * @param {!LayerCompareOptions} options The layer compare options.
+ */
+const launchLayerCompare = (options) => {
+  if (windowExists(windowId)) {
+    bringToFront(windowId);
+    // TODO: update the existing window
+  } else {
+    const windowOptions = {
+      'id': windowId,
+      'label': 'Compare Layers',
+      'icon': 'fas fa-layer-group',
+      'x': 'center',
+      'y': 'center',
+      'width': 800,
+      'min-width': 400,
+      'max-width': 2000,
+      'height': 600,
+      'min-height': 300,
+      'max-height': 2000,
+      'show-close': true
+    };
+
+    const template = `<${directiveTag}></${directiveTag}>`;
+    createWindow(windowOptions, template, undefined, undefined, undefined, options);
+  }
+};
+
+exports = {
+  LayerCompareOptions,
+  directive,
+  directiveTag,
+  Controller,
+  launchLayerCompare,
+  windowId
+};

--- a/src/os/ui/layers.js
+++ b/src/os/ui/layers.js
@@ -321,7 +321,7 @@ os.ui.LayersCtrl.prototype.toggleTileLayers = function() {
 
       if (type && type != ol.LayerType.VECTOR) {
         // toggle tiles
-        layers[i].setLayerVisible(this.showTiles());
+        layers[i].setEnabled(this.showTiles());
       }
     }
   }

--- a/src/os/ui/layers.js
+++ b/src/os/ui/layers.js
@@ -115,8 +115,6 @@ os.ui.LayersCtrl = function($scope, $element) {
     this.menus_['.add-data-group'] = os.ui.menu.import.MENU;
   }
 
-  this.selectedActionsOpen_ = false;
-
   var map = os.MapContainer.getInstance();
   map.listen(os.events.LayerEventType.ADD, this.search, false, this);
   map.listen(os.events.LayerEventType.REMOVE, this.search, false, this);
@@ -284,34 +282,6 @@ os.ui.LayersCtrl.prototype.openMenu = function(selector) {
         my: 'left top+3',
         at: 'left bottom',
         of: target
-      });
-    }
-  }
-};
-
-
-/**
- * Open the Selected Actions menu.
- * @param {angular.Scope.Event} event The ng-click event.
- * @export
- */
-os.ui.LayersCtrl.prototype.openSelectedActionsMenu = function(event) {
-  if (this.scope) {
-    if (this.selectedActionsOpen_) {
-      this.selectedActionsOpen_ = false;
-      event.target.blur();
-      os.ui.menu.layer.MENU.close();
-    } else {
-      this.selectedActionsOpen_ = true;
-      os.dispatcher.listenOnce(os.ui.GlobalMenuEventType.MENU_CLOSE, () => {
-        this.selectedActionsOpen_ = false;
-      });
-
-      const context = this.scope['selected'] || [];
-      os.ui.menu.layer.MENU.open(context, {
-        my: 'left top+3',
-        at: 'left bottom',
-        of: event.target
       });
     }
   }

--- a/src/os/ui/layers.js
+++ b/src/os/ui/layers.js
@@ -115,6 +115,8 @@ os.ui.LayersCtrl = function($scope, $element) {
     this.menus_['.add-data-group'] = os.ui.menu.import.MENU;
   }
 
+  this.selectedActionsOpen_ = false;
+
   var map = os.MapContainer.getInstance();
   map.listen(os.events.LayerEventType.ADD, this.search, false, this);
   map.listen(os.events.LayerEventType.REMOVE, this.search, false, this);
@@ -279,9 +281,37 @@ os.ui.LayersCtrl.prototype.openMenu = function(selector) {
     var target = this.element.find(selector);
     if (target && target.length > 0) {
       menu.open(undefined, {
-        my: 'left top',
+        my: 'left top+3',
         at: 'left bottom',
         of: target
+      });
+    }
+  }
+};
+
+
+/**
+ * Open the Selected Actions menu.
+ * @param {angular.Scope.Event} event The ng-click event.
+ * @export
+ */
+os.ui.LayersCtrl.prototype.openSelectedActionsMenu = function(event) {
+  if (this.scope) {
+    if (this.selectedActionsOpen_) {
+      this.selectedActionsOpen_ = false;
+      event.target.blur();
+      os.ui.menu.layer.MENU.close();
+    } else {
+      this.selectedActionsOpen_ = true;
+      os.dispatcher.listenOnce(os.ui.GlobalMenuEventType.MENU_CLOSE, () => {
+        this.selectedActionsOpen_ = false;
+      });
+
+      const context = this.scope['selected'] || [];
+      os.ui.menu.layer.MENU.open(context, {
+        my: 'left top+3',
+        at: 'left bottom',
+        of: event.target
       });
     }
   }

--- a/src/os/ui/menu/defaultwindowsmenu.js
+++ b/src/os/ui/menu/defaultwindowsmenu.js
@@ -1,6 +1,7 @@
 goog.provide('os.ui.menu.windows.default');
 
 goog.require('os.config.ServerSettings');
+goog.require('os.config.Settings');
 goog.require('os.metrics.keys');
 goog.require('os.ui.events.UIEvent');
 goog.require('os.ui.events.UIEventType');
@@ -10,9 +11,20 @@ goog.require('os.ui.windowSelector');
 
 
 /**
+ * Settings keys for default windows.
+ * @enum {string}
+ */
+os.ui.menu.windows.default.SettingsKey = {
+  LAYERS_DEFAULTS: 'os.layers.defaults'
+};
+
+
+/**
  * Add default windows to the Windows menu.
  */
 os.ui.menu.windows.default.setup = function() {
+  const settings = os.config.Settings.getInstance();
+
   os.ui.menu.windows.setup();
 
   // add windows
@@ -33,25 +45,30 @@ os.ui.menu.windows.default.setup = function() {
     'html': 'adddata'
   }, true);
 
-  var layers = os.ui.menu.windows.addWindow('layers', {
+  const layersDefaults = /** @type {osx.window.WindowOptions} */ (
+    settings.get(os.ui.menu.windows.default.SettingsKey.LAYERS_DEFAULTS, {}));
+
+  const layersWindowOptions = Object.assign({
     'key': 'layers',
-    'icon': 'fa fa-layer-group',
+    'icon': 'fas fa-layer-group',
     'label': 'Layers',
     'description': 'View and manipulate layers on the map',
-    'x': '0',
-    'y': '96',
-    'width': '350',
-    'height': '550',
-    'min-width': '300',
-    'max-width': '1000',
-    'min-height': '250',
-    'max-height': '2000',
-    'show-close': 'true',
+    'x': 12,
+    'y': 96,
+    'width': 400,
+    'height': 550,
+    'min-width': 300,
+    'max-width': 1000,
+    'min-height': 350,
+    'max-height': 2000,
+    'show-close': true,
     'help-context': 'layers',
     'shortcut': 'alt+l',
     'html': '<layerswin tab="layers"></layerswin>',
     'metricKey': os.metrics.keys.Map.SHOW_LAYER_WINDOW
-  }, true);
+  }, layersDefaults);
+
+  var layers = os.ui.menu.windows.addWindow('layers', layersWindowOptions, true);
 
   // layers is open by default
   if (layers) {

--- a/src/os/ui/menu/layermenu.js
+++ b/src/os/ui/menu/layermenu.js
@@ -15,6 +15,7 @@ goog.require('os.metrics.keys');
 goog.require('os.ui.ex.ExportDirective');
 goog.require('os.ui.featureListDirective');
 goog.require('os.ui.layer.EllipseColumnsUI');
+goog.require('os.ui.layer.compare.LayerCompareUI');
 goog.require('os.ui.menu.Menu');
 goog.require('os.ui.menu.MenuItem');
 goog.require('os.ui.menu.MenuItemType');
@@ -91,6 +92,12 @@ os.ui.menu.layer.setup = function() {
         handler: os.ui.menu.layer.onSaveAs_,
         metricKey: os.metrics.Layer.SAVE_AS,
         sort: -10000 // we want this to appear right below save
+      }, {
+        label: 'Compare Layers',
+        tooltip: 'Compare two layers side-by-side',
+        icons: ['<i class="fas fa-fw fa-layer-group"></i>'],
+        beforeRender: os.ui.menu.layer.visibleIfCanCompare,
+        handler: os.ui.menu.layer.handleCompareLayers
       }, {
         label: 'Go To',
         eventType: os.action.EventType.GOTO,
@@ -599,4 +606,30 @@ os.ui.menu.layer.onIdentify_ = function(event) {
 
   identifyTimer.listen(goog.Timer.TICK, toggleOpacity);
   identifyTimer.start();
+};
+
+
+/**
+ * Enables the option when two layers are selected.
+ * @param {os.ui.menu.layer.Context} context The menu context.
+ * @this {os.ui.menu.MenuItem}
+ */
+os.ui.menu.layer.visibleIfCanCompare = function(context) {
+  const layers = os.ui.menu.layer.getLayersFromContext(context);
+  this.visible = !!layers && layers.length === 2;
+};
+
+
+/**
+ * Extract the feature from an event and launch the external link.
+ * @param {!os.ui.menu.MenuEvent<os.ui.menu.layer.Context>} event The menu event.
+ */
+os.ui.menu.layer.handleCompareLayers = function(event) {
+  var layers = os.ui.menu.layer.getLayersFromContext(event.getContext());
+  if (layers && layers.length === 2) {
+    os.ui.layer.compare.LayerCompareUI.launchLayerCompare({
+      left: [layers[0]],
+      right: [layers[1]]
+    });
+  }
 };

--- a/views/layer/compare/layercompare.html
+++ b/views/layer/compare/layercompare.html
@@ -1,0 +1,30 @@
+<div class="flex-fill w-100 d-flex flex-column">
+  <div class="d-flex flex-fill flex-column modal-body">
+    <div class="form-group">
+      <button class="btn btn-primary" ng-click="ctrl.fit()" title="Fit loaded layers to fully display in the view">
+        <i class="fas fa-expand-arrows-alt"></i>
+        Fit to Window
+      </button>
+      <button class="btn btn-primary" ng-click="ctrl.swap()" title="Swap the compare order">
+        <i class="fas fa-exchange-alt"></i>
+        Swap Layers
+      </button>
+    </div>
+    <div class="d-flex flex-fill border c-layer-compare-container js-layer-compare-container">
+      <div class="c-layer-compare-slider js-layer-compare-slider">
+        <div class="c-layer-compare-handle" ng-mousedown="ctrl.toggleDrag($event)">
+          <i class="fas fa-angle-left"></i>
+          <i class="fas fa-angle-right"></i>
+        </div>
+      </div>
+      <div class="c-layer-compare-item js-layer-compare-right"></div>
+      <div class="c-layer-compare-item c-layer-compare-top js-layer-compare-left"></div>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-secondary" ng-click="ctrl.close()">
+      <i class="fas fa-times"></i>
+      Close
+    </button>
+  </div>
+</div>

--- a/views/layer/compare/layercompare.html
+++ b/views/layer/compare/layercompare.html
@@ -1,10 +1,6 @@
 <div class="flex-fill w-100 d-flex flex-column">
   <div class="d-flex flex-fill flex-column modal-body">
     <div class="form-group">
-      <button class="btn btn-primary" ng-click="ctrl.fit()" title="Fit loaded layers to fully display in the view">
-        <i class="fas fa-expand-arrows-alt"></i>
-        Fit to Window
-      </button>
       <button class="btn btn-primary" ng-click="ctrl.swap()" title="Swap the compare order">
         <i class="fas fa-exchange-alt"></i>
         Swap Layers

--- a/views/layers.html
+++ b/views/layers.html
@@ -36,36 +36,20 @@
       </div>
     </div>
     <div class="col-auto pl-0">
+      <div class="btn-group">
+        <button class="btn btn-sm btn-secondary" title="Toggle Tile Layers" ng-click="layers.toggleTileLayers()">
+          <img ng-src="{{tilesBtnIcon}}">
+        </button>
+        <button class="btn btn-sm btn-secondary" title="Toggle Feature Layers" ng-click="layers.toggleFeatureLayers()">
+          <img ng-src="{{featuresBtnIcon}}">
+        </button>
+      </div>
       <div class="btn-group add-data-group" ng-right-click="layers.openMenu('.add-data-group')">
         <button class="btn btn-sm btn-success" title="Add data to the map" ng-click="layers.toggle('addData')"
           ng-class="{active: layers.isWindowActive('addData')}">
           <i class="fa fa-plus"></i>
-          Add Data
         </button>
         <button class="btn btn-sm btn-success dropdown-toggle" ng-click="layers.openMenu('.add-data-group')"></button>
-      </div>
-    </div>
-  </div>
-
-  <div class="form-row align-items-center flex-shrink-0 mt-1">
-    <div class="col-auto d-flex flex-fill justify-content-between">
-      <div>
-        <button class="btn btn-sm btn-secondary" title="Toggle Tile Layers" ng-click="layers.toggleTileLayers()">
-          <img ng-src="{{tilesBtnIcon}}">
-          Toggle Tiles
-        </button>
-        <button class="btn btn-sm btn-secondary" title="Toggle Feature Layers" ng-click="layers.toggleFeatureLayers()">
-          <img ng-src="{{featuresBtnIcon}}">
-          Toggle Features
-        </button>
-      </div>
-      <div class="flex-shrink-0">
-        <button class="btn btn-sm btn-primary dropdown-toggle" title="Perform actions on selected layer(s)"
-            ng-click="layers.openSelectedActionsMenu($event)"
-            ng-disabled="!selected || !selected.length">
-          <i class="far fa-check-square"></i>
-          Selected Actions
-        </button>
       </div>
     </div>
   </div>

--- a/views/layers.html
+++ b/views/layers.html
@@ -36,20 +36,36 @@
       </div>
     </div>
     <div class="col-auto pl-0">
-      <div class="btn-group">
-        <button class="btn btn-sm btn-secondary" title="Toggle Tile Layers" ng-click="layers.toggleTileLayers()">
-          <img ng-src="{{tilesBtnIcon}}">
-        </button>
-        <button class="btn btn-sm btn-secondary" title="Toggle Feature Layers" ng-click="layers.toggleFeatureLayers()">
-          <img ng-src="{{featuresBtnIcon}}">
-        </button>
-      </div>
       <div class="btn-group add-data-group" ng-right-click="layers.openMenu('.add-data-group')">
         <button class="btn btn-sm btn-success" title="Add data to the map" ng-click="layers.toggle('addData')"
           ng-class="{active: layers.isWindowActive('addData')}">
           <i class="fa fa-plus"></i>
+          Add Data
         </button>
         <button class="btn btn-sm btn-success dropdown-toggle" ng-click="layers.openMenu('.add-data-group')"></button>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-row align-items-center flex-shrink-0 mt-1">
+    <div class="col-auto d-flex flex-fill justify-content-between">
+      <div>
+        <button class="btn btn-sm btn-secondary" title="Toggle Tile Layers" ng-click="layers.toggleTileLayers()">
+          <img ng-src="{{tilesBtnIcon}}">
+          Toggle Tiles
+        </button>
+        <button class="btn btn-sm btn-secondary" title="Toggle Feature Layers" ng-click="layers.toggleFeatureLayers()">
+          <img ng-src="{{featuresBtnIcon}}">
+          Toggle Features
+        </button>
+      </div>
+      <div class="flex-shrink-0">
+        <button class="btn btn-sm btn-primary dropdown-toggle" title="Perform actions on selected layer(s)"
+            ng-click="layers.openSelectedActionsMenu($event)"
+            ng-disabled="!selected || !selected.length">
+          <i class="far fa-check-square"></i>
+          Selected Actions
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This adds a new UI that compares two layers side-by-side with a slider control in the middle. To get to the UI, select two layers in the Layers window, right-click (or hit the new Selected Actions button), and choose Compare Layers.

### Other Changes

- Changed the default width of the Layers window to avoid collapsing the new/updated buttons by default. Layers window defaults can also be configured via the `os.layers.defaults` settings key.
- The Toggle Tiles button now correctly sets the enabled state (checkbox) instead of the layer visibility state (eye icon, which isn't displayed on tile layers).

