### PR TITLE
build(lint): re-enable html linting and lint in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "lint:html": "html-validate 'views/**/*.html'",
     "lint:css": "sass-lint -v -s scss -i 'scss/nolint/**/*.scss' 'scss/**/*.scss'",
     "lint:js": "eslint --cache 'src/**/*.js' 'tasks/**/*.js'",
-    "lint": "npm run lint:js && npm run lint:css",
+    "lint": "run-p lint:js lint:css lint:html",
     "precompile:resolve": "cp addlayer.js .build",
     "compile:resolve": "os-resolve --outputDir .build --defineRoots $(cat .build/version)",
     "postcompile:resolve": "node scripts/addlayer-replace.js",


### PR DESCRIPTION
This was disabled on the release branch and merged into master.

I also made the lint steps run in parallel because they're all independent and this should speed up the build a bit.