### PR TITLE
fix(electron): set maximum memory in preload script and fix type

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
     "npm-run-all": "^4.1.5",
     "opensphere-build-closure-helper": "^7.0.0",
     "opensphere-build-index": "^4.0.0",
-    "opensphere-build-resolver": "^8.1.0",
+    "opensphere-build-resolver": "^9.0.0",
     "opensphere-state-schema": "^2.10.0",
     "postcss": "^8.2.6",
     "postcss-cli": "^8.3.1",

--- a/scripts/electron/preload.js
+++ b/scripts/electron/preload.js
@@ -4,7 +4,7 @@ const url = require('url');
 
 const CookieEventType = require('../cookieeventtype.js');
 const SettingsEventType = require('../settingseventtype.js');
-const {getMaximumMemory, getSystemMemory, setMaximumMemory} = require('../memconfig.js');
+const {getMaximumMemory, getSystemMemory, setMaximumMemory, setMemoryFlags} = require('../memconfig.js');
 
 /**
  * Registered certificate handler.
@@ -165,7 +165,7 @@ const getMaxMemory = () => {
  * @param {number} value The max memory value.
  */
 const setMaxMemory = (value) => {
-  setMaximumMemory(value);
+  setMaximumMemory(String(value));
 };
 
 /**
@@ -245,6 +245,9 @@ const setSettingsFiles = async (value) => settingsFiles = await ipcRenderer.invo
 const restart = () => {
   ipcRenderer.send('restart');
 };
+
+// Set memory flags on the renderer process.
+setMemoryFlags();
 
 // Handle certificate select event from the main process.
 ipcRenderer.on(EventType.CERT_SELECT, selectClientCertificate);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10207,10 +10207,10 @@ opensphere-build-index@^4.0.0:
     bluebird "^3.4.6"
     yargs "^6.3.0"
 
-opensphere-build-resolver@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/opensphere-build-resolver/-/opensphere-build-resolver-8.1.0.tgz#06a3dffe482f7f6496cb99312fbe8af3da5a2227"
-  integrity sha512-IHOUj6ix63Kwv6I8QUjCZ8Q+i9lctHV8YNtmtyf2bTR3bXt6jSFod8RYFZEnNoQm5thmQ0XX99y7Q98LJHX2ww==
+opensphere-build-resolver@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/opensphere-build-resolver/-/opensphere-build-resolver-9.0.0.tgz#c725325d279c34959338f55cb72e5b0826d2d82a"
+  integrity sha512-QrszH6gqVkyFI98XkdZIvOpbDYLJeUe73guegKdh1iLWIo2/bO74WwPsdNXf+bL348l+1P3lDjdZ5k0M1VEwjA==
   dependencies:
     bluebird "^3.7.2"
     clone "^2.1.2"


### PR DESCRIPTION
Changes to support upgrading Electron to the latest (currently 13.1.6).

This PR supplements ngageoint/opensphere-electron/pull/42.

- Loads maximum memory config in the preload script.
- Electron 13.x limits types that can be passed across the context bridge, and numbers are not allowed. Converted the memory value to a string before sending to the main process.