### PR TITLE
fix(importer): compare mappings by id and field

### DIFF
--- a/src/os/im/importer.js
+++ b/src/os/im/importer.js
@@ -583,14 +583,10 @@ os.im.Importer.prototype.addMapping_ = function(mapping) {
     this.mappings = [mapping];
   } else {
     var endIndex = this.mappings.length - 1;
-    const mapIndex = this.mappings.findIndex((temp) => temp.toField == mapping.toField);
 
     if (os.implements(this.mappings[endIndex], os.im.mapping.AltMappingId)) {
       // if alt mapping is already at the end, leave it there
       this.mappings.splice(endIndex, 0, mapping);
-    } else if (mapIndex >= 0) {
-      // if the mapping already exists, replace it
-      this.mappings.splice(mapIndex, 1, mapping);
     } else {
       this.mappings.push(mapping);
     }


### PR DESCRIPTION
Mappings don't all have a `toField` property, so that isn't a useful way to compare them. Consider mappings equivalent if they share an id and field.