### PR TITLE
fix(importer): revert mapping comparison

### DIFF
--- a/src/os/im/importer.js
+++ b/src/os/im/importer.js
@@ -583,14 +583,10 @@ os.im.Importer.prototype.addMapping_ = function(mapping) {
     this.mappings = [mapping];
   } else {
     var endIndex = this.mappings.length - 1;
-    const mapIndex = this.mappings.findIndex((temp) => temp.toField == mapping.toField);
 
     if (os.implements(this.mappings[endIndex], os.im.mapping.AltMappingId)) {
       // if alt mapping is already at the end, leave it there
       this.mappings.splice(endIndex, 0, mapping);
-    } else if (mapIndex >= 0) {
-      // if the mapping already exists, replace it
-      this.mappings.splice(mapIndex, 1, mapping);
     } else {
       this.mappings.push(mapping);
     }


### PR DESCRIPTION
This reverts deduplication added for ellipse mappings in #1318, because it does not work with all mapping types (`toField` is specific to `RenameMapping`). This causes mappings like LAT/LON to replace one another. We will need to consider a different approach for the ellipse mapping issue.