### PR TITLE
fix(query): use IMapContainer instance and add flyToExtent to interface

### DIFF
--- a/src/os/map/imapcontainer.js
+++ b/src/os/map/imapcontainer.js
@@ -66,6 +66,15 @@ class IMapContainer {
    * @return {PluggableMap}
    */
   getMap() {}
+
+  /**
+   * Fits the view to an extent.
+   *
+   * @param {ol.Extent} extent The extent to fit
+   * @param {number=} opt_buffer Scale factor for the extent to provide a buffer around the displayed area
+   * @param {number=} opt_maxZoom The maximum zoom level for the updated view
+   */
+  flyToExtent(extent, opt_buffer, opt_maxZoom) {}
 }
 
 exports = IMapContainer;

--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -551,11 +551,7 @@ class MapContainer extends EventTarget {
   }
 
   /**
-   * Fits the view to an extent.
-   *
-   * @param {ol.Extent} extent The extent to fit
-   * @param {number=} opt_buffer Scale factor for the extent to provide a buffer around the displayed area
-   * @param {number=} opt_maxZoom The maximum zoom level for the updated view
+   * @inheritDoc
    */
   flyToExtent(extent, opt_buffer, opt_maxZoom) {
     if (extent && extent.indexOf(Infinity) != -1 || extent.indexOf(-Infinity) != -1) {

--- a/src/os/ui/ol/olmap.js
+++ b/src/os/ui/ol/olmap.js
@@ -301,11 +301,7 @@ os.ui.ol.OLMap.prototype.containsFeature = function(feature) {
 
 
 /**
- * Fits the view to an extent.
- *
- * @param {ol.Extent} extent The extent to fit
- * @param {number=} opt_buffer Scale factor for the extent to provide a buffer around the displayed area
- * @param {number=} opt_maxZoom The maximum zoom level for the updated view
+ * @inheritDoc
  */
 os.ui.ol.OLMap.prototype.flyToExtent = function(extent, opt_buffer, opt_maxZoom) {
   var map = this.getMap();

--- a/src/os/ui/query/area/userarea.js
+++ b/src/os/ui/query/area/userarea.js
@@ -459,7 +459,7 @@ os.ui.query.area.UserAreaCtrl.prototype.getAreaTypeTooltip = function(type) {
  * @protected
  */
 os.ui.query.area.UserAreaCtrl.prototype.setArea = function(area) {
-  var mapContainer = os.map.instance.getMapContainer();
+  var mapContainer = os.map.instance.getIMapContainer();
 
   if (this['area']) {
     // remove the existing preview


### PR DESCRIPTION
`flyToExtent` was implemented on both `OLMap` and `MapContainer`, but was not present on the `IMapContainer` interface. This caused a compile error when transforming map classes, which was incorrectly fixed in `os.ui.query.area.UserAreaCtrl#setArea` by using `getMapContainer`.