### PR TITLE
fix(provider): ensure modal body is located before scrolling

### DIFF
--- a/src/os/ui/providerimport.js
+++ b/src/os/ui/providerimport.js
@@ -171,8 +171,15 @@ os.ui.ProviderImportCtrl.prototype.onTestFinished = function(event) {
 
       // Scroll to the bottom to show any error messages
       this.scope.$applyAsync(() => {
-        const container = this.element.closest('.modal-body');
-        container.animate({'scrollTop': container[0].scrollHeight}, 500);
+        // Depending on how this form is embedded, the modal body may be a child or parent.
+        let container = this.element.find('.modal-body');
+        if (!container.length) {
+          container = this.element.closest('.modal-body');
+        }
+
+        if (container.length) {
+          container.animate({'scrollTop': container[0].scrollHeight}, 500);
+        }
       });
     }
   }


### PR DESCRIPTION
This controller is used both as an embedded form (in Add Server), and as the complete window content (on import auto detect or edit). In the second case, the `modal-body` element is a child of the controller's root element. This wasn't being resolved properly, and the `container[0]` reference was undefined causing an error.