### PR TITLE
feat(importer): alert the user when a mapping a bad column

### DIFF
--- a/src/os/data/filedescriptor.js
+++ b/src/os/data/filedescriptor.js
@@ -5,6 +5,8 @@ goog.require('os.ui.file.ui.defaultFileNodeUIDirective');
 
 const log = goog.require('goog.log');
 const Settings = goog.require('os.config.Settings');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const AlertManager = goog.require('os.alert.AlertManager');
 const IMappingDescriptor = goog.require('os.data.IMappingDescriptor');
 const IUrlDescriptor = goog.require('os.data.IUrlDescriptor');
 const LayerSyncDescriptor = goog.require('os.data.LayerSyncDescriptor');
@@ -182,10 +184,57 @@ class FileDescriptor extends LayerSyncDescriptor {
   updateMappings(layer) {
     const source = /** @type {RequestSource} */ (layer.getSource());
     const importer = source.getImporter();
+    importer.listen(os.events.EventType.COMPLETE, this.alertUser, false, this);
 
     this.saveDescriptor();
     importer.setMappings(this.getMappings());
     source.refresh();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  alertUser(event) {
+    const importer = /** @type {!os.im.IImporter} */ (event.target);
+    const mappings = this.getMappings();
+    const failedMappingsCount = importer.getMappingFailCount();
+    const totalCount = importer.getTotalProcessed();
+    let allFailed = false;
+    const title = this.getTitle();
+    let failMessage = `<div><b>Issues with mappings for ${title}</b></div>`;
+
+    if (totalCount > 0) {
+      for (let i = 0; i < mappings.length; i++) {
+        const mapping = mappings[i];
+        const id = mapping.getId();
+        const numFailed = failedMappingsCount[id];
+        const key = mapping.getId();
+
+        allFailed = (numFailed == totalCount || allFailed);
+
+        if (numFailed !== 0) {
+          const message = `<div> ${key}: ${numFailed} out of ${totalCount} features failed to map this column.<div>`;
+          failMessage += message;
+          // Send failures to the logger
+          goog.log.error(logger,
+              `${key}: Failed to map ${numFailed} out of ${totalCount} features for ${title}.`);
+        } else if (numFailed === 0) {
+          goog.log.info(logger,
+              `${key}: Successfully mapped all ${totalCount} features for ${title}. There were ${numFailed} failures.`);
+        }
+
+        console.log(`${id}: ${numFailed} failed out of ${totalCount}`);
+      }
+    }
+
+    // Generate an alert but only if some failed
+    const someFailed = Object.values(failedMappingsCount).some((m) => m > 0);
+    if (someFailed && this.alertUser_) {
+      failMessage += `<div>${allFailed ? 'All' : 'Some'} Ellipse Data failed to map for this layer. 
+      Please check to ensure your data is formatted correctly.<div>`;
+      const errorType = allFailed ? AlertEventSeverity.ERROR : AlertEventSeverity.WARNING;
+      AlertManager.getInstance().sendAlert(failMessage, errorType);
+    }
   }
 
   /**

--- a/src/os/data/imappingdescriptor.js
+++ b/src/os/data/imappingdescriptor.js
@@ -38,6 +38,12 @@ class IMappingDescriptor {
    * @param {ILayer=} layer
    */
   updateMappings(layer) {}
+
+
+  /**
+   * Log the the number of failed/successful mappings.
+   */
+  alertUser() {}
 }
 
 /**

--- a/src/os/im/mapping/altmapping.js
+++ b/src/os/im/mapping/altmapping.js
@@ -181,15 +181,16 @@ os.im.mapping.AltMapping.prototype.getLabel = function() {
  * @suppress {accessControls} To allow direct access to feature metadata.
  */
 os.im.mapping.AltMapping.prototype.execute = function(feature) {
+  let result = false;
   if (feature && this.field) {
-    var targetField = this.toField || this.field;
+    const targetField = this.toField || this.field;
     if (feature && feature.values_[os.Fields.GEOM_ALT] != null) {
       // don't do a thing.  the alt was set in the point geom
       // just set our derived column to whatever that says
-      os.im.mapping.setItemField(feature, targetField, Math.round(feature.values_[os.Fields.GEOM_ALT]));
+      result = os.im.mapping.setItemField(feature, targetField, Math.round(feature.values_[os.Fields.GEOM_ALT]));
     } else {
       // perform the mapping
-      var current = Number(os.im.mapping.getItemField(feature, this.field));
+      let current = Number(os.im.mapping.getItemField(feature, this.field));
       if (!isNaN(current)) {
         // convert to units set externally.  This defaults to meters, so if it
         // hasn't been changed externally, we are just doing meters to meters
@@ -200,12 +201,12 @@ os.im.mapping.AltMapping.prototype.execute = function(feature) {
 
         if (!this.unitsOverride) {
           // check for a units field
-          var u = os.im.mapping.getBestFieldMatch(feature, this.getUnitsRegExp());
+          const u = os.im.mapping.getBestFieldMatch(feature, this.getUnitsRegExp());
           if (u) {
             this.unitsField = u;
           }
           // if a unit field was detected, get the value and convert it to meters from that
-          var curUnits = /** @type {string|undefined} */(os.im.mapping.getItemField(feature, this.unitsField));
+          let curUnits = /** @type {string|undefined} */(os.im.mapping.getItemField(feature, this.unitsField));
 
           // look up the units from the data in our list of known units (example: FEET ->ft)
           if (curUnits) {
@@ -228,11 +229,12 @@ os.im.mapping.AltMapping.prototype.execute = function(feature) {
       }
 
       // set the new field
-      os.im.mapping.setItemField(feature, targetField, current);
+      result = os.im.mapping.setItemField(feature, targetField, current);
 
       os.feature.setAltitude(feature, targetField);
     }
   }
+  return result;
 };
 
 

--- a/src/os/im/mapping/imapping.js
+++ b/src/os/im/mapping/imapping.js
@@ -92,6 +92,7 @@ os.im.mapping.IMapping.prototype.getFieldsChanged;
  * Executes the mapping on the given item
  * @param {T} item The item to modify
  * @param {S=} opt_targetItem The target item. Could be of different type or the same as item.
+ * @return {boolean} Whether the mapping was successful (i.e. not undefined/empty string/null)
  */
 os.im.mapping.IMapping.prototype.execute;
 

--- a/src/os/im/mapping/latlonmapping.js
+++ b/src/os/im/mapping/latlonmapping.js
@@ -40,16 +40,18 @@ os.im.mapping.MappingRegistry.getInstance().registerMapping(
  * @override
  */
 os.im.mapping.LatLonMapping.prototype.execute = function(item) {
+  const result = false;
   if (this.field) {
-    var fieldValue = os.im.mapping.getItemField(item, this.field) || '';
-
+    let fieldValue = os.im.mapping.getItemField(item, this.field) || '';
     // try to idiot proof the position string
     fieldValue = goog.string.trim(fieldValue.replace(os.geo.COORD_CLEANER, ''));
+
     if (fieldValue) {
-      var location = this.parseLatLon(fieldValue, this.customFormat);
+      result = fieldValue !== undefined || fieldValue !== '' || fieldValue !== null;
+      const location = this.parseLatLon(fieldValue, this.customFormat);
       if (location) {
-        var coord = [location.lon, location.lat];
-        var geom = new ol.geom.Point(coord).osTransform();
+        const coord = [location.lon, location.lat];
+        const geom = new ol.geom.Point(coord).osTransform();
 
         item.suppressEvents();
         item.setGeometry(geom);
@@ -59,4 +61,5 @@ os.im.mapping.LatLonMapping.prototype.execute = function(item) {
       }
     }
   }
+  return result;
 };

--- a/src/os/im/mapping/latmapping.js
+++ b/src/os/im/mapping/latmapping.js
@@ -104,19 +104,22 @@ os.im.mapping.LatMapping.prototype.getScoreType = function() {
  * @inheritDoc
  */
 os.im.mapping.LatMapping.prototype.execute = function(item) {
-  var value = NaN;
+  let value = NaN;
+  let result = false;
   if (this.field) {
-    var fieldValue = os.im.mapping.getItemField(item, this.field);
+    let fieldValue = os.im.mapping.getItemField(item, this.field);
     if (fieldValue != null) {
       fieldValue = String(fieldValue).replace(os.geo.COORD_CLEANER, '');
       value = os.geo.parseLat(fieldValue, this.customFormat);
 
       if (!isNaN(value)) {
-        os.im.mapping.setItemField(item, this.coordField, value);
+        result = os.im.mapping.setItemField(item, this.coordField, value);
         this.addGeometry(item);
       }
     }
   }
+
+  return result;
 };
 
 

--- a/src/os/im/mapping/location/abstractbaselatorlonmapping.js
+++ b/src/os/im/mapping/location/abstractbaselatorlonmapping.js
@@ -88,6 +88,7 @@ os.im.mapping.location.AbstractBaseLatOrLonMapping.prototype.getScoreType = func
  */
 os.im.mapping.location.AbstractBaseLatOrLonMapping.prototype.execute = function(item, targetItem) {
   var value = NaN;
+  let result = false;
   if (!targetItem) {
     targetItem = item;
   }
@@ -99,11 +100,12 @@ os.im.mapping.location.AbstractBaseLatOrLonMapping.prototype.execute = function(
       value = this.parseFn(fieldValue, this.customFormat);
 
       if (!isNaN(value)) {
-        os.im.mapping.setItemField(item, this.coordField, value);
+        result = os.im.mapping.setItemField(item, this.coordField, value);
         this.addGeometry(item, targetItem);
       }
     }
   }
+  return result;
 };
 
 

--- a/src/os/im/mapping/location/baselatlonmapping.js
+++ b/src/os/im/mapping/location/baselatlonmapping.js
@@ -34,12 +34,14 @@ goog.inherits(os.im.mapping.location.BaseLatLonMapping, os.im.mapping.AbstractPo
  * @override
  */
 os.im.mapping.location.BaseLatLonMapping.prototype.execute = function(item, opt_targetItem) {
+  let result = false;
   if (this.field) {
     var fieldValue = os.im.mapping.getItemField(item, this.field) || '';
 
     // try to idiot proof the position string
     fieldValue = goog.string.trim(fieldValue.replace(os.geo.COORD_CLEANER, ''));
     if (fieldValue) {
+      result = fieldValue !== undefined || fieldValue !== '' || fieldValue !== null;
       var location = this.parseLatLon(fieldValue, this.customFormat);
       if (location) {
         var coord = [location.lon, location.lat];
@@ -49,6 +51,7 @@ os.im.mapping.location.BaseLatLonMapping.prototype.execute = function(item, opt_
       }
     }
   }
+  return result;
 };
 
 

--- a/src/os/im/mapping/location/basemgrsmapping.js
+++ b/src/os/im/mapping/location/basemgrsmapping.js
@@ -27,12 +27,14 @@ goog.inherits(os.im.mapping.location.BaseMGRSMapping, os.im.mapping.AbstractPosi
  * @override
  */
 os.im.mapping.location.BaseMGRSMapping.prototype.execute = function(item, opt_targetItem) {
+  let result = false;
   if (this.field) {
     var mgrs = os.im.mapping.getItemField(item, this.field);
     if (mgrs) {
       mgrs = mgrs.replace(/\s/g, '');
       mgrs = mgrs.toUpperCase();
 
+      result = mgrs !== undefined || mgrs !== '' || mgrs !== null;
       if (mgrs.match(os.geo.MGRS_REGEXP)) {
         var coord = osasm.toLonLat(mgrs);
         item[this.field] = coord;
@@ -41,6 +43,7 @@ os.im.mapping.location.BaseMGRSMapping.prototype.execute = function(item, opt_ta
       }
     }
   }
+  return result;
 };
 
 

--- a/src/os/im/mapping/lonmapping.js
+++ b/src/os/im/mapping/lonmapping.js
@@ -44,6 +44,8 @@ os.im.mapping.LonMapping.LON_REGEX = /(\b|_)lon(g(i(t(u(d(e)?)?)?)?)?)?(\b|_)/i;
  */
 os.im.mapping.LonMapping.prototype.execute = function(item) {
   var value = NaN;
+  let result = false;
+
   if (this.field) {
     var fieldValue = os.im.mapping.getItemField(item, this.field);
     if (fieldValue != null) {
@@ -51,11 +53,13 @@ os.im.mapping.LonMapping.prototype.execute = function(item) {
       value = os.geo.parseLon(fieldValue, this.customFormat);
 
       if (!isNaN(value)) {
-        os.im.mapping.setItemField(item, this.coordField, value);
+        result = os.im.mapping.setItemField(item, this.coordField, value);
         this.addGeometry(item);
       }
     }
   }
+
+  return result;
 };
 
 

--- a/src/os/im/mapping/mapping.js
+++ b/src/os/im/mapping/mapping.js
@@ -106,6 +106,7 @@ os.im.mapping.getItemFields = function(item) {
  * @param {Object} item
  * @param {string} field
  * @param {*} value
+ * @return {boolean}
  */
 os.im.mapping.setItemField = function(item, field, value) {
   if (os.instanceOf(item, ol.Feature.NAME)) {
@@ -120,6 +121,8 @@ os.im.mapping.setItemField = function(item, field, value) {
   } else {
     delete item[field];
   }
+
+  return value !== undefined || value !== '' || value !== null;
 };
 
 

--- a/src/os/im/mapping/mgrsmapping.js
+++ b/src/os/im/mapping/mgrsmapping.js
@@ -41,9 +41,11 @@ os.im.mapping.MappingRegistry.getInstance().registerMapping(
  * @override
  */
 os.im.mapping.MGRSMapping.prototype.execute = function(item) {
+  let result = false;
   if (this.field) {
     var mgrs = os.im.mapping.getItemField(item, this.field);
     if (mgrs) {
+      result = mgrs !== undefined || mgrs !== '' || mgrs !== null;
       mgrs = mgrs.replace(/\s/g, '');
       mgrs = mgrs.toUpperCase();
 
@@ -58,4 +60,5 @@ os.im.mapping.MGRSMapping.prototype.execute = function(item) {
       }
     }
   }
+  return result;
 };

--- a/src/os/im/mapping/radiusmapping.js
+++ b/src/os/im/mapping/radiusmapping.js
@@ -110,20 +110,23 @@ os.im.mapping.RadiusMapping.prototype.getLabel = function() {
  * @inheritDoc
  */
 os.im.mapping.RadiusMapping.prototype.execute = function(item) {
+  let result = false;
   if (this.field && this.toField) {
-    var current = os.math.parseNumber(os.im.mapping.getItemField(item, this.field));
+    let current = os.math.parseNumber(os.im.mapping.getItemField(item, this.field));
     if (!isNaN(current)) {
       if (this.units) {
         current = os.math.convertUnits(current, os.fields.DEFAULT_RADIUS_UNIT, this.units);
       }
 
-      os.im.mapping.setItemField(item, this.toField, current);
+      result = os.im.mapping.setItemField(item, this.toField, current);
 
       if (this.units && this.unitsField) {
-        os.im.mapping.setItemField(item, this.unitsField, this.units);
+        result = result && os.im.mapping.setItemField(item, this.unitsField, this.units);
       }
     }
   }
+
+  return result;
 };
 
 

--- a/src/os/im/mapping/renamemapping.js
+++ b/src/os/im/mapping/renamemapping.js
@@ -37,6 +37,7 @@ goog.inherits(os.im.mapping.RenameMapping, os.im.mapping.AbstractMapping);
  */
 os.im.mapping.RenameMapping.ID = 'Rename';
 
+
 // Register the mapping.
 os.im.mapping.MappingRegistry.getInstance().registerMapping(
     os.im.mapping.RenameMapping.ID, os.im.mapping.RenameMapping);
@@ -78,16 +79,19 @@ os.im.mapping.RenameMapping.prototype.getFieldsChanged = function() {
  * @inheritDoc
  */
 os.im.mapping.RenameMapping.prototype.execute = function(item) {
+  let result = false;
   if (this.field && this.toField && this.toField != this.field) {
     var current = os.im.mapping.getItemField(item, this.field);
     if (current != null) {
-      os.im.mapping.setItemField(item, this.toField, current);
+      result = os.im.mapping.setItemField(item, this.toField, current);
 
       if (!this.keepOriginal) {
         os.im.mapping.setItemField(item, this.field, undefined);
       }
     }
   }
+
+  return result;
 };
 
 

--- a/src/os/im/mapping/rulemapping.js
+++ b/src/os/im/mapping/rulemapping.js
@@ -165,17 +165,20 @@ os.im.mapping.RuleMapping.prototype.getScoreType = function() {
  * @inheritDoc
  */
 os.im.mapping.RuleMapping.prototype.execute = function(item, targetItem) {
+  let result = false;
   if (this.field && this.targetField) {
-    var fieldValue = os.im.mapping.getItemField(item, this.field);
-    var rules = this.getRules();
-    var staticValue = this.staticValue;
+    const fieldValue = os.im.mapping.getItemField(item, this.field);
+    const rules = this.getRules();
+    const staticValue = this.staticValue;
 
     if (staticValue) {
+      result = staticValue !== undefined || staticValue !== '' || staticValue !== null;
       // map to the static value every time
       targetItem[this.targetField] = staticValue;
     } else if (fieldValue && rules) {
+      result = fieldValue !== undefined || fieldValue !== '' || fieldValue !== null;
       // select the appropriate rule and use its mappedValue
-      var rule = ol.array.find(rules, function(r) {
+      const rule = ol.array.find(rules, function(r) {
         return r['initialValue'] == fieldValue;
       });
 
@@ -184,6 +187,7 @@ os.im.mapping.RuleMapping.prototype.execute = function(item, targetItem) {
       }
     }
   }
+  return result;
 };
 
 

--- a/src/os/im/mapping/staticmapping.js
+++ b/src/os/im/mapping/staticmapping.js
@@ -55,9 +55,11 @@ os.im.mapping.StaticMapping.prototype.getLabel = function() {
  * @inheritDoc
  */
 os.im.mapping.StaticMapping.prototype.execute = function(item) {
+  let result = false;
   if (item && this.field && (this.replace || os.im.mapping.getItemField(item, this.field) == null)) {
-    os.im.mapping.setItemField(item, this.field, this.value);
+    result = os.im.mapping.setItemField(item, this.field, this.value);
   }
+  return result;
 };
 
 

--- a/src/os/im/mapping/time/datemapping.js
+++ b/src/os/im/mapping/time/datemapping.js
@@ -52,9 +52,11 @@ os.im.mapping.time.DateMapping.prototype.getScore = function() {
  * @inheritDoc
  */
 os.im.mapping.time.DateMapping.prototype.updateItem = function(t, item) {
+  let result = false;
   if (this.field) {
-    os.im.mapping.setItemField(item, this.field, os.time.format(new Date(t), os.time.Duration.DAY));
+    result = os.im.mapping.setItemField(item, this.field, os.time.format(new Date(t), os.time.Duration.DAY));
   }
+  return result;
 };
 
 

--- a/src/os/im/mapping/time/datetimemapping.js
+++ b/src/os/im/mapping/time/datetimemapping.js
@@ -142,19 +142,21 @@ os.im.mapping.time.DateTimeMapping.TIMEZONE_REGEX = /(Z|UTC|[+-]\d\d+:?\d\d)$/;
  * @inheritDoc
  */
 os.im.mapping.time.DateTimeMapping.prototype.execute = function(item) {
+  let result = false;
   if (this.field && this.format) {
     var current = /** @type {string|number} */ (os.im.mapping.getItemField(item, this.field));
     var t = this.getTimestamp(current);
 
     if (this.applyTime_) {
       var old = os.im.mapping.getItemField(item, os.data.RecordField.TIME) || null; // not an ITime! See THIN-8508
-      os.im.mapping.setItemField(item, os.data.RecordField.TIME, this.getTime(t, old));
+      result = os.im.mapping.setItemField(item, os.data.RecordField.TIME, this.getTime(t, old));
     } else if (t) {
       // only modify the original field if the time wasn't mapped to recordTime. note that this will prevent the
       // field from being used by other date mappings because the format will no longer apply.
-      this.updateItem(t, item);
+      result = this.updateItem(t, item);
     }
   }
+  return result;
 };
 
 
@@ -310,11 +312,14 @@ os.im.mapping.time.DateTimeMapping.prototype.getRegex = function() {
  *
  * @param {number} t The time in ms UTC
  * @param {T} item The item to update
+ * @return {boolean}
  */
 os.im.mapping.time.DateTimeMapping.prototype.updateItem = function(t, item) {
+  let result = false;
   if (this.field) {
-    os.im.mapping.setItemField(item, this.field, new Date(t).toISOString());
+    result = os.im.mapping.setItemField(item, this.field, new Date(t).toISOString());
   }
+  return result;
 };
 
 

--- a/src/os/im/mapping/wktmapping.js
+++ b/src/os/im/mapping/wktmapping.js
@@ -97,6 +97,7 @@ os.im.mapping.WKTMapping.prototype.getScoreType = function() {
  * @inheritDoc
  */
 os.im.mapping.WKTMapping.prototype.execute = function(item) {
+  let result = false;
   if (this.field) {
     var fieldValue = os.im.mapping.getItemField(item, this.field);
     if (fieldValue) {
@@ -106,6 +107,7 @@ os.im.mapping.WKTMapping.prototype.execute = function(item) {
       });
 
       if (geom) {
+        result = geom !== undefined || geom !== '' || geom !== null;
         item.suppressEvents();
         item.set(this.field, undefined);
         item.setGeometry(geom);
@@ -113,6 +115,7 @@ os.im.mapping.WKTMapping.prototype.execute = function(item) {
       }
     }
   }
+  return result;
 };
 
 


### PR DESCRIPTION
Send the user an alert when the mapping results in an undefined column. It should tell the user what mapping failed, and how many out of the total failed. A warning message appears is some but not all features fail to map, an error message appears if all features fail to map. 

~~This will only show for mappings that use the `toField` attribute (anything extending `os.im.mapping.RenameMapping`)~~
This will now only show for ellipse mappings (radius, semi major, semi minor, and orientation).

I have hit a snag though with CSV files and being able to get the total number of results from the importer that I'm not sure how to work around just yet. 