### PR TITLE
fix(featureactions): fix missing right click menu on feature actions

### DIFF
--- a/src/plugin/featureaction/featureactionnodemenu.js
+++ b/src/plugin/featureaction/featureactionnodemenu.js
@@ -387,7 +387,9 @@ const onToggleOffEvent_ = function(event) {
 };
 
 exports = {
-  MENU,
+  get MENU() {
+    return MENU;
+  },
   EventType,
   setup,
   dispose,


### PR DESCRIPTION
Right now if you open up feature actions and right click on one or more selected FAs, the right click context menu will not show up.