### PR TITLE
fix(places): places now save their uninterpolated geometries

### DIFF
--- a/src/os/interpolate.js
+++ b/src/os/interpolate.js
@@ -34,6 +34,7 @@ const SettingsKey = {
 let TransformSet;
 
 /**
+ * Local interpolate config.
  * @type {!Config}
  */
 const interpolateConfig = {
@@ -68,8 +69,7 @@ let overrideMethod = null;
  * @return {boolean} Whether or not all the values needed for interpolation are present
  */
 const getEnabled = function() {
-  var config = interpolateConfig;
-  return !!(interpolateEnabled && config.distance > 1000);
+  return !!(interpolateEnabled && interpolateConfig.distance > 1000);
 };
 
 /**
@@ -94,7 +94,6 @@ const getConfig = function() {
  */
 const setConfig = function(config) {
   if (config) {
-    var interpolateConfig = interpolateConfig;
     interpolateConfig.method = /** @type {Method} */ (config['method']) || interpolateConfig.method;
     interpolateConfig.distance = /** @type {number} */ (config['distance']) || interpolateConfig.thresholdPercent;
   }

--- a/src/os/ui/featureedit.js
+++ b/src/os/ui/featureedit.js
@@ -1451,6 +1451,11 @@ os.ui.FeatureEditCtrl.prototype.saveGeometry_ = function(feature) {
   } else if (this.originalGeometry && (!geom || geom === this.originalGeometry)) {
     geom = this.originalGeometry.clone();
     feature.setGeometry(geom);
+
+    const method = /** @type {os.interpolate.Method} */ (geom.get(os.interpolate.METHOD_FIELD));
+    os.interpolate.beginTempInterpolation(undefined, method);
+    os.interpolate.interpolateFeature(feature);
+    os.interpolate.endTempInterpolation();
   }
 
   this.updateAltMode(feature);

--- a/src/plugin/file/kml/kmltreeexporter.js
+++ b/src/plugin/file/kml/kmltreeexporter.js
@@ -10,6 +10,7 @@ const GeometryCollection = goog.require('ol.geom.GeometryCollection');
 const Point = goog.require('ol.geom.Point');
 const RecordField = goog.require('os.data.RecordField');
 const osFeature = goog.require('os.feature');
+const {ORIGINAL_GEOM_FIELD} = goog.require('os.interpolate');
 const osSource = goog.require('os.source');
 const TriState = goog.require('os.structs.TriState');
 const osStyle = goog.require('os.style');
@@ -18,6 +19,7 @@ const AbstractKMLExporter = goog.require('os.ui.file.kml.AbstractKMLExporter');
 const xml = goog.require('os.xml');
 const pluginFileKmlExport = goog.require('plugin.file.kml.export');
 
+const Geometry = goog.requireType('ol.geom.Geometry');
 const kml = goog.requireType('plugin.file.kml');
 
 
@@ -321,7 +323,7 @@ class KMLTreeExporter extends AbstractKMLExporter {
       var geomAltitudeMode;
       var featAltitudeMode = feature.get(RecordField.ALTITUDE_MODE);
 
-      geometry = feature.getGeometry();
+      geometry = /** @type {Geometry} */ (feature.get(ORIGINAL_GEOM_FIELD)) || feature.getGeometry();
       if (geometry) {
         geometry = geometry.clone().toLonLat();
         geomAltitudeMode = geometry.get(RecordField.ALTITUDE_MODE);

--- a/src/plugin/places/places.js
+++ b/src/plugin/places/places.js
@@ -23,6 +23,7 @@ const kml = goog.require('plugin.file.kml');
 const KMLField = goog.require('plugin.file.kml.KMLField');
 const KMLTreeExporter = goog.require('plugin.file.kml.KMLTreeExporter');
 const KMLNodeAdd = goog.require('plugin.file.kml.cmd.KMLNodeAdd');
+const {METHOD_FIELD} = goog.require('os.interpolate');
 const {getKMLRoot, updateFolder, updatePlacemark} = goog.require('plugin.file.kml.ui');
 
 const KMLLayerNode = goog.requireType('plugin.file.kml.ui.KMLLayerNode');
@@ -88,7 +89,8 @@ const ExportFields = [
   Fields.SEMI_MINOR_UNITS,
   Fields.ORIENTATION,
   Fields.BEARING,
-  RecordField.RING_OPTIONS
+  RecordField.RING_OPTIONS,
+  METHOD_FIELD
 ];
 
 /**

--- a/src/plugin/places/placesmenu.js
+++ b/src/plugin/places/placesmenu.js
@@ -11,6 +11,7 @@ const DataManager = goog.require('os.data.DataManager');
 const LayerNode = goog.require('os.data.LayerNode');
 const RecordField = goog.require('os.data.RecordField');
 const osFeature = goog.require('os.feature');
+const {ORIGINAL_GEOM_FIELD} = goog.require('os.interpolate');
 const VectorLayer = goog.require('os.layer.Vector');
 const metrics = goog.require('os.metrics');
 const VectorSource = goog.require('os.source.Vector');
@@ -772,7 +773,7 @@ const saveSpatialToPlaces = function(event, opt_annotation) {
     if (features.length === 1) {
       name = osFeature.getTitle(features[0]);
 
-      var featureGeom = features[0].getGeometry();
+      var featureGeom = features[0].get(ORIGINAL_GEOM_FIELD) || features[0].getGeometry();
       if (featureGeom) {
         geometry = featureGeom.clone();
       }

--- a/src/plugin/places/ui/quickaddplaces.js
+++ b/src/plugin/places/ui/quickaddplaces.js
@@ -8,6 +8,7 @@ const {ROOT} = goog.require('os');
 const CommandProcessor = goog.require('os.command.CommandProcessor');
 const ParallelCommand = goog.require('os.command.ParallelCommand');
 const RecordField = goog.require('os.data.RecordField');
+const interpolate = goog.require('os.interpolate');
 const FeatureEditCtrl = goog.require('os.ui.FeatureEditCtrl');
 const Module = goog.require('os.ui.Module');
 const WindowEventType = goog.require('os.ui.WindowEventType');
@@ -155,6 +156,12 @@ class Controller extends Disposable {
         },
         startTime: Date.now()
       }));
+
+      // re-interpolate the feature now to ensure that it has the original geometry and correct interpolation method
+      const method = /** @type {interpolate.Method} */ (geometry.get(interpolate.METHOD_FIELD));
+      interpolate.beginTempInterpolation(undefined, method);
+      interpolate.interpolateFeature(place.getFeature());
+      interpolate.endTempInterpolation();
 
       if (place) {
         this.added.push(place);


### PR DESCRIPTION
Places can now be modified properly based on their originally drawn geometries rather than their interpolated ones. This should not affect exports of KML geometries in other contexts, only when we write them to Places.