### PR TITLE
fix(file): cleans up issues with id/visibility columns

### DIFF
--- a/src/os/im/featureimporter.js
+++ b/src/os/im/featureimporter.js
@@ -91,7 +91,11 @@ os.im.FeatureImporter.prototype.addItemInternal = function(item) {
       // this works around inadvertant duplicate IDs, but maintains the original ID
       var realId = feature.id_;
       feature.setId(ol.getUid(feature) + '');
-      feature.values_[os.Fields.ID] = realId;
+
+      // set the ID field only if it wasn't already set
+      if (feature.values_[os.Fields.ID] == null) {
+        feature.values_[os.Fields.ID] = realId;
+      }
     }
 
     // simplify the geometry if possible

--- a/src/plugin/file/kml/kmlparser.js
+++ b/src/plugin/file/kml/kmlparser.js
@@ -1804,7 +1804,7 @@ const logger = log.getLogger('plugin.file.kml.KMLParser');
  * @private
  * @const
  */
-KMLParser.SKIPPED_COLUMNS_ = /^(geometry|recordtime|time|styleurl|_kmlStyle)$/i;
+KMLParser.SKIPPED_COLUMNS_ = /^(geometry|recordtime|time|styleurl|visibility|_kmlStyle)$/i;
 
 
 /**


### PR DESCRIPTION
ID columns will now no longer replace or lose their columns on importing exported data. KMLs no longer show a phantom visibility column.