### PR TITLE
build(ol): fix compiled error with missing ol.ext namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "ol-cesium/externs/olcsx.js"
       ],
       "entry_point": [
+        "goog:ol.ext",
         "goog:osmain"
       ],
       "extra_annotation_name": [

--- a/src/os/ol/ext.js
+++ b/src/os/ol/ext.js
@@ -1,0 +1,14 @@
+/**
+ * @fileoverview This fixes a compiler issue where ol.ext.rbush fails to load because ol.ext doesn't exist. In the
+ *               compiled application, the goog.provide call for ol.ext.rbush quotes the string which does not rename
+ *               any of that namespace, but the ol.ext.rbush assignment at the top of the file is using compiled
+ *               symbols that were never created.
+ */
+goog.module('ol.ext');
+goog.module.declareLegacyNamespace();
+
+/**
+ * Create the ol.ext namespace.
+ * @type {!Object}
+ */
+exports = {};

--- a/src/os/ol/typedefs.js
+++ b/src/os/ol/typedefs.js
@@ -3,14 +3,9 @@
  * loaded as an externs file, the Closure Compiler assumes "ol" is already
  * defined which causes errors in the compiled output.
  *
- * The 'ol.ext' provide is added due to a similar issue with the 'ol.ext.*'
- * provides in openlayers/build/ol.ext. The ol.ext namespace is never created,
- * so the child namespaces fail to initialize.
- *
  * @suppress {checkTypes} To ignore JSDoc references to OL types, so they don't
  *                        need goog.require statements.
  */
-goog.provide('ol.ext');
 goog.provide('ol.typedefs');
 
 


### PR DESCRIPTION
The `ol.ext` compiler issue is dependent on application load order. This provides a new module that will create the namespace, that can be loaded as the first application `entry_point`. If any plugins are in use, this needs to be added to their `entry_point` configuration as well. The resolver will dedupe these, but `ol.ext` needs to be required first in the generated `.build/index.js`.