### PR TITLE
fix(overview): simplify resolution constraint on the overview map

### DIFF
--- a/src/os/mixin/mixin.js
+++ b/src/os/mixin/mixin.js
@@ -99,10 +99,6 @@ ol.renderer.canvas.VectorLayer.prototype.forEachFeatureAtCoordinate = function(c
    * @suppress {accessControls}
    */
   ol.renderer.canvas.Map.prototype.renderFrame = function(frameState) {
-    if (frameState && os.MapContainer.getInstance().is3DEnabled()) {
-      frameState.viewState.rotation = 0;
-    }
-
     // Browsers differ wildly in their interpretation of style.width/height = 100%
     // on a canvas and how that style width/height is related to the canvas width/height.
     //

--- a/src/plugin/overview/overviewmapcontrol.js
+++ b/src/plugin/overview/overviewmapcontrol.js
@@ -68,6 +68,7 @@ class OverviewMap extends OLOverviewMap {
   /**
    * Updates the view with the current projection
    *
+   * @suppress {accessControls} To allow replacing the resolution constraint function.
    * @private
    */
   updateView_() {
@@ -76,6 +77,13 @@ class OverviewMap extends OLOverviewMap {
       minZoom: osMap.MIN_ZOOM,
       maxZoom: osMap.MAX_ZOOM
     });
+
+    // Don't contrain the view resolution for the overview map. This improves overview map behavior when fitting the
+    // view to the current map extent. Without this, small changes in rotation can drastically change the resolution
+    // which makes the overmap appear jumpy. This is especially prevalent in the 3D view.
+    const minResolution = view.getMinResolution();
+    const maxResolution = view.getMaxResolution();
+    view.constraints_.resolution = (resolution) => Math.max(minResolution, Math.min(maxResolution, resolution));
 
     if (this.getMap()) {
       var mainView = this.getMap().getView();


### PR DESCRIPTION
The new layer compare feature does not work well when the main map is in 3D and the camera rotated.

This is caused by a mixin we added to prevent some unwanted behavior with the overview map, where small changes in rotation would cause the overview map to jump to a new zoom level that was 0.5-1 from the current zoom. When using mouse rotate in 3D, this causes the overview map to flicker as it zooms in/out rapidly as you rotate the camera.

To resolve this behavior, the resolution constraint has been simplified for the overview map's view to only constrain resolution within the min/max values.