### PR TITLE
fix(filter): fixes filter remove select, validation type bug

### DIFF
--- a/src/os/ui/filter/coltypecheckvalidation.js
+++ b/src/os/ui/filter/coltypecheckvalidation.js
@@ -37,17 +37,14 @@ const colTypeCheckLink = function($scope, $element, $attrs, $ctrl) {
        * @return {string|undefined}
        */
       function(viewValue) {
+        // try the type, but if for some reason we don't understand the type, use string which allows anything
         var key = $scope['expr']['column']['type'];
-        var pattern = FilterPatterns[key];
+        var pattern = FilterPatterns[key] || FilterPatterns['string'];
 
         if (pattern && pattern.test(viewValue)) {
           $ctrl.$setValidity('type', true);
           $element.attr('title', '');
           return viewValue;
-        } else {
-          $ctrl.$setValidity('type', false);
-          $element.attr('title', 'Please enter a valid ' + key);
-          return undefined;
         }
       });
 };

--- a/src/os/ui/filter/filterpatterns.js
+++ b/src/os/ui/filter/filterpatterns.js
@@ -7,7 +7,9 @@ goog.module.declareLegacyNamespace();
  */
 exports = {
   'string': /.*/,
+  'text': /.*/,
   'decimal': /^\-?\d+((\.|\,)\d+)?$/,
   'integer': /^\-?\d+$/,
+  'real': /^\-?\d+((\.|\,)\d+)?$/,
   'recordtime': /^\-?\d+((\.|\,)\d+)?$/
 };

--- a/src/os/ui/filter/ui/groupnodeui.js
+++ b/src/os/ui/filter/ui/groupnodeui.js
@@ -14,17 +14,20 @@ const GroupNode = goog.requireType('os.ui.filter.ui.GroupNode');
 const directive = () => ({
   restrict: 'AE',
   replace: true,
-  template: '<span class="flex-fill form-inline">' +
-      '<span class="flex-fill">' +
-      '<select class="custom-select" ng-model="item.grouping"' +
-      ' ng-options="key for (key, value) in groupUi.groups"' +
-      ' title="Whether results can match any or all filters in the group"/>' +
-      '</span>' +
-      '<span>' +
-      '<span ng-show="!groupUi.isRoot" ng-click="groupUi.remove()">' +
-      '<i class="fa fa-times fa-fw c-glyph" title="Remove the expression"></i></span>' +
-      '</span>' +
-      '</span>',
+  template: `
+      <span class="flex-fill form-inline">
+        <span class="flex-fill">
+          <select class="custom-select" ng-model="item.grouping"
+            ng-options="key for (key, value) in groupUi.groups"
+            title="Whether results can match any or all filters in the group">
+          </select>
+        </span>
+        <span>
+          <span ng-show="!groupUi.isRoot" ng-click="groupUi.remove()">
+            <i class="fa fa-times fa-fw c-glyph" title="Remove the expression"></i>
+          </span>
+        </span>
+      </span>`,
   controller: Controller,
   controllerAs: 'groupUi'
 });


### PR DESCRIPTION
The `<select>` element wasn't being terminated correctly, causing the rest of the HTML to be dropped in rendering. I also encountered an issue with SHP columns being typed as "text" and "real", which caused us to be unable to create feature action filters on them.