### PR TITLE
Fix state provider instance and filter load bug

### DIFF
--- a/src/os/data/datamanager.js
+++ b/src/os/data/datamanager.js
@@ -227,7 +227,11 @@ class DataManager extends EventTarget {
         var clazz = this.providerTypes_[type].clazz;
 
         if (clazz.getInstance) {
+          // Class uses goog.addSingletonGetter getInstance function.
           dp = clazz.getInstance();
+        } else if (clazz['getInstance']) {
+          // Class uses a static exported getInstance function.
+          dp = /** @type {IDataProvider} */ (clazz['getInstance']());
         } else {
           dp = /** @type {IDataProvider} */ (new clazz());
         }

--- a/src/os/state/v2/basefilterstate.js
+++ b/src/os/state/v2/basefilterstate.js
@@ -2,6 +2,7 @@ goog.module('os.state.v2.BaseFilter');
 
 const {getChildren, getFirstElementChild} = goog.require('goog.dom');
 const {loadXml, serialize} = goog.require('goog.dom.xml');
+const {find} = goog.require('ol.array');
 const FilterEntry = goog.require('os.filter.FilterEntry');
 const {getFilterManager, getQueryManager} = goog.require('os.query.instance');
 const AbstractState = goog.require('os.state.AbstractState');
@@ -174,12 +175,12 @@ class BaseFilter extends XMLState {
 
         var filters = /** @type {Array} */ (filtersNode ? filtersNode.getElementsByTagName('filter') : []);
         // Does this filterid exist for this layer
-        var found = filters.find(function(filter) {
+        var found = find(filters, function(filter) {
           return filter.getAttribute('id') == filterId && filter.getAttribute('type') == layerId ||
               filter.getAttribute('id') == cloneId && filter.getAttribute('type') == layerId;
         });
         if (!found) {
-          var similiar = filters.find(function(filter) {
+          var similiar = find(filters, function(filter) {
             return filter.getAttribute('id') == filterId;
           });
           if (similiar) {

--- a/src/os/ui/state/stateprovider.js
+++ b/src/os/ui/state/stateprovider.js
@@ -63,6 +63,7 @@ class StateProvider extends DescriptorProvider {
   /**
    * Get the global instance.
    * @return {!StateProvider}
+   * @export
    */
   static getInstance() {
     if (!instance) {


### PR DESCRIPTION
In `DataManager#createProvider` we check for a `setInstance` function on the provider class. This works if the class uses `addSingletonGetter` to add the call, but not with a `static getInstance` function. The latter will be compiled to a different symbol, which prevents the data manager from detecting its presence.

Static functions do not work well with interfaces, so instead of implementing an interface and checking that in the data manager, this uses `@export` to prevent renaming the function so the data manager can look for `clazz['getInstance']`.

This also fixes a bug caused by replacing `ol.array.find` with `Array#find`, on something that isn't an array. In this situation, the object is a `NodeList`.