### PR TITLE
fix(wms): remove empty wms parameters

### DIFF
--- a/src/os/ui/ogc/ogcserver.js
+++ b/src/os/ui/ogc/ogcserver.js
@@ -1102,6 +1102,10 @@ export default class OGCServer extends AbstractLoadingServer {
                 this.wmsParams_ = new QueryData();
               }
               this.wmsParams_.extend(newParams);
+
+              // if the resource has a trailing &, the QueryData ends up with empty key/value pairs,
+              // which causes issues elsewhere, so strip them here
+              this.wmsParams_.remove('');
             }
           }
         }


### PR DESCRIPTION
Certain Geoserver WMS resource URLs had trailing &'s, which the goog URI code was parsing into empty parameters. These were causing states containing those layers to fail to write. This prevents that issue at the source of the problem and anything else that may have misbehaved from an empty KVP.

fixes #1372 