### PR TITLE
fix(kml): ignore altitude in LatLonQuad coordinates

### DIFF
--- a/src/os/geo/geo.js
+++ b/src/os/geo/geo.js
@@ -1660,14 +1660,15 @@ export const getAverageAltitude = function(coords) {
 };
 
 /**
- * Tests to see if two coordinates are in the same spot.
+ * Tests if two coordinates share the same x/y value, within a tolerance of 1E-12. Altitude is not considered if
+ * present.
  *
  * @param {Array<number>} c1 The first coordinate
  * @param {Array<number>} c2 The second coordinate
  * @return {boolean} If the coordinates are the same
  */
 export const isSameCoordinate = function(c1, c2) {
-  if (c1 == null || c2 == null || !c1.length == 2 || !c2.length == 2) {
+  if (c1 == null || c2 == null || c1.length < 2 || c2.length < 2) {
     return false;
   }
 

--- a/src/os/mixin/imagesourcemixin.js
+++ b/src/os/mixin/imagesourcemixin.js
@@ -98,7 +98,9 @@ ImageSource.prototype.originalGetImage = ImageSource.prototype.getImage;
  */
 ImageSource.prototype.getImage = function(extent, resolution, pixelRatio, projection) {
   const image = this.originalGetImage(extent, resolution, pixelRatio, projection);
-  image.olSource = this;
+  if (image) {
+    image.olSource = this;
+  }
   return image;
 };
 

--- a/test/os/geo/geo.test.js
+++ b/test/os/geo/geo.test.js
@@ -1343,4 +1343,25 @@ describe('os.geo', function() {
   it('should convert negative lon close to whole degrees to DMS with symbols', function() {
     expect(geo.toSexagesimal(-168.9999999, true, true)).toEqual('169° 00\' 00.00" W');
   });
+
+  it('should test if two coordinates are the same', function() {
+    // Including null always returns false
+    expect(geo.isSameCoordinate(null, null)).toBe(false);
+    expect(geo.isSameCoordinate([0, 0], null)).toBe(false);
+    expect(geo.isSameCoordinate(null, [0, 0])).toBe(false);
+
+    // Coordinates with fewer than 2 values always return false
+    expect(geo.isSameCoordinate([0], [0])).toBe(false);
+    expect(geo.isSameCoordinate([0], [0, 0])).toBe(false);
+    expect(geo.isSameCoordinate([0, 0], [0])).toBe(false);
+
+    // Same coordinates return true
+    expect(geo.isSameCoordinate([0, 0], [0, 0])).toBe(true);
+    expect(geo.isSameCoordinate([5, 10], [5, 10])).toBe(true);
+    expect(geo.isSameCoordinate([12.345, 67.89], [12.345, 67.89])).toBe(true);
+
+    // Both values must match
+    expect(geo.isSameCoordinate([5, 10], [5, 11])).toBe(false);
+    expect(geo.isSameCoordinate([5, 10], [6, 10])).toBe(false);
+  });
 });


### PR DESCRIPTION
- Fixed the high level issue that values beyond `lon, lat` in a `LatLonQuad` should be ignored.
- `isSameCoordinate`'s length check was not working because the `!` was misplaced which converted the length to a boolean. Those expressions would have always evaluated to false, so those checks effectively did nothing. I changed the checks to verify the coordinate has at least 2 values to avoid breaking cases where an altitude (or potentially time) is present.