### PR TITLE
feat(vector): allow using a function for custom highlight

### DIFF
--- a/src/os/source/vectorsource.js
+++ b/src/os/source/vectorsource.js
@@ -2770,10 +2770,14 @@ export default class Vector extends OLVectorSource {
         }
 
         for (var i = 0, n = items.length; i < n; i++) {
-          var customStyle = items[i].get(StyleType.CUSTOM_HIGHLIGHT);
+          var feature = items[i];
+          var customStyle = /** @type {osStyle.StyleConfigLike} */ (feature.get(StyleType.CUSTOM_HIGHLIGHT));
           var style = replace ? defaultStyle : customStyle || defaultStyle;
+          if (typeof style === 'function') {
+            style = style(feature);
+          }
 
-          items[i].set(StyleType.HIGHLIGHT, style);
+          feature.set(StyleType.HIGHLIGHT, style);
         }
         osStyle.setFeaturesStyle(items, this);
       }

--- a/src/os/style/style.js
+++ b/src/os/style/style.js
@@ -173,6 +173,11 @@ export const DEFAULT_LOB_MULTIPLIER = 1;
 export const ARROW_ICON = ROOT + 'images/arrow.png';
 
 /**
+ * @typedef {function(Feature):Object|Object}
+ */
+export let StyleConfigLike;
+
+/**
  * @type {Object<string, *>}
  */
 export const POINT_CONFIG = {

--- a/src/os/ui/search/featureresultcard.js
+++ b/src/os/ui/search/featureresultcard.js
@@ -22,6 +22,7 @@ const {listen, unlisten} = goog.require('ol.events');
 
 const Feature = goog.requireType('ol.Feature');
 const {default: AbstractSearchResult} = goog.requireType('os.search.AbstractSearchResult');
+const {StyleConfigLike} = goog.requireType('os.style');
 
 
 /**
@@ -74,7 +75,7 @@ export default class Controller extends Disposable {
 
     /**
      * The style config to use when highlighting the search result.
-     * @type {!Object}
+     * @type {!StyleConfigLike}
      * @protected
      */
     this.highlightConfig = DEFAULT_HIGHLIGHT_CONFIG;
@@ -160,7 +161,9 @@ export default class Controller extends Disposable {
    */
   addFeatureHighlight() {
     if (this.feature && this.layer) {
-      this.feature.set(StyleType.HIGHLIGHT, this.highlightConfig);
+      const highlightConfig = typeof this.highlightConfig === 'function' ?
+          this.highlightConfig(this.feature) : this.highlightConfig;
+      this.feature.set(StyleType.HIGHLIGHT, highlightConfig);
       setFeatureStyle(this.feature);
       notifyStyleChange(this.layer, [this.feature]);
     }


### PR DESCRIPTION
Vector sources check a custom highlight field on features when setting the highlight style. This is currently expected to be an object, but this PR allows it to be a function that returns the config object. This is similar to how OpenLayers handles styles, and allows the highlight to be dynamic if needed.

I also changed the hover interaction so the highlighted feature will be cleared on view change. This is in support of changing highlight styles based on the current map view, for example filling polygons until they take up too much of the view. The highlight clear does not immediately happen in 2D because OpenLayers only replays existing canvas draw instructions while interacting for performance reasons. Once interaction stops, features will be redrawn without the highlight. In 3D the change happens immediately on pan/zoom.