### PR TITLE
Replace/document stylelint-disable usage

### DIFF
--- a/scss/os/_mixins.scss
+++ b/scss/os/_mixins.scss
@@ -1,11 +1,9 @@
 @mixin grab-cursor {
   cursor: grab;
-  cursor: -webkit-grab; // stylelint-disable-line declaration-block-no-duplicate-properties, value-no-vendor-prefix
 }
 
 @mixin grabbing-cursor {
   cursor: grabbing;
-  cursor: -webkit-grabbing; // stylelint-disable-line declaration-block-no-duplicate-properties, value-no-vendor-prefix
 }
 
 // This extends bootstraps bg-<variants> to also have background colors
@@ -45,18 +43,16 @@
 }
 
 @mixin font-awesome {
-  // stylelint-disable order/properties-alphabetical-order
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
   display: inline-block;
   // Fall back on the Font Awesome 4 font-family for backward compatibility.
   font-family: 'Font Awesome 5 Free', 'FontAwesome';
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
   font-style: normal;
   font-variant: normal;
   font-weight: 900;
   line-height: 1;
   text-rendering: auto;
-  // stylelint-enable order/properties-alphabetical-order
 }
 
 @mixin u-bg-color-content($color) {

--- a/scss/os/_ngvalidate.scss
+++ b/scss/os/_ngvalidate.scss
@@ -6,13 +6,13 @@ form {
   div:not([ng-form]).ng-invalid.ng-dirty,
   select.ng-invalid.ng-dirty,
   textarea.ng-invalid.ng-dirty {
-    @extend .form-control, .is-invalid; // stylelint-disable-line at-rule-disallowed-list
+    @extend .form-control, .is-invalid; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
   }
 
   .select2-container.ng-invalid.ng-dirty {
     .select2-choice,
     .select2-choices {
-      @extend .form-control, .is-invalid; // stylelint-disable-line at-rule-disallowed-list
+      @extend .form-control, .is-invalid; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
     }
   }
 }

--- a/scss/os/_overrides_bootstrap.scss
+++ b/scss/os/_overrides_bootstrap.scss
@@ -161,7 +161,10 @@ ul {
 }
 
 // Replace the autofilled input colors in Webkit-based browsers
-@-webkit-keyframes autofill { // stylelint-disable-line at-rule-no-vendor-prefix
+// Reference: https://stackoverflow.com/a/37432260
+
+// stylelint-disable at-rule-no-vendor-prefix, property-no-vendor-prefix
+@-webkit-keyframes autofill {
   to {
     background: $input-bg;
     color: $input-color;
@@ -169,9 +172,10 @@ ul {
 }
 
 input:-webkit-autofill {
-  -webkit-animation-fill-mode: both; // stylelint-disable-line property-no-vendor-prefix
-  -webkit-animation-name: autofill; // stylelint-disable-line property-no-vendor-prefix
+  -webkit-animation-fill-mode: both;
+  -webkit-animation-name: autofill;
 }
+// stylelint-enable at-rule-no-vendor-prefix, property-no-vendor-prefix
 
 .mb-1px {
   margin-bottom: 1px;

--- a/scss/os/_overrides_jqueryui.scss
+++ b/scss/os/_overrides_jqueryui.scss
@@ -106,7 +106,7 @@
   z-index: $zindex-fixed + 1;
 
   // This gets the same styles defined for dropdown-menu. Used for when themes specify after the fact
-  @extend .dropdown-menu; // stylelint-disable-line at-rule-disallowed-list
+  @extend .dropdown-menu; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
 
   // jQueryUI offsets active menu items. Disable that.
   .ui-state-active {
@@ -120,7 +120,7 @@
     padding: 0;
 
     // This gets the same styles defined for dropdown-item. Used for when themes specify after the fact
-    @extend .dropdown-item; // stylelint-disable-line at-rule-disallowed-list
+    @extend .dropdown-item; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
 
     i.fa,
     i.fab,
@@ -142,14 +142,14 @@
         text-decoration: none;
 
         // This gets the same styles defined for dropdown-item:focus. Used for when themes specify after the fact
-        @extend .dropdown-item, :focus; // stylelint-disable-line at-rule-disallowed-list
+        @extend .dropdown-item, :focus; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
       }
     }
   }
 
   .ui-menu-divider {
     // This gets the same styles defined for dropdown-divider. Used for when themes specify after the fact
-    @extend .dropdown-divider; // stylelint-disable-line at-rule-disallowed-list
+    @extend .dropdown-divider; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
   }
 
   .dropdown-item {

--- a/scss/os/_overrides_openlayers.scss
+++ b/scss/os/_overrides_openlayers.scss
@@ -184,9 +184,7 @@
 .ol-attribution,
 .ol-attribution.ol-uncollapsible {
   bottom: .25rem;
-  // Chrome < 41 needs initial
-  height: initial;
-  height: unset; // stylelint-disable-line declaration-block-no-duplicate-properties
+  height: unset;
   left: .25rem;
   right: auto;
   text-align: left;
@@ -248,9 +246,7 @@
     bottom: auto;
     left: auto;
     min-width: 10rem;
-    // Chrome < 41 needs initial
-    padding: initial;
-    padding: unset; // stylelint-disable-line declaration-block-no-duplicate-properties
+    padding: unset;
   }
 }
 

--- a/scss/os/_overrides_select2.scss
+++ b/scss/os/_overrides_select2.scss
@@ -42,26 +42,22 @@
         }
       }
 
-      .select2-search-field {
-        input.select2-input {
-          background: transparent;
-          border: 0;
-          box-shadow: none;
-          color: $body-color;
-          font-family: $font-family-base;
-          padding: 0;
+      .select2-search-field input.select2-input {
+        background: transparent;
+        border: 0;
+        box-shadow: none;
+        color: $body-color;
+        font-family: $font-family-base;
+        padding: 0;
 
-          // stylelint-disable-next-line max-nesting-depth
-          &.select2-active {
-            background: $input-bg no-repeat 100% !important;
-          }
+        &.select2-active {
+          background: $input-bg no-repeat 100% !important;
+        }
 
-          // stylelint-disable-next-line max-nesting-depth
-          &::placeholder {
-            color: $input-placeholder-color;
-            // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
-            opacity: 1;
-          }
+        &::placeholder {
+          color: $input-placeholder-color;
+          // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
+          opacity: 1;
         }
       }
 

--- a/scss/os/_overrides_select2.scss
+++ b/scss/os/_overrides_select2.scss
@@ -6,7 +6,7 @@
   }
 
   .select2-choice {
-    @extend .form-control; // stylelint-disable-line at-rule-disallowed-list
+    @extend .form-control; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
     background-image: none;
     height: $input-height;
     text-decoration: none !important;
@@ -23,7 +23,7 @@
     width: 100%;
 
     .select2-choices {
-      @extend .form-control; // stylelint-disable-line at-rule-disallowed-list
+      @extend .form-control; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
       background-image: none;
       min-width: 10rem;
 
@@ -94,7 +94,7 @@
 
   // Single select2
   .select2-search input {
-    @extend .form-control; // stylelint-disable-line at-rule-disallowed-list
+    @extend .form-control; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
     background-image: none;
   }
 

--- a/scss/os/_overrides_tuieditor.scss
+++ b/scss/os/_overrides_tuieditor.scss
@@ -217,7 +217,7 @@
     }
 
     blockquote {
-      @extend .blockquote; // stylelint-disable-line at-rule-disallowed-list
+      @extend .blockquote; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
       border-left: 4px solid $gray-600;
       margin-bottom: 1rem;
       margin-top: 0;
@@ -230,7 +230,7 @@
     }
 
     attr {
-      @extend .initialism; // stylelint-disable-line at-rule-disallowed-list
+      @extend .initialism; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
     }
 
     table {
@@ -399,7 +399,7 @@
       .te-url-input,
       .te-image-url-input,
       .te-alt-text-input {
-        @extend .form-control; // stylelint-disable-line at-rule-disallowed-list
+        @extend .form-control; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
       }
     }
 
@@ -411,13 +411,13 @@
     }
 
     .te-ok-button {
-      @extend .btn; // stylelint-disable-line at-rule-disallowed-list
-      @extend .btn-primary; // stylelint-disable-line at-rule-disallowed-list
+      @extend .btn; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
+      @extend .btn-primary; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
     }
 
     .te-close-button {
-      @extend .btn; // stylelint-disable-line at-rule-disallowed-list
-      @extend .btn-secondary; // stylelint-disable-line at-rule-disallowed-list
+      @extend .btn; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
+      @extend .btn-secondary; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
     }
   }
 
@@ -483,8 +483,8 @@
     }
 
     .tui-scrollsync {
-      @extend .btn; // stylelint-disable-line at-rule-disallowed-list
-      @extend .btn-secondary; // stylelint-disable-line at-rule-disallowed-list
+      @extend .btn; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
+      @extend .btn-secondary; // stylelint-disable-line at-rule-disallowed-list -- Reusing Bootstrap styles.
 
       &:after {
         font-size: $font-size-sm;

--- a/scss/os/_timeline.scss
+++ b/scss/os/_timeline.scss
@@ -231,9 +231,7 @@
 .axis {
   text {
     font: 10px sans-serif;
-    // Chrome < 41 needs initial
-    stroke: initial;
-    stroke: unset; // stylelint-disable-line declaration-block-no-duplicate-properties
+    stroke: unset;
   }
 
   path,

--- a/scss/os/_tristate.scss
+++ b/scss/os/_tristate.scss
@@ -130,9 +130,7 @@
   border: 3px solid #555;
   border-right: 0;
   border-top: 0;
-  // Chrome < 41 needs initial
-  display: initial;
-  display: unset; // stylelint-disable-line declaration-block-no-duplicate-properties
+  display: unset;
   height: 5.5px;
   transform: rotate(-45deg);
   width: 9px;
@@ -141,9 +139,7 @@
 .c-tristate-both label {
   background: #555;
   border-radius: 2px;
-  // Chrome < 41 needs initial
-  display: initial;
-  display: unset; // stylelint-disable-line declaration-block-no-duplicate-properties
+  display: unset;
   height: 9px;
   left: 2px;
   top: 2px;

--- a/scss/os/_tristate.scss
+++ b/scss/os/_tristate.scss
@@ -64,20 +64,11 @@
 // Tristate checkbox
 
 .c-tristate {
-  background: #fcfff4;
-  // stylelint-disable-next-line declaration-block-no-duplicate-properties
-  background:
-    linear-gradient(
-      #fcfff4 0%,
-      #dfe5d7 40%,
-      #b3bead 100%
-    );
+  background: $gray-100;
   border-radius: 3px;
   box-sizing: border-box;
   cursor: pointer;
   display: inline-block;
-  // stylelint-disable-next-line function-name-case
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfff4', endColorstr='#b3bead', GradientType=0);
   flex-shrink: 0;
   height: 13px;
   margin-left: 15px auto;


### PR DESCRIPTION
We have a number of `stylelint-disable` lines in our SCSS. I revisited these to either replace them with compliant SCSS or document why they're still needed.

Below is a summary of the changes, in order of the commits in this PR.

1. Removed `cursor: -webkit-(grab|grabbing)` because these are automatically added by our sass build. The font smoothing vendor prefixes are allowed, and improve the look of Font Awesome icons on MacOS. Because vendor prefixes are dropped for the sort, these are expected to be sorted as `font-smoothing`.
2. We enforce a max nesting depth and had one violation that wasn't caught by the old `sass-lint` rules, but was easily fixed by combining selectors without intermediate styles.
3. We had a number of `<style>: initial` properties that were directed at Chrome < 41, which did not support `unset`. We no longer support Chrome < 41, so these were removed.
4. Adding gradients to tri state checkboxes both had a duplicate `background` for browsers that did not support gradients, and an IE `filter` function that violated the lowercase function name rule. The gradient isn't needed, and has been replaced with a flat `background` color which now uses the `$gray-100` variable instead of a more arbitrary gray.
5. Documented the remaining disable lines. Most of these were reusing Bootstrap styles for UI's provided by other vendor libraries (Angular, jQuery, select2, and tui-editor). We also have some SCSS that replaces the form autofill styles in Webkit-based browsers, which we will also continue to allow.

Resolves #141.