### PR TITLE
fix(state): fix issue loading states with filters

### DIFF
--- a/src/os/state/v2/basefilterstate.js
+++ b/src/os/state/v2/basefilterstate.js
@@ -1,5 +1,6 @@
 goog.declareModuleId('os.state.v2.BaseFilter');
 
+import {forEach} from '../../array/array.js';
 import FilterEntry from '../../filter/filterentry.js';
 import {getFilterManager, getQueryManager} from '../../query/queryinstance.js';
 import {XMLNS, appendElement, clone as cloneXml} from '../../xml.js';
@@ -169,7 +170,7 @@ export default class BaseFilter extends XMLState {
     if (filtersNode !== undefined && entries !== undefined) {
       entries = entries ? entries.getElementsByTagName('queryEntry') : [];
 
-      entries.forEach(function(entry) {
+      forEach(entries, function(entry) {
         var filterId = entry.getAttribute('filterId');
         var layerId = entry.getAttribute('layerId');
         var cloneId = filterId + '_' + layerId;


### PR DESCRIPTION
This was another overzealous replacement (on my part) for a `forEach` convenience method on something that's not an array (`NodeList`). Switched back to the convenience method that works on array-like objects.