### PR TITLE
Feat layer compare improvements

### DIFF
--- a/src/os/ui/menu/layermenu.js
+++ b/src/os/ui/menu/layermenu.js
@@ -123,13 +123,13 @@ export const setup = function() {
         label: 'Add to Left Compare',
         tooltip: 'Add the layer to the left side of the Layer Compare window',
         icons: ['<i class="fas fa-fw fa-layer-group"></i>'],
-        beforeRender: visibleIfCanAddToCompare,
+        beforeRender: goog.partial(visibleIfCanAddToCompare, 'left'),
         handler: handleAddLeftCompareLayers
       }, {
         label: 'Add to Right Compare',
         tooltip: 'Add the layer to the right side of the Layer Compare window',
         icons: ['<i class="fas fa-fw fa-layer-group"></i>'],
-        beforeRender: visibleIfCanAddToCompare,
+        beforeRender: goog.partial(visibleIfCanAddToCompare, 'right'),
         handler: handleAddRightCompareLayers
       }, {
         label: 'Go To',
@@ -651,11 +651,12 @@ const handleCompareLayers = function(event) {
 };
 
 /**
- * Show when selecting at least 1 layer and the Layer Compare window is already open.
+ * Show when an item isn't already on one side of the compare.
+ * @param {string} target The target side to check.
  * @param {Context} context The menu context.
  * @this {MenuItem}
  */
-const visibleIfCanAddToCompare = function(context) {
+const visibleIfCanAddToCompare = function(target, context) {
   let layers = getLayersFromContext(context);
   const controller = LayerCompareUI.getCompareController();
 
@@ -664,10 +665,10 @@ const visibleIfCanAddToCompare = function(context) {
 
   let hasLayer = false;
   if (controller && layers) {
-    hasLayer = layers.some((layer) => controller.hasLayer(layer));
+    hasLayer = layers.some((layer) => controller.hasLayer(layer, target));
   }
 
-  this.visible = LayerCompareUI.exists() && !!layers && layers.length > 0 && !hasLayer;
+  this.visible = !!controller && !!layers && layers.length > 0 && !hasLayer;
 };
 
 /**

--- a/views/layer/compare/layercompare.html
+++ b/views/layer/compare/layercompare.html
@@ -2,7 +2,7 @@
   <div class="d-flex flex-fill flex-column modal-body">
     <div class="form-row justify-content-between mx-2">
       <div>
-        <button class="btn btn-secondary" ng-click="ctrl.moveSelected('right')" title="Move selected layers to the right" ng-disabled="ctrl.leftSelected.length == 0">
+        <button class="btn btn-secondary" ng-click="ctrl.moveSelected('right')" title="Move selected layers to the right" ng-disabled="ctrl.disableMoveRight()">
           <i class="fas fa-fw fa-angle-right"></i> Move Selected
         </button>
       </div>
@@ -17,7 +17,7 @@
       </div>
 
       <div>
-        <button class="btn btn-secondary" ng-click="ctrl.moveSelected('left')" title="Move selected layers to the left" ng-disabled="ctrl.rightSelected.length == 0">
+        <button class="btn btn-secondary" ng-click="ctrl.moveSelected('left')" title="Move selected layers to the left" ng-disabled="ctrl.disableMoveLeft()">
           <i class="fas fa-fw fa-angle-left"></i> Move Selected
         </button>
       </div>


### PR DESCRIPTION
Makes the following improvements to the layer compare window:
- Adds the ability to zoom to layers in it with the right click menu.
- Allows adding the same layer to both sides of the compare for better comparisons against static data.
- Fixes issues with having the same layer on the same side more than once.
- Handles layers that are removed from the main map and disposed.