### PR TITLE
fix(places): only add temp preview feature to map container

### DIFF
--- a/src/os/ui/featureedit.js
+++ b/src/os/ui/featureedit.js
@@ -899,9 +899,11 @@ export class Controller extends Disposable {
     if (this.previewFeature) {
       this.saveToFeature(this.previewFeature);
 
-      var mapContainer = getMapContainer();
-      mapContainer.removeFeature(this.previewFeature);
-      mapContainer.addFeature(this.previewFeature);
+      if (this.previewFeature.getId() === this.tempFeatureId) {
+        const mapContainer = getMapContainer();
+        mapContainer.removeFeature(this.previewFeature);
+        mapContainer.addFeature(this.previewFeature);
+      }
 
       var layer = osFeature.getLayer(this.previewFeature);
       if (layer) {


### PR DESCRIPTION
This is an adjustment to [this change](https://github.com/ngageoint/opensphere/commit/4d5009c8b2fa7d8293fd85721e70b82fcdd3f479#diff-4d3b504b078016ec0674f86dbe54918b5224d8cd98ada9f0a6d801c1d26d74ee) which was intended to correct the preview not appearing in 3D when creating a new place from the Places tab. The geometry was not being synchronized if the feature initially had no geometry, so re-adding the feature resolved the issue. However we _only_ want to add the feature to the map container if it's a temporary preview feature (ie, during Create not Edit).