### PR TITLE
fix(state): allow filter sources to be null

### DIFF
--- a/src/os/state/v2/basefilterstate.js
+++ b/src/os/state/v2/basefilterstate.js
@@ -30,10 +30,10 @@ export default class BaseFilter extends XMLState {
     this.title = 'Filters';
 
     /**
-     * @type {!Array<!VectorSource>}
+     * @type {Array<!VectorSource>}
      * @protected
      */
-    this.sources = [];
+    this.sources = null;
   }
 
   /**
@@ -80,14 +80,14 @@ export default class BaseFilter extends XMLState {
   }
 
   /**
-   * @param {!Array<!VectorSource>} sources
+   * @param {Array<!VectorSource>} sources
    */
   setSources(sources) {
     this.sources = sources;
   }
 
   /**
-   * @return {!Array<!VectorSource>}
+   * @return {Array<!VectorSource>}
    */
   getSources() {
     return this.sources;


### PR DESCRIPTION
In the ESM transition, `this.sources` was initialized as an empty array. This fixed a compiler error (class properties must be defined in the constructor) but caused a bug with applications expecting the sources to be null/undefined if `setSources` was never called. This change represents the original behavior, which will process filters in `saveInternal` if the sources array is not defined.