### PR TITLE
Fix issues with annotations in screen capture

### DIFF
--- a/src/os/ui/capture/htmlrenderer.js
+++ b/src/os/ui/capture/htmlrenderer.js
@@ -39,7 +39,6 @@ export default class HtmlRenderer extends ElementRenderer {
         var pixelRatio = canvas.width / rect.width;
         var options = {
           backgroundColor: null,
-          canvas: canvas,
           scale: pixelRatio
         };
 

--- a/src/plugin/capture/annotationtailrenderer.js
+++ b/src/plugin/capture/annotationtailrenderer.js
@@ -30,11 +30,13 @@ export default class AnnotationTailRenderer extends SvgRenderer {
    * @inheritDoc
    */
   getRenderElement() {
-    if (this.overlay_) {
-      var overlayEl = this.overlay_.getElement();
-      if (overlayEl) {
-        return overlayEl.querySelector('svg.c-annotation__svg');
-      }
+    // Only render the tail if it's visible within the current viewport. This is tested by checking the height/width of
+    // the element within the viewport. These will be 0 if the element is not rendered in the viewport.
+    const overlayEl = this.overlay_ ? this.overlay_.getElement() : null;
+    const tailEl = this.overlay_ ? overlayEl.querySelector('svg.c-annotation__svg') : null;
+    const rect = tailEl ? tailEl.getBoundingClientRect() : null;
+    if (rect && rect.width > 0 && rect.height > 0) {
+      return tailEl;
     }
 
     return null;


### PR DESCRIPTION
- The map canvas was being passed to `html2canvas` as the target canvas. This is incorrect, as we expect to draw the annotation to its own canvas then draw that to the overall screenshot canvas using the computed offset. This was breaking the map canvas in 2D (the library was resizing it and drawing to it), and making capture fail in 3D (`html2canvas` expects a 2D canvas).
- In 3D, the tail for annotations currently outside the map view were being drawn in the top/left corner of the screenshot. This was due to not testing if the SVG element was visible prior to adding it to the screenshot.

Fixes #738.