### PR TITLE
Fix feature memory leaks in file import and RBush mixin

### DIFF
--- a/src/os/mixin/rbushmixin.js
+++ b/src/os/mixin/rbushmixin.js
@@ -56,12 +56,17 @@ RBush.prototype.getInExtent = function(extent) {
 
   featureSets.sort(sortLength);
 
+  let result = featureSets[0];
+
   // if more than one returned results, dedupe them
   if (setsContainingFeatures > 1) {
     var merged = Array.prototype.concat.apply([], featureSets);
     removeDuplicates(merged, undefined, /** @type {function(?):string|undefined} */ (getUid));
-    return merged;
+    result = merged;
   }
 
-  return featureSets[0];
+  // Clear feature sets so the module won't keep feature references in memory.
+  featureSets.length = 0;
+
+  return result;
 };

--- a/src/os/parse/baseparserconfig.js
+++ b/src/os/parse/baseparserconfig.js
@@ -67,6 +67,13 @@ export default class BaseParserConfig {
   }
 
   /**
+   * Clear preview data from the config.
+   */
+  clearPreview() {
+    this['preview'] = [];
+  }
+
+  /**
    * Updates the preview data and columns from the source.
    *
    * @param {Array<IMapping>=} opt_mappings Mappings to apply to preview items.

--- a/src/os/parse/csv/csvparserconfig.js
+++ b/src/os/parse/csv/csvparserconfig.js
@@ -52,6 +52,14 @@ export default class CsvParserConfig extends FileParserConfig {
   }
 
   /**
+   * @inheritDoc
+   */
+  clearPreview() {
+    super.clearPreview();
+    this['linePreview'] = [];
+  }
+
+  /**
    * Updates the unparsed line preview.
    */
   updateLinePreview() {

--- a/src/os/ui/im/fileimportwizard.js
+++ b/src/os/ui/im/fileimportwizard.js
@@ -54,6 +54,7 @@ export default class Controller extends WizardController {
     if (this.config) {
       this.config['file'] = null;
       this.config['descriptor'] = null;
+      this.config.clearPreview();
     }
   }
 


### PR DESCRIPTION
- When importing a file, the preview features used to display data in the import wizard were not being removed from the parser config. They are now cleaned up when import finishes (complete or cancel).
- The RBush mixin was holding references to features in the module-scoped `featureSets` array. That array is recreated on each call, and references are no longer needed when the call completes. The array is now cleared once the result set has been determined to avoid retaining features in memory.

Fixes #1039.