### PR TITLE
Fix issues with Saved Places field display

### DIFF
--- a/src/plugin/places/places.js
+++ b/src/plugin/places/places.js
@@ -3,6 +3,7 @@ goog.declareModuleId('plugin.places');
 import * as annotation from '../../os/annotation/annotation.js';
 import CommandProcessor from '../../os/command/commandprocessor.js';
 import SequenceCommand from '../../os/command/sequencecommand.js';
+import ColumnDefinition from '../../os/data/columndefinition.js';
 import RecordField from '../../os/data/recordfield.js';
 import * as osFeature from '../../os/feature/feature.js';
 import Fields from '../../os/fields/fields.js';
@@ -110,12 +111,13 @@ export const SourceFields = [
   Fields.LAT_DMS,
   Fields.LON_DMS,
   Fields.MGRS,
+  Fields.ALT,
   Fields.SEMI_MAJOR,
   Fields.SEMI_MINOR,
   Fields.SEMI_MAJOR_UNITS,
   Fields.SEMI_MINOR_UNITS,
-  Fields.TIME,
-  Fields.ORIENTATION
+  Fields.ORIENTATION,
+  new ColumnDefinition(Fields.TIME, RecordField.TIME)
 ];
 
 /**

--- a/src/plugin/places/places.js
+++ b/src/plugin/places/places.js
@@ -96,9 +96,9 @@ export const ExportFields = [
 ];
 
 /**
- * Fields that should be displayed on the Places source.
+ * Fields that should be displayed on the Places source. These will be set on the source via ISource#setColumns.
  *
- * @type {!Array<string>}
+ * @type {!Array<!(ColumnDefinition|string)>}
  */
 export const SourceFields = [
   KMLField.NAME,


### PR DESCRIPTION
This fixes a couple of issues with fields displayed for Saved Places:

- The `TIME` column was being used for time, which doesn't exist until the place is exported/imported (the KML exporter saves the field). Instead, the internal `recordTime` column is now used by the source. This fixes time not displaying in Feature Info for new places.
- Altitude will now be displayed in Feature Info for places.
- Ellipse fields (semi major/minor and orientation) were not displaying for newly created places, but would display after app refresh. This is due to mappings being detected/executed by the KML importer on refresh. This was fixed by detecting/executing mappings when a place is created/edited, so fields should always be accurately displayed in Feature Info.

Fixes #1080.