### PR TITLE
feat(shp): add multipoint and multipolygon import/export support

### DIFF
--- a/test/plugin/file/shp/shp.test.js
+++ b/test/plugin/file/shp/shp.test.js
@@ -1,0 +1,169 @@
+goog.require('ol.geom.LineString');
+goog.require('ol.geom.MultiLineString');
+goog.require('ol.geom.MultiPoint');
+goog.require('ol.geom.MultiPolygon');
+goog.require('ol.geom.Point');
+goog.require('ol.geom.Polygon');
+goog.require('plugin.file.shp');
+
+describe('plugin.file.shp', () => {
+  const LineString = goog.module.get('ol.geom.LineString');
+  const MultiLineString = goog.module.get('ol.geom.MultiLineString');
+  const MultiPoint = goog.module.get('ol.geom.MultiPoint');
+  const MultiPolygon = goog.module.get('ol.geom.MultiPolygon');
+  const Point = goog.module.get('ol.geom.Point');
+  const Polygon = goog.module.get('ol.geom.Polygon');
+
+  const {
+    TYPE,
+    getFlatGroupCoordinates,
+    getPartCoordinatesFromGeometry,
+    getShapeTypeFromGeometry
+  } = goog.module.get('plugin.file.shp');
+
+  const coordsEqual = (a, b) => JSON.stringify(a) == JSON.stringify(b);
+
+  it('flattens geometry coordinates down to coordinate groups', () => {
+    let coordinates = [0, 0];
+    expect(getFlatGroupCoordinates(coordinates)).toBe(coordinates);
+
+    coordinates = [[0, 0], [1, 1]];
+    expect(getFlatGroupCoordinates(coordinates)).toBe(coordinates);
+
+    coordinates = [[[0, 0], [1, 1]], [[2, 2], [3, 3]]];
+    let result = getFlatGroupCoordinates(coordinates);
+    let expected = [[0, 0], [1, 1], [2, 2], [3, 3]];
+    expect(coordsEqual(result, expected)).toBe(true);
+
+    coordinates = [
+      [[[0, 0], [0, 1], [1, 1], [0, 0]]],
+      [[[2, 0], [2, 1], [2, 2], [2, 0]]]
+    ];
+    result = getFlatGroupCoordinates(coordinates);
+    expected = [[0, 0], [0, 1], [1, 1], [0, 0], [2, 0], [2, 1], [2, 2], [2, 0]];
+    expect(coordsEqual(result, expected)).toBe(true);
+  });
+
+  it('gets part coordinates from a point', () => {
+    const point = new Point([0, 0]);
+    const partCoords = getPartCoordinatesFromGeometry(point);
+    expect(coordsEqual(partCoords, [point.getCoordinates()])).toBe(true);
+  });
+
+  it('gets part coordinates from a multi-point', () => {
+    const multiPoint = new MultiPoint([[0, 0], [1, 1]]);
+    const partCoords = getPartCoordinatesFromGeometry(multiPoint);
+    expect(coordsEqual(partCoords, multiPoint.getCoordinates())).toBe(true);
+  });
+
+  it('gets part coordinates from a line', () => {
+    const line = new LineString([[0, 0], [1, 1]]);
+    const partCoords = getPartCoordinatesFromGeometry(line);
+    expect(coordsEqual(partCoords, [line.getCoordinates()])).toBe(true);
+  });
+
+  it('gets part coordinates from a multi-line', () => {
+    const multiLine = new MultiLineString([[[0, 0], [1, 1]], [[2, 2], [3, 3]]]);
+    const partCoords = getPartCoordinatesFromGeometry(multiLine);
+    expect(coordsEqual(partCoords, multiLine.getCoordinates())).toBe(true);
+  });
+
+  it('gets part coordinates from a polygon', () => {
+    const polygon = new Polygon([[[0, 0], [0, 1], [1, 1], [0, 0]]]);
+    const partCoords = getPartCoordinatesFromGeometry(polygon);
+    expect(coordsEqual(partCoords, polygon.getCoordinates())).toBe(true);
+  });
+
+  it('gets part coordinates from a multi-polygon', () => {
+    const multiPolygon = new MultiPolygon([
+      [[[0, 0], [0, 1], [1, 1], [0, 0]]],
+      [[[2, 0], [2, 1], [2, 2], [2, 0]]]
+    ]);
+    const expected = [
+      [[0, 0], [0, 1], [1, 1], [0, 0]],
+      [[2, 0], [2, 1], [2, 2], [2, 0]]
+    ];
+    const partCoords = getPartCoordinatesFromGeometry(multiPolygon);
+    expect(coordsEqual(partCoords, expected)).toBe(true);
+  });
+
+  it('does not return a shape when geometry is not defined or unsupported', () => {
+    expect(getShapeTypeFromGeometry()).toBe(-1);
+    expect(getShapeTypeFromGeometry(null)).toBe(-1);
+  });
+
+  it('gets the correct shape type from a point geometry', () => {
+    const point = new Point([0, 0]);
+    expect(getShapeTypeFromGeometry(point)).toBe(TYPE.POINT);
+
+    point.setCoordinates([0, 0, 0]);
+    expect(getShapeTypeFromGeometry(point)).toBe(TYPE.POINT);
+
+    point.setCoordinates([0, 0, 1000]);
+    expect(getShapeTypeFromGeometry(point)).toBe(TYPE.POINTZ);
+  });
+
+  it('gets the correct shape type from a multi-point geometry', () => {
+    const multiPoint = new MultiPoint([[0, 0], [1, 1]]);
+    expect(getShapeTypeFromGeometry(multiPoint)).toBe(TYPE.MULTIPOINT);
+
+    multiPoint.setCoordinates([[0, 0, 0], [1, 1, 0]]);
+    expect(getShapeTypeFromGeometry(multiPoint)).toBe(TYPE.MULTIPOINT);
+
+    multiPoint.setCoordinates([[0, 0, 0], [1, 1, 1000]]);
+    expect(getShapeTypeFromGeometry(multiPoint)).toBe(TYPE.MULTIPOINTZ);
+  });
+
+  it('gets the correct shape type from a line geometry', () => {
+    const line = new LineString([[0, 0], [1, 1]]);
+    expect(getShapeTypeFromGeometry(line)).toBe(TYPE.POLYLINE);
+
+    line.setCoordinates([[0, 0, 0], [1, 1, 0]]);
+    expect(getShapeTypeFromGeometry(line)).toBe(TYPE.POLYLINE);
+
+    line.setCoordinates([[0, 0, 0], [1, 1, 1000]]);
+    expect(getShapeTypeFromGeometry(line)).toBe(TYPE.POLYLINEZ);
+  });
+
+  it('gets the correct shape type from a multi-line geometry', () => {
+    const multiLine = new MultiLineString([[[0, 0], [1, 1]], [[2, 2], [3, 3]]]);
+    expect(getShapeTypeFromGeometry(multiLine)).toBe(TYPE.POLYLINE);
+
+    multiLine.setCoordinates([[[0, 0, 0], [1, 1, 0]], [[2, 2, 0], [3, 3, 0]]]);
+    expect(getShapeTypeFromGeometry(multiLine)).toBe(TYPE.POLYLINE);
+
+    multiLine.setCoordinates([[[0, 0, 0], [1, 1, 0]], [[2, 2, 0], [3, 3, 1000]]]);
+    expect(getShapeTypeFromGeometry(multiLine)).toBe(TYPE.POLYLINEZ);
+  });
+
+  it('gets the correct shape type from a polygon geometry', () => {
+    const polygon = new Polygon([[[0, 0], [0, 1], [1, 1], [0, 0]]]);
+    expect(getShapeTypeFromGeometry(polygon)).toBe(TYPE.POLYGON);
+
+    polygon.setCoordinates([[[0, 0, 0], [0, 1, 0], [1, 1, 0], [0, 0, 0]]]);
+    expect(getShapeTypeFromGeometry(polygon)).toBe(TYPE.POLYGON);
+
+    polygon.setCoordinates([[[0, 0, 0], [0, 1, 0], [1, 1, 1000], [0, 0, 0]]]);
+    expect(getShapeTypeFromGeometry(polygon)).toBe(TYPE.POLYGONZ);
+  });
+
+  it('gets the correct shape type from a multi-polygon geometry', () => {
+    const multiPolygon = new MultiPolygon([
+      [[[0, 0], [0, 1], [1, 1], [0, 0]]],
+      [[[2, 0], [2, 1], [2, 2], [2, 0]]]
+    ]);
+    expect(getShapeTypeFromGeometry(multiPolygon)).toBe(TYPE.POLYGON);
+
+    multiPolygon.setCoordinates([
+      [[[0, 0, 0], [0, 1, 0], [1, 1, 0], [0, 0, 0]]],
+      [[[2, 0, 0], [2, 1, 0], [2, 2, 0], [2, 0, 0]]]
+    ]);
+    expect(getShapeTypeFromGeometry(multiPolygon)).toBe(TYPE.POLYGON);
+
+    multiPolygon.setCoordinates([
+      [[[0, 0, 0], [0, 1, 0], [1, 1, 0], [0, 0, 0]]],
+      [[[2, 0, 0], [2, 1, 1000], [2, 2, 0], [2, 0, 0]]]
+    ]);
+    expect(getShapeTypeFromGeometry(multiPolygon)).toBe(TYPE.POLYGONZ);
+  });
+});


### PR DESCRIPTION
The SHP exporter previously split both `MultiPoint` and `MultiPolygon` geometries into individual geometries. The SHP specification supports both of these via the `MultiPoint/MultiPointZ` shape and `Polygon/PolygonZ` with `parts` for each polygon/ring. This support was implemented in the exporter. I also consolidated and documented some of the logic that was duplicated between allocating space for a geometry and appending the geometry to the buffer.

The SHP parser did not implement support for `MultiPoint` shapes. This is now implemented so OpenSphere can import these geometries.

Resolves #433.