### PR TITLE
feat(style): add toConfig support to text reader

### DIFF
--- a/src/os/style/stylereader.js
+++ b/src/os/style/stylereader.js
@@ -115,6 +115,11 @@ class StyleReader extends AbstractReader {
       if (stroke) {
         this.readers['stroke'].toConfig(stroke, obj);
       }
+
+      var text = s.getText();
+      if (text) {
+        this.readers['text'].toConfig(text, obj);
+      }
     }
   }
 }

--- a/src/os/style/textreader.js
+++ b/src/os/style/textreader.js
@@ -2,7 +2,9 @@ goog.declareModuleId('os.style.TextReader');
 
 import AbstractReader from './abstractreader.js';
 import {getFont} from './label.js';
+import StyleField from './stylefield.js';
 
+const {asString} = goog.require('ol.color');
 const Fill = goog.require('ol.style.Fill');
 const Stroke = goog.require('ol.style.Stroke');
 const Text = goog.require('ol.style.Text');
@@ -82,6 +84,20 @@ class TextReader extends AbstractReader {
       offsetY: offsetY,
       placement: placement
     });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  toConfig(style, obj) {
+    if (style instanceof Text) {
+      const fill = style.getFill();
+      if (fill) {
+        // Set the same field vector label controls use to override the color. This will ensure highlight/select still
+        // work properly, or any UI that might want to change the label color.
+        obj[StyleField.LABEL_COLOR] = asString(/** @type {Array<number>|string} */ (fill.getColor()));
+      }
+    }
   }
 }
 

--- a/src/plugin/file/kml/kml.js
+++ b/src/plugin/file/kml/kml.js
@@ -43,6 +43,10 @@ const IconOrigin = goog.require('ol.style.IconOrigin');
 const Style = goog.require('ol.style.Style');
 const olXml = goog.require('ol.xml');
 
+const Fill = goog.requireType('ol.style.Fill');
+const Image = goog.requireType('ol.style.Image');
+const Stroke = goog.requireType('ol.style.Stroke');
+const Text = goog.requireType('ol.style.Text');
 const {default: ITime} = goog.requireType('os.time.ITime');
 
 
@@ -335,20 +339,19 @@ export const readStyle = function(node, objectStack) {
     // don't create a style config if nothing was parsed from the element
     return null;
   }
-  var fillStyle = /** @type {ol.style.Fill} */
+  var fillStyle = /** @type {Fill} */
       ('fillStyle' in styleObject ?
         styleObject['fillStyle'] : KML.DEFAULT_FILL_STYLE_);
   var fill = /** @type {boolean|undefined} */ (styleObject['fill']);
-  var imageStyle = /** @type {ol.style.Image} */
+  var imageStyle = /** @type {Image} */
       ('imageStyle' in styleObject ?
         styleObject['imageStyle'] : KML.DEFAULT_IMAGE_STYLE_);
   if (imageStyle == KML.DEFAULT_NO_IMAGE_STYLE_) {
     imageStyle = undefined;
   }
-  var textStyle = /** @type {ol.style.Text} */
-      ('textStyle' in styleObject ?
-        styleObject['textStyle'] : KML.DEFAULT_TEXT_STYLE_);
-  var strokeStyle = /** @type {ol.style.Stroke} */
+  // Intentionally removed using the default OpenLayers text style, to use OpenSphere defaults instead.
+  var textStyle = /** @type {Text} */ ('textStyle' in styleObject ? styleObject['textStyle'] : null);
+  var strokeStyle = /** @type {Stroke} */
       ('strokeStyle' in styleObject ?
         styleObject['strokeStyle'] : KML.DEFAULT_STROKE_STYLE_);
   var outline = /** @type {boolean|undefined} */

--- a/test/os/style/textreader.test.js
+++ b/test/os/style/textreader.test.js
@@ -1,0 +1,59 @@
+goog.require('ol.style.Fill');
+goog.require('ol.style.Text');
+goog.require('ol.style.TextPlacement');
+goog.require('os.style.TextReader');
+
+describe('os.style.TextReader', function() {
+  const Fill = goog.module.get('ol.style.Fill');
+  const Text = goog.module.get('ol.style.Text');
+  const TextPlacement = goog.module.get('ol.style.TextPlacement');
+  const {default: TextReader} = goog.module.get('os.style.TextReader');
+
+  let config;
+  let reader;
+
+  beforeEach(function() {
+    config = {
+      text: 'Test label!',
+      textAlign: 'yep',
+      textBaseline: 'here',
+      placement: TextPlacement.LINE,
+      font: 'bold 72px/72px Comic Sans',
+      fillColor: 'rgba(255,255,0,1)',
+      strokeColor: 'rgba(255,0,255,1)',
+      strokeWidth: 5,
+      offsetX: 12,
+      offsetY: 34,
+      extraProperty: true
+    };
+
+    reader = new TextReader();
+  });
+
+  it('should create a text style', function() {
+    const text = reader.getOrCreateStyle(config);
+    expect(text.getText()).toBe(config.text);
+    expect(text.getTextAlign()).toBe(config.textAlign);
+    expect(text.getTextBaseline()).toBe(config.textBaseline);
+    expect(text.getPlacement()).toBe(config.placement);
+    expect(text.getFont()).toBe(config.font);
+    expect(text.getFill().getColor()).toBe(config.fillColor);
+    expect(text.getStroke().getColor()).toBe(config.strokeColor);
+    expect(text.getStroke().getWidth()).toBe(config.strokeWidth);
+    expect(text.getOffsetX()).toBe(config.offsetX);
+    expect(text.getOffsetY()).toBe(config.offsetY);
+  });
+
+  it('should convert a style to a config', function() {
+    const config = {};
+    const style = new Text({
+      fill: new Fill({
+        color: 'rgba(255,0,255,1)'
+      })
+    });
+
+    reader.toConfig(style, config);
+
+    expect(config.labelColor).toBe(style.getFill().getColor());
+  });
+});


### PR DESCRIPTION
Implemented the `toConfig` method in `TextReader`. This is used by the KML parser to convert the parsed OpenLayers style into an OpenSphere style config object, which will accurately portray the label as defined in the KML.

Resolves #1194.