### PR TITLE
fix(state): only include remote layers in state files

### DIFF
--- a/src/os/state/v4/baselayerstate.js
+++ b/src/os/state/v4/baselayerstate.js
@@ -19,9 +19,9 @@ import StyleField from '../../style/stylefield.js';
 import {tagsFromXML} from '../../tag/tag.js';
 import {isLayerDeprecated, showDeprecatedWarning} from '../../ui/util/deprecated.js';
 import {addBase} from '../../uri/uri.js';
-import {hasUrlScheme} from '../../url/url.js';
 import {appendElement, appendElementNS, createElement, getElementValueOrDefault} from '../../xml.js';
 import AbstractState from '../abstractstate.js';
+import {isLayerRemote} from '../state.js';
 import {getStateManager} from '../stateinstance.js';
 import XMLState from '../xmlstate.js';
 import LayerTag from './layertag.js';
@@ -87,24 +87,6 @@ export default class BaseLayerState extends XMLState {
   }
 
   /**
-   * Checks if a layer was loaded using only remote resources.
-   *
-   * @param {Object<string, *>} layerOptions The layer options.
-   * @return {boolean} If the layer was loaded from the file system.
-   * @protected
-   */
-  isRemote(layerOptions) {
-    const url = /** @type {string|undefined} */ (layerOptions['url']);
-    const url2 = /** @type {string|undefined} */ (layerOptions['url2']);
-    const urls = /** @type {Array<string>|undefined} */ (layerOptions['urls']) || [];
-
-    // Considered remote if at least one URL exists, and every defined URL has a remote scheme. Scheme-relative URL's
-    // are generally discouraged and not considered.
-    const definedUrls = [url, url2, ...urls].filter((url) => !!url);
-    return definedUrls.length > 0 && definedUrls.every(hasUrlScheme);
-  }
-
-  /**
    * Checks if the provided layer is valid for addition to the state file
    *
    * @param {ILayer} layer The layer
@@ -127,7 +109,7 @@ export default class BaseLayerState extends XMLState {
       }
 
       // skip resources that are not remote (these are handled separately)
-      return this.isRemote(layerOptions);
+      return isLayerRemote(layerOptions);
     } catch (e) {
       // may not be a ILayer... so don't persist it
     }

--- a/src/os/url/url.js
+++ b/src/os/url/url.js
@@ -7,6 +7,12 @@ goog.declareModuleId('os.url');
 export const MAILTO_REGEXP = /^mailto:/;
 
 /**
+ * Regular expression to test if a string starts with a URL scheme.
+ * @type {RegExp}
+ */
+export const URL_SCHEME_REGEXP = /^(ftp|http|https):\/\//;
+
+/**
  * Regular expression for validating URLs.  Copied from Angular.js.  This one is good for testing things you expect to
  * be a single URL (as opposed to multiple).
  * @type {RegExp}
@@ -19,6 +25,20 @@ export const URL_REGEXP = /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?
  * @type {RegExp}
  */
 export const URL_REGEXP_LINKY = /((ftp|https?):\/\/|(mailto:)?[A-Za-z0-9._%+-]+@)[^\s'"]*[^\s.;,{}<>'"]/;
+
+/**
+ * Test if a string has a URL scheme.
+ * @param {string|null|undefined} value The value.
+ * @return {boolean}
+ */
+export const hasUrlScheme = (value) => !!value && URL_SCHEME_REGEXP.test(value);
+
+/**
+ * Test if a string is a URL.
+ * @param {string|null|undefined} value The value.
+ * @return {boolean}
+ */
+export const isUrl = (value) => !!value && URL_REGEXP.test(value);
 
 /**
  * Convert a {@link goog.Uri.QueryData} to an object.

--- a/test/os/state/state.test.js
+++ b/test/os/state/state.test.js
@@ -1,0 +1,41 @@
+goog.require('os.state');
+
+describe('os.state', () => {
+  const {
+    isLayerRemote,
+    registerLayerStateUrlProperty
+  } = goog.module.get('os.state');
+
+  it('tests if a layer is remote', () => {
+    const layerOptions = {};
+    expect(isLayerRemote(layerOptions)).toBe(false);
+
+    layerOptions['notATestedUrl'] = 'https://www.google.com/';
+    expect(isLayerRemote(layerOptions)).toBe(false);
+
+    layerOptions['url'] = 'local://not-remote/';
+    expect(isLayerRemote(layerOptions)).toBe(false);
+
+    layerOptions['url2'] = 'https://url.is.not/remote/';
+    expect(isLayerRemote(layerOptions)).toBe(false);
+
+    layerOptions['url'] = 'http://now.its/remote';
+    expect(isLayerRemote(layerOptions)).toBe(true);
+
+    layerOptions['urls'] = ['https://one.remote/', 'file://not-the-other/'];
+    expect(isLayerRemote(layerOptions)).toBe(false);
+
+    layerOptions['urls'] = ['https://one.remote/', 'ftp://and.the/other'];
+    expect(isLayerRemote(layerOptions)).toBe(true);
+  });
+
+  it('registers url properties to test for layer states', () => {
+    const layerOptions = {
+      'myUrlProperty': ['https://some.url.com']
+    };
+    expect(isLayerRemote(layerOptions)).toBe(false);
+
+    registerLayerStateUrlProperty('myUrlProperty');
+    expect(isLayerRemote(layerOptions)).toBe(true);
+  });
+});

--- a/test/os/url/url.test.js
+++ b/test/os/url/url.test.js
@@ -4,29 +4,61 @@ goog.require('os.url');
 
 describe('os.url', function() {
   const QueryData = goog.module.get('goog.Uri.QueryData');
-  const osUrl = goog.module.get('os.url');
+  const {
+    URL_REGEXP,
+    URL_SCHEME_REGEXP,
+    hasUrlScheme,
+    isUrl,
+    queryDataToObject
+  } = goog.module.get('os.url');
+
+  it('should match URL schemes properly', function() {
+    var url = 'barf';
+    expect(URL_SCHEME_REGEXP.test(url)).toBe(false);
+    expect(hasUrlScheme(url)).toBe(false);
+    url = 'file://barf.com';
+    expect(URL_SCHEME_REGEXP.test(url)).toBe(false);
+    expect(hasUrlScheme(url)).toBe(false);
+    url = 'URL: http://barf.com';
+    expect(URL_SCHEME_REGEXP.test(url)).toBe(false);
+    expect(hasUrlScheme(url)).toBe(false);
+
+    url = 'http://barf.com';
+    expect(URL_SCHEME_REGEXP.test(url)).toBe(true);
+    expect(hasUrlScheme(url)).toBe(true);
+    url = 'https://barf.com';
+    expect(URL_SCHEME_REGEXP.test(url)).toBe(true);
+    expect(hasUrlScheme(url)).toBe(true);
+    url = 'ftp://barf.com';
+    expect(URL_SCHEME_REGEXP.test(url)).toBe(true);
+    expect(hasUrlScheme(url)).toBe(true);
+  });
 
   it('should match URLs properly', function() {
     var url = 'barf';
-    expect(osUrl.URL_REGEXP.test(url)).not.toBe(true);
+    expect(URL_REGEXP.test(url)).toBe(false);
+    expect(isUrl(url)).toBe(false);
     url = 'http://barf.com';
-    expect(osUrl.URL_REGEXP.test(url)).toBe(true);
+    expect(URL_REGEXP.test(url)).toBe(true);
+    expect(isUrl(url)).toBe(true);
     url = 'http://barf.com%28parens%29';
-    expect(osUrl.URL_REGEXP.test(url)).toBe(true);
+    expect(URL_REGEXP.test(url)).toBe(true);
+    expect(isUrl(url)).toBe(true);
     url = 'http://barf.com/(parentheses)';
-    expect(osUrl.URL_REGEXP.test(url)).toBe(true);
+    expect(URL_REGEXP.test(url)).toBe(true);
+    expect(isUrl(url)).toBe(true);
   });
 
   it('should convert QueryData objects to a map', function() {
     var qd = null;
 
     // null QueryData reference
-    var obj = osUrl.queryDataToObject(qd);
+    var obj = queryDataToObject(qd);
     expect(obj).toBeDefined();
     expect(goog.object.isEmpty(obj)).toBe(true);
 
     qd = new QueryData('TEST1=a&TEST2=a,b,c&TEST3=');
-    obj = osUrl.queryDataToObject(qd);
+    obj = queryDataToObject(qd);
     expect(obj).toBeDefined();
     expect(goog.object.getCount(obj)).toBe(3);
 
@@ -41,7 +73,7 @@ describe('os.url', function() {
 
     // can provide the object to store key/value pairs
     var otherObj = {};
-    obj = osUrl.queryDataToObject(qd, otherObj);
+    obj = queryDataToObject(qd, otherObj);
     expect(obj).toBe(otherObj);
   });
 });


### PR DESCRIPTION
State files previously included any layer that didn't use a `local://` or `file://` scheme in their URL, or any layer that didn't define our canned set of properties (`url` and `url2`). This was causing layers added from a [GeoPackage](https://github.com/ngageoint/opensphere-plugin-geopackage) to be included because GPKG feature layers use the `gpkg://` scheme and GPKG tile layers do not have a URL.

We will now determine if a layer should be included by:

- Gathering defined URLs from layer options using `url`, `url2` (used by file plugins like SHP), and `urls` (used by tile layers).
- Checking if _at least_ one URL is defined.
- All defined URL's must be a remote URL, which currently tests if the string starts with an http, https, or ftp scheme. Please comment if we should support other schemes by default or if the scheme list needs to be pluggable.

If an application/plugin uses URL properties other than the above, they may register additional properties to check with `registerLayerStateUrlProperty`.