### PR TITLE
Fix issues with Go To

### DIFF
--- a/src/os/layer/image.js
+++ b/src/os/layer/image.js
@@ -6,6 +6,7 @@ import * as dispatcher from '../dispatcher.js';
 import LayerEvent from '../events/layerevent.js';
 import LayerEventType from '../events/layereventtype.js';
 import PropertyChangeEvent from '../events/propertychangeevent.js';
+import {reduceExtentFromLayers} from '../fn/fn.js';
 import IGroupable from '../igroupable.js';
 import osImplements from '../implements.js';
 import SourcePropertyChange from '../source/propertychange.js';
@@ -26,6 +27,7 @@ const GoogEventType = goog.require('goog.events.EventType');
 const {getRandomString} = goog.require('goog.string');
 
 const {listen} = goog.require('ol.events');
+const {createEmpty, isEmpty} = goog.require('ol.extent');
 const ImageLayer = goog.require('ol.layer.Image');
 const ImageSource = goog.require('ol.source.Image');
 const ImageStatic = goog.require('ol.source.ImageStatic');
@@ -666,15 +668,16 @@ export default class Image extends ImageLayer {
    */
   supportsAction(type, opt_actionArgs) {
     switch (type) {
-      case EventType.IDENTIFY:
       case EventType.GOTO:
+        const layerExtent = reduceExtentFromLayers(/** @type {!ol.Extent} */ (createEmpty()), this);
+        return !isEmpty(layerExtent);
+      case EventType.IDENTIFY:
+      case EventType.REFRESH:
         return true;
       case EventType.RENAME:
         return !!opt_actionArgs && goog.isArrayLike(opt_actionArgs) && opt_actionArgs.length === 1;
       case EventType.REMOVE_LAYER:
         return this.isRemovable();
-      case EventType.REFRESH:
-        return true;
       default:
         break;
     }

--- a/src/os/layer/tile.js
+++ b/src/os/layer/tile.js
@@ -43,7 +43,7 @@ const GoogEventType = goog.require('goog.events.EventType');
 const {getRandomString} = goog.require('goog.string');
 
 const events = goog.require('ol.events');
-const {createEmpty, getArea, isEmpty} = goog.require('ol.extent');
+const {createEmpty, isEmpty} = goog.require('ol.extent');
 const Property = goog.require('ol.layer.Property');
 const OLTileLayer = goog.require('ol.layer.Tile');
 const TileImage = goog.require('ol.source.TileImage');
@@ -956,11 +956,8 @@ export default class Tile extends OLTileLayer {
   supportsAction(type, opt_actionArgs) {
     switch (type) {
       case EventType.GOTO:
-        var projExtent = osMap.PROJECTION.getExtent();
-        var layerExtent = reduceExtentFromLayers(/** @type {!ol.Extent} */ (createEmpty()), this);
-        var projArea = getArea(projExtent);
-        var layerArea = getArea(layerExtent);
-        return !isEmpty(layerExtent) && layerArea / projArea < 0.8;
+        const layerExtent = reduceExtentFromLayers(/** @type {!ol.Extent} */ (createEmpty()), this);
+        return !isEmpty(layerExtent);
       case EventType.IDENTIFY:
       case EventType.REFRESH:
       case EventType.SHOW_DESCRIPTION:

--- a/src/os/layer/vectortile.js
+++ b/src/os/layer/vectortile.js
@@ -8,7 +8,6 @@ import PropertyChangeEvent from '../events/propertychangeevent.js';
 import {reduceExtentFromLayers} from '../fn/fn.js';
 import IGroupable from '../igroupable.js';
 import osImplements from '../implements.js';
-import * as osMap from '../map/map.js';
 import * as math from '../math/math.js';
 import {dispatcher} from '../os.js';
 import registerClass from '../registerclass.js';
@@ -558,11 +557,8 @@ export default class VectorTile extends VectorTileLayer {
   supportsAction(type, opt_actionArgs) {
     switch (type) {
       case ActionEventType.GOTO:
-        var projExtent = osMap.PROJECTION.getExtent();
-        var layerExtent = reduceExtentFromLayers(/** @type {!ol.Extent} */ (olExtent.createEmpty()), this);
-        var projArea = olExtent.getArea(projExtent);
-        var layerArea = olExtent.getArea(layerExtent);
-        return !olExtent.isEmpty(layerExtent) && layerArea / projArea < 0.8;
+        const layerExtent = reduceExtentFromLayers(/** @type {!ol.Extent} */ (olExtent.createEmpty()), this);
+        return !olExtent.isEmpty(layerExtent);
       case ActionEventType.IDENTIFY:
       case ActionEventType.REFRESH:
       case ActionEventType.SHOW_DESCRIPTION:

--- a/src/os/mapcontainer.js
+++ b/src/os/mapcontainer.js
@@ -19,7 +19,7 @@ import OSEventType from './events/eventtype.js';
 import LayerEvent from './events/layerevent.js';
 import LayerEventType from './events/layereventtype.js';
 import PropertyChangeEvent from './events/propertychangeevent.js';
-import {normalize as normalizeExtent, normalizeToCenter} from './extent.js';
+import {clamp as clampExtent, normalize as normalizeExtent, normalizeToCenter} from './extent.js';
 import * as osFeature from './feature/feature.js';
 import {filterFalsey, noop, reduceExtentFromGeometries} from './fn/fn.js';
 import {normalizeLongitude} from './geo/geo2.js';
@@ -569,6 +569,10 @@ export default class MapContainer extends EventTarget {
 
         if (opt_buffer && opt_buffer > 0) {
           olExtent.scaleFromCenter(extent, opt_buffer);
+
+          // Clamp the extent within the current map projection.
+          const projExtent = osMap.PROJECTION.getExtent();
+          clampExtent(extent, projExtent, extent);
         } else {
           // THIN-6449: prevent flying to excessive zoom levels if a buffer wasn't provided. if one was provided,
           // assume the caller knows what they are doing.

--- a/src/plugin/arc/layer/arcimagelayerconfig.js
+++ b/src/plugin/arc/layer/arcimagelayerconfig.js
@@ -2,10 +2,12 @@ goog.declareModuleId('plugin.arc.layer.ArcImageLayerConfig');
 
 import AbstractLayerConfig from '../../../os/layer/config/abstractlayerconfig.js';
 import Image from '../../../os/layer/image.js';
+import {PROJECTION} from '../../../os/map/map.js';
 import CrossOrigin from '../../../os/net/crossorigin.js';
 import * as net from '../../../os/net/net.js';
 import * as proj from '../../../os/proj/proj.js';
 
+const {transformExtent} = goog.require('ol.proj');
 const ImageArcGISRest = goog.require('ol.source.ImageArcGISRest');
 
 const Projection = goog.requireType('ol.proj.Projection');
@@ -78,6 +80,17 @@ class ArcImageLayerConfig extends AbstractLayerConfig {
     // image layers are hidden by default, we want this one to show
     imageLayer.setHidden(false);
     imageLayer.restore(options);
+
+    let extent = /** @type {ol.Extent} */ (options['extent']);
+    if (extent) {
+      const extentProjection = /** @type {ol.ProjectionLike} */ (options['extentProjection']);
+      if (extentProjection) {
+        extent = transformExtent(extent, extentProjection, PROJECTION);
+      }
+
+      imageLayer.setExtent(extent);
+    }
+
     return imageLayer;
   }
 

--- a/src/plugin/arc/layer/arclayerdescriptor.js
+++ b/src/plugin/arc/layer/arclayerdescriptor.js
@@ -8,6 +8,7 @@ import TimeFormat from '../../../os/im/mapping/timeformat.js';
 import TimeType from '../../../os/im/mapping/timetype.js';
 import osImplements from '../../../os/implements.js';
 import LayerType from '../../../os/layer/layertype.js';
+import {EPSG4326} from '../../../os/proj/proj.js';
 import registerClass from '../../../os/registerclass.js';
 import IARCDescriptor from '../../../os/ui/arc/iarcdescriptor.js';
 import ColorControlType from '../../../os/ui/colorcontroltype.js';
@@ -245,16 +246,10 @@ class ArcLayerDescriptor extends LayerSyncDescriptor {
       this.setAttribution(ct);
     }
 
-    var extent = /** @type {Object} */ (config['extent']);
-    if (extent) {
-      try {
-        if (extent['wkid'] === 4326) {
-          var olExtent = [extent['xmin'], extent['ymin'], extent['xmax'], extent['ymax']];
-          this.setExtent(olExtent);
-        }
-      } catch (e) {
-        // failed to extract extent info from the config
-      }
+    const extent = /** @type {Object} */ (config['extent']);
+    const olExtent = arc.readEsriExtent(extent, EPSG4326);
+    if (olExtent) {
+      this.setExtent(olExtent);
     }
 
     var timeInfo = /** @type {Object} */ (config['timeInfo']);

--- a/src/plugin/arc/node/arcservicenode.js
+++ b/src/plugin/arc/node/arcservicenode.js
@@ -4,6 +4,7 @@ import ConfigDescriptor from '../../../os/data/configdescriptor.js';
 import DataManager from '../../../os/data/datamanager.js';
 import LayerType from '../../../os/layer/layertype.js';
 import Request from '../../../os/net/request.js';
+import {EPSG4326} from '../../../os/proj/proj.js';
 import ColorControlType from '../../../os/ui/colorcontroltype.js';
 import BaseProvider from '../../../os/ui/data/baseprovider.js';
 import DescriptorNode from '../../../os/ui/data/descriptornode.js';
@@ -185,8 +186,7 @@ class ArcServiceNode extends LoadingNode {
    */
   addImageLayer_(json) {
     const id = this.server_.getId() + BaseProvider.ID_DELIMITER + /** @type {string} */ (json['name']);
-    const extent = /** @type {Object<string, number>} */ (json['extent']);
-    const wkid = /** @type {number} */ (extent['spatialReference']['latestWkid']);
+    const extent = arc.readEsriExtent(/** @type {Object} */ (json['extent']), EPSG4326);
     const config = {
       'id': id,
       'url': this.url_,
@@ -194,8 +194,8 @@ class ArcServiceNode extends LoadingNode {
       'description': json['description'],
       'provider': this.server_.getLabel(),
       'title': json['name'],
-      'extent': [extent['xmin'], extent['ymin'], extent['xmax'], extent['ymax']],
-      'extentProjection': wkid === 3857 ? 'EPSG:3857' : 'EPSG:4326',
+      'extent': extent,
+      'extentProjection': EPSG4326,
       'layerType': LayerType.TILES,
       'icons': Icons.TILES,
       'colorControl': ColorControlType.PICKER_RESET

--- a/test/plugin/arc/layer/arclayerdescriptor.test.js
+++ b/test/plugin/arc/layer/arclayerdescriptor.test.js
@@ -13,7 +13,10 @@ describe('plugin.arc.layer.ArcLayerDescriptor', function() {
     'description': 'The Power of Arc Layers',
     'id': 'someLayerId',
     'extent': {
-      'wkid': 4326,
+      'spatialReference': {
+        'latestWkid': 4326,
+        'wkid': 4326
+      },
       'xmin': 40,
       'ymin': 20,
       'xmax': 60,
@@ -53,7 +56,10 @@ describe('plugin.arc.layer.ArcLayerDescriptor', function() {
     'description': 'An arc layer that only supports tiles',
     'id': 'someLayerId',
     'extent': {
-      'wkid': 4326,
+      'spatialReference': {
+        'latestWkid': 4326,
+        'wkid': 4326
+      },
       'xmin': 40,
       'ymin': 20,
       'xmax': 60,

--- a/test/plugin/arc/node/arcservicenode.test.js
+++ b/test/plugin/arc/node/arcservicenode.test.js
@@ -24,7 +24,10 @@ describe('plugin.arc.node.ArcServiceNode', function() {
       'description': 'The Power of Arc Layers',
       'id': 'someLayerId',
       'extent': {
-        'wkid': 4326,
+        'spatialReference': {
+          'latestWkid': 4326,
+          'wkid': 4326
+        },
         'xmin': 40,
         'ymin': 20,
         'xmax': 60,


### PR DESCRIPTION
This fixes/changes Go To behavior for Image, Tile, and VectorTile layers.

- Image layers were not setting the layer extent, so Go To would not work.
- Tile and VectorTile layers would not show Go To if the extent was 80% of the current projection's extent. This behavior has been removed, so the option will display as long as the extent is not empty.
- Arc layers were not handling the extent projection. The extent will now be parsed into an appropriate projection, if the extent's source projection is supported by OpenSphere.
- When zooming to a large extent, the 50% buffer that was applied would sometimes exceed the world extent, which would cause the 2D view to zoom a world over. This has been fixed.

Other Changes

- Fixed test JSON for Arc, which put `wkid` directly under `extent`. This should be under `spatialReference`, per the [specification](https://developers.arcgis.com/web-map-specification/objects/extent/).
- Fixed issues computing the extent for features with multiple geometries in EPSG:3857 (or non-degree projections). The `getThinnestExtent` function used a threshold that was based on degree units, which did not work well when the projection is in meters. That function now takes an optional epsilon value, and the `getFunctionalExtent` functions will now pass a projection-appropriate value.