### PR TITLE
fix(layer): don't show rotation controls if columns aren't present

### DIFF
--- a/src/os/ui/layer/vectorlayerui.js
+++ b/src/os/ui/layer/vectorlayerui.js
@@ -363,7 +363,9 @@ export class Controller extends DefaultLayerUICtrl {
    * @export
    */
   showRotationOption() {
-    if (this.scope != null) {
+    // Do not show the option if there aren't columns to pick from. This is typically the case when multiple layers are
+    // selected and are unlikely to have the same columns.
+    if (this.scope != null && this.scope['columns'] && this.scope['columns'].length) {
       var shape = this.scope['shape'] || '';
       var centr = this.scope['centerShape'] || '';
       return shape == osStyle.ShapeType.ICON || (osStyle.CENTER_REGEXP.test(shape) && centr == osStyle.ShapeType.ICON);


### PR DESCRIPTION
The icon rotation controls are dependent on having columns to choose from, and should not be displayed in the absence of columns. This also fixes an issue where selecting multiple vector layers will clear the rotation column, because no columns are present and the column selection is changed to an empty string.