### PR TITLE
KML default altitude mode and line tessellate support

### DIFF
--- a/src/plugin/cesium/sync/linestring.js
+++ b/src/plugin/cesium/sync/linestring.js
@@ -47,8 +47,36 @@ export const createLineStringPrimitive = (feature, geometry, style, context, opt
   const lineGeometryToCreate = geometry.get('extrude') ? 'WallGeometry' :
     heightReference === Cesium.HeightReference.CLAMP_TO_GROUND ? 'GroundPolylineGeometry' : 'PolylineGeometry';
   const positions = getLineStringPositions(geometry, opt_flatCoords, opt_offset, opt_end);
-  const method = /** @type {InterpolationMethod} */ (feature.get(interpolate.METHOD_FIELD));
+  const method = /** @type {InterpolationMethod} */ (geometry.get(interpolate.METHOD_FIELD)) ||
+  /** @type {InterpolationMethod} */ (feature.get(interpolate.METHOD_FIELD));
   return createLinePrimitive(positions, context, style, lineGeometryToCreate, method);
+};
+
+
+/**
+ * Get the Cesium arc type from the interpolation method.
+ * @param {InterpolationMethod=} opt_method The interpolation method.
+ * @return {Cesium.ArcType}
+ */
+const getArcType = (opt_method) => {
+  let arcType = Cesium.ArcType.NONE;
+
+  const method = opt_method || interpolate.getMethod();
+  switch (method) {
+    case InterpolationMethod.NONE:
+      arcType = Cesium.ArcType.NONE;
+      break;
+    case InterpolationMethod.GEODESIC:
+      arcType = Cesium.ArcType.GEODESIC;
+      break;
+    case InterpolationMethod.RHUMB:
+      arcType = Cesium.ArcType.RHUMB;
+      break;
+    default:
+      break;
+  }
+
+  return arcType;
 };
 
 
@@ -93,7 +121,7 @@ const createLinePrimitive = (positions, context, style, opt_type, opt_method) =>
   const geometry = new Cesium[type]({
     positions: positions,
     vertexFormat: appearance.vertexFormat,
-    arcType: opt_method === InterpolationMethod.RHUMB ? Cesium.ArcType.RHUMB : Cesium.ArcType.GEODESIC,
+    arcType: getArcType(opt_method),
     width: width
   });
 

--- a/src/plugin/file/kml/kmlparser.js
+++ b/src/plugin/file/kml/kmlparser.js
@@ -27,6 +27,7 @@ import ColorControlType from '../../../os/ui/colorcontroltype.js';
 import ControlType from '../../../os/ui/controltype.js';
 import * as osUiFileKml from '../../../os/ui/file/kml/kml.js';
 import * as ui from '../../../os/ui/ui.js';
+import AltitudeMode from '../../../os/webgl/altitudemode.js';
 import * as xml from '../../../os/xml.js';
 import JsonField from './jsonfield.js';
 import * as kml from './kml.js';
@@ -1152,6 +1153,12 @@ export default class KMLParser extends AsyncZipParser {
             object[Fields.GEOM_ALT] = object[Fields.GEOM_ALT] || coord[2];
           }
         }
+      }
+
+      // KML specification defaults altitudeMode to clampToGround for all geometry types.
+      var altitudeMode = geometry.get(RecordField.ALTITUDE_MODE);
+      if (!altitudeMode) {
+        geometry.set(RecordField.ALTITUDE_MODE, AltitudeMode.CLAMP_TO_GROUND);
       }
 
       // convert to application projection


### PR DESCRIPTION
This fixes a couple issues identified in #907. Namely:

- I don't think we are properly defaulting altitudeMode to clampToGround
- I don't think we are properly reading tessellate, which should correspond to os.interpolate.Method.NONE if 0

The first is true of all geometries. The KML specification states altitude mode should default to `clampToGround` for all geometry types. The KML parser will now do this if `altitudeMode` is not set on the parsed geometry.

For the second item, if `tessellate` is disabled (0 or false) we will disable interpolation on the geometry. I also updated the Cesium converter to use `Cesium.ArcType.NONE` when interpolation is disabled. This will render geometries as defined by the KML spec.