### PR TITLE
fix(state): use os.array.forEach on NodeList

### DIFF
--- a/src/os/state/v2/layerstate.js
+++ b/src/os/state/v2/layerstate.js
@@ -1,5 +1,6 @@
 goog.declareModuleId('os.state.v2.LayerState');
 
+import {forEach} from '../../array/array.js';
 import {isColorString, padHexColor, toHexString} from '../../color.js';
 import LayerAdd from '../../command/layeraddcmd.js';
 import DataManager from '../../data/datamanager.js';
@@ -633,7 +634,7 @@ export default class LayerState extends XMLState {
                   case LayerTag.LABEL_COLUMNS:
                     var labels = [];
                     var labelColumns = getChildren(styleList[j]);
-                    labelColumns.forEach(function(label) {
+                    forEach(labelColumns, function(label) {
                       labels.push({
                         'column': label.getAttribute('column'),
                         'showColumn': label.getAttribute('showColumn') == 'true' ? true : false

--- a/src/os/state/v3/layerstate.js
+++ b/src/os/state/v3/layerstate.js
@@ -2,6 +2,7 @@ goog.declareModuleId('os.state.v3.LayerState');
 
 import AlertEventSeverity from '../../alert/alerteventseverity.js';
 import AlertManager from '../../alert/alertmanager.js';
+import {forEach} from '../../array/array.js';
 import {isColorString, padHexColor, toHexString} from '../../color.js';
 import LayerAdd from '../../command/layeraddcmd.js';
 import DataManager from '../../data/datamanager.js';
@@ -688,7 +689,7 @@ export default class LayerState extends XMLState {
                   case LayerTag.LABEL_COLUMNS:
                     var labels = [];
                     var labelColumns = getChildren(styleList[j]);
-                    labelColumns.forEach(function(label) {
+                    forEach(labelColumns, function(label) {
                       labels.push({
                         'column': label.getAttribute('column'),
                         'showColumn': label.getAttribute('showColumn') == 'true' ? true : false

--- a/src/os/state/v4/baselayerstate.js
+++ b/src/os/state/v4/baselayerstate.js
@@ -2,6 +2,7 @@ goog.declareModuleId('os.state.v4.BaseLayerState');
 
 import AlertEventSeverity from '../../alert/alerteventseverity.js';
 import AlertManager from '../../alert/alertmanager.js';
+import {forEach} from '../../array/array.js';
 import {isColorString, padHexColor, toRgbArray, toServerString} from '../../color.js';
 import LayerAdd from '../../command/layeraddcmd.js';
 import DataManager from '../../data/datamanager.js';
@@ -871,7 +872,7 @@ export default class BaseLayerState extends XMLState {
             case LayerTag.LABEL_COLUMNS:
               var labels = [];
               var labelColumns = getChildren(styleList[j]);
-              labelColumns.forEach(function(label) {
+              forEach(labelColumns, function(label) {
                 labels.push({
                   'column': label.getAttribute('column'),
                   'showColumn': label.getAttribute('showColumn') == 'true' ? true : false


### PR DESCRIPTION
This is another regression from the ESM transition. I reviewed all `forEach` calls in our state code since this has come up a few times there. All remaining calls are on arrays.