### PR TITLE
Fixes for ArcGIS feature layers

### DIFF
--- a/src/plugin/arc/arc.js
+++ b/src/plugin/arc/arc.js
@@ -39,6 +39,12 @@ export const ServerType = {
 export const ID = 'arc';
 
 /**
+ * The default value to use for maxRecordCount, based on the Arc specification default.
+ * @type {number}
+ */
+export const DEFAULT_MAX_RECORD_COUNT = 1000;
+
+/**
  * Returns a more recognizable type from an ESRI Type.
  *
  * @param {string} esriType

--- a/src/plugin/arc/layer/arcfeaturelayerconfig.js
+++ b/src/plugin/arc/layer/arcfeaturelayerconfig.js
@@ -50,6 +50,11 @@ class ArcFeatureLayerConfig extends AbstractDataSourceLayerConfig {
     source.setTimeEnabled(this.animate !== undefined ? this.animate : false);
     source.setTitle(this.title);
 
+    const maxRecordCount = /** @type {number|undefined} */ (options['maxRecordCount']);
+    if (maxRecordCount != null) {
+      source.setMaxRecordCount(maxRecordCount);
+    }
+
     var layer = this.getLayer(source, options);
     if (options) {
       layer.restore(options);
@@ -139,7 +144,9 @@ class ArcFeatureLayerConfig extends AbstractDataSourceLayerConfig {
   }
 
   /**
-   * @inheritDoc
+   * Create a new Arc request source for the layer.
+   * @return {!ArcRequestSource}
+   * @override
    */
   getSource(options) {
     return new ArcRequestSource();

--- a/src/plugin/arc/layer/arclayerdescriptor.js
+++ b/src/plugin/arc/layer/arclayerdescriptor.js
@@ -426,6 +426,11 @@ class ArcLayerDescriptor extends LayerSyncDescriptor {
     var options = {};
     options['id'] = this.getId() + BaseProvider.ID_DELIMITER + 'features';
 
+    // color will change with user choices, baseColor maintains the original layer color for reset
+    options['baseColor'] = this.getColor();
+    options['color'] = this.getColor();
+    options[ControlType.COLOR] = ColorControlType.PICKER_RESET;
+
     var params = new QueryData();
     params.set('f', 'json');
     params.set('inSR', '4326');

--- a/src/plugin/arc/layer/arclayerdescriptor.js
+++ b/src/plugin/arc/layer/arclayerdescriptor.js
@@ -92,6 +92,29 @@ class ArcLayerDescriptor extends LayerSyncDescriptor {
     this.deprecated_ = false;
 
     this.descriptorType = arc.ID;
+
+    /**
+     * The maximum number of records that will be returned by a single request.
+     * @type {number}
+     * @private
+     */
+    this.maxRecordCount_ = arc.DEFAULT_MAX_RECORD_COUNT;
+  }
+
+  /**
+   * Get the max record count for the layer.
+   * @return {number}
+   */
+  getMaxRecordCount() {
+    return this.maxRecordCount_;
+  }
+
+  /**
+   * Set the max record count for the layer.
+   * @param {number} value The value.
+   */
+  setMaxRecordCount(value) {
+    this.maxRecordCount_ = value;
   }
 
   /**
@@ -299,6 +322,11 @@ class ArcLayerDescriptor extends LayerSyncDescriptor {
       this.setFeaturesEnabled(true);
     }
 
+    const maxRecordCount = /** @type {number|undefined} */ (config['maxRecordCount']);
+    if (maxRecordCount != null) {
+      this.setMaxRecordCount(maxRecordCount);
+    }
+
     this.featureType_ = arc.createFeatureType(config);
     if (!this.featureType_) {
       // if a feature type could not be created, assume features aren't supported
@@ -458,6 +486,11 @@ class ArcLayerDescriptor extends LayerSyncDescriptor {
     options['load'] = true;
     options['tags'] = this.getTags();
     options['provider'] = this.getProvider();
+
+    const maxRecordCount = this.getMaxRecordCount();
+    if (maxRecordCount !== arc.DEFAULT_MAX_RECORD_COUNT) {
+      options['maxRecordCount'] = maxRecordCount;
+    }
 
     if (!this.getTilesEnabled()) {
       options['attributions'] = [this.getAttribution()];

--- a/src/plugin/arc/source/arcrequestsource.js
+++ b/src/plugin/arc/source/arcrequestsource.js
@@ -3,6 +3,7 @@ goog.declareModuleId('plugin.arc.source.ArcRequestSource');
 import Request from '../../../os/net/request.js';
 import registerClass from '../../../os/registerclass.js';
 import RequestSource from '../../../os/source/requestsource.js';
+import {DEFAULT_MAX_RECORD_COUNT} from '../arc.js';
 
 const dispose = goog.require('goog.dispose');
 const log = goog.require('goog.log');
@@ -38,6 +39,13 @@ class ArcRequestSource extends RequestSource {
      */
     this.loadCount_ = 0;
 
+    /**
+     * The maximum number of records that will be returned by a single request.
+     * @type {number}
+     * @private
+     */
+    this.maxRecordCount_ = DEFAULT_MAX_RECORD_COUNT;
+
     // all ArcRequestSources should be lockable
     this.setLockable(true);
   }
@@ -56,6 +64,22 @@ class ArcRequestSource extends RequestSource {
   abortRequest() {
     this.disposeIdRequests_();
     super.abortRequest();
+  }
+
+  /**
+   * Get the max record count for the layer.
+   * @return {number}
+   */
+  getMaxRecordCount() {
+    return this.maxRecordCount_;
+  }
+
+  /**
+   * Set the max record count for the layer.
+   * @param {number} value The value.
+   */
+  setMaxRecordCount(value) {
+    this.maxRecordCount_ = value;
   }
 
   /**
@@ -92,8 +116,8 @@ class ArcRequestSource extends RequestSource {
 
     // when no features are found, some arc servers return null, others return an empty array
     if (ids && Array.isArray(ids) && ids.length > 0) {
-      for (var i = 0, ii = ids.length; i < ii; i += ArcRequestSource.MAX) {
-        j = Math.min(ii, i + ArcRequestSource.MAX);
+      for (var i = 0, ii = ids.length; i < ii; i += this.maxRecordCount_) {
+        j = Math.min(ii, i + this.maxRecordCount_);
         params.set('objectIds', ids.slice(i, j).join(','));
 
         var request = new Request(url);
@@ -176,8 +200,9 @@ registerClass(className, ArcRequestSource);
 /**
  * @type {number}
  * @const
+ * @deprecated Please use plugin.arc.DEFAULT_MAX_RECORD_COUNT instead.
  */
-ArcRequestSource.MAX = 1000;
+ArcRequestSource.MAX = DEFAULT_MAX_RECORD_COUNT;
 
 
 /**

--- a/test/plugin/arc/layer/arclayerdescriptor.test.js
+++ b/test/plugin/arc/layer/arclayerdescriptor.test.js
@@ -48,7 +48,8 @@ describe('plugin.arc.layer.ArcLayerDescriptor', function() {
         'type': 'esriFieldTypeNumber'
       }
     ],
-    'capabilities': 'Map,Query,Data'
+    'capabilities': 'Map,Query,Data',
+    'maxRecordCount': 12345
   };
 
   var mapConfig = {
@@ -186,6 +187,8 @@ describe('plugin.arc.layer.ArcLayerDescriptor', function() {
     expect(params.get('returnIdsOnly')).toBe('true');
     expect(params.get('time')).toBe('{time}');
 
+    expect(featureOptions['baseColor']).toBe('#380070');
+    expect(featureOptions['color']).toBe('#380070');
     expect(featureOptions['type']).toBe('arcfeature');
     expect(featureOptions['id']).toBe('someLayerId#features');
     expect(featureOptions['layerType']).toBe('Tile and Feature Groups');
@@ -195,5 +198,6 @@ describe('plugin.arc.layer.ArcLayerDescriptor', function() {
     expect(featureOptions['spatial']).toBe(true);
     expect(featureOptions['temporal']).toBe(true);
     expect(featureOptions['filter']).toBe(true);
+    expect(featureOptions['maxRecordCount']).toBe(12345);
   });
 });


### PR DESCRIPTION
- ArcGIS tile layers use the color from the service metadata's `drawingInfo.renderer`, but feature layers do not. That object defines how features should be rendered to the map, so feature layers should use this color as well.
- FeatureServer service metadata also defines a `maxRecordCount`, which is the maximum number of records that will be returned by a request. The Arc request source was chunking requests by the default value of 1000, when it should be getting this number from the service metadata. Doing so will reduce the number of requests made to load features when an Arc service supports requesting more than the default number of records.